### PR TITLE
Introduce kernel procedures

### DIFF
--- a/miden-lib/asm/sat/account.masm
+++ b/miden-lib/asm/sat/account.masm
@@ -6,11 +6,11 @@ use.miden::sat::layout
 #! Output: [ACCT_HASH]
 #!
 #! - ACCT_HASH is the hash of the account data.
-export.get_acct_hash
+export.get_current_hash
     # prepare the stack for computing the account hash
     exec.layout::get_acct_data_ptr padw padw padw
 
-    # stream account data and compute sequential hash. We perform two `mem_stream` operations 
+    # stream account data and compute sequential hash. We perform two `mem_stream` operations
     # because account data consists of exactly 4 words.
     mem_stream mem_stream
 
@@ -28,8 +28,41 @@ end
 #!
 #! - value is the value to increment the nonce by. value can be at most 2^32 - 1 otherwise this
 #!   procedure panics.
-export.incr_account_nonce
+export.incr_nonce
     u32assert.1
     exec.layout::get_acct_nonce add
     exec.layout::set_acct_nonce
+end
+
+# TODO: change to re-export once supported.
+#! Returns the account id.
+#!
+#! Stack: []
+#! Output: [acct_id]
+#!
+#! - acct_id is the account id.
+export.get_id
+    exec.layout::get_acct_id
+end
+
+# TODO: change to re-export once supported.
+#! Returns the account nonce.
+#!
+#! Stack: []
+#! Output: [nonce]
+#!
+#! - nonce is the account nonce.
+export.get_nonce
+    exec.layout::get_acct_nonce
+end
+
+# TODO: change to re-export once supported.
+#! Returns the initial account hash.
+#!
+#! Stack: []
+#! Output: [H]
+#!
+#! - H is the initial account hash.
+export.get_initial_hash
+    exec.layout::get_init_acct_hash
 end

--- a/miden-lib/asm/sat/epilogue.masm
+++ b/miden-lib/asm/sat/epilogue.masm
@@ -168,7 +168,7 @@ export.finalize_transaction
     exec.layout::get_init_acct_hash
 
     # compute the final account hash
-    exec.account::get_acct_hash
+    exec.account::get_current_hash
 
     # check if the account has changed
     eqw

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -134,6 +134,16 @@ export.set_blk_hash
     push.BLK_HASH_PTR mem_storew dropw
 end
 
+#! Returns the block hash of the last known block at the time of transaction execution.
+#!
+#! Stack: []
+#! Output: [BH]
+#!
+#! - BH is the block hash of the last known block at the time of transaction execution.
+export.get_blk_hash
+    padw push.BLK_HASH_PTR mem_loadw
+end
+
 #! Sets the account id.
 #!
 #! Stack: [acct_id]

--- a/miden-lib/asm/sat/tx.masm
+++ b/miden-lib/asm/sat/tx.masm
@@ -1,0 +1,34 @@
+use.miden::sat::epilogue
+use.miden::sat::layout
+
+#! Returns the block hash of the last known block at the time of transaction execution.
+#!
+#! Inputs: []
+#! Outputs: [H]
+#!
+#! H is the last known block hash.
+export.get_block_hash
+    exec.layout::get_blk_hash
+end
+
+#! Returns the input notes hash. This is computed as a sequential hash of (nullifier, script_root)
+#! tuples over all input notes.
+#!
+#! Inputs: []
+#! Outputs: [COM]
+#!
+#! COM is the input notes hash.
+export.get_input_notes_hash
+    exec.layout::get_nullifier_com
+end
+
+#! Returns the output notes hash. This is computed as a sequential hash of (note_hash, note_metadata)
+#! tuples over all output notes.
+#!
+#! Inputs: []
+#! Outputs: [COM]
+#!
+#! COM is the output notes hash.
+export.get_output_notes_hash
+    exec.epilogue::process_created_notes
+end

--- a/miden-lib/tests/test_epilogue.rs
+++ b/miden-lib/tests/test_epilogue.rs
@@ -22,7 +22,7 @@ fn test_epilogue() {
         begin
             exec.prologue::prepare_transaction
             exec.create_mock_notes
-            push.1 exec.account::incr_account_nonce
+            push.1 exec.account::incr_nonce
             exec.finalize_transaction
         end
         "


### PR DESCRIPTION
This is an initial draft for the kernel procedures.  We currently support:

- `miden::sat::account::get_id`
- `miden::sat::account::get_nonce`
- `miden::sat::account::get_initial_hash`
- `miden::sat::account::get_current_hash`
- `miden::sat::account::incr_nonce`
- `miden::sat::tx::get_input_notes_hash`
- `miden::sat::tx::get_output_notes_hash`

The remaining procedures have dependencies on the SMT and vault implementation.