### PR TITLE
DRAFT: Refactor masm to support upstream `mem_stream` and `adv_pipe` changes

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -16,18 +16,18 @@ default = ["std"]
 std = ["assembly/std", "processor/std"]
 
 [dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 
 [dev-dependencies]
-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+crypto = { package = "miden-crypto", version = "0.5", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects"}
-miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", features = ["internals"] }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", features = ["internals"] }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
 
 
 [build-dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev" }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }

--- a/miden-lib/asm/sat/account.masm
+++ b/miden-lib/asm/sat/account.masm
@@ -36,7 +36,7 @@ export.get_current_hash
 
     # stream account data and compute sequential hash. We perform two `mem_stream` operations
     # because account data consists of exactly 4 words.
-    mem_stream mem_stream
+    mem_stream hperm mem_stream hperm
 
     # extract account hash
     dropw swapw dropw

--- a/miden-lib/asm/sat/epilogue.masm
+++ b/miden-lib/asm/sat/epilogue.masm
@@ -50,7 +50,7 @@ proc.compute_created_note_vault_hash
         # read assets from memory.
         # if this is the last permutation of the loop and we have an odd number of assets then we
         # implicitly pad the last word of the hasher rate with ZERO's by reading from empty memory.
-        mem_stream
+        mem_stream hperm
         # => [PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
         # check if we should loop again
@@ -135,7 +135,7 @@ export.process_created_notes
         dropw
 
         # permute over (note_hash, note_metadata)
-        mem_stream
+        mem_stream hperm
 
         # increment created note pointer and check if we should loop again
         movup.12 push.CREATED_NOTE_HASHING_MEM_DIFF add dup movdn.13 dup.14 neq

--- a/miden-lib/asm/sat/note_setup.masm
+++ b/miden-lib/asm/sat/note_setup.masm
@@ -28,7 +28,7 @@ export.prepare_note.4
 
     # load the note inputs from the advice provider
     # TODO: optimize this to load items directly onto the stack.
-    locaddr.0 padw padw padw adv_pipe adv_pipe
+    locaddr.0 padw padw padw adv_pipe hperm adv_pipe hperm
     # => [PERM, PERM, PERM, addr', INPUTS_HASH]
 
     # extract inputs hash and assert it matches commitment stored in memory

--- a/miden-lib/asm/sat/prologue.masm
+++ b/miden-lib/asm/sat/prologue.masm
@@ -60,7 +60,7 @@ proc.process_block_data
     # => [ZERO, ZERO, ZERO, block_data_ptr]
 
     # read the block data
-    adv_pipe adv_pipe adv_pipe
+    adv_pipe hperm adv_pipe hperm adv_pipe hperm
     # => [PERM, PERM, PERM, block_data_ptr']
 
     # extract digest from hasher rate elements (h_0, ..., h_3)
@@ -147,7 +147,7 @@ proc.process_acct_data
     padw padw padw
 
     # read the account data
-    adv_pipe adv_pipe
+    adv_pipe hperm adv_pipe hperm
 
     # extract digest from hasher rate elements (h_0, ..., h_3)
     dropw swapw dropw
@@ -207,7 +207,7 @@ proc.authenticate_note.2
     # => [PAD, PAD, PAD, mem_ptr, MMR_LEAF, AUTH_DIGEST]
 
     # read the core hash and note root from the advice provider
-    adv_pipe
+    adv_pipe hperm
     # => [PERM, PERM, PERM, mem_ptr', MMR_LEAF, AUTH_DIGEST]
 
     # extract the digest and assert it matches MMR_LEAF
@@ -272,7 +272,7 @@ proc.process_consumed_note
 
     # read note data from the advice provider
     padw padw padw
-    adv_pipe adv_pipe
+    adv_pipe hperm adv_pipe hperm
     # => [PERM, PERM, PERM, note_data_ptr + 4, note_ptr, i]
 
     # extract nullifier (digest)
@@ -324,7 +324,7 @@ proc.process_consumed_note
     # loop and read assets from the advice provider
     while.true
         # read assets from advice provider
-        adv_pipe
+        adv_pipe hperm
         # => [PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
 
         # check if we should loop again

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -23,12 +23,12 @@ default = ["std"]
 std = ["assembly/std", "crypto/std", "miden-core/std"]
 
 [dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+crypto = { package = "miden-crypto", version = "0.5", default-features = false }
 hashbrown = { version = "0.13.2" }
-miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
-miden-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
-miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "frisitano-next-dev", default-features = false }
+miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Make changes to masm logic to account for changes to `mem_stream` and `adv_pipe` mechanics. This involves adding the `hperm` operation after `mem_stream` and `adv_pipe`. We should do a sweep of the tx kernel logic to see if we can extract some performance improvements from this decoupling, I think there are a few places in which we can. 