### PR TITLE
rustfmt: set edition to 2021

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,7 @@
 # commented out settings are not currently stable. once they become stable, we'll
 # evaluate and enable them.
 
+edition = "2021"
 array_width = 80
 attr_fn_like_width = 80
 chain_width = 80


### PR DESCRIPTION
rustfmt will remove leading `::` used to disambiguate `use` imports in edition 2018+. This sets the edition so the tool will no longer remove it.