### PR TITLE
Define basic account object

### DIFF
--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -21,3 +21,4 @@ std = ["assembly/std", "crypto/std"]
 [dependencies]
 assembly = {  package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 crypto = {  package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+miden-core = {  package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -70,6 +70,11 @@ impl AccountId {
         self.is_fungible_faucet() || self.is_non_fungible_faucet()
     }
 
+    /// Returns a slice of field elements defining this account ID.
+    pub fn as_elements(&self) -> &[Felt] {
+        &self.0
+    }
+
     // SEED GENERATORS
     // --------------------------------------------------------------------------------------------
 

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -1,0 +1,79 @@
+use super::{AccountError, Digest};
+use assembly::{parse_module, ModuleAst};
+use crypto::merkle::MerkleTree;
+use miden_core::Program; // TODO: we should be able to import it from the assembly crate
+
+// ACCOUNT CODE
+// ================================================================================================
+
+/// Describes public interface of an account.
+///
+/// Account's public interface consists of a set of account methods, each method being a Miden VM
+/// program. Thus, MAST root of each method commits to the underlying program. We commit to the
+/// entire account interface by building a simple Merkle tree out of all method MAST roots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountCode {
+    method_tree: MerkleTree,
+    module: ModuleAst,
+    // methods: Vec<Program>, commented out because Program doesn't currently implement Eq and
+    // PartialEq. Also, there might be a better way of describing a set of programs as they
+    // might share a lot of common code blocks. In a way, we want something like a Program
+    // struct but with many entry points.
+}
+
+impl AccountCode {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Creates and returns a new definition of an account's interface compiled from the specified
+    /// source code.
+    pub fn new(source: &str) -> Result<Self, AccountError> {
+        let _module_ast = parse_module(source)?;
+
+        // TODO: compile module AST into a set of program MASTs. To do this we need to expose
+        // a new method on the assembler to compile a module rather than a program (something
+        // similar to Assembler::compile_module() but without internal parameters).
+        //
+        // Open question: how to initialize the assembler? Specifically, which libraries to
+        // initialize it with. stdlib and midenlib are the two libraries we need for sure - but
+        // how to handle accounts which rely on some user-defined libraries? i.e., should there
+        // be a way to specify an "on-chain" library somehow?
+
+        // TODO: build a Merkle tree out of MAST roots of compiled programs. The roots should
+        // be sorted so that the same set of programs always resolves to the same root. If the
+        // number of programs is not a power of two, the remaining leaves should be set to ZEROs.
+
+        todo!()
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a commitment to an account's public interface.
+    pub fn root(&self) -> Digest {
+        self.method_tree.root().into()
+    }
+
+    /// Returns the number of public interface methods defined for this account.
+    pub fn num_methods(&self) -> usize {
+        todo!()
+    }
+
+    /// Returns true if a method with the specified root is defined for this account.
+    pub fn has_method(&self, _root: Digest) -> bool {
+        todo!()
+    }
+
+    /// Returns an account interface method at the specified index.
+    ///
+    /// # Panics
+    /// Panics if the provided index is out of bounds.
+    pub fn get_method_by_index(&self, _index: usize) -> &Program {
+        todo!()
+    }
+
+    /// Returns an account interface method with the specified root or None if such method is not
+    /// defined for this account.
+    pub fn get_method_by_root(&self, _root: Digest) -> Option<&Program> {
+        todo!()
+    }
+}

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,4 +1,123 @@
-use super::{AccountError, Felt, Hasher, StarkField, Word, ZERO};
+use super::{assets::Asset, AccountError, Digest, Felt, Hasher, StarkField, Word, ZERO};
 
 mod account_id;
 pub use account_id::AccountId;
+
+mod code;
+pub use code::AccountCode;
+
+mod storage;
+pub use storage::AccountStorage;
+use storage::StorageItem;
+
+mod vault;
+pub use vault::AccountVault;
+
+// ACCOUNT
+// ================================================================================================
+
+/// An account which can store assets and define rules for manipulating them.
+///
+/// An account consists of the following components:
+/// - Account ID, which uniquely identifies the account and also defines basic properties of the
+///   account.
+/// - Account vault, which stores assets owned by the account.
+/// - Account storage, which is a key-value map (both keys and values are words) used to store
+///   arbitrary user-defined data.
+/// - Account code, which is a set of Miden VM programs defining the public interface of the
+///   account.
+/// - Account nonce, a value which is incremented whenever account state is updated.
+///
+/// Out of the the above components account ID is always immutable (once defined it can never be
+/// changed). Other components may be mutated throughout the lifetime of the account. However,
+/// account state can be changed only by invoking one of account interface methods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Account {
+    id: AccountId,
+    vault: AccountVault,
+    storage: AccountStorage,
+    code: AccountCode,
+    nonce: Felt,
+}
+
+impl Account {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Creates and returns a new account initialized with the specified ID, storage items, and
+    /// code.
+    ///
+    /// The vault of the account is initially empty and nonce is set to ZERO.
+    ///
+    /// # Errors
+    /// Returns an error if compilation of the source code fails.
+    pub fn new(
+        id: AccountId,
+        storage_items: &[StorageItem],
+        code_source: &str,
+    ) -> Result<Self, AccountError> {
+        Ok(Self {
+            id,
+            vault: AccountVault::default(),
+            storage: AccountStorage::new(storage_items),
+            code: AccountCode::new(code_source)?,
+            nonce: ZERO,
+        })
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns hash of this account.
+    ///
+    /// Hash of an account is computed as hash(id, nonce, vault_root, storage_root, code_root).
+    /// Computing the account hash requires 2 permutations of the hash function.
+    pub fn hash(&self) -> Digest {
+        let mut elements = [ZERO; 16];
+        elements[..3].copy_from_slice(self.id.as_elements());
+        elements[3] = self.nonce;
+        elements[4..8].copy_from_slice(self.vault.root().as_elements());
+        elements[8..12].copy_from_slice(self.storage.root().as_elements());
+        elements[12..].copy_from_slice(self.code.root().as_elements());
+        Hasher::hash_elements(&elements)
+    }
+
+    /// Returns unique identifier of this account.
+    pub fn id(&self) -> AccountId {
+        self.id
+    }
+
+    /// Returns a reference to the vault of this account.
+    pub fn vault(&self) -> &AccountVault {
+        &self.vault
+    }
+
+    /// Returns a reference to the storage of this account.
+    pub fn storage(&self) -> &AccountStorage {
+        &self.storage
+    }
+
+    /// Returns a reference to the code of this account.
+    pub fn code(&self) -> &AccountCode {
+        &self.code
+    }
+
+    /// Returns nonce for this account.
+    pub fn nonce(&self) -> Felt {
+        self.nonce
+    }
+
+    /// Returns true if this account can issue assets.
+    pub fn is_faucet(&self) -> bool {
+        self.id.is_faucet()
+    }
+
+    /// Returns true if this account can issue fungible assets.
+    pub fn is_fungible_faucet(&self) -> bool {
+        self.id.is_fungible_faucet()
+    }
+
+    /// Returns true if this account can issue non-fungible assets.
+    pub fn is_non_fungible_faucet(&self) -> bool {
+        self.id.is_non_fungible_faucet()
+    }
+}

--- a/objects/src/accounts/storage.rs
+++ b/objects/src/accounts/storage.rs
@@ -1,0 +1,51 @@
+use super::{Digest, Hasher, Word, ZERO};
+
+// TYPE ALIASES
+// ================================================================================================
+
+pub type StorageItem = (Word, Word);
+
+// ACCOUNT STORAGE
+// ================================================================================================
+
+/// Account storage is a key-value map where both keys and values are words (4 elements).
+///
+/// Internally, account storage uses a compact Sparse Merkle tree to store the data. To ensure that
+/// the data is randomly distributed across the tree, the index of item in the tree is derived by
+/// hashing the key.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AccountStorage {
+    // TODO: add compact SMT as backing storage
+}
+
+impl AccountStorage {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new instance of account storage initialized with the provided items.
+    pub fn new(_items: &[StorageItem]) -> Self {
+        todo!()
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a commitment to this storage.
+    pub fn root(&self) -> Digest {
+        todo!()
+    }
+
+    /// Returns an item from the storage at the specified key. Both items and keys are Words which
+    /// consist of 4 field elements.
+    ///
+    /// If the item is not present in the storage, [ZERO; 4] is returned.
+    pub fn get_item(&self, key: Word) -> Word {
+        // the index of the item is the hash of its key
+        let _index: Word = Hasher::merge(&[key.into(), [ZERO; 4].into()]).into();
+        todo!("retrieve the item from the tree");
+    }
+
+    /// Returns a list of items contained in this storage.
+    pub fn items(&self) -> &[Word] {
+        todo!()
+    }
+}

--- a/objects/src/accounts/vault.rs
+++ b/objects/src/accounts/vault.rs
@@ -1,0 +1,68 @@
+use super::{AccountError, AccountId, Asset, Digest};
+
+// ACCOUNT VAULT
+// ================================================================================================
+
+/// An asset container for an account.
+///
+/// An account vault can contain an unlimited number of assets. The assets are stored in a Sparse
+/// Merkle tree as follows:
+/// - For fungible assets, the index of a node is defined by the issuing faucet ID, and the value
+///   of the node is the asset itself. Thus, for any fungible asset there will be only one node
+///   in the tree.
+/// - For non-fungible assets, the index is defined by the asset itself, and the asset is also
+///   the value of the node.
+///
+/// An account vault can be reduced to a single hash which is the root of the Sparse Merkle tree.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AccountVault {
+    // TODO: add backing sparse Merkle tree
+    assets: Vec<Asset>,
+}
+
+impl AccountVault {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new account vault initialized with the provided assets.
+    ///
+    /// TODO: return error if there are duplicates in the provided asset list.
+    pub fn new(assets: &[Asset]) -> Self {
+        Self {
+            // TODO: put assets into a Sparse Merkle trees
+            assets: assets.to_vec(),
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a commitment to this vault.
+    pub fn root(&self) -> Digest {
+        todo!()
+    }
+
+    /// Returns true if the specified non-fungible asset is stored in this vault.
+    pub fn has_non_fungible_asset(&self, asset: Asset) -> Result<bool, AccountError> {
+        if asset.is_fungible() {
+            return Err(AccountError::not_a_non_fungible_asset(asset));
+        }
+        todo!()
+    }
+
+    /// Returns the balance of the asset issued by the specified faucet. If the vault does not
+    /// contain such an asset, 0 is returned.
+    ///
+    /// # Errors
+    /// Returns an error if the specified ID is not an ID of a fungible asset faucet.
+    pub fn get_balance(&self, faucet_id: AccountId) -> Result<u64, AccountError> {
+        if !faucet_id.is_fungible_faucet() {
+            return Err(AccountError::not_a_fungible_faucet_id(faucet_id));
+        }
+        todo!()
+    }
+
+    /// Returns a list of assets stored in this vault.
+    pub fn assets(&self) -> &[Asset] {
+        &self.assets
+    }
+}

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -57,6 +57,11 @@ impl Asset {
             _ => false,
         }
     }
+
+    /// Returns true if this asset is a fungible asset.
+    pub const fn is_fungible(&self) -> bool {
+        matches!(self, Self::Fungible(_))
+    }
 }
 
 impl From<Asset> for Word {

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,4 +1,5 @@
-use super::{assets::NonFungibleAsset, AccountId, Word};
+use super::{assets::Asset, assets::NonFungibleAsset, AccountId, Word};
+use assembly::ParsingError;
 use core::fmt;
 
 // ACCOUNT ERROR
@@ -8,7 +9,10 @@ use core::fmt;
 pub enum AccountError {
     AccountIdInvalidFieldElement(String),
     AccountIdTooFewTrailingZeros,
+    CodeParsingFailed(ParsingError),
     FungibleFaucetIdInvalidFirstBit,
+    NotAFungibleFaucetId(AccountId),
+    NotANonFungibleAsset(Asset),
 }
 
 impl AccountError {
@@ -22,6 +26,20 @@ impl AccountError {
 
     pub fn fungible_faucet_id_invalid_first_bit() -> Self {
         Self::FungibleFaucetIdInvalidFirstBit
+    }
+
+    pub fn not_a_fungible_faucet_id(account_id: AccountId) -> Self {
+        Self::NotAFungibleFaucetId(account_id)
+    }
+
+    pub fn not_a_non_fungible_asset(asset: Asset) -> Self {
+        Self::NotANonFungibleAsset(asset)
+    }
+}
+
+impl From<ParsingError> for AccountError {
+    fn from(err: ParsingError) -> Self {
+        Self::CodeParsingFailed(err)
     }
 }
 

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -11,7 +11,7 @@ use crypto::{
 };
 
 mod accounts;
-pub use accounts::AccountId;
+pub use accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault};
 
 pub mod assets;
 pub mod notes;


### PR DESCRIPTION
This PR defines basic structure of the account object. This does not yet include the idea of changing account IDs to 64-bit values. Other things missing:

- Since we don't have an implementation of compact Sparse Merkle tree, account vault and storage have TODOs in their place.
- Account code does actually get compiled into MAST yet. For this, we need to make changes to the assembler to enable compilation of modules into multi-entry programs.
- Serialization of account object is not implemented.

There are some open questions about how to compile program code while also including user-defined libraries. We probably don't need this for the testnet, but if there are some good ways of doing this, we could address it even now.