### PR TITLE
feat(objects): introduce note script inputs

### DIFF
--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -139,6 +139,7 @@ pub enum NoteError {
     DuplicateNonFungibleAsset(NonFungibleAsset),
     EmptyAssetList,
     TooManyAssets(usize),
+    TooManyInputs(usize),
 }
 
 impl NoteError {
@@ -156,6 +157,10 @@ impl NoteError {
 
     pub fn too_many_assets(num_assets: usize) -> Self {
         Self::TooManyAssets(num_assets)
+    }
+
+    pub fn too_many_inputs(num_inputs: usize) -> Self {
+        Self::TooManyInputs(num_inputs)
     }
 }
 

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -1,0 +1,87 @@
+use super::{Digest, Felt, Hasher, NoteError, ZERO};
+
+/// Holds the inputs which are placed onto the stack before a note's script is executed.
+/// - inputs are stored in reverse stack order such that when they are pushed onto stack they are
+///   in the correct order
+/// - hash is computed from inputs in the order they are stored (reverse stack order)
+#[derive(Debug, Eq, PartialEq)]
+pub struct NoteInputs {
+    inputs: [Felt; 16],
+    hash: Digest,
+}
+
+impl NoteInputs {
+    /// Number of note inputs.
+    const NOTE_NUM_INPUTS: usize = 16;
+
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns NoteInputs created from the provided inputs.
+    ///
+    /// The inputs (provided in reverse stack order) are padded with ZERO such that they are always
+    /// of length 16.
+    ///
+    /// # Errors
+    /// Returns an error if the number of provided inputs is greater than 16.
+    pub fn new(inputs: &[Felt]) -> Self {
+        if inputs.len() > Self::NOTE_NUM_INPUTS {
+            NoteError::too_many_inputs(inputs.len());
+        }
+
+        // pad inputs with ZERO to be constant size (16 elements)
+        let mut padded_inputs = [ZERO; Self::NOTE_NUM_INPUTS];
+
+        // insert inputs in reverse stack order starting from the end of the array
+        let start_index = Self::NOTE_NUM_INPUTS - inputs.len();
+        padded_inputs[start_index..].copy_from_slice(inputs);
+
+        // compute hash from padded inputs.
+        let hash = Hasher::hash_elements(&padded_inputs);
+
+        Self {
+            inputs: padded_inputs,
+            hash,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a reference to the inputs.
+    pub fn inputs(&self) -> &[Felt] {
+        &self.inputs
+    }
+
+    /// Returns a hash digest of the inputs. Computed as a linear hash of the inputs.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+}
+
+#[test]
+fn test_input_ordering() {
+    // inputs are provided in reverse stack order
+    let inputs = vec![Felt::new(1), Felt::new(2), Felt::new(3)];
+    // we expect the inputs to be padded to length 16 and to remain in reverse stack order.
+    let expected_ordering = vec![
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        ZERO,
+        Felt::new(1),
+        Felt::new(2),
+        Felt::new(3),
+    ];
+
+    let note_inputs = NoteInputs::new(&inputs);
+    assert_eq!(&expected_ordering, note_inputs.inputs());
+}

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -1,5 +1,8 @@
 use super::{assets::Asset, Digest, Felt, Hasher, NoteError, Vec, Word, WORD_SIZE, ZERO};
 
+mod inputs;
+use inputs::NoteInputs;
+
 mod script;
 pub use script::NoteScript;
 
@@ -13,12 +16,14 @@ pub use vault::NoteVault;
 ///
 /// This struct is a full description of a note which is needed to execute a note in a transaction.
 /// A note consists of:
-/// - A set of assets stored in a vault.
 /// - A script which must be executed in a context of some account to claim the assets.
+/// - A set of inputs which are placed onto the stack before a note's script is executed.
+/// - A set of assets stored in a vault.
 /// - A serial number which can be used to break linkability between note hash and note nullifier.
 #[derive(Debug, Eq, PartialEq)]
 pub struct Note {
     script: NoteScript,
+    inputs: NoteInputs,
     vault: NoteVault,
     serial_num: Word,
 }
@@ -31,14 +36,21 @@ impl Note {
     /// # Errors
     /// Returns an error if:
     /// - Compilation of note script fails.
+    /// - The number of inputs exceeds 16.
     /// - The number of provided assets exceeds 1000.
     /// - The list of assets contains duplicates.
-    pub fn new<S>(script_src: S, assets: &[Asset], serial_num: Word) -> Result<Self, NoteError>
+    pub fn new<S>(
+        script_src: S,
+        inputs: &[Felt],
+        assets: &[Asset],
+        serial_num: Word,
+    ) -> Result<Self, NoteError>
     where
         S: AsRef<str>,
     {
         Ok(Self {
             script: NoteScript::new(script_src)?,
+            inputs: NoteInputs::new(inputs),
             vault: NoteVault::new(assets)?,
             serial_num,
         })
@@ -50,6 +62,11 @@ impl Note {
     /// Returns a reference script which locks the assets of this note.
     pub fn script(&self) -> &NoteScript {
         &self.script
+    }
+
+    /// Returns a reference to the note inputs.
+    pub fn inputs(&self) -> &NoteInputs {
+        &self.inputs
     }
 
     /// Returns a reference to the asset vault of this note.
@@ -64,39 +81,41 @@ impl Note {
 
     /// Returns a commitment to this note.
     ///
-    /// The note hash is computed as hash(hash(hash(serial_num, [0; 4]), script_hash), vault_hash).
+    /// The note hash is computed as:
+    ///   hash(hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash), vault_hash).
     /// This achieves the following properties:
     /// - Every note can be reduced to a single unique hash.
     /// - To compute a note's hash, we do not need to know the note's serial_num. Knowing the hash
-    ///   of the serial_num (as well as script hash and note vault) is sufficient.
-    /// - Moreover, we define `recipient` as hash(hash(serial_num, [0; 4]), script_hash). This
-    ///   allows computing note hash from recipient and note vault.
+    ///   of the serial_num (as well as script hash, input hash and note vault) is sufficient.
+    /// - Moreover, we define `recipient` as:
+    ///     `hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)`
+    ///  This allows computing note hash from recipient and note vault.
     /// - We compute hash of serial_num as hash(serial_num, [0; 4]) to simplify processing within
     ///   the VM.
     pub fn get_hash(&self) -> Digest {
         let serial_num_hash = Hasher::merge(&[self.serial_num.into(), Digest::default()]);
-        let recipient_hash = Hasher::merge(&[serial_num_hash, self.script.hash()]);
-        Hasher::merge(&[recipient_hash, self.vault.hash()])
+        let merge_script = Hasher::merge(&[serial_num_hash, self.script.hash()]);
+        let recipient = Hasher::merge(&[merge_script, self.inputs.hash()]);
+        Hasher::merge(&[recipient, self.vault.hash()])
     }
 
     /// Returns the nullifier for this note.
     ///
-    /// The nullifier is computed as hash(serial_num, script_hash, vault_hash, [0; 4]). This
-    /// achieves the following properties:
+    /// The nullifier is computed as hash(serial_num, script_hash, input_hash, vault_hash).
+    /// This achieves the following properties:
     /// - Every note can be reduced to a single unique nullifier.
     /// - We cannot derive a note's hash from its nullifier.
     /// - To compute the nullifier we must know all components of the note: serial_num,
-    ///   script_hash, and vault hash.
-    /// - We pad with ZEROs at the end to simplify processing within the VM.
+    ///   script_hash, input_hash and vault hash.
     pub fn get_nullifier(&self) -> Digest {
-        // set the total number of elements to be hashed to 16 so that we can absorb them in
+        // The total number of elements to be hashed is 16. We can absorb them in
         // exactly two permutations
         let target_num_elements = 4 * WORD_SIZE;
         let mut elements: Vec<Felt> = Vec::with_capacity(target_num_elements);
         elements.extend_from_slice(&self.serial_num);
         elements.extend_from_slice(self.script.hash().as_elements());
+        elements.extend_from_slice(self.inputs.hash().as_elements());
         elements.extend_from_slice(self.vault.hash().as_elements());
-        elements.resize(target_num_elements, ZERO);
         Hasher::hash_elements(&elements)
     }
 }


### PR DESCRIPTION
This PR introduces note script inputs.  It also updates the way note commitments and nullifies are computed.  

Note Commitment modification:
- An additional 2-1 hash is added as the last step to the hash chain  which involves a hash with the script inputs hash.

Nulifier Modification:
- Introduction of script inputs hash as the third word in the nulifier linear hash. 
- Padding removed as with the introduction of script inputs hash we now have 16 elements to be hashed.

Is there any interesting structure in: 
`Hasher::merge(&[script.hash(), script_inputs.hash()]);`
If we assume that the script is for receiving assets from the note vault and the script input is the account_id of the recipient this would be unique for every user for each wallet type.

closes: #9 