### PR TITLE
feat(objects): migrate to ~64 bit AccountId

### DIFF
--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -11,6 +11,10 @@ keywords = []
 edition = "2021"
 rust-version = "1.65"
 
+[[bench]]
+name = "account_seed"
+harness = false
+
 [lib]
 bench = false
 
@@ -22,3 +26,6 @@ std = ["assembly/std", "crypto/std", "miden-core/std"]
 assembly = {  package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 crypto = {  package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 miden-core = {  package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+
+[dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }

--- a/objects/benches/account_seed.rs
+++ b/objects/benches/account_seed.rs
@@ -1,0 +1,22 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use miden_objects::{AccountId, AccountType};
+
+fn grind_account_seed(c: &mut Criterion) {
+    let init_seed = [
+        1, 18, 222, 14, 56, 94, 222, 213, 12, 57, 86, 1, 22, 34, 187, 100, 210, 1, 18, 222, 14, 56,
+        94, 43, 213, 12, 57, 86, 1, 22, 34, 187,
+    ];
+
+    c.bench_function("Grind regular on-chain account seed", |bench| {
+        bench.iter(|| {
+            AccountId::get_account_seed(init_seed, AccountType::RegularAccountImmutableCode, true)
+        })
+    });
+
+    c.bench_function("Grind fungible faucet on-chain account seed", |bench| {
+        bench.iter(|| AccountId::get_account_seed(init_seed, AccountType::FungibleFaucet, true))
+    });
+}
+
+criterion_group!(account_seed, grind_account_seed);
+criterion_main!(account_seed);

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -3,7 +3,7 @@ use super::{
 };
 
 mod account_id;
-pub use account_id::AccountId;
+pub use account_id::{AccountId, AccountType};
 
 mod code;
 pub use code::AccountCode;
@@ -14,6 +14,9 @@ use storage::StorageItem;
 
 mod vault;
 pub use vault::AccountVault;
+
+#[cfg(test)]
+mod tests;
 
 // ACCOUNT
 // ================================================================================================
@@ -75,7 +78,7 @@ impl Account {
     /// Computing the account hash requires 2 permutations of the hash function.
     pub fn hash(&self) -> Digest {
         let mut elements = [ZERO; 16];
-        elements[..3].copy_from_slice(self.id.as_elements());
+        elements[0] = *self.id;
         elements[3] = self.nonce;
         elements[4..8].copy_from_slice(self.vault.root().as_elements());
         elements[8..12].copy_from_slice(self.storage.root().as_elements());
@@ -86,6 +89,11 @@ impl Account {
     /// Returns unique identifier of this account.
     pub fn id(&self) -> AccountId {
         self.id
+    }
+
+    /// Returns the account type
+    pub fn account_type(&self) -> AccountType {
+        self.id.account_type()
     }
 
     /// Returns a reference to the vault of this account.
@@ -113,13 +121,13 @@ impl Account {
         self.id.is_faucet()
     }
 
-    /// Returns true if this account can issue fungible assets.
-    pub fn is_fungible_faucet(&self) -> bool {
-        self.id.is_fungible_faucet()
+    /// Returns true if this is a regular account.
+    pub fn is_regular_account(&self) -> bool {
+        self.id.is_regular_account()
     }
 
-    /// Returns true if this account can issue non-fungible assets.
-    pub fn is_non_fungible_faucet(&self) -> bool {
-        self.id.is_non_fungible_faucet()
+    /// Returns true if this account is on-chain.
+    pub fn is_on_chain(&self) -> bool {
+        self.id.is_on_chain()
     }
 }

--- a/objects/src/accounts/tests.rs
+++ b/objects/src/accounts/tests.rs
@@ -1,0 +1,33 @@
+use super::{AccountId, AccountType};
+
+const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u64 = 0b0110011011u64 << 54;
+const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN: u64 = 0b0001101110 << 54;
+const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
+const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN: u64 = 0b1101100110 << 54;
+
+#[test]
+fn test_account_tag_identifiers() {
+    let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN)
+        .expect("Valid account ID");
+    assert!(account_id.is_regular_account());
+    assert_eq!(account_id.account_type(), AccountType::RegularAccountImmutableCode);
+    assert!(account_id.is_on_chain());
+
+    let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN)
+        .expect("Valid account ID");
+    assert!(account_id.is_regular_account());
+    assert_eq!(account_id.account_type(), AccountType::RegularAccountUpdatableCode);
+    assert!(!account_id.is_on_chain());
+
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).expect("Valid account ID");
+    assert!(account_id.is_faucet());
+    assert_eq!(account_id.account_type(), AccountType::FungibleFaucet);
+    assert!(account_id.is_on_chain());
+
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN).expect("Valid account ID");
+    assert!(account_id.is_faucet());
+    assert_eq!(account_id.account_type(), AccountType::NonFungibleFaucet);
+    assert!(!account_id.is_on_chain());
+}

--- a/objects/src/accounts/vault.rs
+++ b/objects/src/accounts/vault.rs
@@ -1,4 +1,4 @@
-use super::{AccountError, AccountId, Asset, Digest, Vec};
+use super::{AccountError, AccountId, AccountType, Asset, Digest, Vec};
 use core::default::Default;
 
 // ACCOUNT VAULT
@@ -56,7 +56,7 @@ impl AccountVault {
     /// # Errors
     /// Returns an error if the specified ID is not an ID of a fungible asset faucet.
     pub fn get_balance(&self, faucet_id: AccountId) -> Result<u64, AccountError> {
-        if !faucet_id.is_fungible_faucet() {
+        if !matches!(faucet_id.account_type(), AccountType::FungibleFaucet) {
             return Err(AccountError::not_a_fungible_faucet_id(faucet_id));
         }
         todo!()

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -1,4 +1,6 @@
-use super::{AccountId, AssetError, Digest, Felt, Hasher, StarkField, ToString, Vec, Word, ZERO};
+use super::{
+    AccountId, AccountType, AssetError, Felt, Hasher, StarkField, ToString, Vec, Word, ZERO,
+};
 use core::{fmt, ops::Deref};
 
 // ASSET
@@ -8,35 +10,42 @@ use core::{fmt, ops::Deref};
 ///
 /// All assets are encoded using a single word (4 elements) such that it is easy to determine the
 /// type of an asset both inside and outside Miden VM. Specifically:
-/// - The first bit of a fungible asset is always ONE, and the last 32-bits of the 3rd element
-///   are always set to ZEROs.
-/// - The first bit of a non-fungible asset is always ZERO, and the last 32-bits of the 3rd element
-///   are always set to 2^31 (i.e., ONE followed by 31 ZEROs).
+///   Element 1 will be:
+///    - ZERO for a fungible asset
+///    - non-ZERO for a non-fungible asset
+///   The most significant bit will be:
+///    - ONE for a fungible asset
+///    - ZERO for a non-fungible asset
 ///
 /// The above properties guarantee that there can never be a collision between a fungible and a
-/// non-fungible asset. Collision resistance of both fungible and non-fungible assets is ~110 bits.
-/// However, for fungible assets collision resistance is not important as to get a collision for
-/// fungible assets there must be a collision in account IDs which can be prevented at account
-/// creation time.
+/// non-fungible asset.
 ///
 /// The methodology for constructing fungible and non-fungible assets is described below.
 ///
 /// # Fungible assets
-/// The first 3 elements of a fungible asset are set to the ID of the faucet which issued the
-/// asset. This guarantees the properties described above (the first bit is ONE, and the 32 least
-/// significant bits of the 3rd element are all ZEROs).
+/// The most significant element of a fungible asset is set to the ID of the faucet which issued
+/// the asset. This guarantees the properties described above (the first bit is ONE).
 ///
-/// The last element is set to the amount of the asset. This amount cannot be greater than
-/// 2^63 - 1 and thus requires 63-bits to store.
+/// The least significant element is set to the amount of the asset. This amount cannot be greater
+/// than 2^63 - 1 and thus requires 63-bits to store.
+///
+/// Elements 1 and 2 are set to ZERO.
+///
+/// It is impossible to find a collision between two fungible assets issued by different faucets as
+/// the faucet_id is included in the description of the asset and this is guaranteed to be different
+/// for each faucet as per the faucet creation logic.
 ///
 /// # Non-fungible assets
 /// The 4 elements of non-fungible assets are computed as follows:
 /// - First the asset data is hashed. This compresses an asset of an arbitrary length to 4 field
-///   elements.
-/// - The result of step 1 is hashed together with the ID of the faucet which issued the asset.
-///   This guarantees that finding two assets with the same hash is infeasible.
-/// - Lastly, the first bit of the result is set to ZERO, and the last 32 bits of the 3rd element
-///   are set to 2^31 (i.e., ONE followed by 32 ZEROs).
+///   elements: [d0, d1, d2, d3].
+/// - d1 is then replaced with the faucet_id which issues the asset: [d0, faucet_id, d2, d3].
+/// - Lastly, the most significant bit of d3 is set to ZERO.
+///
+/// It is impossible to find a collision between two non-fungible assets issued by different faucets
+/// as the faucet_id is included in the description of the non-fungible asset and this is guaranteed
+/// to be different as per the faucet creation logic. Collision resistance for non-fungible assets
+/// issued by the same faucet is ~2^95.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Asset {
     Fungible(FungibleAsset),
@@ -134,16 +143,15 @@ impl FungibleAsset {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The provided faucet ID is not for a fungible asset faucet.
-    /// - The provide amount is greater than 2^63 - 1.
+    /// - The faucet_id is not a valid fungible faucet ID.
+    /// - The provided amount is greater than 2^63 - 1.
     pub fn new(faucet_id: AccountId, amount: u64) -> Result<Self, AssetError> {
-        if !faucet_id.is_fungible_faucet() {
-            return Err(AssetError::not_a_fungible_faucet_id(faucet_id));
-        }
-
         // construct the asset and make sure it passes the validation logic
         let asset = Self { faucet_id, amount };
+
+        // validate fungible asset
         asset.validate()?;
+
         Ok(asset)
     }
 
@@ -210,20 +218,14 @@ impl FungibleAsset {
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
+    /// Validates this fungible asset.
+    /// # Errors
     /// Returns an error if:
-    /// - The first bit of the asset is not ONE.
-    /// - The 32 least significant bits of the 3rd element are not set to ZEROs.
-    /// - The amount is greater than or equal to 2^63.
+    /// - The faucet_id is not a valid fungible faucet ID.
+    /// - The provided amount is greater than 2^63 - 1.
     fn validate(&self) -> Result<(), AssetError> {
-        let id_elements: &[Felt; 3] = &self.faucet_id;
-        let first_bit = id_elements[0].as_int() >> 63;
-        if first_bit != 1 {
-            return Err(AssetError::fungible_asset_invalid_first_bit());
-        }
-
-        let tag = id_elements[2].as_int() as u32;
-        if tag != AccountId::FUNGIBLE_FAUCET_TAG {
-            return Err(AssetError::fungible_asset_invalid_tag(tag));
+        if !matches!(self.faucet_id.account_type(), AccountType::FungibleFaucet) {
+            return Err(AssetError::not_a_fungible_faucet_id(self.faucet_id));
         }
 
         if self.amount > Self::MAX_AMOUNT {
@@ -236,9 +238,9 @@ impl FungibleAsset {
 
 impl From<FungibleAsset> for Word {
     fn from(asset: FungibleAsset) -> Self {
-        let mut result: Word = asset.faucet_id.into();
-        debug_assert_eq!(result[3], ZERO);
-        result[3] = Felt::new(asset.amount);
+        let mut result = Word::default();
+        result[0] = Felt::new(asset.amount);
+        result[3] = *asset.faucet_id;
         result
     }
 }
@@ -246,9 +248,9 @@ impl From<FungibleAsset> for Word {
 impl From<FungibleAsset> for [u8; 32] {
     fn from(asset: FungibleAsset) -> Self {
         let mut result = [0_u8; 32];
-        let id_bytes: [u8; 24] = asset.faucet_id.into();
-        result[..24].copy_from_slice(&id_bytes);
-        result[24..].copy_from_slice(&asset.amount.to_le_bytes());
+        let id_bytes: [u8; 8] = asset.faucet_id.into();
+        result[..8].copy_from_slice(&asset.amount.to_le_bytes());
+        result[24..].copy_from_slice(&id_bytes);
         result
     }
 }
@@ -263,9 +265,12 @@ impl TryFrom<Word> for FungibleAsset {
     type Error = AssetError;
 
     fn try_from(value: Word) -> Result<Self, Self::Error> {
-        let faucet_id = AccountId::try_from([value[0], value[1], value[2]])
-            .map_err(AssetError::invalid_account_id)?;
-        let amount = value[3].as_int();
+        // return an error if elements 1 and 2 are not zero
+        if (value[1], value[2]) != (ZERO, ZERO) {
+            return Err(AssetError::fungible_asset_invalid_word(value));
+        }
+        let faucet_id = AccountId::try_from(value[3]).map_err(AssetError::invalid_account_id)?;
+        let amount = value[0].as_int();
         Self::new(faucet_id, amount)
     }
 }
@@ -290,12 +295,9 @@ impl fmt::Display for FungibleAsset {
 /// A commitment to a non-fungible asset.
 ///
 /// A non-fungible asset consists of 4 field elements which are computed by hashing asset data
-/// (which can be of arbitrary length) with the ID of the faucet which issued the asset, and then
-/// setting bits in the result to ensure the the asset encoding is correct.
-///
-/// Specifically:
-/// - The first bit of the asset is set to ZERO.
-/// - The 32 least significant bits of the 3rd element are set to 2^31.
+/// (which can be of arbitrary length) to produce: [d0, d1, d2, d3].  We then replace d1 with the
+/// faucet_id that issued the asset: [d0, faucet_id, d2, d3]. We then set the most significant bit
+/// of the most significant element to ZERO.
 ///
 /// [NonFungibleAsset] itself does not contain the actual asset data. The container for this data
 /// [NonFungibleAssetDetails] struct.
@@ -312,7 +314,7 @@ impl NonFungibleAsset {
     /// Returns an error if the provided faucet ID is not for a non-fungible asset faucet.
     pub fn new(details: &NonFungibleAssetDetails) -> Result<Self, AssetError> {
         let data_hash = Hasher::hash(details.asset_data());
-        Self::from_parts(details.faucet_id(), data_hash)
+        Self::from_parts(details.faucet_id(), data_hash.into())
     }
 
     /// Return a non-fungible asset created from the specified faucet and using the provided
@@ -323,44 +325,40 @@ impl NonFungibleAsset {
     ///
     /// # Errors
     /// Returns an error if the provided faucet ID is not for a non-fungible asset faucet.
-    pub fn from_parts(faucet_id: AccountId, data_hash: Digest) -> Result<Self, AssetError> {
-        if !faucet_id.is_non_fungible_faucet() {
+    pub fn from_parts(faucet_id: AccountId, mut data_hash: Word) -> Result<Self, AssetError> {
+        if !matches!(faucet_id.account_type(), AccountType::NonFungibleFaucet) {
             return Err(AssetError::not_a_non_fungible_faucet_id(faucet_id));
         }
-
-        // hash faucet ID and asset data hash together
-        let faucet_id: Word = faucet_id.into();
-        let mut asset: Word = Hasher::merge(&[faucet_id.into(), data_hash]).into();
+        // set the element 1 to the faucet_id
+        data_hash[1] = *faucet_id;
 
         // set the first bit of the asset to 0; we can do this because setting the first bit to 0
         // will always result in a valid field element.
-        asset[0] = Felt::new((asset[0].as_int() << 1) >> 1);
+        data_hash[3] = Felt::new((data_hash[3].as_int() << 1) >> 1);
 
-        // set the 32 least significant bits of the 3rd element to the non-fungible asset tag
-        let temp = (asset[2].as_int() >> 32) << 32;
-        asset[2] = Felt::new(temp | AccountId::NON_FUNGIBLE_FAUCET_TAG as u64);
+        // construct an asset
+        let asset = Self(data_hash);
 
-        // construct an asset and make sure it passes validation logic
-        let asset = Self(asset);
-        asset.validate()?;
         Ok(asset)
     }
 
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
+    /// Validates this non-fungible asset.
+    /// # Errors
     /// Returns an error if:
-    /// - The first bit of the asset is not ZERO.
-    /// - The 32 least significant bits of the 3rd element are not set to 2^31.
+    /// - The faucet_id is not a valid non-fungible faucet ID.
+    /// - The most significant bit of the asset is not ZERO.
     fn validate(&self) -> Result<(), AssetError> {
-        let first_bit = self.0[0].as_int() >> 63;
-        if first_bit != 0 {
-            return Err(AssetError::non_fungible_asset_invalid_first_bit());
+        let faucet_id: AccountId = self.0[1].try_into().map_err(AssetError::InvalidAccountId)?;
+
+        if !matches!(faucet_id.account_type(), AccountType::NonFungibleFaucet) {
+            return Err(AssetError::not_a_fungible_faucet_id(faucet_id));
         }
 
-        let tag = self.0[2].as_int() as u32;
-        if tag != AccountId::NON_FUNGIBLE_FAUCET_TAG {
-            return Err(AssetError::non_fungible_asset_invalid_tag(tag));
+        if self.0[3].as_int() >> 63 != 0 {
+            return Err(AssetError::non_fungible_asset_invalid_first_bit());
         }
 
         Ok(())
@@ -441,7 +439,7 @@ impl NonFungibleAssetDetails {
     /// # Errors
     /// Returns an error if the provided faucet ID is not for a non-fungible asset faucet.
     pub fn new(faucet_id: AccountId, asset_data: Vec<u8>) -> Result<Self, AssetError> {
-        if !faucet_id.is_non_fungible_faucet() {
+        if !matches!(faucet_id.account_type(), AccountType::NonFungibleFaucet) {
             return Err(AssetError::not_a_non_fungible_faucet_id(faucet_id));
         }
 

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,4 +1,4 @@
-use super::{assets::Asset, assets::NonFungibleAsset, AccountId, String, ToString, Word};
+use super::{assets::Asset, assets::NonFungibleAsset, AccountId, String, Word};
 use assembly::ParsingError;
 use core::fmt;
 
@@ -8,7 +8,8 @@ use core::fmt;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AccountError {
     AccountIdInvalidFieldElement(String),
-    AccountIdTooFewTrailingZeros,
+    AccountIdTooFewOnes,
+    SeedDigestTooFewTrailingZeros,
     CodeParsingFailed(ParsingError),
     FungibleFaucetIdInvalidFirstBit,
     NotAFungibleFaucetId(AccountId),
@@ -20,8 +21,12 @@ impl AccountError {
         Self::AccountIdInvalidFieldElement(msg)
     }
 
-    pub fn account_id_too_few_trailing_zeros() -> Self {
-        Self::AccountIdTooFewTrailingZeros
+    pub fn account_id_too_few_ones() -> Self {
+        Self::AccountIdTooFewOnes
+    }
+
+    pub fn seed_digest_too_few_trailing_zeros() -> Self {
+        Self::SeedDigestTooFewTrailingZeros
     }
 
     pub fn fungible_faucet_id_invalid_first_bit() -> Self {
@@ -61,8 +66,9 @@ pub enum AssetError {
     AssetAmountNotSufficient(u64, u64),
     FungibleAssetInvalidFirstBit,
     FungibleAssetInvalidTag(u32),
+    FungibleAssetInvalidWord(Word),
     InconsistentFaucetIds(AccountId, AccountId),
-    InvalidAccountId(String),
+    InvalidAccountId(AccountError),
     InvalidFieldElement(String),
     NonFungibleAssetInvalidFirstBit,
     NonFungibleAssetInvalidTag(u32),
@@ -88,12 +94,16 @@ impl AssetError {
         Self::FungibleAssetInvalidTag(tag)
     }
 
+    pub fn fungible_asset_invalid_word(word: Word) -> Self {
+        Self::FungibleAssetInvalidWord(word)
+    }
+
     pub fn inconsistent_faucet_ids(id1: AccountId, id2: AccountId) -> Self {
         Self::InconsistentFaucetIds(id1, id2)
     }
 
     pub fn invalid_account_id(err: AccountError) -> Self {
-        Self::InvalidAccountId(err.to_string())
+        Self::InvalidAccountId(err)
     }
 
     pub fn invalid_field_element(msg: String) -> Self {

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -10,7 +10,7 @@ use crypto::{
 };
 
 mod accounts;
-pub use accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault};
+pub use accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault};
 
 pub mod assets;
 pub mod notes;


### PR DESCRIPTION
This PR migrates from 24 byte AccountId to 64 bits (a single field element). It introduces additional modifications to non-fungible assets suggested in #8.