### PR TITLE
feat: introduce tx-compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "objects",
   "miden-lib",
+  "miden-tx",
 ]
 
 [profile.release]

--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -18,6 +18,8 @@ std = ["assembly/std", "processor/std"]
 [dependencies]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
 
 [dev-dependencies]
 crypto = { package = "miden-crypto", version = "0.5", default-features = false }

--- a/miden-lib/asm/sat/kernel.masm
+++ b/miden-lib/asm/sat/kernel.masm
@@ -1,0 +1,196 @@
+use.miden::sat::account
+use.miden::sat::account_vault
+use.miden::sat::note
+use.miden::sat::tx
+
+# TODO: change to re-export once supported.
+#! Returns the account id.
+#!
+#! Stack: []
+#! Output: [acct_id]
+#!
+#! - acct_id is the account id.
+export.get_account_id
+    exec.account::get_id
+end
+
+# TODO: change to re-export once supported.
+#! Returns the account nonce.
+#!
+#! Stack: []
+#! Output: [nonce]
+#!
+#! - nonce is the account nonce.
+export.get_account_nonce
+    exec.account::get_nonce
+end
+
+# TODO: change to re-export once supported.
+#! Returns the initial account hash.
+#!
+#! Stack: []
+#! Output: [H]
+#!
+#! - H is the initial account hash.
+export.get_initial_account_hash
+    exec.account::get_initial_hash
+end
+
+#! Computes and returns the account hash from account data stored in memory.
+#!
+#! Stack: []
+#! Output: [ACCT_HASH]
+#!
+#! - ACCT_HASH is the hash of the account data.
+export.get_current_account_hash
+    exec.account::get_current_hash
+end
+
+#! Increments the account nonce by the provided value.
+#!
+#! Stack: [value]
+#! Output: []
+#!
+#! - value is the value to increment the nonce by. value can be at most 2^32 - 1 otherwise this
+#!   procedure panics.
+export.incr_account_nonce
+    exec.account::incr_nonce
+end
+
+#! Gets an item from the account storage. Panics if the index is out of bounds.
+#!
+#! Stack: [index]
+#! Output: [VALUE]
+#!
+#! - index is the index of the item to get.
+#! - VALUE is the value of the item.
+export.get_account_item
+    exec.account::get_item
+end
+
+#! Sets an item in the account storage. Panics if the index is out of bounds.
+#!
+#! Stack: [index, V']
+#! Output: [R', V]
+#!
+#! - index is the index of the item to set.
+#! - V' is the value to set.
+#! - V is the previous value of the item.
+#! - R' is the new storage root.
+export.set_account_item
+    exec.account::set_item
+end
+
+#! Sets the code of the account the transaction is being executed against. This procedure can only
+#! executed on regular accounts with updatable code. Otherwise, this procedure fails.
+#!
+#! Stack: [CODE_ROOT]
+#! Output: []
+#!
+#! - CODE_ROOT is the hash of the code to set.
+export.set_account_code
+    exec.account::set_code
+end
+
+# TODO: Add vault based procedures (add_asset, remove_asset, mint, burn)
+
+#! Returns the balance of a fungible asset associated with a faucet_id. 
+#! Panics if the asset is not a fungible asset.
+#!
+#! Stack: [faucet_id]
+#! Output: [balance]
+#!
+#! - faucet_id is the faucet id of the fungible asset of interest.
+#! - balance is the vault balance of the fungible asset.
+export.account_vault_get_balance
+    exec.account_vault::get_balance
+end
+
+#! Returns a boolean indicating whether the non-fungible asset is present in the vault.
+#! Panics if the ASSET is a fungible asset.
+#!
+#! Stack: [ASSET]
+#! Output: [has_asset]
+#!
+#! - ASSET is the non-fungible asset of interest
+#! - has_asset is a boolean indicating whether the account vault has the asset of interest
+export.account_vault_has_non_fungible_asset
+    exec.account_vault::has_non_fungible_asset
+end
+
+#! Writes the assets of the currently executing note into memory starting at the specified address.
+#!
+#! Inputs: [dest_ptr]
+#! Outputs: [num_assets, dest_ptr]
+#!
+#! - dest_ptr is the memory address to write the assets.
+#! - num_assets is the number of assets in the currently executing note.
+export.get_note_assets
+    exec.note::get_assets
+end
+
+#! Returns the sender of the note currently being processed. Panics if a note is not being
+#! processed.
+#!
+#! Inputs: []
+#! Outputs: [sender]
+#!
+#! - sender is the sender of the note currently being processed.
+export.get_note_sender
+    exec.note::get_sender
+end
+
+#! Returns the block number of the last known block at the time of transaction execution.
+#!
+#! Inputs: []
+#! Outputs: [num]
+#!
+#! num is the last known block number.
+export.get_block_number
+    exec.tx::get_block_number
+end
+
+#! Returns the block hash of the last known block at the time of transaction execution.
+#!
+#! Inputs: []
+#! Outputs: [H]
+#!
+#! H is the last known block hash.
+export.get_block_hash
+    exec.tx::get_block_hash
+end
+
+#! Returns the input notes hash. This is computed as a sequential hash of (nullifier, script_root)
+#! tuples over all input notes.
+#!
+#! Inputs: []
+#! Outputs: [COM]
+#!
+#! COM is the input notes hash.
+export.get_input_notes_hash
+    exec.tx::get_input_notes_hash
+end
+
+#! Returns the output notes hash. This is computed as a sequential hash of (note_hash, note_metadata)
+#! tuples over all output notes.
+#!
+#! Inputs: []
+#! Outputs: [COM]
+#!
+#! COM is the output notes hash.
+export.get_output_notes_hash
+    exec.tx::get_output_notes_hash
+end
+
+#! Creates a new note and returns a pointer to the memory address at which the note is stored.
+#!
+#! Inputs: [ASSET, tag, RECIPIENT]
+#! Outputs: [ptr]
+#!
+#! ASSET is the asset to be included in the note.
+#! tag is the tag to be included in the note.
+#! RECIPIENT is the recipient of the note.
+#! ptr is the pointer to the memory address at which the note is stored.
+export.create_note
+    exec.tx::create_note
+end

--- a/miden-lib/asm/sat/layout.masm
+++ b/miden-lib/asm/sat/layout.masm
@@ -18,6 +18,9 @@ const.NUM_CREATED_NOTES_PTR=2
 # The memory address at which a pointer to the consumed note being executed is stored.
 const.CURRENT_CONSUMED_NOTE_PTR=3
 
+# The memory address at which the index of the current consumed note is stored.
+const.CURRENT_CONSUMED_NOTE_IDX=4
+
 # GLOBAL INPUTS
 # -------------------------------------------------------------------------------------------------
 
@@ -169,6 +172,22 @@ end
 #! Output: []
 export.set_current_consumed_note_ptr
     push.CURRENT_CONSUMED_NOTE_PTR mem_store
+end
+
+#! Returns the index of the consumed note being executed.
+#!
+#! Stack: []
+#! Output: [idx]
+export.get_current_consumed_note_idx
+    push.CURRENT_CONSUMED_NOTE_IDX mem_load
+end
+
+#! Sets the index of the consumed note being executed.
+#!
+#! Stack: [idx]
+#! Output: []
+export.set_current_consumed_note_idx
+    push.CURRENT_CONSUMED_NOTE_IDX mem_store
 end
 
 # GLOBAL INPUTS

--- a/miden-lib/asm/sat/note.masm
+++ b/miden-lib/asm/sat/note.masm
@@ -97,3 +97,27 @@ export.get_assets
     assert_eqw
     # => [num_assets, dest_ptr]
 end
+
+#! Increments the number of consumed notes by one. Returns the index of the next note to be consumed.
+#!
+#! Inputs: []
+#! Outputs: [note_idx]
+export.increment_current_consumed_note_idx
+    # get the current consumed note index
+    exec.layout::get_current_consumed_note_idx
+    # => [note_idx]
+    
+    # increment the index of the current consumed note and save back to memory
+    dup add.1 exec.layout::set_current_consumed_note_idx
+    # => [note_idx]
+end
+
+#! Sets the current consumed note pointer to 0. This should be called after all consumed notes have
+#! been processed.
+#!
+#! Inputs: []
+#! Outputs: []
+export.reset_current_consumed_note_ptr
+    # set the current consumed note pointer to 0
+    push.0 exec.layout::set_current_consumed_note_ptr
+end

--- a/miden-lib/asm/sat/note_setup.masm
+++ b/miden-lib/asm/sat/note_setup.masm
@@ -1,19 +1,23 @@
 use.miden::sat::layout
+use.miden::sat::note
 
 # NOTE SETUP SCRIPT
 # =================================================================================================
 
 #! Prepares the virtual machine for execution of a consumed note.  This involves:
-#! 1. Updating the current consumed note pointer.
+#! 1. Updating the current consumed note index and pointer.
 #! 2. Loading the note inputs from the advice provider.
 #! 3. Authenticating the note inputs against the inputs hash stored in memory.
 #!
-#! Stack: [idx]
+#! Stack: []
 #! Output: [i15, i14, ..., i0]
 #!
-#! idx is the index of the consumed note.
 #! i15, i14, ..., i0 are the inputs of the consumed note.
 export.prepare_note.4
+    # load the note index onto the stack
+    exec.note::increment_current_consumed_note_idx
+    # => [idx]
+
     # convert the index of the consumed note being executed to a pointer and store in memory
     exec.layout::get_consumed_note_ptr 
     # => [note_ptr]

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -35,6 +35,68 @@ impl Library for MidenLib {
     }
 }
 
+// SINGLE ACCOUNT TRANSACTION (SAT) KERNEL
+// ================================================================================================
+
+pub struct SatKernel;
+
+impl SatKernel {
+    // SAT KERNEL METHODS
+    // --------------------------------------------------------------------------------------------
+    /// Returns masm source code which encodes the transaction kernel system procedures.
+    pub fn kernel() -> &'static str {
+        include_str!("../asm/sat/kernel.masm")
+    }
+
+    // SAT KERNEL SECTIONS
+    // --------------------------------------------------------------------------------------------
+    /// Returns masm source code which encodes the transaction kernel prologue.
+    pub fn prologue() -> &'static str {
+        "\
+        use.miden::sat::prologue
+
+        begin
+            exec.prologue::prepare_transaction
+        end
+        "
+    }
+
+    /// Returns masm source code which encodes the transaction kernel epilogue.
+    pub fn epilogue() -> &'static str {
+        "\
+        use.miden::sat::epilogue
+
+        begin
+            exec.epilogue::finalize_transaction
+        end"
+    }
+
+    /// Returns masm source code which encodes the transaction kernel note setup script.
+    pub fn note_setup() -> &'static str {
+        "\
+        use.miden::sat::note_setup
+
+        begin
+            exec.note_setup::prepare_note
+        end
+        "
+    }
+
+    /// Returns masm source code which encodes the transaction kernel note teardown script.
+    pub fn note_processing_teardown() -> &'static str {
+        "\
+        use.miden::sat::note
+
+        begin
+            exec.note::reset_current_consumed_note_ptr
+        end
+        "
+    }
+}
+
+// TEST
+// ================================================================================================
+
 #[test]
 fn test_compile() {
     let path = "miden::sat::layout::get_consumed_note_ptr";

--- a/miden-lib/tests/common/data.rs
+++ b/miden-lib/tests/common/data.rs
@@ -1,8 +1,12 @@
 use super::{
     Account, AccountCode, AccountId, AccountStorage, AccountVault, Asset, BlockHeader, ChainMmr,
     Digest, ExecutedTransaction, Felt, FieldElement, FungibleAsset, MerkleStore, NodeIndex,
-    NonFungibleAsset, NonFungibleAssetDetails, Note, NoteOrigin, SimpleSmt, StorageItem,
-    TransactionInputs, Word, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH,
+    NonFungibleAsset, NonFungibleAssetDetails, Note, NoteOrigin, NoteScript, SimpleSmt,
+    StorageItem, TransactionInputs, Word, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH,
+};
+use assembly::{
+    ast::{ModuleAst, ProgramAst},
+    Assembler,
 };
 use test_utils::rand;
 
@@ -115,7 +119,11 @@ fn mock_account_vault() -> AccountVault {
     AccountVault::new(&[fungible_asset, non_fungible_asset]).unwrap()
 }
 
-fn mock_account(nonce: Option<Felt>) -> Account {
+fn mock_account(
+    nonce: Option<Felt>,
+    code: Option<AccountCode>,
+    assembler: &mut Assembler,
+) -> Account {
     // Create account id
     let account_id =
         AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
@@ -134,18 +142,24 @@ fn mock_account(nonce: Option<Felt>) -> Account {
     )
     .unwrap();
 
-    let account_code = "\
-    export.account_procedure_1
-        push.1.2
-        add
-    end
-
-    export.account_procedure_2
-        push.2.1
-        sub
-    end
-    ";
-    let account_code = AccountCode::new(account_code, account_id).unwrap();
+    let account_code = match code {
+        Some(code) => code,
+        None => {
+            let account_code = "\
+            export.account_procedure_1
+                push.1.2
+                add
+            end
+        
+            export.account_procedure_2
+                push.2.1
+                sub
+            end
+            ";
+            let account_module_ast = ModuleAst::parse(account_code).unwrap();
+            AccountCode::new(account_id, account_module_ast, assembler).unwrap()
+        }
+    };
 
     // Create account vault
     let account_vault = mock_account_vault();
@@ -166,11 +180,14 @@ fn mock_account(nonce: Option<Felt>) -> Account {
 }
 
 pub fn mock_inputs() -> TransactionInputs {
+    // Create assembler and assembler context
+    let mut assembler = Assembler::default();
+
     // Create an account with storage items
-    let account = mock_account(None);
+    let account = mock_account(None, None, &mut assembler);
 
     // Consumed notes
-    let mut consumed_notes = mock_consumed_notes();
+    let mut consumed_notes = mock_consumed_notes(&mut assembler);
 
     // Chain data
     let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
@@ -187,17 +204,21 @@ pub fn mock_inputs() -> TransactionInputs {
 }
 
 pub fn mock_executed_tx() -> ExecutedTransaction {
+    // Create assembler and assembler context
+    let mut assembler = Assembler::default();
+
     // Initial Account
-    let initial_account = mock_account(Some(Felt::ZERO));
+    let initial_account = mock_account(Some(Felt::ZERO), None, &mut assembler);
 
     // Finial Account (nonce incremented by 1)
-    let final_account = mock_account(Some(Felt::ONE));
+    let final_account =
+        mock_account(Some(Felt::ONE), Some(initial_account.code().clone()), &mut assembler);
 
     // Consumed notes
-    let mut consumed_notes = mock_consumed_notes();
+    let mut consumed_notes = mock_consumed_notes(&mut assembler);
 
     // Created notes
-    let created_notes = mock_created_notes();
+    let created_notes = mock_created_notes(&mut assembler);
 
     // Chain data
     let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
@@ -222,7 +243,7 @@ pub fn mock_executed_tx() -> ExecutedTransaction {
     )
 }
 
-fn mock_consumed_notes() -> Vec<Note> {
+fn mock_consumed_notes(assembler: &mut Assembler) -> Vec<Note> {
     // Note Assets
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
     let faucet_id_2 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN + 10).unwrap();
@@ -234,10 +255,14 @@ fn mock_consumed_notes() -> Vec<Note> {
     // Sender account
     let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 
+    // create note script
+    let note_program_ast = ProgramAst::parse("begin push.1 drop end").unwrap();
+    let (note_script, _) = NoteScript::new(note_program_ast, assembler).unwrap();
+
     // Consumed Notes
     const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
     let note_1 = Note::new(
-        "begin push.1 end",
+        note_script.clone(),
         &[Felt::new(1)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_1,
@@ -249,7 +274,7 @@ fn mock_consumed_notes() -> Vec<Note> {
 
     const SERIAL_NUM_2: Word = [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)];
     let note_2 = Note::new(
-        "begin push.1 end",
+        note_script,
         &[Felt::new(2)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_2,
@@ -262,7 +287,7 @@ fn mock_consumed_notes() -> Vec<Note> {
     vec![note_1, note_2]
 }
 
-fn mock_created_notes() -> Vec<Note> {
+fn mock_created_notes(assembler: &mut Assembler) -> Vec<Note> {
     // Note assets
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
     let faucet_id_2 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN + 10).unwrap();
@@ -274,10 +299,14 @@ fn mock_created_notes() -> Vec<Note> {
     // sender account
     let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 
+    // create note script
+    let note_program_ast = ProgramAst::parse("begin push.1 drop end").unwrap();
+    let (note_script, _) = NoteScript::new(note_program_ast, assembler).unwrap();
+
     // Created Notes
     const SERIAL_NUM_1: Word = [Felt::new(9), Felt::new(10), Felt::new(11), Felt::new(12)];
     let note_1 = Note::new(
-        "begin push.1 end",
+        note_script.clone(),
         &[Felt::new(1)],
         &[fungible_asset_1, fungible_asset_2],
         SERIAL_NUM_1,
@@ -289,7 +318,7 @@ fn mock_created_notes() -> Vec<Note> {
 
     const SERIAL_NUM_2: Word = [Felt::new(13), Felt::new(14), Felt::new(15), Felt::new(16)];
     let note_2 = Note::new(
-        "begin push.1 end",
+        note_script.clone(),
         &[Felt::new(2)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_2,
@@ -301,7 +330,7 @@ fn mock_created_notes() -> Vec<Note> {
 
     const SERIAL_NUM_3: Word = [Felt::new(17), Felt::new(18), Felt::new(19), Felt::new(20)];
     let note_3 = Note::new(
-        "begin push.1 end",
+        note_script,
         &[Felt::new(2)],
         &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
         SERIAL_NUM_3,

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -6,7 +6,7 @@ pub use crypto::{
 pub use miden_lib::{memory, MidenLib};
 pub use miden_objects::{
     assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
-    notes::{Note, NoteOrigin, NoteVault, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
+    notes::{Note, NoteOrigin, NoteScript, NoteVault, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
     transaction::{ExecutedTransaction, ProvenTransaction, TransactionInputs},
     Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault, BlockHeader,
     ChainMmr, StorageItem,

--- a/miden-lib/tests/mod.rs
+++ b/miden-lib/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod common;

--- a/miden-lib/tests/test_note.rs
+++ b/miden-lib/tests/test_note.rs
@@ -41,7 +41,6 @@ fn test_get_sender() {
 
         begin
             exec.prologue::prepare_transaction
-            push.0
             exec.note_setup::prepare_note
             dropw dropw dropw dropw
             exec.note::get_sender
@@ -79,7 +78,6 @@ fn test_get_vault_data() {
             exec.prologue::prepare_transaction
 
             # prepare note 0
-            push.0
             exec.note_setup::prepare_note
             
             # drop the note inputs
@@ -93,7 +91,6 @@ fn test_get_vault_data() {
             push.{note_0_num_assets} assert_eq
 
             # prepare note 1
-            push.1
             exec.note_setup::prepare_note
 
             # drop the note inputs
@@ -146,7 +143,6 @@ fn test_get_assets() {
             exec.prologue::prepare_transaction
 
             # prepare note 0
-            push.0
             exec.note_setup::prepare_note
 
             # drop the note inputs
@@ -165,7 +161,6 @@ fn test_get_assets() {
             eq.{DEST_POINTER_NOTE_0} assert
 
             # prepare note 1
-            push.1
             exec.note_setup::prepare_note
 
             # drop the note inputs

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "miden-tx"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["std"]
+std = ["assembly/std", "crypto/std", "miden-core/std"]
+
+[dependencies]
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+crypto = { package = "miden-crypto", version = "0.5", default-features = false }
+miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-objects = { package = "miden-objects", path = "../objects"}
+miden-lib = { package = "miden-lib", path = "../miden-lib" }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "miden-tx"
 version = "0.1.0"
+description = "Miden rollup transaction compiler, executor, and prover"
+authors = ["miden contributors"]
+readme = "README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/miden-base"
+categories = ["no-std"]
+keywords = []
 edition = "2021"
+rust-version = "1.67"
 
 [features]
 default = ["std"]

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -1,0 +1,407 @@
+use super::{
+    AccountCode, AccountId, Assembler, AssemblyContext, AssemblyContextType, BTreeMap, CodeBlock,
+    CompiledTransaction, Digest, MidenLib, ModuleAst, Note, NoteScript, Operation, Program,
+    ProgramAst, SatKernel, StdLibrary, TransactionError,
+};
+
+#[cfg(test)]
+mod tests;
+
+// TRANSACTION COMPILER
+// ================================================================================================
+
+/// The [TransactionCompiler] is responsible for transaction compilation in the context of the
+/// Miden rollup.
+#[cfg(not(test))]
+pub struct TransactionComplier {
+    assembler: Assembler,
+    account_procedures: BTreeMap<AccountId, Vec<Digest>>,
+    prologue: CodeBlock,
+    epilogue: CodeBlock,
+    note_setup: CodeBlock,
+    note_processing_teardown: CodeBlock,
+}
+
+impl TransactionComplier {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new instance of the `TransactionComplier`.
+    pub fn new() -> TransactionComplier {
+        let assembler = Assembler::default()
+            .with_library(&MidenLib::default())
+            .expect("library is well formed")
+            .with_library(&StdLibrary::default())
+            .expect("library is well formed")
+            .with_kernel(SatKernel::kernel())
+            .expect("kernel is well formed");
+
+        // compile prologue
+        let prologue_ast =
+            ProgramAst::parse(SatKernel::prologue()).expect("prologue is well formed");
+        let prologue = assembler
+            .compile_in_context(
+                &prologue_ast,
+                &mut AssemblyContext::new(AssemblyContextType::Program),
+            )
+            .expect("prologue is well formed");
+
+        // compile epilogue
+        let epilogue_ast =
+            ProgramAst::parse(SatKernel::epilogue()).expect("epilogue is well formed");
+        let epilogue = assembler
+            .compile_in_context(
+                &epilogue_ast,
+                &mut AssemblyContext::new(AssemblyContextType::Program),
+            )
+            .expect("epilogue is well formed");
+
+        // compile note setup
+        let note_setup_ast =
+            ProgramAst::parse(SatKernel::note_setup()).expect("note setup is well formed");
+        let note_setup = assembler
+            .compile_in_context(
+                &note_setup_ast,
+                &mut AssemblyContext::new(AssemblyContextType::Program),
+            )
+            .expect("note setup is well formed");
+
+        // compile note processing teardown
+        let note_processing_teardown_ast = ProgramAst::parse(SatKernel::note_processing_teardown())
+            .expect("note processing teardown is well formed");
+        let note_processing_teardown = assembler
+            .compile_in_context(
+                &note_processing_teardown_ast,
+                &mut AssemblyContext::new(AssemblyContextType::Program),
+            )
+            .expect("note processing teardown is well formed");
+
+        TransactionComplier {
+            assembler,
+            account_procedures: BTreeMap::default(),
+            prologue,
+            epilogue,
+            note_setup,
+            note_processing_teardown,
+        }
+    }
+
+    // CODE COMPILERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Compiles the provided module into [AccountCode] and associates the resulting procedures
+    /// with the specified account ID.
+    pub fn load_account(
+        &mut self,
+        account_id: AccountId,
+        account_code: ModuleAst,
+    ) -> Result<AccountCode, TransactionError> {
+        let account_code = AccountCode::new(account_id, account_code, &mut self.assembler)
+            .map_err(TransactionError::LoadAccountFailed)?;
+        self.account_procedures.insert(account_id, account_code.procedures().to_vec());
+        Ok(account_code)
+    }
+
+    /// Loads the provided account interface (vector of procedure digests) into the `account_procedures` map.
+    /// Returns the old account interface if it previously existed.
+    pub fn load_account_interface(
+        &mut self,
+        account_id: AccountId,
+        procedures: Vec<Digest>,
+    ) -> Option<Vec<Digest>> {
+        self.account_procedures.insert(account_id, procedures)
+    }
+
+    /// Compiles the provided program into the [NoteScript] and checks (to the extent possible)
+    /// if a note could be executed against all accounts with the specified interfaces.
+    pub fn compile_note_script(
+        &mut self,
+        note_script_ast: ProgramAst,
+        target_account_proc: Vec<NoteTarget>,
+    ) -> Result<NoteScript, TransactionError> {
+        let (note_script, code_block) = NoteScript::new(note_script_ast, &mut self.assembler)
+            .map_err(|_| TransactionError::CompileNoteScriptFailed)?;
+        for note_target in target_account_proc.into_iter() {
+            verify_program_account_compatibility(
+                &code_block,
+                &self.get_target_interface(note_target)?,
+            )
+            .map_err(|_| {
+                TransactionError::NoteIncompatibleWithAccountInterface(code_block.hash())
+            })?;
+        }
+
+        Ok(note_script)
+    }
+
+    /// Compiles a transaction which executes the provided notes against the specified account.
+    ///
+    /// The account is assumed to have been previously loaded into this compiler.
+    pub fn compile_transaction(
+        &mut self,
+        account_id: AccountId,
+        notes: Vec<Note>,
+        tx_script: Option<ProgramAst>,
+    ) -> Result<CompiledTransaction, TransactionError> {
+        // Fetch the account interface from the `account_procedures` map. Return an error if the
+        // interface is not found.
+        let target_account_interface = self
+            .account_procedures
+            .get(&account_id)
+            .cloned()
+            .ok_or(TransactionError::AccountInterfaceNotFound(account_id))?;
+
+        // Transaction must contain at least one input note or a transaction script
+        if notes.is_empty() && tx_script.is_none() {
+            return Err(TransactionError::InvalidTransactionInputs);
+        }
+
+        // Create the [AssemblyContext] for compilation of the transaction program
+        let mut assembly_context = AssemblyContext::new(AssemblyContextType::Program);
+
+        // Create note tree and note [CodeBlock]s
+        let (note_tree_root, note_roots) = self.create_note_program_tree(
+            &target_account_interface,
+            &notes,
+            &mut assembly_context,
+        )?;
+
+        // Create the transaction program
+        let (tx_script_code_block, tx_script_hash) =
+            self.create_tx_program(tx_script, &mut assembly_context, target_account_interface)?;
+
+        // Merge transaction script code block and epilogue code block
+        let tx_script_and_epilogue = CodeBlock::new_join([
+            CodeBlock::new_call(tx_script_code_block.hash()),
+            self.epilogue.clone(),
+        ]);
+
+        // Merge prologue and note script tree
+        let prologue_and_notes = CodeBlock::new_join([self.prologue.clone(), note_tree_root]);
+
+        // Merge prologue, note tree, tx script and epilogue
+        let program_root = CodeBlock::new_join([prologue_and_notes, tx_script_and_epilogue]);
+
+        // Create [CodeBlockTable] from [AssemblyContext]
+        let mut cb_table = self
+            .assembler
+            .build_cb_table(assembly_context)
+            .map_err(TransactionError::BuildCodeBlockTableFailed)?;
+
+        // insert note roots into [CodeBlockTable]
+        note_roots.into_iter().for_each(|note_root| {
+            cb_table.insert(note_root);
+        });
+
+        // insert transaction script into [CodeBlockTable]
+        cb_table.insert(tx_script_code_block);
+
+        // Create transaction program
+        let program = Program::with_kernel(program_root, self.assembler.kernel().clone(), cb_table);
+
+        // Create compiled transaction
+        Ok(CompiledTransaction::new(account_id, notes, tx_script_hash, program))
+    }
+
+    /// Returns a ([CodeBlock], Option<Digest>) tuple where the first element is the compiled
+    /// transaction program and the second element is the hash of the transaction program. If no
+    /// transaction script is provided, the first element is a [CodeBlock] containing a single
+    /// [Operation::Noop] and the second element is `None`.
+    fn create_tx_program(
+        &mut self,
+        tx_script: Option<ProgramAst>,
+        assembly_context: &mut AssemblyContext,
+        target_account_interface: Vec<Digest>,
+    ) -> Result<(CodeBlock, Option<Digest>), TransactionError> {
+        let tx_script_is_some = tx_script.is_some();
+        let tx_script_code_block = match tx_script {
+            Some(tx_script) => self
+                .assembler
+                .compile_in_context(&tx_script, assembly_context)
+                .map_err(TransactionError::CompileTxScriptFailed)?,
+            None => CodeBlock::new_span(vec![Operation::Noop]),
+        };
+        verify_program_account_compatibility(&tx_script_code_block, &target_account_interface)
+            .map_err(|_| {
+                TransactionError::TxScriptIncompatibleWithAccountInterface(
+                    tx_script_code_block.hash(),
+                )
+            })?;
+        let tx_script_hash = tx_script_is_some.then_some(tx_script_code_block.hash());
+        Ok((tx_script_code_block, tx_script_hash))
+    }
+
+    /// Returns a [CodeBlock] which contains the note program tree root and a [Vec<CodeBlock>] which
+    /// contains the [CodeBlock]s associated with the notes.
+    fn create_note_program_tree(
+        &mut self,
+        target_account_interface: &[Digest],
+        notes: &[Note],
+        assembly_context: &mut AssemblyContext,
+    ) -> Result<(CodeBlock, Vec<CodeBlock>), TransactionError> {
+        // Create vectors to store note programs and note roots
+        let mut note_programs = Vec::new();
+        let mut note_roots = Vec::new();
+
+        // Create and verify note programs. Note programs are verified against the target account.
+        for note in notes.iter() {
+            let note_root = self
+                .assembler
+                .compile_in_context(note.script().code(), assembly_context)
+                .map_err(|_| TransactionError::CompileNoteScriptFailed)?;
+            verify_program_account_compatibility(&note_root, target_account_interface).map_err(
+                |_| TransactionError::NoteIncompatibleWithAccountInterface(note_root.hash()),
+            )?;
+            note_programs.push(CodeBlock::new_join([
+                self.note_setup.clone(),
+                CodeBlock::new_call(note_root.hash()),
+            ]));
+            note_roots.push(note_root);
+        }
+
+        // Push note processing teardown onto the note programs vector
+        note_programs.push(self.note_processing_teardown.clone());
+
+        // Merge the note programs into a tree using join blocks
+        while note_programs.len() != 1 {
+            // TODO: We should optimize this in the future - however maybe not required as this
+            // part will be handled by a pcall-like operation in the future.
+            // Pad note programs to an even number using a [Operation::Noop] span block
+            if note_programs.len() % 2 != 0 {
+                note_programs.push(CodeBlock::new_span(vec![Operation::Noop]));
+            }
+
+            // convert vector into an iterator
+            let mut note_programs_iter = note_programs.into_iter();
+
+            // create a temporary vector to hold the merged CodeBlocks
+            let mut note_programs_temp = Vec::new();
+
+            // Consume two code blocks at a time and merge them into a single code block
+            while let (Some(left_code_block), Some(right_code_block)) =
+                (note_programs_iter.next(), note_programs_iter.next())
+            {
+                note_programs_temp.push(CodeBlock::new_join([left_code_block, right_code_block]));
+            }
+
+            note_programs = note_programs_temp;
+        }
+
+        Ok((
+            note_programs.into_iter().next().expect("a single root code block exists"),
+            note_roots,
+        ))
+    }
+
+    // HELPERS
+    // --------------------------------------------------------------------------------------------
+    /// Returns the account interface associated with the provided [NoteTarget].
+    ///
+    /// # Errors
+    /// - If the account interface associated with the [AccountId] provided as a target can not be
+    ///   found in the `account_procedures` map.
+    fn get_target_interface(&self, target: NoteTarget) -> Result<Vec<Digest>, TransactionError> {
+        match target {
+            NoteTarget::AccountId(id) => self
+                .account_procedures
+                .get(&id)
+                .cloned()
+                .ok_or(TransactionError::AccountInterfaceNotFound(id)),
+            NoteTarget::Procedures(procs) => Ok(procs),
+        }
+    }
+}
+
+impl Default for TransactionComplier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// TRANSACTION COMPILER HELPERS
+// ------------------------------------------------------------------------------------------------
+
+/// Verifies that the provided program is compatible with the target account interface.
+/// This is achieved by checking that at least one execution branch in the program is compatible
+/// with the target account interface.
+///
+/// # Errors
+/// Returns an error if the note script is not compatible with the target account interface.
+fn verify_program_account_compatibility(
+    program: &CodeBlock,
+    target_account_interface: &[Digest],
+) -> Result<(), TransactionError> {
+    // collect call branches
+    let branches = collect_call_branches(program);
+
+    // if none of the branches are compatible with the target account, return an error
+    if !branches.iter().any(|call_targets| {
+        call_targets.iter().all(|target| target_account_interface.contains(target))
+    }) {
+        return Err(TransactionError::ProgramIncompatibleWithAccountInterface(program.hash()));
+    }
+
+    Ok(())
+}
+
+/// Collect call branches by recursively traversing through program execution branches and
+/// accumulating call targets.
+fn collect_call_branches(code_block: &CodeBlock) -> Vec<Vec<Digest>> {
+    let mut branches = vec![vec![]];
+    recursively_collect_call_branches(code_block, &mut branches);
+    branches
+}
+
+/// Generates a list of calls invoked in each execution branch of the provided code block.
+fn recursively_collect_call_branches(code_block: &CodeBlock, branches: &mut Vec<Vec<Digest>>) {
+    match code_block {
+        CodeBlock::Join(block) => {
+            recursively_collect_call_branches(block.first(), branches);
+            recursively_collect_call_branches(block.second(), branches);
+        }
+        CodeBlock::Split(block) => {
+            let current_len = branches.last().expect("at least one execution branch").len();
+            recursively_collect_call_branches(block.on_false(), branches);
+
+            // If the previous branch had additional calls we need to create a new branch
+            if branches.last().expect("at least one execution branch").len() > current_len {
+                branches.push(
+                    branches.last().expect("at least one execution branch")[..current_len].to_vec(),
+                );
+            }
+
+            recursively_collect_call_branches(block.on_true(), branches);
+        }
+        CodeBlock::Loop(block) => {
+            recursively_collect_call_branches(block.body(), branches);
+        }
+        CodeBlock::Call(block) => {
+            branches
+                .last_mut()
+                .expect("at least one execution branch")
+                .push(block.fn_hash());
+        }
+        CodeBlock::Span(_) => {}
+        CodeBlock::Proxy(_) => {}
+    }
+}
+
+// NOTE TARGET
+// ================================================================================================
+
+#[derive(Clone)]
+pub enum NoteTarget {
+    AccountId(AccountId),
+    Procedures(Vec<Digest>),
+}
+
+// TEST ASSETS
+// ================================================================================================
+#[cfg(test)]
+pub struct TransactionComplier {
+    pub assembler: Assembler,
+    pub account_procedures: BTreeMap<AccountId, Vec<Digest>>,
+    pub prologue: CodeBlock,
+    pub epilogue: CodeBlock,
+    pub note_setup: CodeBlock,
+    pub note_processing_teardown: CodeBlock,
+}

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -1,0 +1,272 @@
+use super::{AccountId, ModuleAst, Note, NoteTarget, Operation, ProgramAst, TransactionComplier};
+use assembly::AssemblyContext;
+use crypto::{Felt, FieldElement, Word};
+use miden_core::code_blocks::CodeBlock;
+use miden_objects::assets::{Asset, FungibleAsset};
+
+// CONSTANTS
+// ================================================================================================
+
+const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u64 = 0b0110011011u64 << 54;
+
+// Mast roots of account procedures:
+const ACCT_PROC_1: &'static str =
+    "0x8ef0092134469a1330e3c468f57c7f085ce611645d09cc7516c786fefc71d794";
+const ACCT_PROC_2: &'static str =
+    "0xff06b90f849c4b262cbfbea67042c4ea017ea0e9c558848a951d44b23370bec5";
+const ACCOUNT_CODE_MASM: &'static str = "\
+export.account_procedure_1
+    push.1.2
+    add
+end
+
+export.account_procedure_2
+    push.2.1
+    sub
+end
+";
+
+// Mast roots of additional procedures:
+const ADD_PROC_1: &'static str =
+    "0x5b6f7afcde4aaf538519c3bf5bb9321fac83cd769a3100c0b1225c9a6d75c9a1";
+const ADD_PROC_2: &'static str =
+    "0xd4b1f9fbad5d0e6d2386509eab6a865298db20095d7315226dfa513ce017c990";
+const ADDITIONAL_PROCEDURES: &'static str = "\
+export.additional_procedure_1
+    push.3.4
+    add
+end
+
+export.additional_procedure_2
+    push.4.5
+    add
+end
+";
+
+// TESTS
+// ================================================================================================
+
+#[test]
+fn test_load_account() {
+    let mut tx_compiler = TransactionComplier::new();
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
+    let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
+    let account_code = tx_compiler.load_account(account_id, account_code_ast).unwrap();
+
+    let acct_procs = [hex_to_bytes(ACCT_PROC_1), hex_to_bytes(ACCT_PROC_2)];
+    for proc in account_code.procedures() {
+        assert!(acct_procs.contains(&proc.as_bytes().to_vec()));
+    }
+}
+
+#[test]
+fn test_compile_valid_note_script() {
+    let test_cases = [
+        (
+            format!(
+                "begin
+                call.{ACCT_PROC_1}
+                call.{ACCT_PROC_2} 
+            end"
+            ),
+            true,
+        ),
+        (
+            format!(
+                "begin
+                if.true
+                    call.{ACCT_PROC_1}
+                    if.true
+                        call.{ACCT_PROC_2}
+                    else
+                        call.{ADD_PROC_1}
+                    end
+                else
+                    call.{ADD_PROC_2}
+                end
+            end"
+            ),
+            true,
+        ),
+        (
+            format!(
+                "begin
+                    call.{ACCT_PROC_1}
+                    if.true
+                        call.{ADD_PROC_1}
+                    else
+                        call.{ADD_PROC_2}
+                end
+            end"
+            ),
+            false,
+        ),
+    ];
+
+    let mut tx_compiler = TransactionComplier::new();
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
+    let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
+    let _account_code = tx_compiler.load_account(account_id, account_code_ast).unwrap();
+    let target_account_proc = NoteTarget::AccountId(account_id);
+
+    // TODO: replace this with anonymous call targets once they are implemented
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN + 1).unwrap();
+    let account_code_ast = ModuleAst::parse(ADDITIONAL_PROCEDURES).unwrap();
+    tx_compiler.load_account(account_id, account_code_ast).unwrap();
+
+    for (note_script_src, expected) in test_cases {
+        let note_script_ast = ProgramAst::parse(note_script_src.as_str()).unwrap();
+
+        let result =
+            tx_compiler.compile_note_script(note_script_ast, vec![target_account_proc.clone()]);
+        match expected {
+            true => assert!(result.is_ok()),
+            false => assert!(result.is_err()),
+        }
+    }
+}
+
+fn mock_consumed_notes(
+    tx_compiler: &mut TransactionComplier,
+    target_account: AccountId,
+) -> Vec<Note> {
+    pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
+
+    pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
+    // Note Assets
+    let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+    let faucet_id_2 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN + 10).unwrap();
+    let faucet_id_3 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN + 20).unwrap();
+    let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
+    let fungible_asset_2: Asset = FungibleAsset::new(faucet_id_2, 200).unwrap().into();
+    let fungible_asset_3: Asset = FungibleAsset::new(faucet_id_3, 300).unwrap().into();
+
+    // Sender account
+    let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
+    // create note script
+    let note_program_ast =
+        ProgramAst::parse(format!("begin call.{ACCT_PROC_1} drop end").as_str()).unwrap();
+    let note_script = tx_compiler
+        .compile_note_script(note_program_ast, vec![NoteTarget::AccountId(target_account)])
+        .unwrap();
+
+    // Consumed Notes
+    const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
+    let note_1 = Note::new(
+        note_script.clone(),
+        &[Felt::new(1)],
+        &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
+        SERIAL_NUM_1,
+        sender,
+        Felt::ZERO,
+        None,
+    )
+    .unwrap();
+
+    const SERIAL_NUM_2: Word = [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)];
+    let note_2 = Note::new(
+        note_script,
+        &[Felt::new(2)],
+        &[fungible_asset_1, fungible_asset_2, fungible_asset_3],
+        SERIAL_NUM_2,
+        sender,
+        Felt::ZERO,
+        None,
+    )
+    .unwrap();
+
+    vec![note_1, note_2]
+}
+
+#[test]
+fn test_transaction_compilation() {
+    let mut tx_compiler = TransactionComplier::new();
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
+    let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
+    let _account_code = tx_compiler.load_account(account_id, account_code_ast).unwrap();
+
+    let notes = mock_consumed_notes(&mut tx_compiler, account_id);
+
+    let tx_script_src = format!(
+        "
+    begin
+        call.{ACCT_PROC_2}
+    end
+    "
+    );
+    let tx_script_ast = ProgramAst::parse(tx_script_src.as_str()).unwrap();
+
+    let tx = tx_compiler
+        .compile_transaction(account_id, notes.clone(), Some(tx_script_ast.clone()))
+        .unwrap();
+
+    let tx_program = tx.tx_program();
+
+    assert_eq!(
+        tx_program.root().hash(),
+        expected_mast_tree(&mut tx_compiler, &notes, &tx_script_ast).hash()
+    );
+}
+
+fn expected_mast_tree(
+    tx_compiler: &mut TransactionComplier,
+    notes: &[Note],
+    tx_script: &ProgramAst,
+) -> CodeBlock {
+    let noop_span = CodeBlock::new_span(vec![Operation::Noop]);
+
+    let note_0_leafs = create_note_leafs(tx_compiler, &notes[0]);
+    let note_1_leafs = create_note_leafs(tx_compiler, &notes[1]);
+    let note_teardown_leafs =
+        CodeBlock::new_join([tx_compiler.note_processing_teardown.clone(), noop_span.clone()]);
+
+    let tx_script_program = tx_compiler
+        .assembler
+        .compile_in_context(
+            tx_script,
+            &mut AssemblyContext::new(assembly::AssemblyContextType::Program),
+        )
+        .unwrap();
+    let tx_script_epilogue_leafs = CodeBlock::new_join([
+        CodeBlock::new_call(tx_script_program.hash()),
+        tx_compiler.epilogue.clone(),
+    ]);
+
+    let note_tree_internal_node = CodeBlock::new_join([note_0_leafs, note_1_leafs]);
+    let note_tree_root = CodeBlock::new_join([note_tree_internal_node, note_teardown_leafs]);
+
+    let prologue_and_note_tree_node =
+        CodeBlock::new_join([tx_compiler.prologue.clone(), note_tree_root]);
+
+    let program_root = CodeBlock::new_join([prologue_and_note_tree_node, tx_script_epilogue_leafs]);
+
+    program_root
+}
+
+fn create_note_leafs(tx_compiler: &mut TransactionComplier, note: &Note) -> CodeBlock {
+    let note_code_block = tx_compiler
+        .assembler
+        .compile_in_context(
+            note.script().code(),
+            &mut AssemblyContext::new(assembly::AssemblyContextType::Program),
+        )
+        .unwrap();
+    CodeBlock::new_join([
+        tx_compiler.note_setup.clone(),
+        CodeBlock::new_call(note_code_block.hash()),
+    ])
+}
+
+// HELPERS
+// ================================================================================================
+fn hex_to_bytes(hex: &str) -> Vec<u8> {
+    (2..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+        .collect::<Vec<_>>()
+}

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -66,26 +66,26 @@ fn test_compile_valid_note_script() {
         (
             format!(
                 "begin
-                call.{ACCT_PROC_1}
-                call.{ACCT_PROC_2} 
-            end"
+                    call.{ACCT_PROC_1}
+                    call.{ACCT_PROC_2} 
+                end"
             ),
             true,
         ),
         (
             format!(
                 "begin
-                if.true
-                    call.{ACCT_PROC_1}
                     if.true
-                        call.{ACCT_PROC_2}
+                        call.{ACCT_PROC_1}
+                        if.true
+                            call.{ACCT_PROC_2}
+                        else
+                            call.{ADD_PROC_1}
+                        end
                     else
-                        call.{ADD_PROC_1}
+                        call.{ADD_PROC_2}
                     end
-                else
-                    call.{ADD_PROC_2}
-                end
-            end"
+                end"
             ),
             true,
         ),
@@ -97,8 +97,8 @@ fn test_compile_valid_note_script() {
                         call.{ADD_PROC_1}
                     else
                         call.{ADD_PROC_2}
-                end
-            end"
+                    end
+                end"
             ),
             false,
         ),
@@ -192,13 +192,7 @@ fn test_transaction_compilation() {
 
     let notes = mock_consumed_notes(&mut tx_compiler, account_id);
 
-    let tx_script_src = format!(
-        "
-    begin
-        call.{ACCT_PROC_2}
-    end
-    "
-    );
+    let tx_script_src = format!("begin call.{ACCT_PROC_2} end");
     let tx_script_ast = ProgramAst::parse(tx_script_src.as_str()).unwrap();
 
     let tx = tx_compiler
@@ -212,6 +206,9 @@ fn test_transaction_compilation() {
         expected_mast_tree(&mut tx_compiler, &notes, &tx_script_ast).hash()
     );
 }
+
+// HELPERS
+// ================================================================================================
 
 fn expected_mast_tree(
     tx_compiler: &mut TransactionComplier,
@@ -262,8 +259,6 @@ fn create_note_leafs(tx_compiler: &mut TransactionComplier, note: &Note) -> Code
     ])
 }
 
-// HELPERS
-// ================================================================================================
 fn hex_to_bytes(hex: &str) -> Vec<u8> {
     (2..hex.len())
         .step_by(2)

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -1,0 +1,14 @@
+use super::{AccountError, AccountId, AssemblyError, Digest};
+
+#[derive(Debug)]
+pub enum TransactionError {
+    InvalidTransactionInputs,
+    LoadAccountFailed(AccountError),
+    AccountInterfaceNotFound(AccountId),
+    ProgramIncompatibleWithAccountInterface(Digest),
+    NoteIncompatibleWithAccountInterface(Digest),
+    TxScriptIncompatibleWithAccountInterface(Digest),
+    CompileNoteScriptFailed,
+    CompileTxScriptFailed(AssemblyError),
+    BuildCodeBlockTableFailed(AssemblyError),
+}

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -1,0 +1,18 @@
+use assembly::{
+    ast::{ModuleAst, ProgramAst},
+    Assembler, AssemblyContext, AssemblyContextType, AssemblyError,
+};
+use crypto::hash::rpo::RpoDigest as Digest;
+use miden_core::{code_blocks::CodeBlock, utils::collections::BTreeMap, Operation, Program};
+use miden_lib::{MidenLib, SatKernel};
+use miden_objects::{
+    notes::{Note, NoteScript},
+    transaction::CompiledTransaction,
+    AccountCode, AccountError, AccountId,
+};
+use miden_stdlib::StdLibrary;
+
+mod compiler;
+pub use compiler::{NoteTarget, TransactionComplier};
+mod error;
+pub use error::TransactionError;

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -250,6 +250,18 @@ impl fmt::Display for AccountId {
     }
 }
 
+impl PartialOrd for AccountId {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AccountId {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.as_int().cmp(&other.0.as_int())
+    }
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -1,10 +1,8 @@
-use super::{AccountError, AccountId, Digest};
-use assembly::{
-    ast::ModuleAst, Assembler, AssemblyContext, AssemblyContextType, LibraryPath, Module,
+use super::{
+    AccountError, AccountId, Assembler, AssemblyContext, AssemblyContextType, Digest, LibraryPath,
+    Module, ModuleAst,
 };
 use crypto::merkle::SimpleSmt;
-use miden_lib::MidenLib;
-use miden_stdlib::StdLibrary;
 
 // ACCOUNT CODE
 // ================================================================================================
@@ -36,19 +34,16 @@ impl AccountCode {
     // --------------------------------------------------------------------------------------------
     /// Creates and returns a new definition of an account's interface compiled from the specified
     /// source code.
-    pub fn new(source: &str, account_id: AccountId) -> Result<Self, AccountError> {
-        let module_ast = ModuleAst::parse(source)?;
+    pub fn new(
+        account_id: AccountId,
+        account_module: ModuleAst,
+        assembler: &mut Assembler,
+    ) -> Result<Self, AccountError> {
         let module = Module::new(
             LibraryPath::new(format!("{}_{}", Self::ACCOUNT_CODE_NAMESPACE_BASE, account_id))
                 .expect("valid path"),
-            module_ast,
+            account_module,
         );
-
-        let assembler = Assembler::default()
-            .with_library(&MidenLib::default())
-            .expect("failed to load miden-lib")
-            .with_library(&StdLibrary::default())
-            .expect("failed to load std-lib");
 
         let mut procedure_digests = assembler
             .compile_module(&module, &mut AssemblyContext::new(AssemblyContextType::Module))
@@ -81,6 +76,11 @@ impl AccountCode {
     /// Returns a reference to the [ModuleAst] backing the [AccountCode].
     pub fn module(&self) -> &ModuleAst {
         &self.module
+    }
+
+    /// Returns a reference to the account procedure digests.
+    pub fn procedures(&self) -> &[Digest] {
+        &self.procedures
     }
 
     /// Returns a reference to the procedure tree.

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,7 +1,8 @@
 use super::{
     assets::{Asset, FungibleAsset, NonFungibleAsset},
-    AccountError, AdviceInputsBuilder, Digest, Felt, Hasher, StarkField, TieredSmt, ToAdviceInputs,
-    ToString, Vec, Word, ZERO,
+    AccountError, AdviceInputsBuilder, Assembler, AssemblyContext, AssemblyContextType, Digest,
+    Felt, Hasher, LibraryPath, Module, ModuleAst, StarkField, TieredSmt, ToAdviceInputs, ToString,
+    Vec, Word, ZERO,
 };
 
 mod account_id;

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -160,6 +160,7 @@ pub enum NoteError {
     DuplicateNonFungibleAsset(NonFungibleAsset),
     EmptyAssetList,
     InvalidOriginIndex(String),
+    ScriptCompilationError(AssemblyError),
     TooManyAssets(usize),
     TooManyInputs(usize),
 }

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -3,6 +3,10 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+use assembly::{
+    ast::{ModuleAst, ProgramAst},
+    Assembler, AssemblyContext, AssemblyContextType, LibraryPath, Module,
+};
 use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},
     merkle::{MerkleError, Mmr, TieredSmt},
@@ -12,6 +16,7 @@ use crypto::{
     },
     Felt, StarkField, Word, WORD_SIZE, ZERO,
 };
+use miden_core::code_blocks::CodeBlock;
 
 mod accounts;
 pub use accounts::{

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -4,7 +4,7 @@ use super::{Digest, Felt, Hasher, NoteError, ZERO};
 /// - inputs are stored in reverse stack order such that when they are pushed onto stack they are
 ///   in the correct order
 /// - hash is computed from inputs in the order they are stored (reverse stack order)
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NoteInputs {
     inputs: [Felt; 16],
     hash: Digest,

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -4,7 +4,7 @@ use super::{AccountId, Felt, Word};
 /// - sender is the account which created the note.
 /// - tag is a tag which can be used to identify the target account for the note.
 /// - num_assets is the number of assets in the note.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NoteMetadata {
     sender: AccountId,
     tag: Felt,

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -1,8 +1,7 @@
-use crate::AccountId;
-
 use super::{
-    assets::Asset, AdviceInputsBuilder, Digest, Felt, Hasher, NoteError, ToAdviceInputs, Vec, Word,
-    WORD_SIZE, ZERO,
+    assets::Asset, AccountId, AdviceInputsBuilder, Assembler, AssemblyContext, AssemblyContextType,
+    CodeBlock, Digest, Felt, Hasher, NoteError, ProgramAst, ToAdviceInputs, Vec, Word, WORD_SIZE,
+    ZERO,
 };
 
 mod inputs;
@@ -49,7 +48,7 @@ pub const NOTE_LEAF_DEPTH: u8 = NOTE_TREE_DEPTH + 1;
 /// - A metadata object which contains information about the sender, the tag and the number of
 ///   assets in the note.
 /// - An origin which provides information about the origin of the note.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Note {
     script: NoteScript,
     inputs: NoteInputs,
@@ -66,26 +65,22 @@ impl Note {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - Compilation of note script fails.
     /// - The number of inputs exceeds 16.
     /// - The number of provided assets exceeds 1000.
     /// - The list of assets contains duplicates.
-    pub fn new<S>(
-        script_src: S,
+    pub fn new(
+        script: NoteScript,
         inputs: &[Felt],
         assets: &[Asset],
         serial_num: Word,
         sender: AccountId,
         tag: Felt,
         origin: Option<NoteOrigin>,
-    ) -> Result<Self, NoteError>
-    where
-        S: AsRef<str>,
-    {
+    ) -> Result<Self, NoteError> {
         let vault = NoteVault::new(assets)?;
         let num_assets = vault.num_assets();
         Ok(Self {
-            script: NoteScript::new(script_src)?,
+            script,
             inputs: NoteInputs::new(inputs),
             vault,
             serial_num,

--- a/objects/src/notes/origin.rs
+++ b/objects/src/notes/origin.rs
@@ -9,7 +9,7 @@ use crypto::merkle::{MerklePath, NodeIndex};
 ///              in.
 /// note_path  - the Merkle path to the note in the note Merkle tree of the block the note was
 ///              created in.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoteOrigin {
     block_num: Felt,
     sub_hash: Digest,


### PR DESCRIPTION
This PR introduces the `tx-compiler` described in #141.  We also modify the note setup script to address the issues described in #143.  We introduce the `kernel` module (`kernel.masm`) which is a module that contains all kernel procedures - this currently re-exports procedures from other modules using the procedure export pattern. Additionally we introduce a rust `TransactionKernel` type which contains all `Kernel` associated data and types.  A note processing teardown program has been introduced which is run at the end of note processing to reset the current consumed note pointer to 0.  