### PR TITLE
Add get assets procedure

### DIFF
--- a/miden-lib/asm/sat/note.masm
+++ b/miden-lib/asm/sat/note.masm
@@ -1,6 +1,9 @@
+use.std::crypto::hashes::native
+use.std::mem
+
 use.miden::sat::layout
 
-#! Returns the sender of the note currently being processed. Returns 0 if a note is not being
+#! Returns the sender of the note currently being processed. Panics if a note is not being
 #! processed.
 #!
 #! Inputs: []
@@ -12,15 +15,85 @@ export.get_sender
     exec.layout::get_current_consumed_note_ptr
     # => [ptr]
 
-    # check if the pointer is zero
-    dup neq.0
-    # => [is_not_zero, ptr]
+    # assert the pointer is not zero - this would suggest the procedure has been called from an 
+    # incorrect context
+    dup neq.0 assert
+    # => [ptr]
 
-    if.true
-        # get the sender from the note pointer
-        exec.layout::get_consumed_note_sender
-        # => [sender]
-    end
-
+    # get the sender from the note pointer
+    exec.layout::get_consumed_note_sender
     # => [sender]
+end
+
+#! Returns the number of assets and vault hash of the note currently being processed. Panics if a
+#! note is not being processed.
+#!
+#! Inputs: []
+#! Outputs: [num_assets, VAULT_HASH]
+#!
+#! - num_assets is the number of assets in the note currently being processed.
+#! - VAULT_HASH is the vault hash of the note currently being processed.
+export.get_vault_data
+    # get the current consumed note pointer
+    exec.layout::get_current_consumed_note_ptr
+    # => [ptr]
+
+    # assert the pointer is not zero - this would suggest the procedure has been called from an 
+    # incorrect context
+    dup neq.0 assert
+    # => [ptr]
+
+    # get the number of assets in the note
+    dup exec.layout::get_consumed_note_num_assets
+    # => [num_assets, ptr]
+
+    # get the vault hash from the note pointer
+    swap exec.layout::get_consumed_note_vault_root
+    # => [VAULT_HASH, num_assets]
+end
+
+#! Writes the assets of the currently executing note into memory starting at the specified address.
+#!
+#! Inputs: [dest_ptr]
+#! Outputs: [num_assets, dest_ptr]
+#!
+#! - dest_ptr is the memory address to write the assets.
+#! - num_assets is the number of assets in the currently executing note.
+export.get_assets
+    # TODO: This needs to be changed to a syscall and moved to user facing api
+    # get the current consumed note vault hash
+    exec.get_vault_data
+    # => [VAULT_HASH, num_assets, dest_ptr]
+
+    # load the vault data from the advice map to the advice stack
+    adv.keyval
+    # => [VAULT_HASH, num_assets, dest_ptr]
+
+    # calculate number of assets rounded up to an even number
+    dup.4 dup is_odd add
+    # => [even_num_assets, VAULT_HASH, num_assets, dest_ptr]
+
+    # calculate the start and end pointer for reading to memory
+    dup.6 add dup.6
+    # => [start_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
+
+    # prepare the stack for reading from the advice stack
+    padw padw padw
+    # => [PAD, PAD, PAD, start_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
+    
+    # read the assets from advice stack to memory
+    exec.mem::pipe_double_words_to_memory
+    # => [PERM, PERM, PERM, end_ptr', end_ptr, VAULT_HASH, num_assets, dest_ptr]
+
+    # extract the digest
+    exec.native::state_to_digest
+    # => [DIGEST, end_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
+
+    # drop pointers fro reading from memory
+    movup.4 drop
+    # => [DIGEST, VAULT_HASH, num_assets, dest_ptr]
+
+    # assert the vault hash is what we expect
+    assert_eqw
+    # => [num_assets, dest_ptr]
 end

--- a/miden-lib/asm/sat/note_setup.masm
+++ b/miden-lib/asm/sat/note_setup.masm
@@ -27,20 +27,33 @@ end
 export.prepare_note.4
     # convert the index of the consumed note being executed to a pointer and store in memory
     exec.layout::get_consumed_note_ptr 
+    # => [note_ptr]
+
+    # set current consumed note pointer to the note being executed
     exec.layout::set_current_consumed_note_ptr
+    # => []
 
     # load the note inputs from the advice provider
     # TODO: optimize this to load items directly onto the stack.
     locaddr.0 padw padw padw adv_pipe adv_pipe
+    # => [PERM, PERM, PERM, addr']
 
     # extract inputs hash and assert it matches commitment stored in memory
     dropw swapw dropw
-    exec.get_current_note_inputs_hash
-    assert_eqw
+    # => [DIG, addr']
+
+    # assert the inputs hash matches the commitment stored in memory
+    exec.get_current_note_inputs_hash assert_eqw
+    # => [addr']
+
+    # drop the addr
+    drop
+    # => []
 
     # read the note inputs onto the stack
     padw loc_loadw.0
     padw loc_loadw.1
     padw loc_loadw.2
     padw loc_loadw.3
+    # => [i15, i14, ..., i0]
 end

--- a/miden-lib/tests/test_note.rs
+++ b/miden-lib/tests/test_note.rs
@@ -1,0 +1,218 @@
+pub mod common;
+use common::{
+    data::mock_inputs, procedures::prepare_word, run_within_tx_kernel, Felt, MemAdviceProvider,
+};
+
+#[test]
+fn test_get_sender_no_sender() {
+    let (merkle_store, inputs) = mock_inputs();
+
+    // calling get_sender should return sender
+    let code = "
+        use.miden::sat::prologue
+        use.miden::sat::note_setup
+        use.miden::sat::note
+
+        begin
+            exec.prologue::prepare_transaction
+            exec.note::get_sender
+        end
+        ";
+    let process = run_within_tx_kernel(
+        "",
+        code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        None,
+        None,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_get_sender() {
+    let (merkle_store, inputs) = mock_inputs();
+
+    // calling get_sender should return sender
+    let code = "
+        use.miden::sat::prologue
+        use.miden::sat::note_setup
+        use.miden::sat::note
+
+        begin
+            exec.prologue::prepare_transaction
+            push.0
+            exec.note_setup::prepare_note
+            dropw dropw dropw dropw
+            exec.note::get_sender
+        end
+        ";
+    let process = run_within_tx_kernel(
+        "",
+        code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        None,
+        None,
+    )
+    .unwrap();
+
+    let sender = inputs.consumed_notes()[0].metadata().sender().into();
+    assert_eq!(process.stack.get(0), sender);
+}
+
+#[test]
+fn test_get_vault_data() {
+    let (merkle_store, inputs) = mock_inputs();
+
+    // for (i, note) in inputs.consumed_notes().iter().enumerate() {
+    let notes = &inputs.consumed_notes();
+    // calling get_vault_data should return vault data
+    let code = format!(
+        "
+        use.miden::sat::prologue
+        use.miden::sat::note_setup
+        use.miden::sat::note
+        use.miden::sat::layout
+
+        begin
+            exec.prologue::prepare_transaction
+
+            # prepare note 0
+            push.0
+            exec.note_setup::prepare_note
+            
+            # drop the note inputs
+            dropw dropw dropw dropw
+
+            # get the vault data
+            exec.note::get_vault_data
+
+            # assert the vault data is correct
+            push.{note_0_vault_root} assert_eqw
+            push.{note_0_num_assets} assert_eq
+
+            # prepare note 1
+            push.1
+            exec.note_setup::prepare_note
+
+            # drop the note inputs
+            dropw dropw dropw dropw
+
+            # get the vault data
+            exec.note::get_vault_data
+
+            # assert the vault data is correct
+            push.{note_1_vault_root} assert_eqw
+            push.{note_1_num_assets} assert_eq
+        end
+        ",
+        note_0_vault_root = prepare_word(&notes[0].vault().hash()),
+        note_0_num_assets = notes[0].vault().num_assets(),
+        note_1_vault_root = prepare_word(&notes[1].vault().hash()),
+        note_1_num_assets = notes[1].vault().num_assets(),
+    );
+
+    // run to ensure success
+    let _process = run_within_tx_kernel(
+        "",
+        &code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(
+            inputs.advice_provider_inputs().with_merkle_store(merkle_store.clone()),
+        ),
+        None,
+        None,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_get_assets() {
+    let (merkle_store, inputs) = mock_inputs();
+
+    const DEST_POINTER_NOTE_0: u64 = 100000000;
+    const DEST_POINTER_NOTE_1: u64 = 200000000;
+
+    let notes = inputs.consumed_notes();
+
+    // calling get_assets should return assets at the specified address
+    let code = format!(
+        "
+        use.miden::sat::prologue
+        use.miden::sat::note_setup
+        use.miden::sat::note
+
+        begin
+            # prepare tx
+            exec.prologue::prepare_transaction
+
+            # prepare note 0
+            push.0
+            exec.note_setup::prepare_note
+
+            # drop the note inputs
+            dropw dropw dropw dropw
+
+            # set the destination pointer for note 0 assets
+            push.{DEST_POINTER_NOTE_0}
+
+            # get the assets
+            exec.note::get_assets
+
+            # assert the number of assets is correct
+            eq.{note_0_num_assets} assert
+
+            # assert the pointer is returned
+            eq.{DEST_POINTER_NOTE_0} assert
+
+            # prepare note 1
+            push.1
+            exec.note_setup::prepare_note
+
+            # drop the note inputs
+            dropw dropw dropw dropw
+
+            # set the destination pointer for note 1 assets
+            push.{DEST_POINTER_NOTE_1}
+
+            # get the assets
+            exec.note::get_assets
+
+            # assert the number of assets is correct
+            eq.{note_1_num_assets} assert
+
+            # assert the pointer is returned
+            eq.{DEST_POINTER_NOTE_1} assert
+        end
+        ",
+        note_0_num_assets = notes[0].vault().num_assets(),
+        note_1_num_assets = notes[1].vault().num_assets(),
+    );
+
+    let process = run_within_tx_kernel(
+        "",
+        &code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        None,
+        None,
+    )
+    .unwrap();
+
+    // check the assets saved to memory for note 0 are correct
+    for (asset, idx) in notes[0].vault().iter().zip(0u64..) {
+        assert_eq!(
+            process.get_memory_value(0, DEST_POINTER_NOTE_0 + idx).unwrap(),
+            <[Felt; 4]>::from(*asset)
+        );
+    }
+
+    // check the assets saved to memory for note 1 are correct
+    for (asset, idx) in notes[1].vault().iter().zip(0u64..) {
+        assert_eq!(
+            process.get_memory_value(0, DEST_POINTER_NOTE_1 + idx).unwrap(),
+            <[Felt; 4]>::from(*asset)
+        );
+    }
+}

--- a/miden-lib/tests/test_note_setup.rs
+++ b/miden-lib/tests/test_note_setup.rs
@@ -2,7 +2,7 @@ pub mod common;
 use common::{
     consumed_note_data_ptr, data::mock_inputs, memory::CURRENT_CONSUMED_NOTE_PTR,
     run_within_tx_kernel, AdviceProvider, Felt, FieldElement, MemAdviceProvider, Process,
-    TX_KERNEL_DIR, ZERO,
+    TX_KERNEL_DIR,
 };
 use miden_objects::transaction::TransactionInputs;
 
@@ -49,54 +49,4 @@ fn note_setup_memory_assertions<A: AdviceProvider>(process: &Process<A>) {
         process.get_memory_value(0, CURRENT_CONSUMED_NOTE_PTR).unwrap()[0],
         Felt::try_from(consumed_note_data_ptr(0)).unwrap()
     );
-}
-
-#[test]
-fn test_get_sender_no_sender() {
-    let (merkle_store, inputs) = mock_inputs();
-    let imports = "use.miden::sat::prologue\nuse.miden::sat::note\n";
-
-    // calling get_sender before prepare note should return 0
-    let code = "
-        begin
-            exec.prologue::prepare_transaction
-            exec.note::get_sender
-        end
-        ";
-    let process = run_within_tx_kernel(
-        imports,
-        code,
-        inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
-        Some(TX_KERNEL_DIR),
-        Some(NOTE_SETUP_FILE),
-    )
-    .unwrap();
-    assert_eq!(process.stack.get(0), ZERO);
-}
-
-#[test]
-fn test_get_sender() {
-    let (merkle_store, inputs) = mock_inputs();
-    let imports = "use.miden::sat::prologue\nuse.miden::sat::note\n";
-
-    // calling get_sender should return sender
-    let code = "
-        begin
-            exec.prologue::prepare_transaction
-            exec.prepare_note
-            exec.note::get_sender
-        end
-        ";
-    let process = run_within_tx_kernel(
-        imports,
-        code,
-        inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
-        Some(TX_KERNEL_DIR),
-        Some(NOTE_SETUP_FILE),
-    )
-    .unwrap();
-    let sender = inputs.consumed_notes()[0].metadata().sender().into();
-    assert_eq!(process.stack.get(0), sender);
 }

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -216,14 +216,7 @@ impl From<&Note> for Vec<Felt> {
         out.extend_from_slice(note.inputs.hash().as_elements());
         out.extend_from_slice(note.vault.hash().as_elements());
         out.extend_from_slice(&Word::from(note.metadata()));
-        let assets: Vec<Felt> =
-            note.vault.iter().flat_map(|asset| <[Felt; 4]>::from(*asset)).collect();
-        out.extend(assets);
-
-        // pad with an empty word if we have an odd number of assets
-        if note.vault.num_assets() % 2 == 1 {
-            out.extend_from_slice(&Word::default());
-        }
+        out.extend(note.vault.to_padded_assets());
 
         // TODO: this is a temporary solution - replace with TryFrom
         let origin = note.origin().as_ref().unwrap();

--- a/objects/src/notes/vault.rs
+++ b/objects/src/notes/vault.rs
@@ -1,4 +1,4 @@
-use super::{Asset, Digest, Hasher, NoteError, Vec, Word, WORD_SIZE};
+use super::{Asset, Digest, Felt, Hasher, NoteError, Vec, Word, WORD_SIZE, ZERO};
 
 // NOTE VAULT
 // ================================================================================================
@@ -86,5 +86,25 @@ impl NoteVault {
     /// Returns an iterator over the assets of this vault.
     pub fn iter(&self) -> core::slice::Iter<Asset> {
         self.assets.iter()
+    }
+
+    pub fn to_padded_assets(&self) -> Vec<Felt> {
+        // if we have an odd number of assets with pad with a single word.
+        let padded_len = if self.assets.len() % 2 == 0 {
+            self.assets.len() * WORD_SIZE
+        } else {
+            (self.assets.len() + 1) * WORD_SIZE
+        };
+
+        // allocate a vector to hold the padded assets
+        let mut padded_assets = Vec::with_capacity(padded_len * WORD_SIZE);
+
+        // populate the vector with the assets
+        padded_assets.extend(self.assets.iter().flat_map(|asset| <[Felt; 4]>::from(*asset)));
+
+        // pad with an empty word if we have an odd number of assets
+        padded_assets.resize(padded_len, ZERO);
+
+        padded_assets
     }
 }

--- a/objects/src/transaction/utils.rs
+++ b/objects/src/transaction/utils.rs
@@ -62,10 +62,15 @@ pub fn generate_advice_provider_inputs(
     let account: [Felt; 16] = account.into();
     advice_stack.extend(account);
 
-    // insert consumed notes data
+    // insert consumed notes data to advice stack
     advice_stack.push(Felt::new(notes.len() as u64));
     let note_data: Vec<Felt> = notes.iter().flat_map(<Vec<Felt>>::from).collect();
     advice_stack.extend(note_data);
+
+    // insert consumed note assets data to advice map
+    for note in notes.iter() {
+        advice_map.insert(note.vault().hash().into_bytes(), note.vault().to_padded_assets());
+    }
 
     // insert consumed notes inputs
     let note_inputs: Vec<Felt> =


### PR DESCRIPTION
This PR introduces the `get_assets` procedure and the `get_vault_data` procedure it depends on. We also modify `get_sender` procedure to panic when it is called from an incorrect context (e.g. tx script) such that it is consistent with other note procedures.