### PR TITLE
chore: ignore pre-commit rev

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# initial pre-commit run
+57a3fca1c0b2ac97a1ca310d11fc1595f92369a0


### PR DESCRIPTION
the pre-commit PR has been merged, this adds the commit that ran pre-commit and formated the code base into the [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file)