### PR TITLE
docs: new version of the architecture overview

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,58 +1,34 @@
 # Architecture
+The Polygon Miden Architecture decribes the concepts of how the participants of the network can interact. 
 
-The Miden Architecture document describes the concept of how the participants of the network interact with each other in Polygon Miden. The architecture reflects our design goal of **building an Ethereum-scaling solution that extends its feature set**. Miden enables developers to build faster, safer, and more private decentralized applications. Rollups allow the creation of new design spaces while retaining the collateral economic security of Ethereum. This is where we innovate while the base layer provides stability and keeps evolving slowly.
+The architecture reflects the design goals for the rollup: 
 
-The [**Actor Model**](https://en.wikipedia.org/wiki/Actor_model) is our inspiration for achieving concurrent, local state changes in distributed systems like a blockchain. In the Actor Model, actors play the role of little state machines, meaning each actor is responsible for their own state. Actors have inboxes to send and receive messages to communicate with other actors. Messages can be read asynchronously.
+* **High throughput** 
+* **Privacy**
+* **Asset Safety**
 
-## Basic Concepts
+On Miden, developers can build dApps currently infeasible anywhere else. 
 
-Users can interact with the network by executing transactions. There are **Accounts** and **Notes** in Polygon Miden, both of which can hold assets. Transactions can be thought of as facilitating changes to account states. They basically take one single account and certain notes as input and output the same account in a different condition along with some other notes.
+## Actor Model 
+The [Actor Model](https://en.wikipedia.org/wiki/Actor_model) inspires Miden to achieve concurrent and local state changes. Actors are little state machines with inboxes, meaning each actor is responsible for their state. Actors can send and receive messages to communicate with other actors. Messages can be read asynchronously.
 
-The Miden architecture's core concepts are as follows: 
+## Concepts in Miden
+There are accounts and notes which can hold assets. Accounts consume and produce notes in transactions. Transactions are account state changes of single accounts. The state model captures all individual states of all accounts and notes. Finally, the execution model describes state progress in a sequence of blocks. 
 
-* Accounts, Notes and Transaction model
-* State and Execution model
+### Accounts
+Accounts can hold assets and define rules how those can be transferred. Accounts can represent users or autonomous smart contracts. This chapter describes the design, the storage types, and the creation of an account.
 
-## Transaction Life Cycle
+### Notes
+Notes are messages carrying assets that accounts can send to each other. A note stores assets and a script that defines how this note can be consumed. This chapter describes the design, the storage types, and the creation of a note.
 
-Let's examine how Alice can send Bob 5 MATIC in Polygon Miden to demonstrate the core protocol. We'll be showcasing all three basic concepts i.e., Accounts, Notes, and Transactions.
+### Assets
+Assets can be fungible and non-fungible. They are stored in the owner’s account itself or in a note. This chapter describes asset issuance, customization, and storage.
 
-_Note: Due to the asynchronous execution model, the assets must be transferred in two separate transactions._
+### Transactions
+Transactions describe production or consumption of notes by a single account. For every transaction there is always a STARK proof in Miden. This chapter describes the transaction design and the different transaction modes.
 
-Let's assume that there exist two accounts in Miden that belong to Alice and Bob respectively.
+### State Model
+State describes everything that is the case at a certain point in time. Individual state of accounts or notes can be stored onchain and offchain to provide privacy. This chapter describes the three different state databases in Miden. 
 
-- Alice owns an **Account** that holds her assets.
-
-    <p align="center">
-        <img src="./diagrams/architecture/transaction_lifecycle/Account_Alice_1.png">
-    </p>
-    
-- Now, Alice executes a **Transaction** that creates a **Note** carrying 5 MATIC and changing her **Account** balance by 5 MATIC.
-
-    <p align="center">
-        <img src="./diagrams/architecture/transaction_lifecycle/Transaction_1.png">
-    </p>
-
-- In Miden, there would be Alice's account, the note and Bob's account (becuase Bob hasn't consumed the note yet).
-
-    <p align="center">
-        <img src="./diagrams/architecture/transaction_lifecycle/Account_Note_Account.png">
-    </p>
-
-- For Bob to finally receive the 5 MATIC, he needs to consume the note that Alice created in her transaction. To do that, Bob needs to execute a second transaction.
-
-    <p align="center">
-        <img src="./diagrams/architecture/transaction_lifecycle/Transaction_2.png">
-    </p>
-
-- Now, Bob gets the 5 MATIC in his account. Voila! the transfer of assets is completed.
-
-    <p align="center">
-        <img src="./diagrams/architecture/transaction_lifecycle/Account_Bob_1.png">
-    </p>
-
-## State and Execution Model
-
-**State model** defines how the current state of all accounts and notes at a certain point in time can be thought of. And the **Execution model** defines the rules about how this state progresses from `t` to `t+1`.
-
-In the upcoming sections of this documentation, we'll dive deeper into State and Exectuions as well.
+### Execution Model
+Execution describes how the state progresses - on an individual level via transactions and at the global level expressed as aggregated state updates in blocks. This chapter describes the execution model and how blocks are built.


### PR DESCRIPTION
As discussed with @bobbinth, I re-worked the architecture overview section. 

Specifically: 
- Goal is for developers to understand how Miden works
- I removed all marketing phrases, e.g., "extending the design space". 
- I removed the tx lifecycle (however, I will add it again under the transaction chapter)
- Overview entails now
    - Goals (as user benefits)
    - Summaries of the chapters that follow

Let me know what you think.