### PR TITLE
bugfix: adv.keyval -> adv.push_mapval

### DIFF
--- a/miden-lib/asm/sat/account.masm
+++ b/miden-lib/asm/sat/account.masm
@@ -214,7 +214,7 @@ end
 #! Stack: [acct_id]
 #! Output: []
 #!
-#! - acct_id is the account id. 
+#! - acct_id is the account id.
 export.validate_id
     # split felt into 32 bit limbs
     u32split
@@ -307,7 +307,7 @@ export.authenticate_procedure.1
     # => [PROC_ROOT, CODE_ROOT]
 
     # load the index of the procedure root onto the advice stack
-    adv.keyval adv_push.1 movdn.4
+    adv.push_mapval adv_push.1 movdn.4
     # => [PROC_ROOT, index, CODE_ROOT]
 
     # push the depth of the code Merkle tree onto the stack

--- a/miden-lib/asm/sat/note.masm
+++ b/miden-lib/asm/sat/note.masm
@@ -15,7 +15,7 @@ export.get_sender
     exec.layout::get_current_consumed_note_ptr
     # => [ptr]
 
-    # assert the pointer is not zero - this would suggest the procedure has been called from an 
+    # assert the pointer is not zero - this would suggest the procedure has been called from an
     # incorrect context
     dup neq.0 assert
     # => [ptr]
@@ -38,7 +38,7 @@ export.get_vault_data
     exec.layout::get_current_consumed_note_ptr
     # => [ptr]
 
-    # assert the pointer is not zero - this would suggest the procedure has been called from an 
+    # assert the pointer is not zero - this would suggest the procedure has been called from an
     # incorrect context
     dup neq.0 assert
     # => [ptr]
@@ -66,7 +66,7 @@ export.get_assets
     # => [VAULT_HASH, num_assets, dest_ptr]
 
     # load the vault data from the advice map to the advice stack
-    adv.keyval
+    adv.push_mapval
     # => [VAULT_HASH, num_assets, dest_ptr]
 
     # calculate number of assets rounded up to an even number
@@ -80,7 +80,7 @@ export.get_assets
     # prepare the stack for reading from the advice stack
     padw padw padw
     # => [PAD, PAD, PAD, start_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
-    
+
     # read the assets from advice stack to memory
     exec.mem::pipe_double_words_to_memory
     # => [PERM, PERM, PERM, end_ptr', end_ptr, VAULT_HASH, num_assets, dest_ptr]
@@ -106,7 +106,7 @@ export.increment_current_consumed_note_idx
     # get the current consumed note index
     exec.layout::get_current_consumed_note_idx
     # => [note_idx]
-    
+
     # increment the index of the current consumed note and save back to memory
     dup add.1 exec.layout::set_current_consumed_note_idx
     # => [note_idx]

--- a/miden-lib/asm/sat/note_setup.masm
+++ b/miden-lib/asm/sat/note_setup.masm
@@ -19,7 +19,7 @@ export.prepare_note.4
     # => [idx]
 
     # convert the index of the consumed note being executed to a pointer and store in memory
-    exec.layout::get_consumed_note_ptr 
+    exec.layout::get_consumed_note_ptr
     # => [note_ptr]
 
     # set current consumed note pointer to the note being executed
@@ -27,7 +27,7 @@ export.prepare_note.4
     # => [note_ptr]
 
     # load the note inputs on to the advice stack
-    exec.layout::get_consumed_note_inputs_hash adv.keyval
+    exec.layout::get_consumed_note_inputs_hash adv.push_mapval
     # => [INPUTS_HASH]
 
     # load the note inputs from the advice provider


### PR DESCRIPTION
the advice instructions were [renamed](https://github.com/0xPolygonMiden/miden-vm/pull/933), this fixes the miden-lib code (otherwise the `build.rs` fails to run)