### PR TITLE
Add `set_code` kernel procedure

### DIFF
--- a/miden-lib/asm/sat/account.masm
+++ b/miden-lib/asm/sat/account.masm
@@ -1,5 +1,23 @@
 use.miden::sat::layout
 
+# CONSTANTS
+# =================================================================================================
+
+# An enum that represents a regular account with updatable code.
+const.REGULAR_ACCOUNT_UPDATABLE_CODE=0
+
+# An enum that represents a regular account with immutable code.
+const.REGULAR_ACCOUNT_IMMUTABLE_CODE=1
+
+# An enum that represents a fungible faucet with immutable code.
+const.FUNGIBLE_FAUCET_ACCOUNT=2
+
+# An enum that represents a non-fungible faucet with immutable code.
+const.NON_FUNGIBLE_FAUCET_ACCOUNT=3
+
+# PROCEDURES
+# =================================================================================================
+
 #! Computes and returns the account hash from account data stored in memory.
 #!
 #! Stack: []
@@ -65,4 +83,47 @@ end
 #! - H is the initial account hash.
 export.get_initial_hash
     exec.layout::get_init_acct_hash
+end
+
+#! Returns the account type of the account the transaction is being executed against.
+#!
+#! The account type can be of the following forms:
+#! - regular account with updatable code: REGULAR_ACCOUNT
+#! - regular account with immutable code: NON_UPDATABLE_ACCOUNT
+#! - fungible asset faucet account with immutable code: FUNGIBLE_FAUCET_ACCOUNT
+#! - non-fungible asset faucet account with immutable code: NON_FUNGIBLE_FAUCET_ACCOUNT
+#!
+#! Stack: []
+#! Output: [acct_type]
+#!
+#! - acct_type is the account type.
+proc.type
+    # get the account id
+    exec.layout::get_acct_id
+    # => [acct_id]
+
+    # compute the account type
+    u32split swap drop u32checked_shr.30
+    # => [acct_type]
+end
+
+#! Sets the code of the account the transaction is being executed against. This procedure can only
+#! executed on regular accounts with updatable code. Otherwise, this procedure fails.
+#!
+#! Stack: [CODE_ROOT]
+#! Output: []
+#!
+#! - CODE_ROOT is the hash of the code to set.
+export.set_code
+    # get the account type
+    exec.type
+    # => [acct_type, CODE_ROOT]
+
+    # check that the account type is a regular account with updatable code
+    push.REGULAR_ACCOUNT_UPDATABLE_CODE assert_eq
+    # => [CODE_ROOT]
+
+    # set the code root
+    exec.layout::set_new_acct_code_root
+    # => []
 end

--- a/miden-lib/asm/sat/epilogue.masm
+++ b/miden-lib/asm/sat/epilogue.masm
@@ -149,6 +149,26 @@ proc.process_created_notes
     movup.4 drop
 end
 
+# ACCOUNT CODE UPDATE
+# =================================================================================================
+
+#! Updates the account code root if the account code has changed. `NEW_ACCT_CODE_ROOT` is set to
+#! the initial account code root in the prologue and as such this procedure will not result in a
+#! change to the account code root if the `account::set_code` procedure has not been invoked in
+#! this transaction.
+#!
+#! Stack: []
+#! Output: []
+proc.update_account_code
+    # check if the account code root has been updated
+    exec.layout::get_new_acct_code_root
+    # => [NEW_ACCT_CODE_ROOT]
+
+    # set the account code root to the new account code root (may not have changed)
+    exec.layout::set_acct_code_root
+    # => []
+end
+
 # TRANSACTION EPILOGUE PROCEDURE
 # =================================================================================================
 
@@ -164,6 +184,9 @@ end
 #! - CREATED_NOTES_COMMITMENT is the commitment of the created notes
 #! - FINAL_ACCOUNT_HASH is the final account hash
 export.finalize_transaction
+    # update account code
+    exec.update_account_code
+
     # get the initial account hash
     exec.layout::get_init_acct_hash
 

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -98,6 +98,9 @@ const.ACCT_STORAGE_ROOT_PTR=102
 # The memory address at which the account code root is stored
 const.ACCT_CODE_ROOT_PTR=103
 
+# The memory address at which the new account code root is stored
+const.ACCT_NEW_CODE_ROOT_PTR=104
+
 # CONSUMED NOTES DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -432,6 +435,46 @@ end
 export.set_acct_nonce
     padw push.ACCT_ID_AND_NONCE_PTR mem_loadw
     drop movup.3 push.ACCT_ID_AND_NONCE_PTR mem_storew dropw
+end
+
+#! Sets the code root of the account.
+#!
+#! Stack: [CODE_ROOT]
+#! Output: []
+#!
+#! - CODE_ROOT is the code root to be set.
+export.set_acct_code_root
+    push.ACCT_CODE_ROOT_PTR mem_storew dropw
+end
+
+#! Returns the code root of the account.
+#!
+#! Stack: []
+#! Output: [CODE_ROOT]
+#!
+#! - CODE_ROOT is the code root of the account.
+export.get_acct_code_root
+    padw push.ACCT_CODE_ROOT_PTR mem_loadw
+end
+
+#! Stores the new account code root in memory.
+#!
+#! Stack: [CODE_ROOT]
+#! Output: []
+#!
+#! - CODE_ROOT is the new account code root.
+export.set_new_acct_code_root
+    push.ACCT_NEW_CODE_ROOT_PTR mem_storew dropw
+end
+
+#! Returns the new account code root.
+#!
+#! Stack: []
+#! Output: [CODE_ROOT]
+#!
+#! - CODE_ROOT is the new account code root.
+export.get_new_acct_code_root
+    padw push.ACCT_NEW_CODE_ROOT_PTR mem_loadw
 end
 
 # CONSUMED NOTES

--- a/miden-lib/asm/sat/prologue.masm
+++ b/miden-lib/asm/sat/prologue.masm
@@ -166,6 +166,11 @@ proc.process_acct_data
     # store a copy of the initial nonce in global inputs
     exec.layout::get_acct_nonce
     exec.layout::set_init_nonce
+
+    # set the new account code root to the initial account code root
+    # this is used for managing code root updates
+    exec.layout::get_acct_code_root
+    exec.layout::set_new_acct_code_root
 end
 
 # CONSUMED NOTES DATA

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -96,6 +96,9 @@ pub const ACCT_STORAGE_ROOT_PTR: u64 = 102;
 /// The memory address at which the account code root is stored.
 pub const ACCT_CODE_ROOT_PTR: u64 = 103;
 
+/// The memory address at which the new account code root is stored
+pub const ACCT_NEW_CODE_ROOT_PTR: u64 = 104;
+
 // NOTES DATA
 // ------------------------------------------------------------------------------------------------
 

--- a/miden-lib/tests/common/data.rs
+++ b/miden-lib/tests/common/data.rs
@@ -7,7 +7,7 @@ use test_utils::rand;
 
 // MOCK DATA
 // ================================================================================================
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u64 = 0b0110011011u64 << 54;
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = 0b0010011011u64 << 54;
 pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
 
 const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
@@ -86,7 +86,7 @@ pub fn mock_chain_data(merkle_store: &mut MerkleStore, consumed_notes: &mut [Not
 pub fn mock_inputs() -> (MerkleStore, TransactionInputs) {
     // Create an account
     let account_id =
-        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
     let account = Account::new(account_id, &[], "proc.test_proc push.1 end", Felt::ZERO).unwrap();
 
     // Create a Merkle store
@@ -112,7 +112,7 @@ pub fn mock_inputs() -> (MerkleStore, TransactionInputs) {
 pub fn mock_executed_tx() -> (MerkleStore, ExecutedTransaction) {
     // AccountId
     let account_id =
-        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
 
     // Initial Account
     let initial_account =

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -1,7 +1,7 @@
 pub use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
     merkle::{MerkleStore, Mmr, NodeIndex, SimpleSmt},
-    FieldElement, StarkField, ZERO,
+    FieldElement, StarkField, ONE, ZERO,
 };
 pub use miden_lib::{memory, MidenLib};
 pub use miden_objects::{

--- a/miden-lib/tests/test_account.rs
+++ b/miden-lib/tests/test_account.rs
@@ -1,0 +1,71 @@
+pub mod common;
+use common::{
+    data::mock_inputs,
+    memory::{ACCT_CODE_ROOT_PTR, ACCT_NEW_CODE_ROOT_PTR},
+    run_within_tx_kernel, Felt, MemAdviceProvider, ONE, ZERO,
+};
+
+#[test]
+pub fn test_set_code_is_not_immediate() {
+    let (merkle_store, inputs) = mock_inputs();
+    let code = "
+        use.miden::sat::prologue
+        use.miden::sat::account
+        begin
+            exec.prologue::prepare_transaction
+            push.1.2.3.4
+            exec.account::set_code
+        end
+        ";
+    let process = run_within_tx_kernel(
+        "",
+        code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        None,
+        None,
+    );
+
+    // assert the code root is not changed
+    assert_eq!(
+        process.get_memory_value(0, ACCT_CODE_ROOT_PTR).unwrap(),
+        inputs.account().code().root().as_elements()
+    );
+
+    // assert the new code root is cached
+    assert_eq!(
+        process.get_memory_value(0, ACCT_NEW_CODE_ROOT_PTR).unwrap(),
+        [ONE, Felt::new(2), Felt::new(3), Felt::new(4)]
+    );
+}
+
+#[test]
+pub fn test_set_code_succeeds() {
+    let (merkle_store, inputs) = mock_inputs();
+    let code = "
+        use.miden::sat::account
+        use.miden::sat::prologue
+        use.miden::sat::epilogue
+
+        begin
+            exec.prologue::prepare_transaction
+            push.0.1.2.3
+            exec.account::set_code
+            exec.epilogue::finalize_transaction
+        end
+        ";
+    let process = run_within_tx_kernel(
+        "",
+        code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        None,
+        None,
+    );
+
+    // assert the code root is changed after the epilogue
+    assert_eq!(
+        process.get_memory_value(0, ACCT_CODE_ROOT_PTR).unwrap(),
+        [ZERO, ONE, Felt::new(2), Felt::new(3)]
+    );
+}

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -1,7 +1,7 @@
 pub mod common;
 use common::{
     consumed_note_data_ptr,
-    data::{mock_inputs, ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN, NONCE},
+    data::{mock_inputs, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN, NONCE},
     memory::{
         ACCT_CODE_ROOT_PTR, ACCT_ID_AND_NONCE_PTR, ACCT_ID_PTR, ACCT_STORAGE_ROOT_PTR,
         ACCT_VAULT_ROOT_PTR, BATCH_ROOT_PTR, BLK_HASH_PTR, BLOCK_NUM_PTR, CHAIN_MMR_NUM_LEAVES_PTR,
@@ -143,7 +143,7 @@ fn account_data_memory_assertions<A: AdviceProvider>(
     // The account id should be stored at ACCT_ID_AND_NONCE_PTR[0]
     assert_eq!(
         process.get_memory_value(0, ACCT_ID_AND_NONCE_PTR).unwrap()[0],
-        Felt::new(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN)
+        Felt::new(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN)
     );
 
     // The account nonce should be stored at ACCT_ID_AND_NONCE_PTR[3]


### PR DESCRIPTION
This PR introduces the `set_code` procedure.  We also introduce a `type` procedure which returns the type of the account.  We should consider if we want to expose this publicly or keep it private?