### PR TITLE
Introduce block header object

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -24,6 +24,7 @@ crypto = { package = "miden-crypto", version = "0.2" }
 miden-objects = { package = "miden-objects", path = "../objects"}
 processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", features = ["internals"] }
 vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
 
 
 [build-dependencies]

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -39,6 +39,33 @@ const.NULLIFIER_COM_PTR=13
 # The memory address at which the initial nonce is stored
 const.INIT_NONCE_PTR=14
 
+# GLOBAL BLOCK DATA
+# -------------------------------------------------------------------------------------------------
+
+# The memory address at which the block data section begins
+const.BLOCK_DATA_SECTION_OFFSET=40
+
+# The memory address at which the previous block hash is stored
+const.PREV_BLOCK_HASH_PTR=40
+
+# The memory address at which the chain root is stored
+const.CHAIN_ROOT_PTR=41
+
+# The memory address at which the state root is stored
+const.STATE_ROOT_PTR=42
+
+# The memory address at which the batch root is stored
+const.BATCH_ROOT_PTR=43
+
+# The memory address at which the proof hash is stored
+const.PROOF_HASH_PTR=44
+
+# The memory address at which the block number is stored
+const.BLOCK_NUM_PTR=45
+
+# The memory address at which the note root is stored
+const.NOTE_ROOT_PTR=46
+
 # ACCOUNT DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -222,6 +249,99 @@ end
 #! - init_nonce is the initial account nonce.
 export.set_init_nonce
     push.INIT_NONCE_PTR mem_store
+end
+
+# BLOCK DATA
+# -------------------------------------------------------------------------------------------------
+
+#! Returns a pointer to the block data section.
+#!
+#! Stack: []
+#! Output: [ptr]
+#!
+#! - ptr is a pointer to the block data section.
+export.get_block_data_ptr
+    push.BLOCK_DATA_SECTION_OFFSET
+end
+
+#! Returns the previous block hash of the last known block.
+#!
+#! Stack: []
+#! Output: [PRV_BLK_HASH]
+#!
+#! - PRV_BLK_HASH is the previous block hash of the last known block.
+export.get_prv_blk_hash
+    padw push.PREV_BLOCK_HASH_PTR mem_loadw
+end
+
+#! Returns the block number of the last known block.
+#!
+#! Stack: []
+#! Output: [blk_num]
+#!
+#! - blk_num is the block number of the last known block.
+export.get_blk_num
+    push.BLOCK_NUM_PTR mem_load
+end
+
+#! Returns the chain root of the last known block.
+#!
+#! Stack: []
+#! Output: [CHAIN_ROOT]
+#!
+#! - CHAIN_ROOT is the chain root of the last known block.
+export.get_chain_root
+    padw push.CHAIN_ROOT_PTR mem_loadw
+end
+
+#! Returns the state root of the last known block.
+#!
+#! Stack: []
+#! Output: [STATE_ROOT]
+#!
+#! - STATE_ROOT is the state root of the last known block.
+export.get_state_root
+    padw push.STATE_ROOT_PTR mem_loadw
+end
+
+#! Returns the batch root of the last known block.
+#!
+#! Stack: []
+#! Output: [BATCH_ROOT]
+#!
+#! - BATCH_ROOT is the batch root of the last known block.
+export.get_batch_root
+    padw push.BATCH_ROOT_PTR mem_loadw
+end
+
+#! Returns the proof hash of the last known block.
+#!
+#! Stack: []
+#! Output: [PROOF_HASH]
+#!
+#! - PROOF_HASH is the proof hash of the last known block.
+export.get_proof_hash
+    padw push.PROOF_HASH_PTR mem_loadw
+end
+
+#! Returns the note root of the last known block.
+#!
+#! Stack: []
+#! Output: [NOTE_ROOT]
+#!
+#! - NOTE_ROOT is the note root of the last known block.
+export.get_note_root
+    padw push.NOTE_ROOT_PTR mem_loadw
+end
+
+#! Sets the note root of the last known block.
+#!
+#! Stack: [NOTE_ROOT]
+#! Output: []
+#!
+#! - NOTE_ROOT is the note root of the last known block.
+export.set_note_root
+    push.NOTE_ROOT_PTR mem_storew dropw
 end
 
 # ACCOUNT DATA

--- a/miden-lib/asm/sat/prologue.masm
+++ b/miden-lib/asm/sat/prologue.masm
@@ -29,6 +29,63 @@ proc.process_global_inputs
     exec.layout::set_nullifier_com
 end
 
+# BLOCK DATA
+# =================================================================================================
+
+#! Process the block data provided via the advice provider. This involves reading the data from
+#! the advice provider and storing it at the appropriate memory addresses. As the block data is
+#! read from the advice provider, the block hash is computed. It is asserted that the computed
+#! block hash matches the block hash stored in the global inputs.
+#!
+#! Stack: []
+#! Advice stack: [NR, PH, CR, SR, BR, PH, BN]
+#! Output: []
+#!
+#! - NR is the note root of the last known block.
+#! - PH is the previous hash of the last known block.
+#! - CR is the chain root of the last known block.
+#! - SR is the state root of the last known block.
+#! - BR is the batch root of the last known block.
+#! - PH is the proof hash of the last known block.
+#! - BN is the block number of the last known block ([block_number, 0, 0, 0]).
+proc.process_block_data
+    # address to store the block data
+    exec.layout::get_block_data_ptr
+    # => [block_data_ptr]
+
+    # prepare the stack for reading block data
+    padw padw padw
+    # => [ZERO, ZERO, ZERO, block_data_ptr]
+
+    # read the block data
+    adv_pipe adv_pipe adv_pipe
+    # => [PERM, PERM, PERM, block_data_ptr']
+
+    # extract digest from hasher rate elements (h_0, ..., h_3)
+    dropw swapw dropw
+    # => [DIG, block_data_ptr']
+
+    # load the note root from the advice provider
+    padw adv_loadw
+    # => [NR, DIG, block_data_ptr']
+
+    # store the note root in memory
+    dupw exec.layout::set_note_root
+    # => [NR, DIG, block_data_ptr']
+
+    # merge the note root with the block data digest
+    hmerge
+    # => [BH, block_data_ptr']
+
+    # assert that the block hash matches the hash in global inputs
+    exec.layout::get_blk_hash assert_eqw
+    # => [block_data_ptr']
+
+    # clear the stack
+    drop
+    # => []
+end
+
 # ACCOUNT DATA
 # =================================================================================================
 
@@ -329,7 +386,8 @@ end
 #!  - Any of the consumed notes do note exist in the note db.
 #!
 #! Stack:        [BH, acct_id, IAH, NC]
-#! Advice stack: [acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR,
+#! Advice stack: [NR, PH, CR, SR, BR, PH, BN,
+#!                acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR,
 #!                num_cn,
 #!                CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M,
 #!                CN1_A1, CN1_A2, ...
@@ -341,6 +399,13 @@ end
 #!
 #! - BH is the latest known block hash at the time of transaction execution.
 #! - acct_id is the account id of the account that the transaction is being executed against.
+#! - NR is the note root of the last known block.
+#! - PH is the previous hash of the last known block.
+#! - CR is the chain root of the last known block.
+#! - SR is the state root of the last known block.
+#! - BR is the batch root of the last known block.
+#! - PH is the proof hash of the last known block.
+#! - BN is the block number of the last known block ([block_number, 0, 0, 0]).
 #! - IAH is the initial account hash of the account that the transaction is being executed against.
 #! - NC is the nullifier commitment of the transaction. This is a sequential hash of all
 #!   (nullifier, script_root) pairs for the notes consumed in the transaction.
@@ -359,6 +424,9 @@ end
 export.prepare_transaction
     # process global inputs
     exec.process_global_inputs
+
+    # process block data
+    exec.process_block_data
 
     # process account data
     exec.process_acct_data

--- a/miden-lib/asm/sat/tx.masm
+++ b/miden-lib/asm/sat/tx.masm
@@ -11,6 +11,16 @@ export.get_block_hash
     exec.layout::get_blk_hash
 end
 
+#! Returns the block number of the last known block at the time of transaction execution.
+#!
+#! Inputs: []
+#! Outputs: [num]
+#!
+#! num is the last known block number.
+export.get_block_number
+    exec.layout::get_blk_num
+end
+
 #! Returns the input notes hash. This is computed as a sequential hash of (nullifier, script_root)
 #! tuples over all input notes.
 #!

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -37,6 +37,33 @@ pub const NULLIFIER_COM_PTR: u64 = 13;
 /// The memory address at which the initial nonce is stored.
 pub const INIT_NONCE_PTR: u64 = 14;
 
+// BLOCK DATA
+// ------------------------------------------------------------------------------------------------
+
+/// The memory address at which the block data section begins
+pub const BLOCK_DATA_SECTION_OFFSET: u64 = 40;
+
+/// The memory address at which the previous block hash is stored
+pub const PREV_BLOCK_HASH_PTR: u64 = 40;
+
+/// The memory address at which the chain root is stored
+pub const CHAIN_ROOT_PTR: u64 = 41;
+
+/// The memory address at which the state root is stored
+pub const STATE_ROOT_PTR: u64 = 42;
+
+/// The memory address at which the batch root is stored
+pub const BATCH_ROOT_PTR: u64 = 43;
+
+/// The memory address at which the proof hash is stored
+pub const PROOF_HASH_PTR: u64 = 44;
+
+/// The memory address at which the block number is stored
+pub const BLOCK_NUM_PTR: u64 = 45;
+
+/// The memory address at which the note root is stored
+pub const NOTE_ROOT_PTR: u64 = 46;
+
 // ACCOUNT DATA
 // ------------------------------------------------------------------------------------------------
 

--- a/miden-lib/tests/common/data.rs
+++ b/miden-lib/tests/common/data.rs
@@ -1,7 +1,9 @@
 use super::{
-    Account, AccountId, Asset, Digest, ExecutedTransaction, Felt, FieldElement, FungibleAsset,
-    Note, TransactionInputs, Word,
+    Account, AccountId, Asset, BlockHeader, Digest, ExecutedTransaction, Felt, FieldElement,
+    FungibleAsset, Note, TransactionInputs, Word,
 };
+
+use test_utils::rand;
 
 // MOCK DATA
 // ================================================================================================
@@ -12,21 +14,34 @@ const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
 
 pub const NONCE: Felt = Felt::ZERO;
 
+pub fn mock_block_header() -> BlockHeader {
+    let prev_hash: Digest = rand::rand_array().into();
+    let block_num: Felt = rand::rand_value();
+    let chain_root: Digest = rand::rand_array().into();
+    let state_root: Digest = rand::rand_array().into();
+    let note_root: Digest = rand::rand_array().into();
+    let batch_root: Digest = rand::rand_array().into();
+    let proof_hash: Digest = rand::rand_array().into();
+
+    BlockHeader::new(
+        prev_hash, block_num, chain_root, state_root, note_root, batch_root, proof_hash,
+    )
+}
+
 pub fn mock_inputs() -> TransactionInputs {
     // Create an account
     let account_id =
         AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
     let account = Account::new(account_id, &[], "proc.test_proc push.1 end", Felt::ZERO).unwrap();
 
-    // Block reference
-    let block_ref: Digest =
-        Digest::new([Felt::new(9), Felt::new(10), Felt::new(11), Felt::new(12)]);
+    // Block header
+    let block_header: BlockHeader = mock_block_header();
 
     // Consumed notes
     let consumed_notes = mock_consumed_notes();
 
     // Transaction inputs
-    TransactionInputs::new(account, block_ref, consumed_notes, None)
+    TransactionInputs::new(account, block_header, consumed_notes, None)
 }
 
 pub fn mock_executed_tx() -> ExecutedTransaction {
@@ -48,9 +63,8 @@ pub fn mock_executed_tx() -> ExecutedTransaction {
     // Created notes
     let created_notes = mock_created_notes();
 
-    // Block reference
-    let block_ref: Digest =
-        Digest::new([Felt::new(9), Felt::new(10), Felt::new(11), Felt::new(12)]);
+    // Block header
+    let block_header: BlockHeader = mock_block_header();
 
     // Executed Transaction
     ExecutedTransaction::new(
@@ -59,7 +73,7 @@ pub fn mock_executed_tx() -> ExecutedTransaction {
         consumed_notes,
         created_notes,
         None,
-        block_ref,
+        block_header,
     )
 }
 

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -7,7 +7,7 @@ pub use miden_objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteVault},
     transaction::{ExecutedTransaction, ProvenTransaction, TransactionInputs},
-    Account, AccountId,
+    Account, AccountId, BlockHeader,
 };
 pub use processor::{
     math::Felt, AdviceInputs, AdviceProvider, ExecutionError, MemAdviceProvider, Process,

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -4,8 +4,9 @@ use common::{
     data::{mock_inputs, ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN, NONCE},
     memory::{
         ACCT_CODE_ROOT_PTR, ACCT_ID_AND_NONCE_PTR, ACCT_ID_PTR, ACCT_STORAGE_ROOT_PTR,
-        ACCT_VAULT_ROOT_PTR, BLK_HASH_PTR, CONSUMED_NOTE_SECTION_OFFSET, INIT_ACCT_HASH_PTR,
-        NULLIFIER_COM_PTR,
+        ACCT_VAULT_ROOT_PTR, BATCH_ROOT_PTR, BLK_HASH_PTR, BLOCK_NUM_PTR, CHAIN_ROOT_PTR,
+        CONSUMED_NOTE_SECTION_OFFSET, INIT_ACCT_HASH_PTR, NOTE_ROOT_PTR, NULLIFIER_COM_PTR,
+        PREV_BLOCK_HASH_PTR, PROOF_HASH_PTR, STATE_ROOT_PTR,
     },
     run_within_tx_kernel, AdviceProvider, Felt, FieldElement, MemAdviceProvider, Process,
     TransactionInputs, Word, TX_KERNEL_DIR,
@@ -31,6 +32,7 @@ fn test_transaction_prologue() {
     );
 
     public_input_memory_assertions(&process, &inputs);
+    block_data_memory_assertions(&process, &inputs);
     account_data_memory_assertions(&process, &inputs);
     consumed_notes_memory_assertions(&process, &inputs);
 }
@@ -42,7 +44,7 @@ fn public_input_memory_assertions<A: AdviceProvider>(
     // The block hash should be stored at the BLK_HASH_PTR
     assert_eq!(
         process.get_memory_value(0, BLK_HASH_PTR).unwrap(),
-        inputs.block_ref().as_elements()
+        inputs.block_header().hash().as_elements()
     );
 
     // The account ID should be stored at the ACCT_ID_PTR
@@ -61,6 +63,59 @@ fn public_input_memory_assertions<A: AdviceProvider>(
     assert_eq!(
         process.get_memory_value(0, NULLIFIER_COM_PTR).unwrap(),
         inputs.consumed_notes_commitment().as_elements()
+    );
+}
+
+fn block_data_memory_assertions<A: AdviceProvider>(
+    process: &Process<A>,
+    inputs: &TransactionInputs,
+) {
+    // The block hash should be stored at the BLK_HASH_PTR
+    assert_eq!(
+        process.get_memory_value(0, BLK_HASH_PTR).unwrap(),
+        inputs.block_header().hash().as_elements()
+    );
+
+    // The previous block hash should be stored at the PREV_BLK_HASH_PTR
+    assert_eq!(
+        process.get_memory_value(0, PREV_BLOCK_HASH_PTR).unwrap(),
+        inputs.block_header().prev_hash().as_elements()
+    );
+
+    // The chain root should be stored at the CHAIN_ROOT_PTR
+    assert_eq!(
+        process.get_memory_value(0, CHAIN_ROOT_PTR).unwrap(),
+        inputs.block_header().chain_root().as_elements()
+    );
+
+    // The state root should be stored at the STATE_ROOT_PTR
+    assert_eq!(
+        process.get_memory_value(0, STATE_ROOT_PTR).unwrap(),
+        inputs.block_header().state_root().as_elements()
+    );
+
+    // The batch root should be stored at the BATCH_ROOT_PTR
+    assert_eq!(
+        process.get_memory_value(0, BATCH_ROOT_PTR).unwrap(),
+        inputs.block_header().batch_root().as_elements()
+    );
+
+    // The note root should be stored at the NOTE_ROOT_PTR
+    assert_eq!(
+        process.get_memory_value(0, NOTE_ROOT_PTR).unwrap(),
+        inputs.block_header().note_root().as_elements()
+    );
+
+    // The proof hash should be stored at the PROOF_HASH_PTR
+    assert_eq!(
+        process.get_memory_value(0, PROOF_HASH_PTR).unwrap(),
+        inputs.block_header().proof_hash().as_elements()
+    );
+
+    // The block number should be stored at the BLOCK_NUM_PTR
+    assert_eq!(
+        process.get_memory_value(0, BLOCK_NUM_PTR).unwrap()[0],
+        inputs.block_header().block_num()
     );
 }
 

--- a/objects/src/block/header.rs
+++ b/objects/src/block/header.rs
@@ -1,0 +1,143 @@
+use super::{Digest, Felt, Hasher, ZERO};
+
+/// The header of a block. It contains metadata about the block, commitments to the current
+/// state of the chain and the hash of the proof that attests to the integrity of the chain.
+///
+/// A block header includes the following fields:
+///
+/// - prev_hash is the hash of the previous blocks header.
+/// - block_num is a unique sequential number of the current block.
+/// - chain_root is a commitment to an MMR of the entire chain where each block is a leaf.
+/// - state_root is a combined commitment to account, and nullifier databases.
+/// - note_root is a commitment to all notes created in the current block.
+/// - batch_root is a commitment to a set of transaction batches executed as a part of this block.
+/// - proof_hash is a hash of a STARK proof attesting to the correct state transition.
+pub struct BlockHeader {
+    prev_hash: Digest,
+    block_num: Felt,
+    chain_root: Digest,
+    state_root: Digest,
+    note_root: Digest,
+    batch_root: Digest,
+    proof_hash: Digest,
+    hash: Digest,
+}
+
+impl BlockHeader {
+    /// Creates a new block header.
+    pub fn new(
+        prev_hash: Digest,
+        block_num: Felt,
+        chain_root: Digest,
+        state_root: Digest,
+        note_root: Digest,
+        batch_root: Digest,
+        proof_hash: Digest,
+    ) -> Self {
+        // compute block hash
+        let hash = Self::compute_hash(
+            prev_hash, chain_root, state_root, batch_root, proof_hash, block_num, note_root,
+        );
+
+        Self {
+            prev_hash,
+            block_num,
+            chain_root,
+            state_root,
+            note_root,
+            batch_root,
+            proof_hash,
+            hash,
+        }
+    }
+
+    // ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the hash of the block header.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+
+    /// Returns the hash of the previous block header.
+    pub fn prev_hash(&self) -> Digest {
+        self.prev_hash
+    }
+
+    /// Returns the block number.
+    pub fn block_num(&self) -> Felt {
+        self.block_num
+    }
+
+    /// Returns the chain root.
+    pub fn chain_root(&self) -> Digest {
+        self.chain_root
+    }
+
+    /// Returns the state root.
+    pub fn state_root(&self) -> Digest {
+        self.state_root
+    }
+
+    /// Returns the note root.
+    pub fn note_root(&self) -> Digest {
+        self.note_root
+    }
+
+    /// Returns the batch root.
+    pub fn batch_root(&self) -> Digest {
+        self.batch_root
+    }
+
+    /// Returns the proof hash.
+    pub fn proof_hash(&self) -> Digest {
+        self.proof_hash
+    }
+
+    // HELPERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Computes the hash of the block header.
+    ///
+    /// The hash is computed as a sequential hash of the following fields:
+    /// prev_hash, chain_root, state_root, note_root, batch_root, proof_hash, block_num.
+    /// The result is then merged with the note_root - merge(note_root, hash) to produce the final
+    /// hash. This is done to make the note_root easily accessible without having to unhash the
+    /// entire header. Having the note_root easily accessible is useful when authenticating notes.
+    fn compute_hash(
+        prev_hash: Digest,
+        chain_root: Digest,
+        state_root: Digest,
+        batch_root: Digest,
+        proof_hash: Digest,
+        block_num: Felt,
+        note_root: Digest,
+    ) -> Digest {
+        let mut elements: Vec<Felt> = Vec::with_capacity(24);
+        elements.extend_from_slice(prev_hash.as_elements());
+        elements.extend_from_slice(chain_root.as_elements());
+        elements.extend_from_slice(state_root.as_elements());
+        elements.extend_from_slice(batch_root.as_elements());
+        elements.extend_from_slice(proof_hash.as_elements());
+        elements.push(block_num);
+        elements.resize(24, ZERO);
+        let body_hash = Hasher::hash_elements(&elements);
+
+        Hasher::merge(&[body_hash, note_root])
+    }
+}
+
+impl From<&BlockHeader> for Vec<Felt> {
+    fn from(header: &BlockHeader) -> Self {
+        let mut elements: Vec<Felt> = Vec::with_capacity(28);
+        elements.extend_from_slice(header.prev_hash.as_elements());
+        elements.extend_from_slice(header.chain_root.as_elements());
+        elements.extend_from_slice(header.state_root.as_elements());
+        elements.extend_from_slice(header.batch_root.as_elements());
+        elements.extend_from_slice(header.proof_hash.as_elements());
+        elements.push(header.block_num);
+        elements.resize(24, ZERO);
+        elements.extend_from_slice(header.note_root.as_elements());
+        elements
+    }
+}

--- a/objects/src/block/mod.rs
+++ b/objects/src/block/mod.rs
@@ -1,0 +1,4 @@
+use super::{Digest, Felt, Hasher, ZERO};
+
+mod header;
+pub use header::BlockHeader;

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -18,6 +18,9 @@ pub use accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType,
 pub mod assets;
 pub mod notes;
 
+pub mod block;
+pub use block::BlockHeader;
+
 mod errors;
 pub use errors::{AccountError, AssetError, NoteError};
 

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -1,6 +1,6 @@
 use miden_core::StackOutputs;
 
-use super::{utils, Account, AdviceInputs, Digest, Note, StackInputs};
+use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Note, StackInputs};
 
 pub struct ExecutedTransaction {
     initial_account: Account,
@@ -8,7 +8,7 @@ pub struct ExecutedTransaction {
     consumed_notes: Vec<Note>,
     created_notes: Vec<Note>,
     tx_script_root: Option<Digest>,
-    block_ref: Digest,
+    block_header: BlockHeader,
 }
 
 impl ExecutedTransaction {
@@ -18,7 +18,7 @@ impl ExecutedTransaction {
         consumed_notes: Vec<Note>,
         created_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
-        block_ref: Digest,
+        block_header: BlockHeader,
     ) -> Self {
         Self {
             initial_account,
@@ -26,7 +26,7 @@ impl ExecutedTransaction {
             consumed_notes,
             created_notes,
             tx_script_root,
-            block_ref,
+            block_header,
         }
     }
 
@@ -57,7 +57,7 @@ impl ExecutedTransaction {
 
     /// Returns the block reference.
     pub fn block_ref(&self) -> Digest {
-        self.block_ref
+        self.block_header.hash()
     }
 
     /// Returns the stack inputs required when executing the transaction.
@@ -66,7 +66,7 @@ impl ExecutedTransaction {
             &self.initial_account.id(),
             &self.initial_account.hash(),
             &self.consumed_notes,
-            &self.block_ref,
+            &self.block_header,
         )
     }
 
@@ -77,7 +77,11 @@ impl ExecutedTransaction {
 
     /// Returns the advice inputs required when executing the transaction.
     pub fn advice_provider_inputs(&self) -> AdviceInputs {
-        utils::generate_advice_provider_inputs(&self.initial_account, &self.consumed_notes)
+        utils::generate_advice_provider_inputs(
+            &self.initial_account,
+            &self.block_header,
+            &self.consumed_notes,
+        )
     }
 
     /// Returns the stack outputs produced as a result of executing a transaction.

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -1,4 +1,4 @@
-use super::{utils, Account, AdviceInputs, Digest, Note, StackInputs, Vec};
+use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Note, StackInputs, Vec};
 
 /// A struct that contains all of the data required to execute a transaction. This includes:
 /// - account: Account that the transaction is being executed against.
@@ -7,7 +7,7 @@ use super::{utils, Account, AdviceInputs, Digest, Note, StackInputs, Vec};
 /// - tx_script_root: An optional transaction script root.
 pub struct TransactionInputs {
     account: Account,
-    block_ref: Digest,
+    block_header: BlockHeader,
     consumed_notes: Vec<Note>,
     tx_script_root: Option<Digest>,
 }
@@ -15,13 +15,13 @@ pub struct TransactionInputs {
 impl TransactionInputs {
     pub fn new(
         account: Account,
-        block_ref: Digest,
+        block_header: BlockHeader,
         consumed_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
     ) -> Self {
         Self {
             account,
-            block_ref,
+            block_header,
             consumed_notes,
             tx_script_root,
         }
@@ -35,9 +35,9 @@ impl TransactionInputs {
         &self.account
     }
 
-    /// Returns the block reference.
-    pub fn block_ref(&self) -> Digest {
-        self.block_ref
+    // Returns the block header.
+    pub fn block_header(&self) -> &BlockHeader {
+        &self.block_header
     }
 
     /// Returns the consumed notes.
@@ -56,13 +56,17 @@ impl TransactionInputs {
             &self.account.id(),
             &self.account.hash(),
             &self.consumed_notes,
-            &self.block_ref,
+            &self.block_header,
         )
     }
 
     /// Returns the advice inputs required when executing the transaction.
     pub fn advice_provider_inputs(&self) -> AdviceInputs {
-        utils::generate_advice_provider_inputs(&self.account, &self.consumed_notes)
+        utils::generate_advice_provider_inputs(
+            &self.account,
+            &self.block_header,
+            &self.consumed_notes,
+        )
     }
 
     /// Returns the consumed notes commitment.

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     notes::{Note, NoteMetadata},
-    Account, AccountId, Digest, Felt, Hasher, StarkField, Vec, Word,
+    Account, AccountId, BlockHeader, Digest, Felt, Hasher, StarkField, Vec, Word,
 };
 use miden_core::{StackInputs, StackOutputs};
 use miden_processor::AdviceInputs;

--- a/objects/src/transaction/utils.rs
+++ b/objects/src/transaction/utils.rs
@@ -1,5 +1,6 @@
 use super::{
-    Account, AccountId, AdviceInputs, Digest, Felt, Hasher, Note, StackInputs, StackOutputs, Word,
+    Account, AccountId, AdviceInputs, BlockHeader, Digest, Felt, Hasher, Note, StackInputs,
+    StackOutputs, Word,
 };
 
 /// Returns the advice inputs required when executing a transaction.
@@ -34,8 +35,14 @@ use super::{
 /// - CN1_A2 is the second asset of consumed note 1.
 /// - CN1_I3..0 are the script inputs of consumed note 1.
 /// - CN2_I3..0 are the script inputs of consumed note 2.
-pub fn generate_advice_provider_inputs(account: &Account, notes: &[Note]) -> AdviceInputs {
+pub fn generate_advice_provider_inputs(
+    account: &Account,
+    block_header: &BlockHeader,
+    notes: &[Note],
+) -> AdviceInputs {
     let mut inputs: Vec<Felt> = Vec::new();
+    let block_data = Vec::<Felt>::from(block_header);
+    inputs.extend(block_data);
     let account: [Felt; 16] = account.into();
     inputs.extend(account);
     inputs.push(Felt::new(notes.len() as u64));
@@ -74,13 +81,13 @@ pub fn generate_stack_inputs(
     account_id: &AccountId,
     account_hash: &Digest,
     notes: &[Note],
-    block_ref: &Digest,
+    block_header: &BlockHeader,
 ) -> StackInputs {
     let mut inputs: Vec<Felt> = Vec::with_capacity(13);
     inputs.extend_from_slice(generate_consumed_notes_commitment(notes).as_elements());
     inputs.extend_from_slice(account_hash.as_elements());
     inputs.push(**account_id);
-    inputs.extend_from_slice(block_ref.as_elements());
+    inputs.extend_from_slice(block_header.hash().as_elements());
     StackInputs::new(inputs)
 }
 


### PR DESCRIPTION
This PR introduces the block header object which holds metadata that succinctly describes the current state of the chain and provides commitments that can be used to authenticate historical and current state. A rust struct has been implemented to encapsulate logic and data related to the block header.  We have also extended the prologue to parse and authenticate block data which is provided via the advice provider and authenticate that it is consistent with the block hash provided via public input.