### PR TITLE
Introduce github CI + `no_std` compatibility 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, repoened, synchronize]
+
+jobs:
+  test:
+    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - name: Test
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -C debug-assertions
+        with:
+          command: test
+          args: --release
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: clippy
+          override: true
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all -- -D clippy::all -D warnings
+
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  no-std:
+    name: no-std
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        target:
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - run: rustup target add wasm32-unknown-unknown
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --no-default-features --target ${{ matrix.target }}

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [features]
 default = ["std"]
-std = ["assembly/std", "crypto/std"]
+std = ["assembly/std", "crypto/std", "miden-core/std"]
 
 [dependencies]
 assembly = {  package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -1,4 +1,4 @@
-use super::{AccountError, Felt, Hasher, StarkField, Word, ZERO};
+use super::{AccountError, Felt, Hasher, StarkField, ToString, Word, ZERO};
 use core::{fmt, ops::Deref};
 
 // ACCOUNT ID

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,4 +1,6 @@
-use super::{assets::Asset, AccountError, Digest, Felt, Hasher, StarkField, Word, ZERO};
+use super::{
+    assets::Asset, AccountError, Digest, Felt, Hasher, StarkField, ToString, Vec, Word, ZERO,
+};
 
 mod account_id;
 pub use account_id::AccountId;

--- a/objects/src/accounts/vault.rs
+++ b/objects/src/accounts/vault.rs
@@ -1,4 +1,5 @@
-use super::{AccountError, AccountId, Asset, Digest};
+use super::{AccountError, AccountId, Asset, Digest, Vec};
+use core::default::Default;
 
 // ACCOUNT VAULT
 // ================================================================================================

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -1,4 +1,4 @@
-use super::{AccountId, AssetError, Digest, Felt, Hasher, StarkField, Word, ZERO};
+use super::{AccountId, AssetError, Digest, Felt, Hasher, StarkField, ToString, Vec, Word, ZERO};
 use core::{fmt, ops::Deref};
 
 // ASSET

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,4 +1,4 @@
-use super::{assets::Asset, assets::NonFungibleAsset, AccountId, Word};
+use super::{assets::Asset, assets::NonFungibleAsset, AccountId, String, ToString, Word};
 use assembly::ParsingError;
 use core::fmt;
 

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
-#[macro_use]
 extern crate alloc;
 
 use crypto::{
@@ -18,3 +17,6 @@ pub mod notes;
 
 mod errors;
 pub use errors::{AccountError, AssetError, NoteError};
+
+mod utils;
+use utils::*;

--- a/objects/src/utils.rs
+++ b/objects/src/utils.rs
@@ -1,0 +1,17 @@
+pub use imports::*;
+
+#[cfg(not(feature = "std"))]
+mod imports {
+    pub use alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    };
+}
+
+#[cfg(feature = "std")]
+mod imports {
+    pub use std::{
+        string::{String, ToString},
+        vec::Vec,
+    };
+}


### PR DESCRIPTION
This PR introduces github ci workflow which is copied from the `miden-vm` repo.  We also introduce a `utils` module in which we specify imports for `std` / `no_std` environments;