### PR TITLE
Note authentication draft

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -16,17 +16,18 @@ default = ["std"]
 std = ["assembly/std", "processor/std"]
 
 [dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
+processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
 
 [dev-dependencies]
-crypto = { package = "miden-crypto", version = "0.2" }
+crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "frisitano-mmr-accumulator", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects"}
-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", features = ["internals"] }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
+processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", features = ["internals"] }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
+test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
 
 
 [build-dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
+processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }

--- a/miden-lib/asm/sat/constants.masm
+++ b/miden-lib/asm/sat/constants.masm
@@ -10,6 +10,9 @@ const.MAX_NUM_CONSUMED_NOTES=1023
 # The size of the memory segment allocated to each note
 const.NOTE_MEM_SIZE=1024
 
+# The depth of the Merkle tree used to commit to notes produced in a block.
+const.NOTE_TREE_DEPTH=20
+
 # PROCEDURES
 # =================================================================================================
 
@@ -41,4 +44,14 @@ end
 #! - note_mem_size is the size of the memory segment allocated to each note.
 export.get_note_mem_size
     push.NOTE_MEM_SIZE
+end
+
+#! Returns the depth of the Merkle tree used to commit to notes produced in a block.
+#!
+#! Stack: []
+#! Output: [note_tree_depth]
+#!
+#! - note_tree_depth is the depth of the Merkle tree used to commit to notes produced in a block.
+export.get_note_tree_depth
+    push.NOTE_TREE_DEPTH
 end

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -66,6 +66,18 @@ const.BLOCK_NUM_PTR=45
 # The memory address at which the note root is stored
 const.NOTE_ROOT_PTR=46
 
+# CHAIN MMR
+# -------------------------------------------------------------------------------------------------
+
+# The memory address at which the chain data section begins
+const.CHAIN_MMR_PTR=60
+
+# The memory address at which the total number of leaves in the chain MMR is stored
+const.CHAIN_MMR_NUM_LEAVES_PTR=60
+
+# The memory address at which the chain mmr peaks are stored
+const.CHAIN_MMR_PEAKS_PTR=61
+
 # ACCOUNT DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -344,6 +356,39 @@ export.set_note_root
     push.NOTE_ROOT_PTR mem_storew dropw
 end
 
+# CHAIN DATA
+# -------------------------------------------------------------------------------------------------
+
+#! Returns a pointer to the chain MMR section.
+#!
+#! Stack: []
+#! Output: [ptr]
+#!
+#! - ptr is a pointer to the chain MMR section.
+export.get_chain_mmr_ptr
+    push.CHAIN_MMR_PTR
+end
+
+#! Sets the number of leaves in the chain MMR.
+#!
+#! Stack: [num_leaves]
+#! Output: []
+#!
+#! - num_leaves is the number of leaves in the chain MMR.
+export.set_chain_mmr_num_leaves
+    push.CHAIN_MMR_NUM_LEAVES_PTR mem_store
+end
+
+#! Returns a pointer to start of the chain MMR peaks section.
+#!
+#! Stack: []
+#! Output: [ptr]
+#!
+#! - ptr is a pointer to the start of the chain MMR peaks section.
+export.get_chain_mmr_peaks_ptr
+    push.CHAIN_MMR_PEAKS_PTR
+end
+
 # ACCOUNT DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -417,12 +462,12 @@ end
 #! Set the hash of the consumed note at the specified memory address.
 #!
 #! Stack: [consumed_note_ptr, H]
-#! Output: []
+#! Output: [H]
 #!
 #! - consumed_note_ptr is the memory address of the consumed note.
 #! - H is the hash of the consumed note.
 export.set_consumed_note_hash
-    mem_storew dropw
+    mem_storew
 end
 
 #! Computes a pointer to the memory address at which the nullifier associated a note with index i

--- a/miden-lib/asm/sat/prologue.masm
+++ b/miden-lib/asm/sat/prologue.masm
@@ -1,3 +1,5 @@
+use.std::collections::mmr
+
 use.miden::sat::constants
 use.miden::sat::layout
 
@@ -86,6 +88,39 @@ proc.process_block_data
     # => []
 end
 
+# CHAIN DATA
+# =================================================================================================
+
+#! Process the chain data provided via the advice provider. This involves reading the MMR data from
+#! the advice provider and storing it at the appropriate memory addresses. As the MMR peaks are
+#! read from the advice provider, the chain root is computed. It is asserted that the computed
+#! chain root matches the chain root stored in the block data section. The number of words that the
+#! advice provider will send for MMR peaks is variable: it will be at least 16 but could be up to
+#! 63. The actual number will be computed based on num_leaves.
+#!
+#! Stack: []
+#! Advice Map: {
+#!              MMR_ROOT: [num_leaves, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14,
+#!                         P15, P16, ..., ...]
+#!             }
+#! Output: []
+#!
+#! - num_leaves is the number of leaves in the MMR.
+#! - P1, P2, ... are the MMR peaks.
+proc.process_chain_data
+    # get a pointer to the chain mmr data
+    exec.layout::get_chain_mmr_ptr
+    # => [chain_mmr_ptr]
+
+    # get the chain root
+    exec.layout::get_chain_root
+    # => [CHAIN_ROOT, chain_mmr_ptr]
+
+    # unpack mmr
+    exec.mmr::unpack
+    # => []
+end
+
 # ACCOUNT DATA
 # =================================================================================================
 
@@ -135,6 +170,65 @@ end
 
 # CONSUMED NOTES DATA
 # =================================================================================================
+
+#! Authenticate the consumed note data provided via the advice provider is consistent with the
+#! the chain history.  This is achieved by:
+#! - authenticating the MMR leaf associated with the block the note was created in.
+#! - authenticating the note root associated with the block the note was created in.
+#! - authenticating the note and its metadata in the note Merkle tree from the block the note was
+#!   created in.
+#!
+#! Stack: [AUTH_DIGEST]
+#! Advice Stack: [leaf_pos, SUB_HASH, NOTE_ROOT, note_index]
+#! Output: []
+#!
+#! - AUTH_DIGEST is the digest of the consumed note data computed as hash(NOTE_HASH, NOTE_METADATA)
+#! - leaf_pos is the position of the leaf in the MMR associated with the block the note was created
+#!   in. This is equivalent to the block number.
+#! - SUB_HASH is the sub hash of the block the note was created in.
+#! - NOTE_ROOT is the note root of the block the note was created in.
+#! - note_index is the index of the note in the note Merkle tree.
+proc.authenticate_note.2
+    # load data required for MMR get operation
+    exec.layout::get_chain_mmr_ptr adv_push.1
+    # => [leaf_pos, chain_mmr_ptr, AUTH_DIGEST]
+
+    # get the chain MMR leaf associated with the block the note was created in
+    exec.mmr::get
+    # => [MMR_LEAF, AUTH_DIGEST]
+
+    # prepare the stack to read the sub hash and note root from the advice provider
+    locaddr.0 padw padw padw
+    # => [PAD, PAD, PAD, mem_ptr, MMR_LEAF, AUTH_DIGEST]
+
+    # read the core hash and note root from the advice provider
+    adv_pipe
+    # => [PERM, PERM, PERM, mem_ptr', MMR_LEAF, AUTH_DIGEST]
+
+    # extract the digest and assert it matches MMR_LEAF
+    dropw movup.8 drop movupw.2 assert_eqw
+    # => [AUTH_DIGEST]
+
+    # load the note root from memory
+    loc_loadw.1 swapw
+    # => [AUTH_DIGEST, NOTE_ROOT]
+
+    # load the index of the note
+    adv_push.1 movdn.4
+    # => [AUTH_DIGEST, note_index, NOTE_ROOT]
+
+    # get the depth of the note tree
+    exec.constants::get_note_tree_depth movdn.4
+    # => [AUTH_DIGEST, depth, note_index, NOTE_ROOT]
+
+    # verify the note hash
+    mtree_verify
+    # => [AUTH_DIGEST, depth, note_index, NOTE_ROOT]
+
+    # clean the stack
+    dropw drop drop dropw
+    # => []
+end
 
 #! Reads data for consumed note i from the advice provider and stores it in memory at the
 #! appropriate memory address. This includes computing and storing the nullifier and the
@@ -272,10 +366,18 @@ proc.process_consumed_note
     # => [NOTE_HASH, note_ptr]
 
     # store note hash in memory and clear stack
-    movup.4 exec.layout::set_consumed_note_hash
-    # => []
+    dup.4 exec.layout::set_consumed_note_hash
+    # => [NOTE_HASH]
 
-    # TODO: assert note hash exists in note db
+    # load the note metadata
+    movup.4 exec.layout::get_consumed_note_metadata
+    # => [NOTE_META, NOTE_HASH]
+
+    # merge the note hash with the note metadata to compute authentication digest
+    hmerge
+    # => [AUTH_DIGEST]
+
+    exec.authenticate_note
 end
 
 #! Process the consumed notes data provided via the advice provider. This involves reading the data
@@ -427,6 +529,9 @@ export.prepare_transaction
 
     # process block data
     exec.process_block_data
+
+    # process chain data
+    exec.process_chain_data
 
     # process account data
     exec.process_acct_data

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -64,6 +64,18 @@ pub const BLOCK_NUM_PTR: u64 = 45;
 /// The memory address at which the note root is stored
 pub const NOTE_ROOT_PTR: u64 = 46;
 
+// CHAIN DATA
+// ------------------------------------------------------------------------------------------------
+
+/// The memory address at which the chain data section begins
+pub const CHAIN_MMR_PTR: u64 = 60;
+
+/// The memory address at which the total number of leaves in the chain MMR is stored
+pub const CHAIN_MMR_NUM_LEAVES_PTR: u64 = 60;
+
+/// The memory address at which the chain mmr peaks are stored
+pub const CHAIN_MMR_PEAKS_PTR: u64 = 61;
+
 // ACCOUNT DATA
 // ------------------------------------------------------------------------------------------------
 

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -1,14 +1,16 @@
 pub use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
+    merkle::{MerkleStore, Mmr, NodeIndex, SimpleSmt},
     FieldElement, StarkField,
 };
 pub use miden_lib::{memory, MidenLib};
 pub use miden_objects::{
     assets::{Asset, FungibleAsset},
-    notes::{Note, NoteVault},
+    notes::{Note, NoteOrigin, NoteVault, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
     transaction::{ExecutedTransaction, ProvenTransaction, TransactionInputs},
     Account, AccountId, BlockHeader,
 };
+use miden_stdlib::StdLibrary;
 pub use processor::{
     math::Felt, AdviceInputs, AdviceProvider, ExecutionError, MemAdviceProvider, Process,
     StackInputs, Word,
@@ -49,7 +51,9 @@ where
 {
     let assembler = assembly::Assembler::default()
         .with_library(&MidenLib::default())
-        .expect("failed to load miden-lib");
+        .expect("failed to load miden-lib")
+        .with_library(&StdLibrary::default())
+        .expect("failed to load std-lib");
 
     let code = match (dir, file) {
         (Some(dir), Some(file)) => load_file_with_code(imports, code, dir, file),

--- a/miden-lib/tests/test_epilogue.rs
+++ b/miden-lib/tests/test_epilogue.rs
@@ -10,7 +10,7 @@ const EPILOGUE_FILE: &str = "epilogue.masm";
 
 #[test]
 fn test_epilogue() {
-    let executed_transaction = mock_executed_tx();
+    let (merkle_store, executed_transaction) = mock_executed_tx();
 
     let created_notes_data_procedure =
         created_notes_data_procedure(executed_transaction.created_notes());
@@ -32,7 +32,9 @@ fn test_epilogue() {
         imports,
         &code,
         executed_transaction.stack_inputs(),
-        MemAdviceProvider::from(executed_transaction.advice_provider_inputs()),
+        MemAdviceProvider::from(
+            executed_transaction.advice_provider_inputs().with_merkle_store(merkle_store),
+        ),
         Some(TX_KERNEL_DIR),
         Some(EPILOGUE_FILE),
     );
@@ -58,7 +60,7 @@ fn test_epilogue() {
 
 #[test]
 fn test_compute_created_note_hash() {
-    let executed_transaction = mock_executed_tx();
+    let (_merkle_store, executed_transaction) = mock_executed_tx();
 
     let created_notes_data_procedure =
         created_notes_data_procedure(executed_transaction.created_notes());

--- a/miden-lib/tests/test_note_setup.rs
+++ b/miden-lib/tests/test_note_setup.rs
@@ -10,7 +10,7 @@ const NOTE_SETUP_FILE: &str = "note_setup.masm";
 
 #[test]
 fn test_note_setup() {
-    let inputs = mock_inputs();
+    let (merkle_store, inputs) = mock_inputs();
     let imports = "use.miden::sat::prologue\n";
     let code = "
         begin
@@ -22,7 +22,7 @@ fn test_note_setup() {
         imports,
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs()),
+        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
         Some(TX_KERNEL_DIR),
         Some(NOTE_SETUP_FILE),
     );

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -23,11 +23,12 @@ default = ["std"]
 std = ["assembly/std", "crypto/std", "miden-core/std"]
 
 [dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-crypto = { package = "miden-crypto", version = "0.2", default-features = false }
-miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-miden-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
+crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "frisitano-mmr-accumulator", default-features = false }
+hashbrown = { version = "0.13.2" }
+miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
+miden-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
+miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
 
 
 [dev-dependencies]

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -148,6 +148,7 @@ pub enum NoteError {
     DuplicateFungibleAsset(AccountId),
     DuplicateNonFungibleAsset(NonFungibleAsset),
     EmptyAssetList,
+    InvalidOriginIndex(String),
     TooManyAssets(usize),
     TooManyInputs(usize),
 }
@@ -163,6 +164,10 @@ impl NoteError {
 
     pub fn empty_asset_list() -> Self {
         Self::EmptyAssetList
+    }
+
+    pub fn invalid_origin_index(msg: String) -> Self {
+        Self::InvalidOriginIndex(msg)
     }
 
     pub fn too_many_assets(num_assets: usize) -> Self {

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 
 use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
+    merkle::Mmr,
     utils::{
         collections::Vec,
         string::{String, ToString},

--- a/objects/src/notes/origin.rs
+++ b/objects/src/notes/origin.rs
@@ -1,0 +1,68 @@
+use super::{Digest, Felt, NoteError, NOTE_TREE_DEPTH};
+use crypto::merkle::{MerklePath, NodeIndex};
+
+/// Represents the origin of a note.  This includes:
+/// block_num  - the block number the note was created in.
+/// sub_hash   - the sub hash of the block the note was created in.
+/// note_root  - the note root of the block the note was created in.
+/// note_index - the index of the note in the note Merkle tree of the block the note was created
+///              in.
+/// note_path  - the Merkle path to the note in the note Merkle tree of the block the note was
+///              created in.
+#[derive(Debug)]
+pub struct NoteOrigin {
+    block_num: Felt,
+    sub_hash: Digest,
+    note_root: Digest,
+    node_index: NodeIndex,
+    note_path: MerklePath,
+}
+
+impl NoteOrigin {
+    /// Creates a new note origin.
+    pub fn new(
+        block_num: Felt,
+        sub_hash: Digest,
+        note_root: Digest,
+        index: u64,
+        note_path: MerklePath,
+    ) -> Result<Self, NoteError> {
+        Ok(Self {
+            block_num,
+            sub_hash,
+            note_root,
+            node_index: NodeIndex::new(NOTE_TREE_DEPTH, index)
+                .map_err(|e| NoteError::invalid_origin_index(e.to_string()))?,
+            note_path,
+        })
+    }
+
+    // ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the block number the note was created in.
+    pub fn block_num(&self) -> Felt {
+        self.block_num
+    }
+
+    /// Returns the sub hash of the block header the note was created in.
+    pub fn sub_hash(&self) -> Digest {
+        self.sub_hash
+    }
+
+    /// Returns the note root of the block header the note was created in.
+    pub fn note_root(&self) -> Digest {
+        self.note_root
+    }
+
+    /// Returns the node index of the note in the note Merkle tree.
+    pub fn node_index(&self) -> NodeIndex {
+        self.node_index
+    }
+
+    /// Returns the Merkle path to the note in the note Merkle tree of the block the note was
+    /// created in.
+    pub fn note_path(&self) -> &MerklePath {
+        &self.note_path
+    }
+}

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -1,6 +1,6 @@
 use miden_core::StackOutputs;
 
-use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Note, StackInputs};
+use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Mmr, Note, StackInputs};
 
 pub struct ExecutedTransaction {
     initial_account: Account,
@@ -9,6 +9,7 @@ pub struct ExecutedTransaction {
     created_notes: Vec<Note>,
     tx_script_root: Option<Digest>,
     block_header: BlockHeader,
+    block_chain: Mmr,
 }
 
 impl ExecutedTransaction {
@@ -19,6 +20,7 @@ impl ExecutedTransaction {
         created_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
         block_header: BlockHeader,
+        block_chain: Mmr,
     ) -> Self {
         Self {
             initial_account,
@@ -27,6 +29,7 @@ impl ExecutedTransaction {
             created_notes,
             tx_script_root,
             block_header,
+            block_chain,
         }
     }
 
@@ -56,7 +59,7 @@ impl ExecutedTransaction {
     }
 
     /// Returns the block reference.
-    pub fn block_ref(&self) -> Digest {
+    pub fn block_hash(&self) -> Digest {
         self.block_header.hash()
     }
 
@@ -80,6 +83,7 @@ impl ExecutedTransaction {
         utils::generate_advice_provider_inputs(
             &self.initial_account,
             &self.block_header,
+            &self.block_chain,
             &self.consumed_notes,
         )
     }

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -1,4 +1,4 @@
-use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Note, StackInputs, Vec};
+use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Mmr, Note, StackInputs, Vec};
 
 /// A struct that contains all of the data required to execute a transaction. This includes:
 /// - account: Account that the transaction is being executed against.
@@ -8,6 +8,7 @@ use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Note, StackInputs
 pub struct TransactionInputs {
     account: Account,
     block_header: BlockHeader,
+    block_chain: Mmr,
     consumed_notes: Vec<Note>,
     tx_script_root: Option<Digest>,
 }
@@ -16,12 +17,14 @@ impl TransactionInputs {
     pub fn new(
         account: Account,
         block_header: BlockHeader,
+        block_chain: Mmr,
         consumed_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
     ) -> Self {
         Self {
             account,
             block_header,
+            block_chain,
             consumed_notes,
             tx_script_root,
         }
@@ -35,9 +38,14 @@ impl TransactionInputs {
         &self.account
     }
 
-    // Returns the block header.
+    /// Returns the block header.
     pub fn block_header(&self) -> &BlockHeader {
         &self.block_header
+    }
+
+    /// Returns the block chain.
+    pub fn block_chain(&self) -> &Mmr {
+        &self.block_chain
     }
 
     /// Returns the consumed notes.
@@ -65,6 +73,7 @@ impl TransactionInputs {
         utils::generate_advice_provider_inputs(
             &self.account,
             &self.block_header,
+            &self.block_chain,
             &self.consumed_notes,
         )
     }

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     notes::{Note, NoteMetadata},
-    Account, AccountId, BlockHeader, Digest, Felt, Hasher, StarkField, Vec, Word,
+    Account, AccountId, BlockHeader, Digest, Felt, Hasher, Mmr, StarkField, Vec, Word,
 };
 use miden_core::{StackInputs, StackOutputs};
 use miden_processor::AdviceInputs;


### PR DESCRIPTION
This is functional draft PR for note authentication.  This is a work in progress and some refactoring is required and additional documentation will be supplemented. This PR introduces a `NoteOrigin` struct which is responsible for holding the information related to the origin of a note - specifically the block header of the block it was created in and in the index of the note in the note tree for that block.  We modify note Felt serialization to include origin information such that the masm code can authenticate the notes origin. We modify the testing patterns such that we can include a `MerkleStore` when constructing the advice provider.

