### PR TITLE
Implement `AssetVault`

### DIFF
--- a/miden-lib/asm/sat/account_vault.masm
+++ b/miden-lib/asm/sat/account_vault.masm
@@ -1,0 +1,65 @@
+use.std::collections::smt
+
+use.miden::sat::account
+use.miden::sat::asset
+use.miden::sat::layout
+
+#! Returns the balance of a fungible asset associated with a faucet_id. 
+#! Panics if the asset is not a fungible asset.
+#!
+#! Stack: [faucet_id]
+#! Output: [balance]
+#!
+#! - faucet_id is the faucet id of the fungible asset of interest.
+#! - balance is the vault balance of the fungible asset.
+export.get_balance
+    # assert that the faucet id is a fungible faucet
+    dup exec.account::is_fungible_faucet assert
+    # => [faucet_id]
+
+    # get the asset vault root
+    exec.layout::get_acct_vault_root
+    # => [ASSET_VAULT_ROOT, faucet_id]
+
+    # prepare the key for fungible asset lookup (pad least significant elements with ZERO)
+    push.0 push.0 push.0 movup.7
+    # => [faucet_id, PAD, PAD, PAD, ASSET_VAULT_ROOT]
+
+    # lookup asset
+    exec.smt::get swapw dropw
+    # => [ASSET]
+
+    # extract asset balance (ASSET[0])
+    drop drop drop
+    # => [balance]
+end
+
+#! Returns a boolean indicating whether the non-fungible asset is present in the vault.
+#! Panics if the ASSET is a fungible asset.
+#!
+#! Stack: [ASSET]
+#! Output: [has_asset]
+#!
+#! - ASSET is the non-fungible asset of interest
+#! - has_asset is a boolean indicating whether the account vault has the asset of interest
+export.has_non_fungible_asset
+    # check if the asset is a non-fungible asset
+    exec.asset::is_non_fungible_asset assert
+    # => [ASSET]
+
+    # prepare the stack to read non-fungible asset from vault
+    exec.layout::get_acct_vault_root swapw
+    # => [ASSET, ACCT_VAULT_ROOT]
+
+    # lookup asset
+    exec.smt::get swapw dropw
+    # => [ASSET]
+
+    # compare with EMTPY_WORD to asses if the asset exists in the vault
+    padw eqw not
+    # => [has_asset, PAD, ASSET]
+
+    # organize the stack for return
+    movdn.4 dropw movdn.4 dropw
+    # => [has_asset]
+end

--- a/miden-lib/asm/sat/asset.masm
+++ b/miden-lib/asm/sat/asset.masm
@@ -43,7 +43,7 @@ end
 #!
 #! ASSET is the asset to check.
 #! is_fungible_asset is a boolean indicating whether the asset is fungible.
-proc.is_fungible_asset
+export.is_fungible_asset
     # check the first element, it will be:
     # - ZERO for a fungible asset
     # - non-ZERO for a non-fungible asset
@@ -66,7 +66,7 @@ export.validate_non_fungible_asset
     dup.2 exec.account::is_non_fungible_faucet assert
     # => [ASSET]
 
-    # assert the most significant bit of the most significant elememnt (ASSET[3]) is 0
+    # assert the most significant bit of the most significant element (ASSET[3]) is 0
     dup u32split swap drop u32checked_shr.31 not assert
     # => [ASSET]
 end
@@ -78,7 +78,7 @@ end
 #!
 #! ASSET is the asset to check.
 #! is_non_fungible_asset is a boolean indicating whether the asset is non-fungible.
-proc.is_non_fungible_asset
+export.is_non_fungible_asset
     # check the first element, it will be:
     # - ZERO for a fungible asset
     # - non-ZERO for a non-fungible asset

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -505,6 +505,26 @@ export.set_acct_storage_root
     push.ACCT_STORAGE_ROOT_PTR mem_storew dropw
 end
 
+#! Returns the account vault root.
+#! 
+#! Stack: []
+#! Output: [ACCT_VAULT_ROOT]
+#!
+#! - ACCT_VAULT_ROOT is the account asset vault root.
+export.get_acct_vault_root
+    padw push.ACCT_VAULT_ROOT_PTR mem_loadw
+end
+
+#! Sets the account vault root.
+#!
+#! Stack: [ACCT_VAULT_ROOT]
+#! Output: []
+#!
+#! - ACCT_VAULT_ROOT is the account vault root to be set.
+export.set_acct_vault_root
+    push.ACCT_VAULT_ROOT_PTR mem_storew dropw
+end
+
 # CONSUMED NOTES
 # -------------------------------------------------------------------------------------------------
 

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use assembly::{Deserializable, Library, LibraryNamespace, MaslLibrary, Version};
+use assembly::{utils::Deserializable, Library, LibraryNamespace, MaslLibrary, Version};
 
 pub mod memory;
 

--- a/miden-lib/tests/common/data.rs
+++ b/miden-lib/tests/common/data.rs
@@ -1,9 +1,9 @@
 use super::{
-    Account, AccountCode, AccountId, AccountStorage, Asset, BlockHeader, ChainMmr, Digest,
-    ExecutedTransaction, Felt, FieldElement, FungibleAsset, MerkleStore, NodeIndex, Note,
-    NoteOrigin, StorageItem, TransactionInputs, Word, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH,
+    Account, AccountCode, AccountId, AccountStorage, AccountVault, Asset, BlockHeader, ChainMmr,
+    Digest, ExecutedTransaction, Felt, FieldElement, FungibleAsset, MerkleStore, NodeIndex,
+    NonFungibleAsset, NonFungibleAssetDetails, Note, NoteOrigin, SimpleSmt, StorageItem,
+    TransactionInputs, Word, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH,
 };
-use crypto::merkle::SimpleSmt;
 use test_utils::rand;
 
 // MOCK DATA
@@ -12,6 +12,9 @@ pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = 0b0010011011
 pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
 
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
+pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1110011100 << 54;
+
+pub const NON_FUNGIBLE_ASSET_DATA: [u8; 4] = [1, 2, 3, 4];
 
 pub const NONCE: Felt = Felt::ZERO;
 
@@ -96,6 +99,22 @@ pub fn mock_chain_data(consumed_notes: &mut [Note]) -> ChainMmr {
     chain_mmr
 }
 
+fn mock_account_vault() -> AccountVault {
+    // prepare fungible asset
+    let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
+    let balance = 100000;
+    let fungible_asset = Asset::Fungible(FungibleAsset::new(faucet_id, balance).unwrap());
+
+    // prepare non fungible asset
+    let faucet_id: AccountId = ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
+    let non_fungible_asset_details =
+        NonFungibleAssetDetails::new(faucet_id, NON_FUNGIBLE_ASSET_DATA.to_vec()).unwrap();
+    let non_fungible_asset =
+        Asset::NonFungible(NonFungibleAsset::new(&non_fungible_asset_details).unwrap());
+
+    AccountVault::new(&[fungible_asset, non_fungible_asset]).unwrap()
+}
+
 fn mock_account(nonce: Option<Felt>) -> Account {
     // Create account id
     let account_id =
@@ -128,10 +147,20 @@ fn mock_account(nonce: Option<Felt>) -> Account {
     ";
     let account_code = AccountCode::new(account_code, account_id).unwrap();
 
+    // Create account vault
+    let account_vault = mock_account_vault();
+
     // Create an account with storage items
-    let account =
-        Account::new(account_id, account_storage, account_code, nonce.unwrap_or(Felt::ZERO))
-            .unwrap();
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+    let account = Account::new(
+        account_id,
+        account_vault,
+        account_storage,
+        account_code,
+        nonce.unwrap_or(Felt::ZERO),
+    )
+    .unwrap();
 
     account
 }

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -5,11 +5,11 @@ pub use crypto::{
 };
 pub use miden_lib::{memory, MidenLib};
 pub use miden_objects::{
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     notes::{Note, NoteOrigin, NoteVault, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
     transaction::{ExecutedTransaction, ProvenTransaction, TransactionInputs},
-    Account, AccountCode, AccountId, AccountStorage, AccountType, BlockHeader, ChainMmr,
-    StorageItem,
+    Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault, BlockHeader,
+    ChainMmr, StorageItem,
 };
 use miden_stdlib::StdLibrary;
 pub use processor::{

--- a/miden-lib/tests/test_asset_vault.rs
+++ b/miden-lib/tests/test_asset_vault.rs
@@ -1,0 +1,105 @@
+pub mod common;
+use common::{
+    data::{
+        mock_inputs, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
+    },
+    run_within_tx_kernel, AccountId, MemAdviceProvider, ONE,
+};
+use crypto::StarkField;
+
+use crate::common::procedures::prepare_word;
+
+#[test]
+fn test_get_balance() {
+    let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
+    let inputs = mock_inputs();
+
+    let code = format!(
+        "
+        use.miden::sat::prologue
+        use.miden::sat::account_vault
+
+        begin
+            exec.prologue::prepare_transaction
+            push.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            exec.account_vault::get_balance
+        end
+    "
+    );
+
+    let process = run_within_tx_kernel(
+        "",
+        &code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        process.stack.get(0).as_int(),
+        inputs.account().vault().get_balance(faucet_id).unwrap()
+    );
+}
+
+#[test]
+fn test_get_balance_non_fungible_fails() {
+    let inputs = mock_inputs();
+
+    let code = format!(
+        "
+        use.miden::sat::prologue
+        use.miden::sat::account_vault
+
+        begin
+            exec.prologue::prepare_transaction
+            push.{ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN}
+            exec.account_vault::get_balance
+        end
+    "
+    );
+
+    let process = run_within_tx_kernel(
+        "",
+        &code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
+        None,
+        None,
+    );
+
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_has_non_fungible_asset() {
+    let inputs = mock_inputs();
+    let non_fungible_asset = inputs.account().vault().assets().next().unwrap();
+
+    let code = format!(
+        "
+        use.miden::sat::prologue
+        use.miden::sat::account_vault
+
+        begin
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset_key}
+            exec.account_vault::has_non_fungible_asset
+        end
+    ",
+        non_fungible_asset_key = prepare_word(&non_fungible_asset.vault_key())
+    );
+
+    let process = run_within_tx_kernel(
+        "",
+        &code,
+        inputs.stack_inputs(),
+        MemAdviceProvider::from(inputs.advice_provider_inputs()),
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(process.stack.get(0), ONE);
+}

--- a/miden-lib/tests/test_epilogue.rs
+++ b/miden-lib/tests/test_epilogue.rs
@@ -40,7 +40,7 @@ fn test_epilogue() {
 
     // assert created notes commitment is correct
     assert_eq!(
-        process.stack.get_top_word(),
+        process.stack.get_word(0),
         executed_transaction.created_notes_commitment().as_elements()
     );
 
@@ -98,7 +98,7 @@ fn test_compute_created_note_hash() {
 
         // assert the note hash is correct
         let expected_hash = note.hash();
-        let actual_hash = process.stack.get_top_word();
+        let actual_hash = process.stack.get_word(0);
         assert_eq!(&actual_hash, expected_hash.as_elements());
     }
 }

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -153,7 +153,7 @@ fn account_data_memory_assertions<A: AdviceProvider>(
     // The account vault root commitment should be stored at ACCT_VAULT_ROOT_PTR
     assert_eq!(
         process.get_memory_value(0, ACCT_VAULT_ROOT_PTR).unwrap(),
-        inputs.account().vault().root().as_elements()
+        inputs.account().vault().commitment().as_elements()
     );
 
     // The account storage root commitment should be stored at ACCT_STORAGE_ROOT_PTR

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -1,5 +1,7 @@
 use super::{AccountError, AccountId, Digest};
-use assembly::{Assembler, AssemblyContext, AssemblyContextType, LibraryPath, Module, ModuleAst};
+use assembly::{
+    ast::ModuleAst, Assembler, AssemblyContext, AssemblyContextType, LibraryPath, Module,
+};
 use crypto::merkle::SimpleSmt;
 use miden_lib::MidenLib;
 use miden_stdlib::StdLibrary;

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -71,6 +71,14 @@ impl Asset {
     pub const fn is_fungible(&self) -> bool {
         matches!(self, Self::Fungible(_))
     }
+
+    /// Returns the key which is used to store this asset in the account vault.
+    pub fn vault_key(&self) -> Word {
+        match self {
+            Self::Fungible(asset) => asset.vault_key(),
+            Self::NonFungible(asset) => asset.vault_key(),
+        }
+    }
 }
 
 impl From<Asset> for Word {
@@ -97,7 +105,7 @@ impl TryFrom<Word> for Asset {
     type Error = AssetError;
 
     fn try_from(value: Word) -> Result<Self, Self::Error> {
-        let first_bit = value[0].as_int() >> 63;
+        let first_bit = value[3].as_int() >> 63;
         match first_bit {
             0 => NonFungibleAsset::try_from(value).map(Asset::from),
             1 => FungibleAsset::try_from(value).map(Asset::from),
@@ -110,7 +118,7 @@ impl TryFrom<[u8; 32]> for Asset {
     type Error = AssetError;
 
     fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
-        let first_bit = value[0] >> 7;
+        let first_bit = value[31] >> 7;
         match first_bit {
             0 => NonFungibleAsset::try_from(value).map(Asset::from),
             1 => FungibleAsset::try_from(value).map(Asset::from),
@@ -171,6 +179,13 @@ impl FungibleAsset {
     /// Returns true if this and the other assets were issued from the same faucet.
     pub fn is_from_same_faucet(&self, other: &Self) -> bool {
         self.faucet_id == other.faucet_id
+    }
+
+    /// Returns the key which is used to store this asset in the account vault.
+    pub fn vault_key(&self) -> Word {
+        let mut key = Word::default();
+        key[3] = *self.faucet_id;
+        key
     }
 
     // OPERATIONS
@@ -269,7 +284,8 @@ impl TryFrom<Word> for FungibleAsset {
         if (value[1], value[2]) != (ZERO, ZERO) {
             return Err(AssetError::fungible_asset_invalid_word(value));
         }
-        let faucet_id = AccountId::try_from(value[3]).map_err(AssetError::invalid_account_id)?;
+        let faucet_id = AccountId::try_from(value[3])
+            .map_err(|e| AssetError::invalid_account_id(e.to_string()))?;
         let amount = value[0].as_int();
         Self::new(faucet_id, amount)
     }
@@ -342,6 +358,12 @@ impl NonFungibleAsset {
         Ok(asset)
     }
 
+    // ACCESSORS
+    // --------------------------------------------------------------------------------------------
+    pub fn vault_key(&self) -> Word {
+        self.0
+    }
+
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
@@ -351,7 +373,8 @@ impl NonFungibleAsset {
     /// - The faucet_id is not a valid non-fungible faucet ID.
     /// - The most significant bit of the asset is not ZERO.
     fn validate(&self) -> Result<(), AssetError> {
-        let faucet_id: AccountId = self.0[1].try_into().map_err(AssetError::InvalidAccountId)?;
+        let faucet_id = AccountId::try_from(self.0[1])
+            .map_err(|e| AssetError::InvalidAccountId(e.to_string()))?;
 
         if !matches!(faucet_id.account_type(), AccountType::NonFungibleFaucet) {
             return Err(AssetError::not_a_fungible_faucet_id(faucet_id));

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,4 +1,7 @@
-use super::{assets::Asset, assets::NonFungibleAsset, AccountId, MerkleError, String, Word};
+use super::{
+    assets::{Asset, FungibleAsset, NonFungibleAsset},
+    AccountId, MerkleError, String, Word,
+};
 use assembly::{AssemblyError, ParsingError};
 use core::fmt;
 
@@ -9,6 +12,11 @@ use core::fmt;
 pub enum AccountError {
     AccountIdInvalidFieldElement(String),
     AccountIdTooFewOnes,
+    AddFungibleAssetBalanceError(AssetError),
+    SubtractFungibleAssetBalanceError(AssetError),
+    DuplicateNonFungibleAsset(NonFungibleAsset),
+    NonFungibleAssetNotFound(NonFungibleAsset),
+    FungibleAssetNotFound(FungibleAsset),
     SeedDigestTooFewTrailingZeros,
     CodeParsingFailed(ParsingError),
     AccountCodeAsselmberError(AssemblyError),
@@ -16,6 +24,7 @@ pub enum AccountError {
     NotAFungibleFaucetId(AccountId),
     NotANonFungibleAsset(Asset),
     DuplicateStorageItems(MerkleError),
+    DuplicateAsset(MerkleError),
 }
 
 impl AccountError {
@@ -70,7 +79,7 @@ pub enum AssetError {
     FungibleAssetInvalidTag(u32),
     FungibleAssetInvalidWord(Word),
     InconsistentFaucetIds(AccountId, AccountId),
-    InvalidAccountId(AccountError),
+    InvalidAccountId(String),
     InvalidFieldElement(String),
     NonFungibleAssetInvalidFirstBit,
     NonFungibleAssetInvalidTag(u32),
@@ -104,7 +113,7 @@ impl AssetError {
         Self::InconsistentFaucetIds(id1, id2)
     }
 
-    pub fn invalid_account_id(err: AccountError) -> Self {
+    pub fn invalid_account_id(err: String) -> Self {
         Self::InvalidAccountId(err)
     }
 

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
-    merkle::{MerkleError, Mmr},
+    merkle::{MerkleError, Mmr, TieredSmt},
     utils::{
         collections::Vec,
         string::{String, ToString},

--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -1,5 +1,5 @@
 use super::{Digest, NoteError};
-use assembly::ProgramAst;
+use assembly::ast::ProgramAst;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct NoteScript {


### PR DESCRIPTION
This is a draft implementation of the `AssetVault`.

@bobbinth I don't think it makes sense to have both `Vec<Asset>` and `TieredSmt` backing the `AssetVault`.  It increase the complexity and introduces a lot of duplication.  I think we should remove it.  One implication is we wont be able to support: 

```rust
    /// Returns a list of assets stored in this vault.
    pub fn assets(&self) -> &[Asset] {
        &self.assets
    }
```


This would have to change to as seen below which requires allocations:

```rust
    /// Returns a list of assets stored in this vault.
    pub fn to_assets(&self) -> Iterator<Item=Asset> {
        ...
    }
```

What do you think?
