### PR TITLE
Introduce `AdviceProviderBuilder` and `ToAdviceInputs` traits

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -20,7 +20,7 @@ assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMide
 processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
 
 [dev-dependencies]
-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "frisitano-mmr-accumulator", default-features = false }
+crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects"}
 miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
 processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", features = ["internals"] }

--- a/miden-lib/asm/sat/note_setup.masm
+++ b/miden-lib/asm/sat/note_setup.masm
@@ -3,17 +3,6 @@ use.miden::sat::layout
 # NOTE SETUP SCRIPT
 # =================================================================================================
 
-#! Reads and returns the inputs hash for the consumed note being executed.
-#!
-#! Stack: []
-#! Output: [inputs_hash]
-#!
-#! inputs_hash is the sequential hash of the inputs of the consumed note being executed.
-proc.get_current_note_inputs_hash
-    exec.layout::get_current_consumed_note_ptr
-    exec.layout::get_consumed_note_inputs_hash
-end
-
 #! Prepares the virtual machine for execution of a consumed note.  This involves:
 #! 1. Updating the current consumed note pointer.
 #! 2. Loading the note inputs from the advice provider.
@@ -30,24 +19,24 @@ export.prepare_note.4
     # => [note_ptr]
 
     # set current consumed note pointer to the note being executed
-    exec.layout::set_current_consumed_note_ptr
-    # => []
+    dup exec.layout::set_current_consumed_note_ptr
+    # => [note_ptr]
+
+    # load the note inputs on to the advice stack
+    exec.layout::get_consumed_note_inputs_hash adv.keyval
+    # => [INPUTS_HASH]
 
     # load the note inputs from the advice provider
     # TODO: optimize this to load items directly onto the stack.
     locaddr.0 padw padw padw adv_pipe adv_pipe
-    # => [PERM, PERM, PERM, addr']
+    # => [PERM, PERM, PERM, addr', INPUTS_HASH]
 
     # extract inputs hash and assert it matches commitment stored in memory
-    dropw swapw dropw
-    # => [DIG, addr']
+    dropw swapw dropw movup.4 drop
+    # => [DIG, INPUTS_HASH]
 
     # assert the inputs hash matches the commitment stored in memory
-    exec.get_current_note_inputs_hash assert_eqw
-    # => [addr']
-
-    # drop the addr
-    drop
+    assert_eqw
     # => []
 
     # read the note inputs onto the stack

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -1,6 +1,6 @@
 pub use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
-    merkle::{MerkleStore, Mmr, NodeIndex, SimpleSmt},
+    merkle::{MerkleStore, NodeIndex, SimpleSmt},
     FieldElement, StarkField, ONE, ZERO,
 };
 pub use miden_lib::{memory, MidenLib};
@@ -8,7 +8,7 @@ pub use miden_objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteOrigin, NoteVault, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
     transaction::{ExecutedTransaction, ProvenTransaction, TransactionInputs},
-    Account, AccountId, AccountStorage, AccountType, BlockHeader, StorageItem,
+    Account, AccountId, AccountStorage, AccountType, BlockHeader, ChainMmr, StorageItem,
 };
 use miden_stdlib::StdLibrary;
 pub use processor::{

--- a/miden-lib/tests/test_account.rs
+++ b/miden-lib/tests/test_account.rs
@@ -24,7 +24,8 @@ const ACCOUNT_ID_INSUFFICIENT_ONES: u64 = 0b1100000110 << 54;
 
 #[test]
 pub fn test_set_code_is_not_immediate() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
+
     let code = "
         use.miden::sat::prologue
         use.miden::sat::account
@@ -38,7 +39,7 @@ pub fn test_set_code_is_not_immediate() {
         "",
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )
@@ -59,7 +60,7 @@ pub fn test_set_code_is_not_immediate() {
 
 #[test]
 pub fn test_set_code_succeeds() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
     let code = "
         use.miden::sat::account
         use.miden::sat::prologue
@@ -76,7 +77,7 @@ pub fn test_set_code_succeeds() {
         "",
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )
@@ -169,7 +170,7 @@ fn test_validate_id_fails_on_insuficcient_ones() {
 #[test]
 fn test_get_item() {
     for storage_item in [STORAGE_ITEM_0, STORAGE_ITEM_1] {
-        let (merkle_store, inputs) = mock_inputs();
+        let inputs = mock_inputs();
         let code = format!(
             "
         use.miden::sat::account
@@ -198,9 +199,7 @@ fn test_get_item() {
             "",
             &code,
             StackInputs::from(inputs.stack_inputs()),
-            MemAdviceProvider::from(
-                inputs.advice_provider_inputs().with_merkle_store(merkle_store),
-            ),
+            MemAdviceProvider::from(inputs.advice_provider_inputs()),
             None,
             None,
         )
@@ -210,7 +209,7 @@ fn test_get_item() {
 
 #[test]
 fn test_get_child_tree_item() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
     let code = format!(
         "
         use.miden::sat::account
@@ -243,7 +242,7 @@ fn test_get_child_tree_item() {
         "",
         &code,
         StackInputs::from(inputs.stack_inputs()),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )
@@ -252,7 +251,7 @@ fn test_get_child_tree_item() {
 
 #[test]
 fn test_set_item() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
 
     // copy the initial account slots (SMT)
     let mut account_smt = inputs.account().storage().slots().clone();
@@ -301,7 +300,7 @@ fn test_set_item() {
         "",
         &code,
         StackInputs::from(inputs.stack_inputs()),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )

--- a/miden-lib/tests/test_epilogue.rs
+++ b/miden-lib/tests/test_epilogue.rs
@@ -10,7 +10,7 @@ const EPILOGUE_FILE: &str = "epilogue.masm";
 
 #[test]
 fn test_epilogue() {
-    let (merkle_store, executed_transaction) = mock_executed_tx();
+    let executed_transaction = mock_executed_tx();
 
     let created_notes_data_procedure =
         created_notes_data_procedure(executed_transaction.created_notes());
@@ -32,9 +32,7 @@ fn test_epilogue() {
         imports,
         &code,
         executed_transaction.stack_inputs(),
-        MemAdviceProvider::from(
-            executed_transaction.advice_provider_inputs().with_merkle_store(merkle_store),
-        ),
+        MemAdviceProvider::from(executed_transaction.advice_provider_inputs()),
         Some(TX_KERNEL_DIR),
         Some(EPILOGUE_FILE),
     )
@@ -61,7 +59,7 @@ fn test_epilogue() {
 
 #[test]
 fn test_compute_created_note_hash() {
-    let (_merkle_store, executed_transaction) = mock_executed_tx();
+    let executed_transaction = mock_executed_tx();
 
     let created_notes_data_procedure =
         created_notes_data_procedure(executed_transaction.created_notes());

--- a/miden-lib/tests/test_note.rs
+++ b/miden-lib/tests/test_note.rs
@@ -5,7 +5,7 @@ use common::{
 
 #[test]
 fn test_get_sender_no_sender() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
 
     // calling get_sender should return sender
     let code = "
@@ -22,7 +22,7 @@ fn test_get_sender_no_sender() {
         "",
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     );
@@ -31,7 +31,7 @@ fn test_get_sender_no_sender() {
 
 #[test]
 fn test_get_sender() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
 
     // calling get_sender should return sender
     let code = "
@@ -51,7 +51,7 @@ fn test_get_sender() {
         "",
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )
@@ -63,7 +63,7 @@ fn test_get_sender() {
 
 #[test]
 fn test_get_vault_data() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
 
     // for (i, note) in inputs.consumed_notes().iter().enumerate() {
     let notes = &inputs.consumed_notes();
@@ -118,9 +118,7 @@ fn test_get_vault_data() {
         "",
         &code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(
-            inputs.advice_provider_inputs().with_merkle_store(merkle_store.clone()),
-        ),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )
@@ -129,7 +127,7 @@ fn test_get_vault_data() {
 
 #[test]
 fn test_get_assets() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
 
     const DEST_POINTER_NOTE_0: u64 = 100000000;
     const DEST_POINTER_NOTE_1: u64 = 200000000;
@@ -194,7 +192,7 @@ fn test_get_assets() {
         "",
         &code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         None,
         None,
     )

--- a/miden-lib/tests/test_note_setup.rs
+++ b/miden-lib/tests/test_note_setup.rs
@@ -10,7 +10,7 @@ const NOTE_SETUP_FILE: &str = "note_setup.masm";
 
 #[test]
 fn test_note_setup() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
     let imports = "use.miden::sat::prologue\n";
     let code = "
         begin
@@ -22,7 +22,7 @@ fn test_note_setup() {
         imports,
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         Some(TX_KERNEL_DIR),
         Some(NOTE_SETUP_FILE),
     )

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -16,7 +16,7 @@ const PROLOGUE_FILE: &str = "prologue.masm";
 
 #[test]
 fn test_transaction_prologue() {
-    let (merkle_store, inputs) = mock_inputs();
+    let inputs = mock_inputs();
     let code = "
         begin
             exec.prepare_transaction
@@ -26,7 +26,7 @@ fn test_transaction_prologue() {
         "",
         code,
         inputs.stack_inputs(),
-        MemAdviceProvider::from(inputs.advice_provider_inputs().with_merkle_store(merkle_store)),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
         Some(TX_KERNEL_DIR),
         Some(PROLOGUE_FILE),
     )
@@ -128,10 +128,10 @@ fn chain_mmr_memory_assertions<A: AdviceProvider>(
     // The number of leaves should be stored at the CHAIN_MMR_NUM_LEAVES_PTR
     assert_eq!(
         process.get_memory_value(0, CHAIN_MMR_NUM_LEAVES_PTR).unwrap()[0],
-        Felt::new(inputs.block_chain().forest() as u64)
+        Felt::new(inputs.block_chain().mmr().forest() as u64)
     );
 
-    for (i, peak) in inputs.block_chain().accumulator().peaks.iter().enumerate() {
+    for (i, peak) in inputs.block_chain().mmr().accumulator().peaks.iter().enumerate() {
         // The peaks should be stored at the CHAIN_MMR_PEAKS_PTR
         assert_eq!(&process.get_memory_value(0, CHAIN_MMR_PEAKS_PTR + i as u64).unwrap(), peak);
     }

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -24,7 +24,7 @@ std = ["assembly/std", "crypto/std", "miden-core/std"]
 
 [dependencies]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "frisitano-mmr-accumulator", default-features = false }
+crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 hashbrown = { version = "0.13.2" }
 miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
 miden-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }

--- a/objects/src/advice.rs
+++ b/objects/src/advice.rs
@@ -1,0 +1,42 @@
+use super::{Felt, Word};
+use assembly::utils::IntoBytes;
+use crypto::merkle::InnerNodeInfo;
+use miden_processor::AdviceInputs;
+
+/// [AdviceInputsBuilder] trait specifies the interface for building advice inputs.
+/// The trait provides three methods for building advice inputs:
+/// - `push_onto_stack` pushes the given values onto the advice stack.
+/// - `insert_into_map` inserts the given values into the advice map.
+/// - `add_merkle_nodes` adds the given merkle nodes to the advice merkle store.
+pub trait AdviceInputsBuilder {
+    /// Pushes the given values onto the advice stack.
+    fn push_onto_stack(&mut self, values: &[Felt]);
+
+    /// Inserts the given values into the advice map.
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>);
+
+    /// Adds the given merkle nodes to the advice merkle store.
+    fn add_merkle_nodes<I: Iterator<Item = InnerNodeInfo>>(&mut self, nodes: I);
+}
+
+/// ToAdviceInputs trait specifies the interface for converting a rust object into advice inputs.
+pub trait ToAdviceInputs {
+    /// Converts the rust object into advice inputs and pushes them onto the given advice inputs
+    /// builder.
+    fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T);
+}
+
+/// Implement the `AdviceInputsBuilder` trait on `AdviceInputs`.
+impl AdviceInputsBuilder for AdviceInputs {
+    fn push_onto_stack(&mut self, values: &[Felt]) {
+        self.extend_stack(values.iter().copied());
+    }
+
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) {
+        self.extend_map([(key.into_bytes(), values)]);
+    }
+
+    fn add_merkle_nodes<I: Iterator<Item = InnerNodeInfo>>(&mut self, nodes: I) {
+        self.extend_merkle_store(nodes);
+    }
+}

--- a/objects/src/block/header.rs
+++ b/objects/src/block/header.rs
@@ -1,4 +1,4 @@
-use super::{Digest, Felt, Hasher, ZERO};
+use super::{AdviceInputsBuilder, Digest, Felt, Hasher, ToAdviceInputs, ZERO};
 
 /// The header of a block. It contains metadata about the block, commitments to the current
 /// state of the chain and the hash of the proof that attests to the integrity of the chain.
@@ -140,17 +140,15 @@ impl BlockHeader {
     }
 }
 
-impl From<&BlockHeader> for Vec<Felt> {
-    fn from(header: &BlockHeader) -> Self {
-        let mut elements: Vec<Felt> = Vec::with_capacity(28);
-        elements.extend_from_slice(header.prev_hash.as_elements());
-        elements.extend_from_slice(header.chain_root.as_elements());
-        elements.extend_from_slice(header.state_root.as_elements());
-        elements.extend_from_slice(header.batch_root.as_elements());
-        elements.extend_from_slice(header.proof_hash.as_elements());
-        elements.push(header.block_num);
-        elements.resize(24, ZERO);
-        elements.extend_from_slice(header.note_root.as_elements());
-        elements
+impl ToAdviceInputs for &BlockHeader {
+    fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T) {
+        // push header data onto the stack
+        target.push_onto_stack(self.prev_hash.as_elements());
+        target.push_onto_stack(self.chain_root.as_elements());
+        target.push_onto_stack(self.state_root.as_elements());
+        target.push_onto_stack(self.batch_root.as_elements());
+        target.push_onto_stack(self.proof_hash.as_elements());
+        target.push_onto_stack(&[self.block_num, ZERO, ZERO, ZERO]);
+        target.push_onto_stack(self.note_root.as_elements());
     }
 }

--- a/objects/src/block/mod.rs
+++ b/objects/src/block/mod.rs
@@ -1,4 +1,4 @@
-use super::{Digest, Felt, Hasher, ZERO};
+use super::{AdviceInputsBuilder, Digest, Felt, Hasher, ToAdviceInputs, ZERO};
 
 mod header;
 pub use header::BlockHeader;

--- a/objects/src/chain/mod.rs
+++ b/objects/src/chain/mod.rs
@@ -1,0 +1,49 @@
+use super::{AdviceInputsBuilder, Felt, Mmr, ToAdviceInputs, ZERO};
+
+// TODO: Consider using a PartialMmr that only contains the Mmr nodes that are relevant to the
+// transaction being processed.
+
+/// A struct that represents the chain Mmr accumulator.
+/// This wraps the [Mmr] object and provides a simple interface to access / modify it.
+/// We use a custom type here as the traits we implement on this type could be context specific.
+///
+/// The Mmr allows for efficient authentication of consumed notes during transaction execution.
+/// Authenticaiton is achieved by providing an inclusion proof for the consumed notes in the
+/// transaction against the chain Mmr root associated with the latest block known at the time
+/// of transaction exectuion.  
+#[derive(Default)]
+pub struct ChainMmr(Mmr);
+
+impl ChainMmr {
+    /// Returns a reference to the Mmr.
+    pub fn mmr(&self) -> &Mmr {
+        &self.0
+    }
+
+    /// Returns a mutable reference to the Mmr.
+    pub fn mmr_mut(&mut self) -> &mut Mmr {
+        &mut self.0
+    }
+}
+
+impl ToAdviceInputs for &ChainMmr {
+    fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T) {
+        // Add the Mmr nodes to the merkle store
+        target.add_merkle_nodes(self.0.inner_nodes());
+
+        // Extract Mmr accumulator
+        let accumulator = self.0.accumulator();
+
+        // create the vector of items to insert into the map
+        // The vector is in the following format:
+        //    elements[0]       = number of leaves in the Mmr
+        //    elements[1..4]    = padding ([Felt::ZERO; 3])
+        //    elements[4..]     = Mmr peak roots
+        let mut elements = vec![Felt::new(accumulator.num_leaves as u64), ZERO, ZERO, ZERO];
+        elements.extend(accumulator.flatten_and_pad_peaks());
+
+        // insert the Mmr accumulator vector into the advice map against the Mmr root, which acts
+        // as the key.
+        target.insert_into_map(accumulator.hash_peaks(), elements);
+    }
+}

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -18,11 +18,17 @@ pub use accounts::{
     Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault, StorageItem,
 };
 
+mod advice;
+use advice::{AdviceInputsBuilder, ToAdviceInputs};
+
 pub mod assets;
 pub mod notes;
 
 pub mod block;
 pub use block::BlockHeader;
+
+pub mod chain;
+pub use chain::ChainMmr;
 
 mod errors;
 pub use errors::{AccountError, AssetError, NoteError};

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -1,6 +1,5 @@
+use super::{utils, Account, AdviceInputs, BlockHeader, ChainMmr, Digest, Note, StackInputs};
 use miden_core::StackOutputs;
-
-use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Mmr, Note, StackInputs};
 
 pub struct ExecutedTransaction {
     initial_account: Account,
@@ -9,7 +8,7 @@ pub struct ExecutedTransaction {
     created_notes: Vec<Note>,
     tx_script_root: Option<Digest>,
     block_header: BlockHeader,
-    block_chain: Mmr,
+    block_chain: ChainMmr,
 }
 
 impl ExecutedTransaction {
@@ -20,7 +19,7 @@ impl ExecutedTransaction {
         created_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
         block_header: BlockHeader,
-        block_chain: Mmr,
+        block_chain: ChainMmr,
     ) -> Self {
         Self {
             initial_account,

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -1,14 +1,15 @@
-use super::{utils, Account, AdviceInputs, BlockHeader, Digest, Mmr, Note, StackInputs, Vec};
+use super::{utils, Account, AdviceInputs, BlockHeader, ChainMmr, Digest, Note, StackInputs, Vec};
 
 /// A struct that contains all of the data required to execute a transaction. This includes:
 /// - account: Account that the transaction is being executed against.
-/// - block_ref: The hash of the latest known block.
+/// - block_header: The header of the latest known block.
+/// - block_chain: The chain mmr associated with the latest known blcok.
 /// - consumed_notes: A vector of consumed notes.
 /// - tx_script_root: An optional transaction script root.
 pub struct TransactionInputs {
     account: Account,
     block_header: BlockHeader,
-    block_chain: Mmr,
+    block_chain: ChainMmr,
     consumed_notes: Vec<Note>,
     tx_script_root: Option<Digest>,
 }
@@ -17,7 +18,7 @@ impl TransactionInputs {
     pub fn new(
         account: Account,
         block_header: BlockHeader,
-        block_chain: Mmr,
+        block_chain: ChainMmr,
         consumed_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
     ) -> Self {
@@ -44,7 +45,7 @@ impl TransactionInputs {
     }
 
     /// Returns the block chain.
-    pub fn block_chain(&self) -> &Mmr {
+    pub fn block_chain(&self) -> &ChainMmr {
         &self.block_chain
     }
 

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,6 +1,7 @@
 use super::{
     notes::{Note, NoteMetadata},
-    Account, AccountId, BlockHeader, Digest, Felt, Hasher, Mmr, StarkField, Vec, Word,
+    Account, AccountId, AdviceInputsBuilder, BlockHeader, ChainMmr, Digest, Felt, Hasher,
+    StarkField, ToAdviceInputs, Vec, Word,
 };
 use miden_core::{StackInputs, StackOutputs};
 use miden_processor::AdviceInputs;

--- a/objects/src/transaction/utils.rs
+++ b/objects/src/transaction/utils.rs
@@ -1,9 +1,9 @@
+use miden_processor::AdviceInputs;
+
 use super::{
-    Account, AccountId, AdviceInputs, BlockHeader, Digest, Felt, Hasher, Mmr, Note, StackInputs,
-    StackOutputs, Word,
+    Account, AccountId, AdviceInputsBuilder, BlockHeader, ChainMmr, Digest, Felt, Hasher, Note,
+    StackInputs, StackOutputs, ToAdviceInputs, Word,
 };
-use assembly::utils::IntoBytes;
-use hashbrown::HashMap;
 
 /// Returns the advice inputs required when executing a transaction.
 /// This includes the initial account, the number of consumed notes, the core consumed note data,
@@ -17,11 +17,11 @@ use hashbrown::HashMap;
 ///               CN2_SN,CN2_SR, CN2_IR, CN2_VR,
 ///               cn2_na,
 ///               CN2_A1, CN2_A2, ...
-///               ...
-///               CN1_I3, CN1_I2, CN1_I1, CN1_I0,
-///               CN2_I3, CN2_I2, CN2_I1, CN2_I0,
 ///               ...]
-/// Advice Map: {CHAIN_ROOT, [num_leaves, PEAK_0, ..., PEAK_N]}
+/// Advice Map: {CHAIN_ROOT:  [num_leaves, PEAK_0, ..., PEAK_N],
+///              CN1_IH:      [CN1_I3, CN1_I2, CN1_I1, CN1_I0],
+///              CN2_IH:      [CN2_I3, CN2_I2, CN2_I1, CN2_I0],
+///              ...}
 /// - acct_id is the account id of the account that the transaction is being executed against.
 /// - nonce is the account nonce.
 /// - AVR is the account vault root.
@@ -35,6 +35,8 @@ use hashbrown::HashMap;
 /// - CN1_M is the metadata of consumed note 1.
 /// - CN1_A1 is the first asset of consumed note 1.
 /// - CN1_A2 is the second asset of consumed note 1.
+/// - CN1_IH is the inputs hash of consumed note 1.
+/// - CN2_SN is the serial number of consumed note 2.
 /// - CN1_I3..0 are the script inputs of consumed note 1.
 /// - CN2_I3..0 are the script inputs of consumed note 2.
 /// - CHAIN_ROOT is the root of the block chain MMR from the last known block.
@@ -44,40 +46,27 @@ use hashbrown::HashMap;
 pub fn generate_advice_provider_inputs(
     account: &Account,
     block_header: &BlockHeader,
-    block_chain: &Mmr,
+    block_chain: &ChainMmr,
     notes: &[Note],
 ) -> AdviceInputs {
-    let mut advice_map: HashMap<[u8; 32], Vec<Felt>> = HashMap::new();
-    let mut advice_stack: Vec<Felt> = Vec::new();
+    let mut advice_inputs = AdviceInputs::default();
 
     // insert block data
-    let block_data = Vec::<Felt>::from(block_header);
-    advice_stack.extend(block_data);
+    block_header.to_advice_inputs(&mut advice_inputs);
 
     // insert block chain mmr
-    let chain_accumulator = block_chain.accumulator();
-    advice_map.insert(chain_accumulator.hash_peaks().into_bytes(), (&chain_accumulator).into());
+    block_chain.to_advice_inputs(&mut advice_inputs);
 
     // insert account data
-    let account: [Felt; 16] = account.into();
-    advice_stack.extend(account);
+    account.to_advice_inputs(&mut advice_inputs);
 
     // insert consumed notes data to advice stack
-    advice_stack.push(Felt::new(notes.len() as u64));
-    let note_data: Vec<Felt> = notes.iter().flat_map(<Vec<Felt>>::from).collect();
-    advice_stack.extend(note_data);
-
-    // insert consumed note assets data to advice map
-    for note in notes.iter() {
-        advice_map.insert(note.vault().hash().into_bytes(), note.vault().to_padded_assets());
+    advice_inputs.push_onto_stack(&[Felt::new(notes.len() as u64)]);
+    for note in notes {
+        note.to_advice_inputs(&mut advice_inputs);
     }
 
-    // insert consumed notes inputs
-    let note_inputs: Vec<Felt> =
-        notes.iter().flat_map(|note| note.inputs().inputs().to_vec()).collect();
-    advice_stack.extend(note_inputs);
-
-    AdviceInputs::default().with_stack(advice_stack).with_map(advice_map)
+    advice_inputs
 }
 
 /// Returns the consumed notes commitment.


### PR DESCRIPTION
- Introduces `AdviceProviderBuilder` and `ToAdviceInputs` traits.  
- Implements `AdviceProviderBuilder` on `AdviceInputs` and `ToAdviceInputs` on the types that we need to load into the advice provider for transaction execution.
- Modifies the note setup script to source note inputs from the advice map.
- Introduces a `ChainMmr` object which wrap the `Mmr` object to support chain mmr data.

Open question: do we want to introduce the `ChainMmr` struct or should we just implement `ToAdviceInputs` on `Mmr` directly.