### PR TITLE
Implement AccountId object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+members = [
+  "objects",
+]
+
+[profile.release]
+codegen-units = 1
+lto = true
+
+[profile.bench]
+codegen-units = 1
+lto = true

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "miden-objects"
+version = "0.1.0"
+description = "Core components of the Miden rollup"
+authors = ["miden contributors"]
+readme = "README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/miden-base"
+categories = ["no-std"]
+keywords = []
+edition = "2021"
+rust-version = "1.65"
+
+[lib]
+bench = false
+
+[features]
+default = ["std"]
+std = ["crypto/std"]
+
+[dependencies]
+crypto = {  package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }

--- a/objects/README.md
+++ b/objects/README.md
@@ -1,0 +1,3 @@
+# Miden Objects
+
+Core components of the Polygon Miden rollup.

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -1,0 +1,208 @@
+use super::{AccountError, Felt, Hasher, StarkField, Word, ZERO};
+use core::{fmt, ops::Deref};
+
+// ACCOUNT ID
+// ================================================================================================
+
+/// Unique identifier of an account.
+///
+/// Account ID consists of 3 field elements (24 bytes). These field elements uniquely identify a
+/// single account and also specify the type of the underlying account. Specifically:
+/// - If the least significant 32 bits of the 3rd element are all ZEROs, the account is a
+///   fungible asset faucet (i.e., it can issue fungible assets).
+/// - If the least significant 32 bits of the 3rd element are set to 2^31 (i.e ONE followed by 31
+///   ZEROs), the account is a non-fungible asset faucet (i.e., it can issue non-fungible assets).
+/// - Otherwise, the account is a regular account.
+///
+/// Additionally, account IDs have the following properties
+/// - For fungible asset faucets account IDs are guaranteed to start with ONE.
+/// - For regular accounts, the last 3 bytes of the ID are guaranteed to be all ZEROs.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AccountId([Felt; 3]);
+
+impl AccountId {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+    pub const FUNGIBLE_FAUCET_TAG: u32 = 0;
+    pub const NON_FUNGIBLE_FAUCET_TAG: u32 = 1 << 31;
+
+    /// Specifies a minimum number of trailing zeros for a valid account ID. Thus, all valid
+    /// account IDs have the last 3 bytes set to zeros.
+    pub const MIN_TRAILING_ZEROS: u32 = 24;
+
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new account ID derived from the specified seed.
+    ///
+    /// The account ID is computed by hashing the seed and using 3 elements of the result to form
+    /// the ID. Specifically we are take elements 0, 1, and 3, omitting element 2. We omit element
+    /// 2 because unlike elements 0 and 3, it has no special structure which we need to carry over
+    /// into the derived account ID. Element 1 could have been omitted just as well.
+    ///
+    /// # Errors
+    /// Returns an error if the resulting account ID does not comply with account ID rules.
+    pub fn new(seed: Word) -> Result<Self, AccountError> {
+        // hash the seed and build the ID from the 1st, 2nd, and 4th elements of the result
+        let hash = Hasher::hash_elements(&seed);
+        let id = Self([hash[0], hash[1], hash[3]]);
+
+        // verify that the ID satisfies all rules
+        id.validate()?;
+
+        Ok(id)
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns true if an account with this ID can issue fungible assets.
+    pub fn is_fungible_faucet(&self) -> bool {
+        self.tag() == Self::FUNGIBLE_FAUCET_TAG
+    }
+
+    /// Returns true if an account with this ID can issue non-fungible assets.
+    pub fn is_non_fungible_faucet(&self) -> bool {
+        self.tag() == Self::NON_FUNGIBLE_FAUCET_TAG
+    }
+
+    /// Returns true if an account with this ID can issue assets.
+    pub fn is_faucet(&self) -> bool {
+        self.is_fungible_faucet() || self.is_non_fungible_faucet()
+    }
+
+    // SEED GENERATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Finds and returns a seed suitable for creating regular account IDs using the provided seed
+    /// as a starting point.
+    pub fn get_account_seed(_init_seed: [u8; 32]) -> Word {
+        todo!()
+    }
+
+    /// Finds and returns a seed suitable for creating account IDs for fungible faucets using the
+    /// provided seed as a starting point.
+    pub fn get_fungible_faucet_seed(_init_seed: [u8; 32]) -> Word {
+        todo!()
+    }
+
+    /// Finds and returns a seed suitable for creating account IDs for non-fungible faucets using
+    /// the provided seed as a starting point.
+    pub fn get_non_fungible_faucet_seed(_init_seed: [u8; 32]) -> Word {
+        todo!()
+    }
+
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the first bit of this account ID.
+    fn first_bit(&self) -> u8 {
+        (self.0[0].as_int() >> 63) as u8
+    }
+
+    /// Returns the last 32 bits of this account ID.
+    fn tag(&self) -> u32 {
+        self.0[2].as_int() as u32
+    }
+
+    /// Returns an error if:
+    /// - This account ID is for a fungible asset but the first bit of the ID is not ONE.
+    /// - There are fewer than 24 trailing ZEROs in this account ID.
+    fn validate(&self) -> Result<(), AccountError> {
+        if self.is_fungible_faucet() {
+            // IDs for fungible faucets must start with ONE
+            if self.first_bit() != 1 {
+                return Err(AccountError::fungible_faucet_id_invalid_first_bit());
+            }
+        } else if self.tag().trailing_zeros() < Self::MIN_TRAILING_ZEROS {
+            // all account IDs must end with at least 24 ZEROs
+            return Err(AccountError::account_id_too_few_trailing_zeros());
+        }
+
+        Ok(())
+    }
+}
+
+impl Deref for AccountId {
+    type Target = [Felt; 3];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<AccountId> for [Felt; 3] {
+    fn from(id: AccountId) -> Self {
+        id.0
+    }
+}
+
+impl From<AccountId> for Word {
+    fn from(id: AccountId) -> Self {
+        [id.0[0], id.0[1], id.0[2], ZERO]
+    }
+}
+
+impl From<AccountId> for [u8; 24] {
+    fn from(id: AccountId) -> Self {
+        let mut result = [0_u8; 24];
+        result[..8].copy_from_slice(&id.0[0].as_int().to_le_bytes());
+        result[8..16].copy_from_slice(&id.0[1].as_int().to_le_bytes());
+        result[16..].copy_from_slice(&id.0[2].as_int().to_le_bytes());
+        result
+    }
+}
+
+/// This conversion is possible because the 3 least significant bytes of an account ID are always
+/// set to zeros.
+impl From<AccountId> for [u8; 21] {
+    fn from(id: AccountId) -> Self {
+        let mut result = [0_u8; 21];
+        result[..8].copy_from_slice(&id.0[0].as_int().to_le_bytes());
+        result[8..16].copy_from_slice(&id.0[1].as_int().to_le_bytes());
+        result[16..].copy_from_slice(&id.0[2].as_int().to_le_bytes()[..5]);
+        result
+    }
+}
+
+impl TryFrom<[Felt; 3]> for AccountId {
+    type Error = AccountError;
+
+    fn try_from(value: [Felt; 3]) -> Result<Self, Self::Error> {
+        let id = Self(value);
+        id.validate()?;
+        Ok(id)
+    }
+}
+
+impl TryFrom<[u8; 24]> for AccountId {
+    type Error = AccountError;
+
+    fn try_from(value: [u8; 24]) -> Result<Self, Self::Error> {
+        let elements =
+            [parse_felt(&value[..8])?, parse_felt(&value[8..16])?, parse_felt(&value[16..])?];
+        Self::try_from(elements)
+    }
+}
+
+impl TryFrom<[u8; 21]> for AccountId {
+    type Error = AccountError;
+
+    fn try_from(value: [u8; 21]) -> Result<Self, Self::Error> {
+        let mut bytes = [0_u8; 24];
+        bytes[..21].copy_from_slice(&value);
+        Self::try_from(bytes)
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn parse_felt(bytes: &[u8]) -> Result<Felt, AccountError> {
+    Felt::try_from(bytes).map_err(|err| AccountError::AccountIdInvalidFieldElement(err.to_string()))
+}

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,0 +1,4 @@
+use super::{AccountError, Felt, Hasher, StarkField, Word, ZERO};
+
+mod account_id;
+pub use account_id::AccountId;

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,0 +1,34 @@
+use core::fmt;
+
+// ACCOUNT ERROR
+// ================================================================================================
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum AccountError {
+    AccountIdInvalidFieldElement(String),
+    AccountIdTooFewTrailingZeros,
+    FungibleFaucetIdInvalidFirstBit,
+}
+
+impl AccountError {
+    pub fn account_id_invalid_field_element(msg: String) -> Self {
+        Self::AccountIdInvalidFieldElement(msg)
+    }
+
+    pub fn account_id_too_few_trailing_zeros() -> Self {
+        Self::AccountIdTooFewTrailingZeros
+    }
+
+    pub fn fungible_faucet_id_invalid_first_bit() -> Self {
+        Self::FungibleFaucetIdInvalidFirstBit
+    }
+}
+
+impl fmt::Display for AccountError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AccountError {}

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
+use crypto::{hash::rpo::Rpo256 as Hasher, Felt, StarkField, Word, ZERO};
+
+mod accounts;
+pub use accounts::AccountId;
+
+mod errors;
+pub use errors::AccountError;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,22 @@
+# commented out settings are not currently stable. once they become stable, we'll
+# evaluate and enable them.
+
+array_width = 80
+attr_fn_like_width = 80
+chain_width = 80
+#condense_wildcard_suffixes = true
+#enum_discrim_align_threshold = 40
+fn_call_width = 80
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#format_macro_matchers = true
+#format_strings = true
+#group_imports = "StdExternalCrate"
+#hex_literal_case = "Lower"
+#imports_granularity = "Crate"
+newline_style = "Unix"
+#normalize_doc_attributes = true
+#reorder_impl_items = true
+single_line_if_else_max_width = 60
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
This PR implements the `AccountId` struct which describes the shape and properties of all account Ids in the Miden rollup.

The PR also sets up the basic crate structure for the repo.