### PR TITLE
deps: update crypto crate and corresponding types

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -22,7 +22,7 @@ vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/mid
 miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
 
 [dev-dependencies]
-crypto = { package = "miden-crypto", version = "0.5", default-features = false }
+crypto = { package = "miden-crypto", version = "0.6", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects"}
 miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
 processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", features = ["internals"] }

--- a/miden-lib/tests/common/data.rs
+++ b/miden-lib/tests/common/data.rs
@@ -76,7 +76,7 @@ pub fn mock_chain_data(consumed_notes: &mut [Note]) -> ChainMmr {
     ];
 
     // convert block hashes into words
-    let block_hashes: Vec<Word> = block_chain.iter().map(|h| Word::from(h.hash())).collect();
+    let block_hashes: Vec<Digest> = block_chain.iter().map(|h| h.hash()).collect();
 
     // instantiate and populate MMR
     let mut chain_mmr = ChainMmr::default();
@@ -137,7 +137,11 @@ fn mock_account(
 
     // create account storage
     let account_storage = AccountStorage::new(
-        vec![STORAGE_ITEM_0, STORAGE_ITEM_1, (CHILD_ROOT_PARENT_LEAF_INDEX, child_smt.root())],
+        vec![
+            STORAGE_ITEM_0,
+            STORAGE_ITEM_1,
+            (CHILD_ROOT_PARENT_LEAF_INDEX, *child_smt.root()),
+        ],
         account_merkle_store,
     )
     .unwrap();

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -133,7 +133,7 @@ fn chain_mmr_memory_assertions<A: AdviceProvider>(
 
     for (i, peak) in inputs.block_chain().mmr().accumulator().peaks.iter().enumerate() {
         // The peaks should be stored at the CHAIN_MMR_PEAKS_PTR
-        assert_eq!(&process.get_memory_value(0, CHAIN_MMR_PEAKS_PTR + i as u64).unwrap(), peak);
+        assert_eq!(process.get_memory_value(0, CHAIN_MMR_PEAKS_PTR + i).unwrap(), Word::from(peak));
     }
 }
 
@@ -159,7 +159,7 @@ fn account_data_memory_assertions<A: AdviceProvider>(
     // The account storage root commitment should be stored at ACCT_STORAGE_ROOT_PTR
     assert_eq!(
         process.get_memory_value(0, ACCT_STORAGE_ROOT_PTR).unwrap(),
-        inputs.account().storage().root()
+        Word::from(inputs.account().storage().root())
     );
 
     // The account code commitment should be stored at (ACCOUNT_DATA_OFFSET + 4)

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -17,7 +17,7 @@ std = ["assembly/std", "crypto/std", "miden-core/std"]
 
 [dependencies]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-crypto = { package = "miden-crypto", version = "0.5", default-features = false }
+crypto = { package = "miden-crypto", version = "0.6", default-features = false }
 miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects"}
 miden-lib = { package = "miden-lib", path = "../miden-lib" }

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -24,7 +24,7 @@ std = ["assembly/std", "crypto/std", "miden-core/std"]
 
 [dependencies]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-crypto = { package = "miden-crypto", version = "0.5", default-features = false }
+crypto = { package = "miden-crypto", version = "0.6", default-features = false }
 hashbrown = { version = "0.13.2" }
 miden-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-lib = { path = "../miden-lib", default-features = false }

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -86,7 +86,7 @@ impl Account {
         elements[0] = *self.id;
         elements[3] = self.nonce;
         elements[4..8].copy_from_slice(self.vault.commitment().as_elements());
-        elements[8..12].copy_from_slice(&self.storage.root());
+        elements[8..12].copy_from_slice(&*self.storage.root());
         elements[12..].copy_from_slice(self.code.root().as_elements());
         Hasher::hash_elements(&elements)
     }
@@ -150,7 +150,7 @@ impl ToAdviceInputs for Account {
         // push core items onto the stack
         target.push_onto_stack(&[*self.id, ZERO, ZERO, self.nonce]);
         target.push_onto_stack(self.vault.commitment().as_elements());
-        target.push_onto_stack(&self.storage.root());
+        target.push_onto_stack(&*self.storage.root());
         target.push_onto_stack(self.code.root().as_elements());
 
         // extend the merkle store with the storage items

--- a/objects/src/accounts/storage.rs
+++ b/objects/src/accounts/storage.rs
@@ -1,5 +1,6 @@
 use super::{AccountError, Word};
 use crypto::merkle::{MerkleStore, NodeIndex, SimpleSmt};
+use miden_processor::crypto::RpoDigest;
 
 // TYPE ALIASES
 // ================================================================================================
@@ -50,14 +51,14 @@ impl AccountStorage {
     // --------------------------------------------------------------------------------------------
 
     /// Returns a commitment to this storage.
-    pub fn root(&self) -> Word {
+    pub fn root(&self) -> RpoDigest {
         self.slots.root()
     }
 
     /// Returns an item from the storage at the specified index.
     ///
     /// If the item is not present in the storage, [ZERO; 4] is returned.
-    pub fn get_item(&self, index: u8) -> Word {
+    pub fn get_item(&self, index: u8) -> RpoDigest {
         let item_index = NodeIndex::new(Self::STORAGE_TREE_DEPTH, index as u64)
             .expect("index is u8 - index within range");
         self.slots.get_node(item_index).expect("index is u8 - index within range")


### PR DESCRIPTION
miden-vm/next is using the next version of crypto, which changed the type of a few interfaces from Word to RpoDigest [ref](https://github.com/0xPolygonMiden/crypto/pull/157). This changed some APIs (like the assembler), and was causing compilation conflicts.

This fixes these errors