### PR TITLE
docs: iterating over transactions section

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
     - [Transactions](architecture/transactions.md)
     - [State](architecture/state.md)
     - [Execution](architecture/execution.md)
+    - [Assets](architecture/assets.md)
 - [Network](./network.md)
     - [Miden Clients](network/miden-clients.md)
     - [Miden Node](network/miden-node.md)


### PR DESCRIPTION
Review after #151, #159, #160 and #161 

As discussed with @bobbinth, I reworked the transactions section.

Specifically:

- Goal is for developers to understand how Miden works
- I removed all marketing phrases, e.g., "extending the design space".
- I added a goal on top - goal of the design is to allow parallel and private transactions
- I removed some diagrams ab transaction execution
- I rephrased some paragraphs to make it a better, more concise read

Let me know what you think.