### PR TITLE
Introduce NoteMetadata struct and refactor memory layout

### DIFF
--- a/miden-lib/asm/sat/epilogue.masm
+++ b/miden-lib/asm/sat/epilogue.masm
@@ -23,21 +23,27 @@ const.CREATED_NOTE_HASHING_MEM_DIFF=1022
 proc.compute_created_note_vault_hash
     # duplicate note pointer - we will use this to save vault hash to memory
     dup
+    # => [note_data_ptr, note_data_ptr]
 
     # get the number of assets from memory
     dup exec.layout::get_created_note_num_assets
+    # => [num_assets, note_data_ptr, note_data_ptr]
 
     # calculate the number of pairs of assets (takes ceiling if we have an odd number)
     add.1 u32checked_div.2
+    # => [num_asset_pairs, note_data_ptr, note_data_ptr]
 
     # initiate counter for assets
     push.0
+    # => [asset_counter, num_asset_pairs, note_data_ptr, note_data_ptr]
 
     # prepare address and stack for reading assets
     movup.2 exec.layout::get_created_note_asset_data_ptr padw padw padw
+    # => [PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
     # check if we should loop
     dup.14 dup.14 neq
+    # => [should_loop, PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
     # loop and read assets from memory
     while.true
@@ -45,23 +51,28 @@ proc.compute_created_note_vault_hash
         # if this is the last permutation of the loop and we have an odd number of assets then we
         # implicitly pad the last word of the hasher rate with ZERO's by reading from empty memory.
         mem_stream
+        # => [PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
         # check if we should loop again
         movup.13 add.1 dup movdn.14 dup.15 neq
+        # => [should_loop, PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
         # TODO: construct final transaction vault here.
     end
 
     # extract digest from hasher rate elements (h_0, ..., h_3)
     dropw swapw dropw
+    # => [VAULT_HASH, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
     # drop accessory variables from stack
     movup.4 drop
     movup.4 drop
     movup.4 drop
+    # => [VAULT_HASH, note_data_ptr]
 
     # save vault hash to memory
     movup.4 exec.layout::set_created_note_vault_hash
+    # => []
 end
 
 #! Computes the hash of a created note with index i. This is computed as follows:

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -70,11 +70,12 @@ const.CONSUMED_NOTE_NUM_PTR=1000
 
 # The offsets at which data of a consumed note is stored relative to the start of its data segment
 const.CONSUMED_NOTE_HASH_OFFSET=0
+const.CONSUMED_NOTE_CORE_DATA_OFFSET=1
 const.CONSUMED_NOTE_SERIAL_NUM_OFFSET=1
 const.CONSUMED_NOTE_SCRIPT_ROOT_OFFSET=2
 const.CONSUMED_NOTE_INPUTS_HASH_OFFSET=3
 const.CONSUMED_NOTE_VAULT_ROOT_OFFSET=4
-const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=5
+const.CONSUMED_NOTE_METADATA_OFFSET=5
 const.CONSUMED_NOTE_ASSETS_OFFSET=6
 
 # CREATED NOTES
@@ -85,11 +86,10 @@ const.CREATED_NOTE_SECTION_OFFSET=10000
 
 # The offsets at which data of a created note is stored relative to the start of its data segment.
 const.CREATED_NOTE_HASH_OFFSET=0
-const.CREATED_NOTE_META_OFFSET=1
+const.CREATED_NOTE_METADATA_OFFSET=1
 const.CREATED_NOTE_RECIPIENT_OFFSET=2
 const.CREATED_NOTE_VAULT_HASH_OFFSET=3
-const.CREATED_NOTE_NUM_ASSETS_OFFSET=4
-const.CREATED_NOTE_ASSETS_OFFSET=5
+const.CREATED_NOTE_ASSETS_OFFSET=4
 
 # MEMORY PROCEDURES
 # =================================================================================================
@@ -284,6 +284,17 @@ export.get_consumed_note_ptr
     add.1 exec.constants::get_note_mem_size mul push.CONSUMED_NOTE_SECTION_OFFSET add
 end
 
+#! Set the hash of the consumed note at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr, H]
+#! Output: []
+#!
+#! - consumed_note_ptr is the memory address of the consumed note.
+#! - H is the hash of the consumed note.
+export.set_consumed_note_hash
+    mem_storew dropw
+end
+
 #! Computes a pointer to the memory address at which the nullifier associated a note with index i
 #! is stored.
 #!
@@ -305,6 +316,18 @@ end
 #! - nullifier is the nullifier of the consumed note.
 export.get_consumed_note_nullifier
     padw movup.4 push.CONSUMED_NOTE_SECTION_OFFSET.1 add add mem_loadw
+end
+
+#! Returns a pointer to the start of the consumed note core data segment for the note located at
+#! the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [ptr]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - ptr is the memory address at which the consumed note core data begins.
+export.get_consumed_note_core_ptr
+    push.CONSUMED_NOTE_CORE_DATA_OFFSET add
 end
 
 #! Returns the script root of a consumed note located at the specified memory address.
@@ -331,6 +354,98 @@ export.get_consumed_note_inputs_hash
     padw
     movup.4 push.CONSUMED_NOTE_INPUTS_HASH_OFFSET add
     mem_loadw
+end
+
+#! Returns the metatdata of a consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [M]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - M is the metadata of the consumed note.
+export.get_consumed_note_metadata
+    padw
+    movup.4 push.CONSUMED_NOTE_METADATA_OFFSET add
+    mem_loadw
+end
+
+#! Sets the metadata of a consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr, M]
+#! Output: []
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - M is the metadata of the consumed note.
+export.set_consumed_note_metadata
+    push.CONSUMED_NOTE_METADATA_OFFSET add
+    mem_storew dropw
+end
+
+#! Returns the number of assets in the consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [num_assets]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - num_assets is the number of assets in the consumed note.
+export.get_consumed_note_num_assets
+    push.CONSUMED_NOTE_METADATA_OFFSET add
+    mem_load
+end
+
+#! Returns a pointer pointer to the start of the assets segment for the consumed note located at
+#! the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [assets_ptr]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - assets_ptr is the memory address at which the assets segment for the consumed note begins.
+export.get_consumed_note_assets_ptr
+    push.CONSUMED_NOTE_ASSETS_OFFSET add
+end
+
+#! Returns the vault root for the consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [V]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - V is the vault root for the consumed note.
+export.get_consumed_note_vault_root
+    padw
+    movup.4 push.CONSUMED_NOTE_VAULT_ROOT_OFFSET add
+    mem_loadw
+end
+
+#! Returns the serial number for the consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [S]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - S is the serial number for the consumed note.
+export.get_consumed_note_serial_num
+    padw
+    movup.4 push.CONSUMED_NOTE_SERIAL_NUM_OFFSET add
+    mem_loadw
+end
+
+#! Returns the sender for the consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [sender]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - sender is the sender for the consumed note.
+export.get_consumed_note_sender
+    padw
+    movup.4 push.CONSUMED_NOTE_METADATA_OFFSET add
+    mem_loadw
+    # => [0, sender, tag, num_assets]
+
+    drop movdn.2 drop drop
+    # => [sender]
 end
 
 # CREATED NOTES
@@ -369,7 +484,7 @@ end
 #! - created_note_data_ptr is the memory address at which the created note data begins.
 #! - num_assets is the number of assets in the created note.
 export.get_created_note_num_assets
-    push.CREATED_NOTE_NUM_ASSETS_OFFSET add mem_load
+    push.CREATED_NOTE_METADATA_OFFSET add mem_load
 end
 
 #! Returns a pointer to the created note asset data

--- a/miden-lib/asm/sat/prologue.masm
+++ b/miden-lib/asm/sat/prologue.masm
@@ -102,69 +102,96 @@ proc.process_consumed_note
     # read core note data
     # ---------------------------------------------------------------------------------------------
 
+    # dup the note index
+    dup
+    # => [i, i]
+
     # compute address to store note hash
     exec.layout::get_consumed_note_ptr
+    # => [note_ptr, i]
 
-    # compute address to store raw note data
-    dup add.1
+    # compute address to store core note data
+    dup exec.layout::get_consumed_note_core_ptr
+    # => [note_data_ptr, note_ptr, i]
 
     # read note data from the advice provider
     padw padw padw
     adv_pipe adv_pipe
+    # => [PERM, PERM, PERM, note_data_ptr + 4, note_ptr, i]
 
-    # extract nullifier
-    dropw swapw dropw
+    # extract nullifier (digest)
+    dropw swapw dropw movup.4 drop
+    # => [DIG, note_ptr, i]
 
     # compute address for nullifier
-    # dup.6 = counter / note index
-    dup.6 exec.layout::get_consumed_note_nullifier_ptr
+    movup.6 exec.layout::get_consumed_note_nullifier_ptr
+    # => [nullifier_ptr, DIG, note_ptr]
 
     # store nullifier in memory and drop from stack
     mem_storew dropw
+    # => [note_ptr]
 
     # ingest note assets
     # ---------------------------------------------------------------------------------------------
 
-    # read the number of assets from the advice provider and store in memory
-    adv_push.1 dup dup.2 mem_store
+    # read the metadata from the advice provider and store in memory
+    padw adv_loadw dup.4
+    # => [note_ptr, NOTE_META, note_ptr]
+
+    exec.layout::set_consumed_note_metadata
+    # => [note_ptr]
+
+    # get the number of assets
+    dup exec.layout::get_consumed_note_num_assets
+    # => [num_assets, note_ptr]
 
     # assert the number of assets is within limits
     dup exec.constants::get_max_assets_per_note lte assert
+    # => [num_assets, note_ptr]
 
     # round up the number of assets to the next multiple of 2 (simplifies reading of assets)
-    dup push.1 u32checked_and
-
-    # pad to multiple of two if odd
-    if.true
-        add.1
-    end
+    dup push.1 u32checked_and add
+    # => [rounded_num_assets, note_ptr]
 
     # initiate counter for assets
     push.0
+    # => [counter, rounded_num_assets, note_ptr]
 
     # prepare address and stack for reading assets
-    movup.2 add.1 padw padw padw
+    dup.2 exec.layout::get_consumed_note_assets_ptr padw padw padw
+    # => [PAD, PAD, PADW, assets_ptr, counter, rounded_num_assets, note_ptr]
 
     # check if the number of assets is greater then 0
     dup.14 dup.14 neq
+    # => [should_loop, PAD, PAD, PAD, assets_ptr, counter, rounded_num_assets, note_ptr]
 
     # loop and read assets from the advice provider
     while.true
         # read assets from advice provider
         adv_pipe
+        # => [PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
 
         # check if we should loop again
         movup.13 push.2 add dup movdn.14 dup.15 neq
+        # => [should_loop, PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
     end
+    # => [PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
 
     # extract digest from hasher rate elements (h_0, ..., h_3)
     dropw swapw dropw
+    # => [DIG, assets_ptr, counter, rounded_num_assets, note_ptr]
 
-    # load expected hash from memory
-    swapw drop drop drop dup movdn.5 push.4 add padw movup.4 mem_loadw
+    # clean and rearrange stack
+    swapw drop drop drop dup movdn.5
+    # => [note_ptr, DIG, note_ptr]
+
+    # get expected note vault from memory
+    exec.layout::get_consumed_note_vault_root
+    # => [V, DIG, note_ptr]
 
     # assert that the computed hash matches the expected hash
     assert_eqw
+    # => [note_ptr]
 
     # compute note hash
     # ---------------------------------------------------------------------------------------------
@@ -172,19 +199,24 @@ proc.process_consumed_note
     # TODO: This should be optimized using the `hperm` operation
 
     # serial number hash - serial_hash = hmerge(serial_number, 0)
-    dup add.1 padw movup.4 mem_loadw padw hmerge
+    dup exec.layout::get_consumed_note_serial_num padw hmerge
+    # => [SERIAL_HASH, note_ptr]
 
     # hash serial_hash with script hash - merge_script = hmerge(serial_hash, script_hash)
-    dup.4 push.2 add padw movup.4 mem_loadw hmerge
+    dup.4 exec.layout::get_consumed_note_script_root hmerge
+    # => [MERGE_SCRIPT, note_ptr]
 
     # hash merge_script with inputs hash - recipient = hmerge(merge_script, inputs_hash)
-    dup.4 push.3 add padw movup.4 mem_loadw hmerge
+    dup.4 exec.layout::get_consumed_note_inputs_hash hmerge
+    # => [RECIPIENT, note_ptr]
 
     # hash recipient with vault hash - note_hash = hmerge(recipient, vault_hash)
-    dup.4 push.4 add padw movup.4 mem_loadw hmerge
+    dup.4 exec.layout::get_consumed_note_vault_root hmerge
+    # => [NOTE_HASH, note_ptr]
 
     # store note hash in memory and clear stack
-    dup.4 mem_storew dropw drop
+    movup.4 exec.layout::set_consumed_note_hash
+    # => []
 
     # TODO: assert note hash exists in note db
 end
@@ -196,12 +228,10 @@ end
 #!
 #! Stack: []
 #! Advice stack: [num_cn,
-#!               CN1_SN, CN1_SR, CN1_IR, CN1_VR,
-#!               cn1_na,
+#!               CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M,
 #!               CN1_A1, CN1_A2, ...
 #!
-#!               CN2_SN,CN2_SR, CN2_IR, CN2_VR,
-#!               cn2_na,
+#!               CN2_SN,CN2_SR, CN2_IR, CN2_VR, CN2_M,
 #!               CN2_A1, CN2_A2, ...
 #!               ...]
 #! Output: []
@@ -211,7 +241,7 @@ end
 #! - CN1_SR is the script root of consumed note 1.
 #! - CN1_IR is the inputs root of consumed note 1.
 #! - CN1_VR is the vault root of consumed note 1.
-#! - cn1_na is the number of assets in consumed note 1.
+#! - CN1_M is the metadata of consumed note 1.
 #! - CN1_A1 is the first asset of consumed note 1.
 #! - CN1_A2 is the second asset of consumed note 1.
 proc.process_consumed_notes_data
@@ -301,11 +331,9 @@ end
 #! Stack:        [BH, acct_id, IAH, NC]
 #! Advice stack: [acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR,
 #!                num_cn,
-#!                CN1_SN, CN1_SR, CN1_IR, CN1_VR,
-#!                cn1_na,
+#!                CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M,
 #!                CN1_A1, CN1_A2, ...
-#!                CN2_SN,CN2_SR, CN2_IR, CN2_VR,
-#!                cn2_na,
+#!                CN2_SN,CN2_SR, CN2_IR, CN2_VR, CN2_M,
 #!                CN2_A1, CN2_A2, ...
 #!                ...]
 #! Output:       []
@@ -325,7 +353,7 @@ end
 #! - CN1_SR is the script root of consumed note 1.
 #! - CN1_IR is the inputs root of consumed note 1.
 #! - CN1_VR is the vault root of consumed note 1.
-#! - cn1_na is the number of assets in consumed note 1.
+#! - CN1_M is the metadata of consumed note 1.
 #! - CN1_A1 is the first asset of consumed note 1.
 #! - CN1_A2 is the second asset of consumed note 1.
 export.prepare_transaction

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -81,7 +81,7 @@ pub const CONSUMED_NOTE_SERIAL_NUM_OFFSET: u64 = 1;
 pub const CONSUMED_NOTE_SCRIPT_ROOT_OFFSET: u64 = 2;
 pub const CONSUMED_NOTE_INPUTS_HASH_OFFSET: u64 = 3;
 pub const CONSUMED_NOTE_VAULT_ROOT_OFFSET: u64 = 4;
-pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: u64 = 5;
+pub const CONSUMED_NOTE_METADATA_OFFSET: u64 = 5;
 pub const CONSUMED_NOTE_ASSETS_OFFSET: u64 = 6;
 
 /// The maximum number of consumed notes that can be processed in a single transaction.
@@ -98,5 +98,4 @@ pub const CREATED_NOTE_HASH_OFFET: u64 = 0;
 pub const CREATED_NOTE_METADATA_OFFSET: u64 = 1;
 pub const CREATED_NOTE_RECIPIENT_OFFSET: u64 = 2;
 pub const CREATED_NOTE_VAULT_HASH_OFFSET: u64 = 3;
-pub const CREATED_NOTE_NUM_ASSETS_OFFSET: u64 = 4;
-pub const CREATED_NOTE_ASSETS_OFFSET: u64 = 5;
+pub const CREATED_NOTE_ASSETS_OFFSET: u64 = 4;

--- a/miden-lib/tests/common/data.rs
+++ b/miden-lib/tests/common/data.rs
@@ -6,6 +6,7 @@ use super::{
 // MOCK DATA
 // ================================================================================================
 pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u64 = 0b0110011011u64 << 54;
+pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
 
 const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
 
@@ -71,6 +72,9 @@ fn mock_consumed_notes() -> Vec<Note> {
     let fungible_asset_2: Asset = FungibleAsset::new(faucet_id_2, 200).unwrap().into();
     let fungible_asset_3: Asset = FungibleAsset::new(faucet_id_3, 300).unwrap().into();
 
+    // Sender account
+    let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
     // Consumed Notes
     const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
     let note_1 = Note::new(
@@ -78,7 +82,8 @@ fn mock_consumed_notes() -> Vec<Note> {
         &[Felt::new(1)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_1,
-        Word::default(),
+        sender,
+        Felt::ZERO,
     )
     .unwrap();
 
@@ -88,7 +93,8 @@ fn mock_consumed_notes() -> Vec<Note> {
         &[Felt::new(2)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_2,
-        Word::default(),
+        sender,
+        Felt::ZERO,
     )
     .unwrap();
 
@@ -104,6 +110,9 @@ fn mock_created_notes() -> Vec<Note> {
     let fungible_asset_2: Asset = FungibleAsset::new(faucet_id_2, 100).unwrap().into();
     let fungible_asset_3: Asset = FungibleAsset::new(faucet_id_3, 100).unwrap().into();
 
+    // sender account
+    let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
     // Created Notes
     const SERIAL_NUM_1: Word = [Felt::new(9), Felt::new(10), Felt::new(11), Felt::new(12)];
     let note_1 = Note::new(
@@ -111,7 +120,8 @@ fn mock_created_notes() -> Vec<Note> {
         &[Felt::new(1)],
         &[fungible_asset_1, fungible_asset_2],
         SERIAL_NUM_1,
-        Word::default(),
+        sender,
+        Felt::ZERO,
     )
     .unwrap();
 
@@ -121,7 +131,8 @@ fn mock_created_notes() -> Vec<Note> {
         &[Felt::new(2)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_2,
-        Word::default(),
+        sender,
+        Felt::ZERO,
     )
     .unwrap();
 
@@ -131,7 +142,8 @@ fn mock_created_notes() -> Vec<Note> {
         &[Felt::new(2)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_3,
-        Word::default(),
+        sender,
+        Felt::ZERO,
     )
     .unwrap();
 

--- a/miden-lib/tests/common/procedures.rs
+++ b/miden-lib/tests/common/procedures.rs
@@ -1,26 +1,22 @@
 use super::{
     memory::{
-        CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_NUM_ASSETS_OFFSET,
-        CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE,
-        NUM_CREATED_NOTES_PTR,
+        CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET,
+        NOTE_MEM_SIZE, NUM_CREATED_NOTES_PTR,
     },
     Note, NoteVault, StarkField, Word,
 };
 
 pub fn created_notes_data_procedure(notes: &[Note]) -> String {
-    let note_0_metadata = prepare_word(&notes[0].metadata());
+    let note_0_metadata = prepare_word(&notes[0].metadata().into());
     let note_0_recipient = prepare_word(&notes[0].recipient());
-    let note_0_num_assets = notes[0].vault().num_assets();
     let note_0_assets = prepare_assets(notes[0].vault());
 
-    let note_1_metadata = prepare_word(&notes[1].metadata());
+    let note_1_metadata = prepare_word(&notes[1].metadata().into());
     let note_1_recipient = prepare_word(&notes[1].recipient());
-    let note_1_num_assets = notes[1].vault().num_assets();
     let note_1_assets = prepare_assets(notes[1].vault());
 
-    let note_2_metadata = prepare_word(&notes[2].metadata());
+    let note_2_metadata = prepare_word(&notes[2].metadata().into());
     let note_2_recipient = prepare_word(&notes[2].recipient());
-    let note_2_num_assets = notes[2].vault().num_assets();
     let note_2_assets = prepare_assets(notes[2].vault());
 
     const NOTE_1_OFFSET: u64 = NOTE_MEM_SIZE;
@@ -36,14 +32,11 @@ pub fn created_notes_data_procedure(notes: &[Note]) -> String {
         push.{note_0_recipient}
         push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add mem_storew dropw
 
-        push.{note_0_num_assets}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add mem_store
+        push.{}
+        push.{CREATED_NOTE_SECTION_OFFSET}.4 add mem_storew dropw
 
         push.{}
         push.{CREATED_NOTE_SECTION_OFFSET}.5 add mem_storew dropw
-
-        push.{}
-        push.{CREATED_NOTE_SECTION_OFFSET}.6 add mem_storew dropw
 
         # populate note 1
         push.{note_1_metadata}
@@ -52,17 +45,14 @@ pub fn created_notes_data_procedure(notes: &[Note]) -> String {
         push.{note_1_recipient}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
 
-        push.{note_1_num_assets}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add add mem_store
+        push.{}
+        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.4 add add mem_storew dropw
 
         push.{}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.5 add add mem_storew dropw
 
         push.{}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.6 add add mem_storew dropw
-
-        push.{}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.7 add add mem_storew dropw
 
         # populate note 2
         push.{note_2_metadata}
@@ -71,17 +61,14 @@ pub fn created_notes_data_procedure(notes: &[Note]) -> String {
         push.{note_2_recipient}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
 
-        push.{note_2_num_assets}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add add mem_store
+        push.{}
+        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.4 add add mem_storew dropw
 
         push.{}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.5 add add mem_storew dropw
 
         push.{}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.6 add add mem_storew dropw
-
-        push.{}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.7 add add mem_storew dropw
 
         # set num created notes
         push.{}.{NUM_CREATED_NOTES_PTR} mem_store

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -148,7 +148,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
         // The number of assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 5)
         assert_eq!(
             process.get_memory_value(0, consumed_note_data_ptr(note_idx) + 5).unwrap(),
-            [Felt::new(note.vault().num_assets() as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+            Word::from(note.metadata())
         );
 
         // The assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 6..)

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -1,0 +1,48 @@
+use super::{AccountId, Felt, Word};
+
+/// Represents metadata associated with a note. This includes the sender, tag, and number of assets.
+/// - sender is the account which created the note.
+/// - tag is a tag which can be used to identify the target account for the note.
+/// - num_assets is the number of assets in the note.
+#[derive(Debug, Eq, PartialEq)]
+pub struct NoteMetadata {
+    sender: AccountId,
+    tag: Felt,
+    num_assets: Felt,
+}
+
+impl NoteMetadata {
+    /// Returns a new note metadata object created with the specified parameters.
+    pub fn new(sender: AccountId, tag: Felt, num_assets: Felt) -> Self {
+        Self {
+            sender,
+            tag,
+            num_assets,
+        }
+    }
+
+    /// Returns the account which created the note.
+    pub fn sender(&self) -> AccountId {
+        self.sender
+    }
+
+    /// Returns the tag associated with the note.
+    pub fn tag(&self) -> Felt {
+        self.tag
+    }
+
+    /// Returns the number of assets in the note.
+    pub fn num_assets(&self) -> Felt {
+        self.num_assets
+    }
+}
+
+impl From<&NoteMetadata> for Word {
+    fn from(metadata: &NoteMetadata) -> Self {
+        let mut elements = Word::default();
+        elements[0] = metadata.num_assets;
+        elements[1] = metadata.tag;
+        elements[2] = metadata.sender.into();
+        elements
+    }
+}

--- a/objects/src/transaction/created_note.rs
+++ b/objects/src/transaction/created_note.rs
@@ -1,4 +1,4 @@
-use super::{Digest, Felt, StarkField, Vec, Word};
+use super::{Digest, Felt, NoteMetadata, StarkField, Vec, Word};
 
 /// Holds information about a note that was created by a transaction.
 /// Contains:
@@ -11,12 +11,12 @@ use super::{Digest, Felt, StarkField, Vec, Word};
 ///     - ZERO
 pub struct CreatedNoteInfo {
     note_hash: Digest,
-    note_metadata: Word,
+    note_metadata: NoteMetadata,
 }
 
 impl CreatedNoteInfo {
     /// Creates a new CreatedNoteInfo object.
-    pub fn new(note_hash: Digest, note_metadata: Word) -> Self {
+    pub fn new(note_hash: Digest, note_metadata: NoteMetadata) -> Self {
         Self {
             note_hash,
             note_metadata,
@@ -29,8 +29,8 @@ impl CreatedNoteInfo {
     }
 
     /// Returns the metadata of the note that was created.
-    pub fn note_metadata(&self) -> Word {
-        self.note_metadata
+    pub fn metadata(&self) -> &NoteMetadata {
+        &self.note_metadata
     }
 }
 
@@ -38,7 +38,7 @@ impl From<CreatedNoteInfo> for [Felt; 8] {
     fn from(cni: CreatedNoteInfo) -> Self {
         let mut elements: [Felt; 8] = Default::default();
         elements[..4].copy_from_slice(cni.note_hash.as_elements());
-        elements[4..].copy_from_slice(&cni.note_metadata);
+        elements[4..].copy_from_slice(&Word::from(cni.metadata()));
         elements
     }
 }
@@ -47,7 +47,7 @@ impl From<CreatedNoteInfo> for [Word; 2] {
     fn from(cni: CreatedNoteInfo) -> Self {
         let mut elements: [Word; 2] = Default::default();
         elements[0].copy_from_slice(cni.note_hash.as_elements());
-        elements[1].copy_from_slice(&cni.note_metadata);
+        elements[1].copy_from_slice(&Word::from(cni.metadata()));
         elements
     }
 }
@@ -55,8 +55,7 @@ impl From<CreatedNoteInfo> for [Word; 2] {
 impl From<CreatedNoteInfo> for [u8; 64] {
     fn from(cni: CreatedNoteInfo) -> Self {
         let mut elements: [u8; 64] = [0; 64];
-        let note_metadata_bytes = cni
-            .note_metadata
+        let note_metadata_bytes = Word::from(cni.metadata())
             .iter()
             .flat_map(|x| x.as_int().to_le_bytes())
             .collect::<Vec<u8>>();

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,4 +1,7 @@
-use super::{notes::Note, Account, AccountId, Digest, Felt, Hasher, StarkField, Vec, Word};
+use super::{
+    notes::{Note, NoteMetadata},
+    Account, AccountId, Digest, Felt, Hasher, StarkField, Vec, Word,
+};
 use miden_core::{StackInputs, StackOutputs};
 use miden_processor::AdviceInputs;
 

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -1,6 +1,6 @@
 use super::{
     AccountId, ConsumedNoteInfo, CreatedNoteInfo, Digest, Felt, Hasher, StackInputs, StackOutputs,
-    Vec,
+    Vec, Word,
 };
 use miden_core::ProgramInfo;
 use miden_verifier::{verify, ExecutionProof, VerificationError};
@@ -80,7 +80,7 @@ impl ProvenTransaction {
         let mut elements: Vec<Felt> = Vec::with_capacity(self.created_notes.len() * 8);
         for note in self.created_notes.iter() {
             elements.extend_from_slice(note.note_hash().as_elements());
-            elements.extend_from_slice(&note.note_metadata());
+            elements.extend_from_slice(&Word::from(note.metadata()));
         }
         Hasher::hash_elements(&elements)
     }

--- a/objects/src/transaction/utils.rs
+++ b/objects/src/transaction/utils.rs
@@ -1,5 +1,5 @@
 use super::{
-    Account, AccountId, AdviceInputs, Digest, Felt, Hasher, Note, StackInputs, StackOutputs,
+    Account, AccountId, AdviceInputs, Digest, Felt, Hasher, Note, StackInputs, StackOutputs, Word,
 };
 
 /// Returns the advice inputs required when executing a transaction.
@@ -29,7 +29,7 @@ use super::{
 /// - CN1_SR is the script root of consumed note 1.
 /// - CN1_IR is the inputs root of consumed note 1.
 /// - CN1_VR is the vault root of consumed note 1.
-/// - cn1_na is the number of assets in consumed note 1.
+/// - CN1_M is the metadata of consumed note 1.
 /// - CN1_A1 is the first asset of consumed note 1.
 /// - CN1_A2 is the second asset of consumed note 1.
 /// - CN1_I3..0 are the script inputs of consumed note 1.
@@ -105,7 +105,7 @@ pub fn generate_created_notes_commitment(notes: &[Note]) -> Digest {
     let mut elements: Vec<Felt> = Vec::with_capacity(notes.len() * 8);
     for note in notes.iter() {
         elements.extend_from_slice(note.hash().as_elements());
-        elements.extend_from_slice(&note.metadata());
+        elements.extend_from_slice(&Word::from(note.metadata()));
     }
 
     Hasher::hash_elements(&elements)


### PR DESCRIPTION
This PR introduces a rust struct `NoteMetadata` that is used to represent note metadata.  This struct is structured as follows:

```rust
pub struct NoteMetadata {
    sender: AccountId,
    tag: Felt,
    num_assets: Felt,
}
```
We modify kernel memory layout to remove the row that previously existed for `*_NUM_ASSETS` for created and consumed notes and instead use the `num_assets` field from metadata.

This PR also introduces some additional getters and setters to improve the readability of the prologue.