### PR TITLE
docs: mdbook fix book.toml

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,9 +5,7 @@ multilingual = false
 src = "src"
 title = "Polygon Miden Documentation"
 
-[output.katex]
-
 [output.html]
 
 [preprocessor.katex]
-renderers = ["html"]
+after = ["links"]


### PR DESCRIPTION
output.katex doesn't work anymore and needs to be removed from book.toml

https://github.com/lzanini/mdbook-katex/issues/68