### PR TITLE
Add storage procedures

### DIFF
--- a/miden-lib/asm/sat/account.masm
+++ b/miden-lib/asm/sat/account.masm
@@ -18,6 +18,9 @@ const.NON_FUNGIBLE_FAUCET_ACCOUNT=3
 # Specifies a minimum number of ones for a valid account ID.
 const.MIN_ACCOUNT_ONES=5
 
+# The depth of the account storage sparse merkle tree
+const.STORAGE_TREE_DEPTH=8
+
 # PROCEDURES
 # =================================================================================================
 
@@ -217,4 +220,48 @@ export.set_code
     # set the code root
     exec.layout::set_new_acct_code_root
     # => []
+end
+
+#! Gets an item from the account storage. Panics if the index is out of bounds.
+#!
+#! Stack: [index]
+#! Output: [VALUE]
+#!
+#! - index is the index of the item to get.
+#! - VALUE is the value of the item.
+export.get_item
+    # get the storage root
+    exec.layout::get_acct_storage_root
+    # => [storage_root, index]
+
+    # get the item from storage
+    movup.4 push.STORAGE_TREE_DEPTH mtree_get
+    # => [VALUE, ROOT]
+
+    # drop the root
+    swapw dropw
+    # => [VALUE]
+end
+
+#! Sets an item in the account storage. Panics if the index is out of bounds.
+#!
+#! Stack: [index, V']
+#! Output: [R', V]
+#!
+#! - index is the index of the item to set.
+#! - V' is the value to set.
+#! - V is the previous value of the item.
+#! - R' is the new storage root.
+export.set_item
+    # get the storage root
+    exec.layout::get_acct_storage_root
+    # => [R, index, V']
+
+    # set the item in storage
+    movup.4 push.STORAGE_TREE_DEPTH mtree_set
+    # => [V, R']
+
+    # set the new storage root
+    swapw exec.layout::set_acct_storage_root
+    # => [V]
 end

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -485,6 +485,26 @@ export.get_new_acct_code_root
     padw push.ACCT_NEW_CODE_ROOT_PTR mem_loadw
 end
 
+#! Returns the account storage root.
+#!
+#! Stack: []
+#! Output: [STORAGE_ROOT]
+#!
+#! - STORAGE_ROOT is the account storage root.
+export.get_acct_storage_root
+    padw push.ACCT_STORAGE_ROOT_PTR mem_loadw
+end
+
+#! Sets the account storage root.
+#!
+#! Stack: [STORAGE_ROOT]
+#! Output: []
+#!
+#! - STORAGE_ROOT is the account storage root.
+export.set_acct_storage_root
+    push.ACCT_STORAGE_ROOT_PTR mem_storew dropw
+end
+
 # CONSUMED NOTES
 # -------------------------------------------------------------------------------------------------
 

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -8,7 +8,7 @@ pub use miden_objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteOrigin, NoteVault, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
     transaction::{ExecutedTransaction, ProvenTransaction, TransactionInputs},
-    Account, AccountId, AccountType, BlockHeader,
+    Account, AccountId, AccountStorage, AccountType, BlockHeader, StorageItem,
 };
 use miden_stdlib::StdLibrary;
 pub use processor::{

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -159,7 +159,7 @@ fn account_data_memory_assertions<A: AdviceProvider>(
     // The account storage root commitment should be stored at ACCT_STORAGE_ROOT_PTR
     assert_eq!(
         process.get_memory_value(0, ACCT_STORAGE_ROOT_PTR).unwrap(),
-        inputs.account().storage().root().as_elements()
+        inputs.account().storage().root()
     );
 
     // The account code commitment should be stored at (ACCOUNT_DATA_OFFSET + 4)

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,5 +1,6 @@
 use super::{
-    assets::Asset, AccountError, Digest, Felt, Hasher, StarkField, ToString, Vec, Word, ZERO,
+    assets::Asset, AccountError, BTreeSet, Digest, Felt, Hasher, StarkField, ToString, Vec, Word,
+    ZERO,
 };
 
 mod account_id;
@@ -10,7 +11,7 @@ pub use code::AccountCode;
 
 mod storage;
 pub use storage::AccountStorage;
-use storage::StorageItem;
+pub use storage::StorageItem;
 
 mod vault;
 pub use vault::AccountVault;
@@ -57,14 +58,14 @@ impl Account {
     /// Returns an error if compilation of the source code fails.
     pub fn new(
         id: AccountId,
-        storage_items: &[StorageItem],
+        storage: AccountStorage,
         code_source: &str,
         nonce: Felt,
     ) -> Result<Self, AccountError> {
         Ok(Self {
             id,
             vault: AccountVault::default(),
-            storage: AccountStorage::new(storage_items),
+            storage,
             code: AccountCode::new(code_source)?,
             nonce,
         })
@@ -82,7 +83,7 @@ impl Account {
         elements[0] = *self.id;
         elements[3] = self.nonce;
         elements[4..8].copy_from_slice(self.vault.root().as_elements());
-        elements[8..12].copy_from_slice(self.storage.root().as_elements());
+        elements[8..12].copy_from_slice(&self.storage.root());
         elements[12..].copy_from_slice(self.code.root().as_elements());
         Hasher::hash_elements(&elements)
     }
@@ -147,7 +148,7 @@ impl From<&Account> for [Felt; 16] {
         elements[0] = *account.id;
         elements[3] = account.nonce;
         elements[4..8].copy_from_slice(account.vault.root().as_elements());
-        elements[8..12].copy_from_slice(account.storage.root().as_elements());
+        elements[8..12].copy_from_slice(&account.storage.root());
         elements[12..].copy_from_slice(account.code.root().as_elements());
         elements
     }

--- a/objects/src/accounts/storage.rs
+++ b/objects/src/accounts/storage.rs
@@ -1,47 +1,91 @@
-use super::{Digest, Hasher, Word, ZERO};
+use super::{AccountError, BTreeSet, Word};
+use crypto::merkle::{MerkleStore, NodeIndex, SimpleSmt};
 
 // TYPE ALIASES
 // ================================================================================================
 
-pub type StorageItem = (Word, Word);
+pub type StorageItem = (u8, Word);
 
 // ACCOUNT STORAGE
 // ================================================================================================
 
-/// Account storage is a key-value map where both keys and values are words (4 elements).
-///
-/// Internally, account storage uses a compact Sparse Merkle tree to store the data. To ensure that
-/// the data is randomly distributed across the tree, the index of item in the tree is derived by
-/// hashing the key.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Account storage is composed of two components. The first component is a simple sparse Merkle
+/// tree of depth 8 which is index addressable. This provides the user with 256 Word slots. Users
+/// that require additional storage can use the second component which is a `MerkleStore`. This
+/// will allow the user to store any Merkle structures they need.  This is achieved by storing the
+/// root of the Merkle structure as a leaf in the simple sparse merkle tree. When `AccountStorage`
+/// is serialized it will check to see if any of the leafs in the simple sparse Merkle tree are
+/// Merkle roots of other Merkle structures.  If any Merkle roots are found then the Merkle
+/// structures will be persisted in the `AccountStorage` `MerkleStore`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountStorage {
-    // TODO: add compact SMT as backing storage
+    slots: SimpleSmt,
+    store: MerkleStore,
 }
 
 impl AccountStorage {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// Depth of the storage tree.
+    pub const STORAGE_TREE_DEPTH: u8 = 8;
+
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new instance of account storage initialized with the provided items.
-    pub fn new(_items: &[StorageItem]) -> Self {
-        Self {}
+    pub fn new(
+        items: Vec<StorageItem>,
+        store: MerkleStore,
+    ) -> Result<AccountStorage, AccountError> {
+        // make sure there are no duplicate items for the same index
+        let mut unique = BTreeSet::new();
+        let unique = items.iter().all(move |item| unique.insert(item.0));
+        if !unique {
+            return Err(AccountError::DuplicateStorageItems);
+        }
+
+        // construct storage slots smt
+        let slots = SimpleSmt::new(Self::STORAGE_TREE_DEPTH)
+            .expect("depth is valid")
+            .with_leaves(items.into_iter().map(|x| (x.0 as u64, x.1)))
+            .expect("`StorageItem` index is u8 - index within range");
+        Ok(Self { slots, store })
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
     /// Returns a commitment to this storage.
-    pub fn root(&self) -> Digest {
-        Digest::default()
+    pub fn root(&self) -> Word {
+        self.slots.root()
     }
 
-    /// Returns an item from the storage at the specified key. Both items and keys are Words which
-    /// consist of 4 field elements.
+    /// Returns an item from the storage at the specified index.
     ///
     /// If the item is not present in the storage, [ZERO; 4] is returned.
-    pub fn get_item(&self, key: Word) -> Word {
-        // the index of the item is the hash of its key
-        let _index: Word = Hasher::merge(&[key.into(), [ZERO; 4].into()]).into();
-        todo!("retrieve the item from the tree");
+    pub fn get_item(&self, index: u8) -> Word {
+        let item_index = NodeIndex::new(Self::STORAGE_TREE_DEPTH, index as u64)
+            .expect("index is u8 - index within range");
+        self.slots.get_node(item_index).expect("index is u8 - index within range")
+    }
+
+    /// Sets an item from the storage at the specified index.
+    pub fn set_item(&mut self, index: u8, value: Word) -> Word {
+        let old_value = self.get_item(index);
+        self.slots
+            .insert_leaf(index as u64, value)
+            .expect("index is u8 - index within range");
+        old_value
+    }
+
+    /// Returns a reference to the sparse Merkle tree that backs the storage slots.
+    pub fn slots(&self) -> &SimpleSmt {
+        &self.slots
+    }
+
+    /// Returns a reference to the Merkle store that backs the storage.
+    pub fn store(&self) -> &MerkleStore {
+        &self.store
     }
 
     /// Returns a list of items contained in this storage.

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -14,6 +14,7 @@ pub enum AccountError {
     FungibleFaucetIdInvalidFirstBit,
     NotAFungibleFaucetId(AccountId),
     NotANonFungibleAsset(Asset),
+    DuplicateStorageItems,
 }
 
 impl AccountError {

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -7,14 +7,16 @@ use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
     merkle::Mmr,
     utils::{
-        collections::Vec,
+        collections::{BTreeSet, Vec},
         string::{String, ToString},
     },
     Felt, StarkField, Word, WORD_SIZE, ZERO,
 };
 
 mod accounts;
-pub use accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault};
+pub use accounts::{
+    Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault, StorageItem,
+};
 
 pub mod assets;
 pub mod notes;


### PR DESCRIPTION
This PR changes `AccountStorage` such that it is implemented as described in #92.  We introduce storage procedures to get and set account storage items. 