### PR TITLE
Introduce `create_account` kernel section

### DIFF
--- a/miden-lib/asm/sat/internal/account.masm
+++ b/miden-lib/asm/sat/internal/account.masm
@@ -1,3 +1,4 @@
+use.miden::sat::internal::constants
 use.miden::sat::internal::layout
 
 # CONSTANTS
@@ -217,7 +218,6 @@ export.validate_id
 
     # check if the number of ones is at least MIN_ACCOUNT_ONES ones.
     push.MIN_ACCOUNT_ONES u32unchecked_gte assert
-    # => []
 end
 
 #! Sets the code of the account the transaction is being executed against. This procedure can only
@@ -312,4 +312,66 @@ export.authenticate_procedure.1
     # drop accessory variables
     movup.4 drop movup.4 drop swapw dropw
     # => [PROC_ROOT]
+end
+
+#! Validates that the account seed, provided via the advice map, satisfies the seed requirements.
+#! 
+#! Validation is performed via the following steps:
+#! 1. compute the hash of (SEED, CODE_ROOT, STORAGE_ROOT, 0, 0, 0, 0)
+#! 2. Assert the least significant element of the digest is equal to the account id of the account
+#!    the transaction is being executed against.
+#! 3. Assert the most significant element has sufficient proof of work (trailing zeros) for the account
+#!    type the transaction is being executed against.
+#!
+#! Stack: []
+#! Output: []
+export.validate_seed
+        # pad capacity elements of hasher and populate first four elements of the rate with the account id seed
+        padw exec.layout::get_acct_id push.0.0.0 adv.push_mapval adv_loadw
+        # => [SEED, 0, 0, 0, 0]
+
+        # populate last four elements of the hasher rate with the code root
+        exec.layout::get_acct_code_root
+        # => [CODE_ROOT, SEED, 0, 0, 0, 0]
+
+        # perform first permutation of seed and code_root (from advice stack) perm(seed, code_root)
+        hperm
+        # => [RATE, RATE, PERM]
+
+        # clear rate elements
+        dropw dropw
+        # => [PERM]
+
+        # perform second permutation perm(storage_root, 0, 0, 0, 0)
+        exec.layout::get_acct_storage_root padw hperm
+        # => [RATE, RATE, CAP]
+
+        # extract digest
+        dropw swapw dropw 
+        # => [DIG]
+
+        # assert the account id matches the account id of the new account and extract pow
+        # element
+        movdn.3 drop drop exec.layout::get_acct_id eq assert
+        # => [pow]
+
+        # construct a modulus to check the min number of trailing zeros required in the pow
+        exec.constants::get_regular_account_seed_digest_modulus
+        # => [modulus, pow]
+
+        exec.layout::get_acct_id
+        # => [acct_id, modulus, pow]
+
+        exec.is_faucet
+        # => [is_faucet, modulus, pow]
+
+        exec.constants::get_faucet_seed_digest_modulus_multiplier
+        # => [modulus_mul, is_faucet, modulus, pow]
+
+        mul mul swap
+        # => [pow, modulus]
+
+        # assert that the pow is valid
+        u32split drop u32unchecked_divmod assertz drop 
+        # => []
 end

--- a/miden-lib/asm/sat/internal/constants.masm
+++ b/miden-lib/asm/sat/internal/constants.masm
@@ -16,6 +16,14 @@ const.NOTE_TREE_DEPTH=20
 # The maximum number of notes that can be created in a single transaction (2^12)
 const.MAX_NUM_CREATED_NOTES=4096
 
+# Specifies a modulus used to asses if an account seed digest has the required number of trailing
+# zeros for a regular account (2^23).
+const.REGULAR_ACCOUNT_SEED_DIGEST_MODULUS=8388608
+
+# Specifies a modulus multiplier used to asses if an account seed digest has the required number of 
+# trailing zeros for a faucet account (2^8).
+const.FAUCET_SEED_DIGEST_EXTRA_MODULUS_MULTIPLIER=256
+
 # PROCEDURES
 # =================================================================================================
 
@@ -67,4 +75,38 @@ end
 #! - max_num_created_notes is the max number of notes that can be created in a single transaction.
 export.get_max_num_created_notes
     push.MAX_NUM_CREATED_NOTES
+end
+
+#! Returns a modulus used to asses if an account seed digest has the required number of trailing
+#! zeros for a regular account (2^23).
+#!
+#! Stack: []
+#! Output: [REGULAR_ACCOUNT_SEED_DIGEST_MODULUS]
+#!
+#! - REGULAR_ACCOUNT_SEED_DIGEST_MODULUS is a modulus used to asses if a seed digest has the
+#!   required number of trailing zeros for a regular account.
+export.get_regular_account_seed_digest_modulus
+    push.REGULAR_ACCOUNT_SEED_DIGEST_MODULUS
+end
+
+#! Returns a modulus multiplier used to asses if an account seed digest has the required number of 
+#! trailing zeros for a faucet account (2^8).
+#!
+#! Stack: []
+#! Output: [FAUCET_SEED_DIGEST_EXTRA_MODULUS_MULTIPLIER]
+#!
+#! - FAUCET_SEED_DIGEST_EXTRA_MODULUS_MULTIPLIER is a modulus multiplier used to asses if a seed 
+#!   digest has the required number of trailing zeros for a faucet account.
+export.get_faucet_seed_digest_modulus_multiplier
+    push.FAUCET_SEED_DIGEST_EXTRA_MODULUS_MULTIPLIER
+end
+
+#! Returns the root of an empty tiered sparse Merkle tree.
+#!
+#! Stack: []
+#! Output: [EMPTY_SMT_ROOT]
+#!
+#! - EMPTY_SMT_ROOT is the root of an empty tiered sparse Merkle tree.
+export.get_empty_smt_root
+    push.15321474589252129342.17373224439259377994.15071539326562317628.3312677166725950353
 end

--- a/miden-lib/asm/sat/internal/layout.masm
+++ b/miden-lib/asm/sat/internal/layout.masm
@@ -54,20 +54,23 @@ const.PREV_BLOCK_HASH_PTR=200
 # The memory address at which the chain root is stored
 const.CHAIN_ROOT_PTR=201
 
-# The memory address at which the state root is stored
-const.STATE_ROOT_PTR=202
+# The memory address at which the account root is stored
+const.ACCT_DB_ROOT_PTR=202
+
+# The memory address at which the nullifier root is stored
+const.NULLIFIER_ROOT_PTR=203
 
 # The memory address at which the batch root is stored
-const.BATCH_ROOT_PTR=203
+const.BATCH_ROOT_PTR=204
 
 # The memory address at which the proof hash is stored
-const.PROOF_HASH_PTR=204
+const.PROOF_HASH_PTR=205
 
 # The memory address at which the block number is stored
-const.BLOCK_NUM_PTR=205
+const.BLOCK_NUM_PTR=206
 
 # The memory address at which the note root is stored
-const.NOTE_ROOT_PTR=206
+const.NOTE_ROOT_PTR=207
 
 # CHAIN MMR
 # -------------------------------------------------------------------------------------------------
@@ -339,14 +342,24 @@ export.get_chain_root
     padw push.CHAIN_ROOT_PTR mem_loadw
 end
 
-#! Returns the state root of the last known block.
+#! Returns the account db root of the last known block.
 #!
 #! Stack: []
-#! Output: [STATE_ROOT]
+#! Output: [ACCT_ROOT]
 #!
-#! - STATE_ROOT is the state root of the last known block.
-export.get_state_root
-    padw push.STATE_ROOT_PTR mem_loadw
+#! - ACCT_ROOT is the account root of the last known block.
+export.get_account_db_root
+    padw push.ACCT_DB_ROOT_PTR mem_loadw
+end
+
+#! Returns the nullifier db root of the last known block.
+#!
+#! Stack: []
+#! Output: [NULLIFIER_ROOT]
+#!
+#! - NULLIFIER_ROOT is the nullifier root of the last known block.
+export.get_nullifier_db_root
+    padw push.NULLIFIER_ROOT_PTR mem_loadw
 end
 
 #! Returns the batch root of the last known block.

--- a/miden-lib/asm/sat/internal/prologue.masm
+++ b/miden-lib/asm/sat/internal/prologue.masm
@@ -1,7 +1,10 @@
+use.std::collections::smt
 use.std::collections::mmr
 
+use.miden::sat::internal::account
 use.miden::sat::internal::constants
 use.miden::sat::internal::layout
+use.miden::sat::internal::utils
 
 # PUBLIC INPUTS
 # =================================================================================================
@@ -20,15 +23,19 @@ use.miden::sat::internal::layout
 proc.process_global_inputs
     # store the block hash
     exec.layout::set_blk_hash
+    # => [acct_id, IAH, NC]
 
     # store the account id
     exec.layout::set_global_acct_id
+    # => [IAH, NC]
 
     # store the initial account hash
     exec.layout::set_init_acct_hash
+    # => [NC]
 
     # store the nullifier commitment
     exec.layout::set_nullifier_com
+    # => []
 end
 
 # BLOCK DATA
@@ -40,16 +47,17 @@ end
 #! block hash matches the block hash stored in the global inputs.
 #!
 #! Stack: []
-#! Advice stack: [NR, PH, CR, SR, BR, PH, BN]
+#! Advice stack: [NR, PH, CR, AR, NUL_R, BR, PH, block_number, 0, 0, 0, 0, 0, 0, 0]
 #! Output: []
 #!
 #! - NR is the note root of the last known block.
 #! - PH is the previous hash of the last known block.
 #! - CR is the chain root of the last known block.
-#! - SR is the state root of the last known block.
+#! - AR is the account root of the last known block.
+#! - NUL_R is the nullifier root of the last known block.
 #! - BR is the batch root of the last known block.
 #! - PH is the proof hash of the last known block.
-#! - BN is the block number of the last known block ([block_number, 0, 0, 0]).
+#! - block_number is the block number of the last known block.
 proc.process_block_data
     # address to store the block data
     exec.layout::get_block_data_ptr
@@ -60,7 +68,7 @@ proc.process_block_data
     # => [ZERO, ZERO, ZERO, block_data_ptr]
 
     # read the block data
-    adv_pipe hperm adv_pipe hperm adv_pipe hperm
+    adv_pipe hperm adv_pipe hperm adv_pipe hperm adv_pipe hperm
     # => [PERM, PERM, PERM, block_data_ptr']
 
     # extract digest from hasher rate elements (h_0, ..., h_3)
@@ -124,11 +132,53 @@ end
 # ACCOUNT DATA
 # =================================================================================================
 
+#! Validates that the account the transaction is being executed against satisfies the criteria
+#! for a new account. 
+#!
+#! Stack: []
+#! Output: []
+#!
+#!
+#! Apply the following validation to the new account:
+#!   * assert that the account id is valid.
+#!   * assert that the account vault is empty.
+#!   * assert that the account nonce is set to 0.
+#!   * read the account seed from the advice provider and assert it satisfies seed requirements.
+proc.validate_new_account
+    # Assert the account id of the account is valid
+    exec.layout::get_acct_id exec.account::validate_id
+    # => []
+
+    # Assert the account nonce is 0
+    exec.layout::get_acct_nonce eq.0 assert
+    # => []
+
+    # Assert the initial vault is empty
+    # -----------------------------------------------------------------------------------------
+    # get the account vault root
+    exec.layout::get_acct_vault_root
+    # => [ACCT_VAULT_ROOT]
+
+    # push empty vault root onto stack 
+    exec.constants::get_empty_smt_root
+    # => [EMPTY_VAULT_ROOT, ACCT_VAULT_ROOT]
+
+    assert_eqw
+    # => []
+
+    # Assert the provided account seed satisfies the seed requirements
+    # -----------------------------------------------------------------------------------------
+    exec.account::validate_seed
+    # => []
+end
+
 #! Process the account data provided via the advice provider. This involves reading the data from
 #! the advice provider and storing it at the appropriate memory addresses. As the account data is
-#! read from the advice provider, the account hash is computed. It is asserted that the computed
-#! account hash matches the account hash stored in the global inputs. It is also asserted that the
-#! account id matches the account id provided via the stack public inputs.
+#! read from the advice provider, the account hash is computed.  If the account is new then the 
+#! global initial account hash is updated and the new account is validated.  If the account
+#! already exists then it is asserted that the computed account hash matches the account hash 
+#! provided via global inputs. It is also asserted that the account id matches the account id 
+#! provided via the stack public inputs.
 #!
 #! Stack: []
 #! Advice stack: [acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR]
@@ -142,35 +192,55 @@ end
 proc.process_acct_data
     # address to store the account data
     exec.layout::get_acct_data_ptr
+    # => [acct_data_ptr]
 
     # prepare the stack for reading account data
     padw padw padw
+    # => [ZERO, ZERO, ZERO, acct_data_ptr]
 
-    # read the account data
+    # read the account data  
     adv_pipe hperm adv_pipe hperm
+    # => [ACT_DATA', ACCT_HASH, CAP', act_data_ptr']
 
-    # extract digest from hasher rate elements (h_0, ..., h_3)
-    dropw swapw dropw
+    # extract digest from hasher rate elements (h_0, ..., h_3) and drop pointer
+    dropw swapw dropw movup.4 drop 
+    # => [ACCT_HASH]
 
-    # assert that the account hash matches the hash in global inputs
-    exec.layout::get_init_acct_hash assert_eqw
+    # check if the account is new
+    padw exec.layout::get_init_acct_hash eqw movdn.8 dropw dropw
+    # => [is_new, ACCT_HASH]
+
+    # process conditional logic depending on whether the account is new or existing
+    if.true
+        # set the initial account hash
+        exec.layout::set_init_acct_hash
+        # => []
+
+        # validate the new account
+        exec.validate_new_account
+        # => []
+    else
+        # assert that the existing account hash matches the hash in global inputs
+        exec.layout::get_init_acct_hash assert_eqw
+        # => []
+    end
 
     # assert the account id matches the account id in global inputs
     exec.layout::get_global_acct_id
     exec.layout::get_acct_id
     assert_eq
-
-    # clear the stack
-    drop
+    # => []
 
     # store a copy of the initial nonce in global inputs
     exec.layout::get_acct_nonce
     exec.layout::set_init_nonce
+    # => []
 
     # set the new account code root to the initial account code root
     # this is used for managing code root updates
     exec.layout::get_acct_code_root
     exec.layout::set_new_acct_code_root
+    # => []
 end
 
 # CONSUMED NOTES DATA

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -55,19 +55,22 @@ pub const PREV_BLOCK_HASH_PTR: MemoryAddress = 200;
 pub const CHAIN_ROOT_PTR: MemoryAddress = 201;
 
 /// The memory address at which the state root is stored
-pub const STATE_ROOT_PTR: MemoryAddress = 202;
+pub const ACCT_DB_ROOT_PTR: MemoryAddress = 202;
+
+/// The memory address at which the nullifier db root is store
+pub const NULLIFIER_DB_ROOT_PTR: MemoryAddress = 203;
 
 /// The memory address at which the batch root is stored
-pub const BATCH_ROOT_PTR: MemoryAddress = 203;
+pub const BATCH_ROOT_PTR: MemoryAddress = 204;
 
 /// The memory address at which the proof hash is stored
-pub const PROOF_HASH_PTR: MemoryAddress = 204;
+pub const PROOF_HASH_PTR: MemoryAddress = 205;
 
 /// The memory address at which the block number is stored
-pub const BLOCK_NUM_PTR: MemoryAddress = 205;
+pub const BLOCK_NUM_PTR: MemoryAddress = 206;
 
 /// The memory address at which the note root is stored
-pub const NOTE_ROOT_PTR: MemoryAddress = 206;
+pub const NOTE_ROOT_PTR: MemoryAddress = 207;
 
 // CHAIN DATA
 // ------------------------------------------------------------------------------------------------

--- a/miden-lib/tests/common/mod.rs
+++ b/miden-lib/tests/common/mod.rs
@@ -92,6 +92,7 @@ pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
 
 pub fn prepare_transaction(
     account: Account,
+    account_seed: Option<Word>,
     block_header: BlockHeader,
     chain: ChainMmr,
     notes: Vec<Note>,
@@ -110,5 +111,6 @@ pub fn prepare_transaction(
 
     let program = assembler.compile(code).unwrap();
 
-    PreparedTransaction::new(account, block_header, chain, notes, None, program)
+    PreparedTransaction::new(account, account_seed, block_header, chain, notes, None, program)
+        .unwrap()
 }

--- a/miden-lib/tests/test_asset_vault.rs
+++ b/miden-lib/tests/test_asset_vault.rs
@@ -1,7 +1,8 @@
 pub mod common;
 use common::{
     data::{
-        mock_inputs, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
+        mock_inputs, AccountStatus, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
+        ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
     },
     prepare_transaction, run_tx, AccountId, MemAdviceProvider, ONE,
 };
@@ -11,7 +12,7 @@ use crate::common::procedures::prepare_word;
 
 #[test]
 fn test_get_balance() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let code = format!(
@@ -28,7 +29,7 @@ fn test_get_balance() {
     );
 
     let transaction =
-        prepare_transaction(account, block_header, chain, notes, &code, "", None, None);
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
 
     let process = run_tx(
         transaction.tx_program().clone(),
@@ -45,7 +46,7 @@ fn test_get_balance() {
 
 #[test]
 fn test_get_balance_non_fungible_fails() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     let code = format!(
         "
@@ -61,7 +62,7 @@ fn test_get_balance_non_fungible_fails() {
     );
 
     let transaction =
-        prepare_transaction(account, block_header, chain, notes, &code, "", None, None);
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
 
     let process = run_tx(
         transaction.tx_program().clone(),
@@ -74,7 +75,7 @@ fn test_get_balance_non_fungible_fails() {
 
 #[test]
 fn test_has_non_fungible_asset() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
     let non_fungible_asset = account.vault().assets().next().unwrap();
 
     let code = format!(
@@ -91,7 +92,8 @@ fn test_has_non_fungible_asset() {
         non_fungible_asset_key = prepare_word(&non_fungible_asset.vault_key())
     );
 
-    let inputs = prepare_transaction(account, block_header, chain, notes, &code, "", None, None);
+    let inputs =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
 
     let process = run_tx(
         inputs.tx_program().clone(),

--- a/miden-lib/tests/test_note.rs
+++ b/miden-lib/tests/test_note.rs
@@ -1,12 +1,14 @@
 pub mod common;
 use common::{
-    data::mock_inputs, prepare_transaction, procedures::prepare_word, run_tx, Felt,
-    MemAdviceProvider, Note,
+    data::{mock_inputs, AccountStatus},
+    prepare_transaction,
+    procedures::prepare_word,
+    run_tx, Felt, MemAdviceProvider, Note,
 };
 
 #[test]
 fn test_get_sender_no_sender() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     // calling get_sender should return sender
     let code = "
@@ -21,7 +23,7 @@ fn test_get_sender_no_sender() {
         ";
 
     let transaction =
-        prepare_transaction(account, block_header, chain, notes, &code, "", None, None);
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
 
     let process = run_tx(
         transaction.tx_program().clone(),
@@ -33,7 +35,7 @@ fn test_get_sender_no_sender() {
 
 #[test]
 fn test_get_sender() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     // calling get_sender should return sender
     let code = "
@@ -50,7 +52,7 @@ fn test_get_sender() {
         ";
 
     let transaction =
-        prepare_transaction(account, block_header, chain, notes, &code, "", None, None);
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
 
     let process = run_tx(
         transaction.tx_program().clone(),
@@ -64,8 +66,8 @@ fn test_get_sender() {
 }
 
 #[test]
-fn test_get_vault_info() {
-    let (account, block_header, chain, notes) = mock_inputs();
+fn test_get_vault_data() {
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     // calling get_vault_info should return vault info
     let code = format!(
@@ -112,7 +114,7 @@ fn test_get_vault_info() {
     );
 
     let transaction =
-        prepare_transaction(account, block_header, chain, notes, &code, "", None, None);
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
 
     // run to ensure success
     let _process = run_tx(
@@ -125,7 +127,7 @@ fn test_get_vault_info() {
 
 #[test]
 fn test_get_assets() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     const DEST_POINTER_NOTE_0: u32 = 100000000;
     const DEST_POINTER_NOTE_1: u32 = 200000000;
@@ -220,8 +222,17 @@ fn test_get_assets() {
         NOTE_1_ASSET_ASSERTIONS = construct_asset_assertions(&notes[1]),
     );
 
-    let inputs =
-        prepare_transaction(account, block_header, chain, notes.clone(), &code, "", None, None);
+    let inputs = prepare_transaction(
+        account,
+        None,
+        block_header,
+        chain,
+        notes.clone(),
+        &code,
+        "",
+        None,
+        None,
+    );
 
     let _process = run_tx(
         inputs.tx_program().clone(),

--- a/miden-lib/tests/test_note_setup.rs
+++ b/miden-lib/tests/test_note_setup.rs
@@ -1,6 +1,8 @@
 pub mod common;
 use common::{
-    consumed_note_data_ptr, data::mock_inputs, memory::CURRENT_CONSUMED_NOTE_PTR,
+    consumed_note_data_ptr,
+    data::{mock_inputs, AccountStatus},
+    memory::CURRENT_CONSUMED_NOTE_PTR,
     prepare_transaction, run_tx, AdviceProvider, Felt, FieldElement, MemAdviceProvider, Process,
     TX_KERNEL_DIR,
 };
@@ -10,7 +12,7 @@ const NOTE_SETUP_FILE: &str = "note_setup.masm";
 
 #[test]
 fn test_note_setup() {
-    let (account, block_header, chain, notes) = mock_inputs();
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
 
     let imports = "use.miden::sat::internal::prologue\n";
     let code = "
@@ -22,6 +24,7 @@ fn test_note_setup() {
 
     let inputs = prepare_transaction(
         account,
+        None,
         block_header,
         chain,
         notes,

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -2,9 +2,12 @@ use super::{
     AccountError, AccountId, AssemblyError, Digest, ExecutionError, NodeIndex,
     TransactionResultError,
 };
-use miden_objects::TransactionWitnessError;
+use core::fmt;
+use miden_objects::{PreparedTransactionError, TransactionWitnessError};
 use miden_verifier::VerificationError;
 
+// TRANSACTION ERROR
+// ================================================================================================
 #[derive(Debug)]
 pub enum TransactionError {
     TransactionCompilerError(TransactionCompilerError),
@@ -12,6 +15,17 @@ pub enum TransactionError {
     DataStoreError(DataStoreError),
 }
 
+impl fmt::Display for TransactionError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionError {}
+
+// TRANSACTION COMPILER ERROR
+// ================================================================================================
 #[derive(Debug)]
 pub enum TransactionCompilerError {
     InvalidTransactionInputs,
@@ -25,10 +39,22 @@ pub enum TransactionCompilerError {
     BuildCodeBlockTableFailed(AssemblyError),
 }
 
+impl fmt::Display for TransactionCompilerError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionCompilerError {}
+
+// TRANSACTION EXECUTOR ERROR
+// ================================================================================================
 #[derive(Debug)]
 pub enum TransactionExecutorError {
     CompileNoteScriptFailed(TransactionCompilerError),
     CompileTransactionError(TransactionCompilerError),
+    ConstructPreparedTransactionFailed(PreparedTransactionError),
     ExecuteTransactionProgramFailed(ExecutionError),
     FetchAccountCodeFailed(DataStoreError),
     FetchTransactionDataFailed(DataStoreError),
@@ -36,6 +62,17 @@ pub enum TransactionExecutorError {
     TransactionResultError(TransactionResultError),
 }
 
+impl fmt::Display for TransactionExecutorError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionExecutorError {}
+
+// TRANSACTION PROVER ERROR
+// ================================================================================================
 #[derive(Debug)]
 pub enum TransactionProverError {
     ProveTransactionProgramFailed(ExecutionError),
@@ -43,14 +80,45 @@ pub enum TransactionProverError {
     CorruptTransactionWitnessConsumedNoteData(TransactionWitnessError),
 }
 
+impl fmt::Display for TransactionProverError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionProverError {}
+
+// TRANSACTION VERIFIER ERROR
+// ================================================================================================
 #[derive(Debug)]
 pub enum TransactionVerifierError {
     TransactionVerificationFailed(VerificationError),
     InsufficientProofSecurityLevel(u32, u32),
 }
 
+impl fmt::Display for TransactionVerifierError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionVerifierError {}
+
+// DATA STORE ERROR
+// ================================================================================================
 #[derive(Debug)]
 pub enum DataStoreError {
     AccountNotFound(AccountId),
     NoteNotFound(u32, NodeIndex),
 }
+
+impl fmt::Display for DataStoreError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DataStoreError {}

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -153,13 +153,15 @@ impl<D: DataStore> TransactionExecutor<D> {
             .compile_transaction(account_id, &notes, tx_script)
             .map_err(TransactionExecutorError::CompileTransactionError)?;
 
-        Ok(PreparedTransaction::new(
+        PreparedTransaction::new(
             account,
+            None,
             block_header,
             block_chain,
             notes,
             tx_script_root,
             tx_program,
-        ))
+        )
+        .map_err(TransactionExecutorError::ConstructPreparedTransactionFailed)
     }
 }

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -1,19 +1,20 @@
 use super::{
-    Account, AccountId, BlockHeader, ChainMmr, DataStore, DataStoreError, Note, NoteOrigin,
+    AccountId, BlockHeader, ChainMmr, DataStore, DataStoreError, Note, NoteOrigin,
     TransactionExecutor, TransactionProver, TransactionVerifier,
 };
 use assembly::{
     ast::{ModuleAst, ProgramAst},
     Assembler,
 };
-use crypto::{StarkField, ONE};
+use crypto::StarkField;
+use miden_core::Felt;
 use miden_objects::{
     mock::{
-        mock_inputs, prepare_word, CHILD_ROOT_PARENT_LEAF_INDEX, CHILD_SMT_DEPTH,
+        mock_inputs, prepare_word, AccountStatus, CHILD_ROOT_PARENT_LEAF_INDEX, CHILD_SMT_DEPTH,
         CHILD_STORAGE_INDEX_0,
     },
     transaction::{CreatedNotes, FinalAccountStub},
-    AccountCode, TryFromVmResult,
+    Account, AccountCode, TryFromVmResult,
 };
 use miden_prover::ProvingOptions;
 use processor::MemAdviceProvider;
@@ -28,7 +29,7 @@ pub struct MockDataStore {
 
 impl MockDataStore {
     pub fn new() -> Self {
-        let (account, block_header, block_chain, notes) = mock_inputs();
+        let (account, block_header, block_chain, notes) = mock_inputs(AccountStatus::Existing);
         Self {
             account,
             block_header,
@@ -232,7 +233,7 @@ fn test_transaction_result_account_delta() {
         .unwrap();
 
     // nonce delta
-    assert!(transaction_result.account_delta().nonce == Some(ONE));
+    assert!(transaction_result.account_delta().nonce == Some(Felt::new(2)));
 
     // storage delta
     assert_eq!(transaction_result.account_delta().storage.slots_delta.updated_slots().len(), 1);

--- a/objects/benches/account_seed.rs
+++ b/objects/benches/account_seed.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use crypto::hash::rpo::RpoDigest as Digest;
 use miden_objects::{AccountId, AccountType};
 
 fn grind_account_seed(c: &mut Criterion) {
@@ -9,12 +10,26 @@ fn grind_account_seed(c: &mut Criterion) {
 
     c.bench_function("Grind regular on-chain account seed", |bench| {
         bench.iter(|| {
-            AccountId::get_account_seed(init_seed, AccountType::RegularAccountImmutableCode, true)
+            AccountId::get_account_seed(
+                init_seed,
+                AccountType::RegularAccountImmutableCode,
+                true,
+                Digest::default(),
+                Digest::default(),
+            )
         })
     });
 
     c.bench_function("Grind fungible faucet on-chain account seed", |bench| {
-        bench.iter(|| AccountId::get_account_seed(init_seed, AccountType::FungibleFaucet, true))
+        bench.iter(|| {
+            AccountId::get_account_seed(
+                init_seed,
+                AccountType::FungibleFaucet,
+                true,
+                Digest::default(),
+                Digest::default(),
+            )
+        })
     });
 }
 

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -10,7 +10,7 @@ use crypto::{
 };
 
 mod account_id;
-pub use account_id::{AccountId, AccountType};
+pub use account_id::{validate_account_seed, AccountId, AccountType};
 
 mod code;
 pub use code::AccountCode;
@@ -138,6 +138,11 @@ impl Account {
     /// Returns true if this account is on-chain.
     pub fn is_on_chain(&self) -> bool {
         self.id.is_on_chain()
+    }
+
+    /// Returns true if the account is new (i.e. it has not been initialized yet).
+    pub fn is_new(&self) -> bool {
+        self.nonce == ZERO
     }
 }
 

--- a/objects/src/chain/mod.rs
+++ b/objects/src/chain/mod.rs
@@ -11,7 +11,7 @@ use super::{AdviceInputsBuilder, Felt, Mmr, ToAdviceInputs, ZERO};
 /// Authenticaiton is achieved by providing an inclusion proof for the consumed notes in the
 /// transaction against the chain Mmr root associated with the latest block known at the time
 /// of transaction exectuion.  
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ChainMmr(Mmr);
 
 impl ChainMmr {

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -30,6 +30,10 @@ pub enum AccountError {
     DuplicateStorageItems(MerkleError),
     DuplicateAsset(MerkleError),
     NonceMustBeMonotonicallyIncreasing(u64, u64),
+    InconsistentAccountIdSeed {
+        expected: AccountId,
+        actual: AccountId,
+    },
 }
 
 impl AccountError {
@@ -212,6 +216,40 @@ impl fmt::Display for NoteError {
 #[cfg(feature = "std")]
 impl std::error::Error for NoteError {}
 
+// PREPARED TRANSACTION ERROR
+// ===============================================================================================
+#[derive(Debug)]
+pub enum PreparedTransactionError {
+    InvalidAccountIdSeedError(AccountError),
+    AccountIdSeedNoteProvided,
+}
+
+impl fmt::Display for PreparedTransactionError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PreparedTransactionError {}
+
+// EXECUTED TRANSACTION ERROR
+// ===============================================================================================
+#[derive(Debug)]
+pub enum ExecutedTransactionError {
+    InvalidAccountIdSeedError(AccountError),
+    AccountIdSeedNoteProvided,
+}
+
+impl fmt::Display for ExecutedTransactionError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ExecutedTransactionError {}
+
 // TRANSACTION RESULT ERROR
 // ================================================================================================
 #[derive(Debug)]
@@ -227,6 +265,15 @@ pub enum TransactionResultError {
     UpdatedAccountCodeInvalid(AccountError),
 }
 
+impl fmt::Display for TransactionResultError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionResultError {}
+
 // TRANSACTION WITNESS ERROR
 // ================================================================================================
 #[derive(Debug)]
@@ -234,3 +281,12 @@ pub enum TransactionWitnessError {
     ConsumedNoteDataNotFound,
     InvalidConsumedNoteDataLength,
 }
+
+impl fmt::Display for TransactionWitnessError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionWitnessError {}

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -22,8 +22,8 @@ use miden_processor::{AdviceInputs, StackOutputs};
 
 mod accounts;
 pub use accounts::{
-    Account, AccountCode, AccountDelta, AccountId, AccountStorage, AccountStub, AccountType,
-    AccountVault, StorageItem,
+    validate_account_seed, Account, AccountCode, AccountDelta, AccountId, AccountStorage,
+    AccountStub, AccountType, AccountVault, StorageItem,
 };
 
 mod advice;
@@ -40,7 +40,8 @@ pub use chain::ChainMmr;
 
 mod errors;
 pub use errors::{
-    AccountError, AssetError, NoteError, TransactionResultError, TransactionWitnessError,
+    AccountError, AssetError, ExecutedTransactionError, NoteError, PreparedTransactionError,
+    TransactionResultError, TransactionWitnessError,
 };
 
 mod result;

--- a/objects/src/mock.rs
+++ b/objects/src/mock.rs
@@ -9,9 +9,10 @@ use assembly::{
     ast::{ModuleAst, ProgramAst},
     Assembler,
 };
+use crypto::merkle::SimpleSmt;
 use miden_core::utils::string::{String, ToString};
 use miden_core::{
-    crypto::merkle::{MerkleStore, NodeIndex, SimpleSmt},
+    crypto::merkle::{MerkleStore, NodeIndex},
     FieldElement,
 };
 use miden_lib::{MidenLib, SatKernel};
@@ -32,7 +33,13 @@ pub fn assembler() -> Assembler {
 
 // MOCK DATA
 // ================================================================================================
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = 0b0010011011u64 << 54;
+pub const ACCOUNT_SEED_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: [u64; 4] = [
+    5950491586293629690,
+    3173174058297886549,
+    16553747801483039178,
+    11841717777847436894,
+];
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = 3972335011818762557;
 pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
 
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
@@ -59,16 +66,40 @@ pub fn mock_block_header(
     block_num: Felt,
     chain_root: Option<Digest>,
     note_root: Option<Digest>,
+    accts: &[Account],
 ) -> BlockHeader {
+    let acct_db = SimpleSmt::with_leaves(
+        64,
+        accts
+            .iter()
+            .flat_map(|acct| {
+                if acct.is_new() {
+                    None
+                } else {
+                    Some(((*acct.id()).as_int(), *acct.hash()))
+                }
+            })
+            .collect::<Vec<_>>(),
+    )
+    .expect("failed to create account db");
+
     let prev_hash: Digest = rand::rand_array().into();
     let chain_root: Digest = chain_root.unwrap_or(rand::rand_array().into());
-    let state_root: Digest = rand::rand_array().into();
+    let acct_root: Digest = acct_db.root();
+    let nullifier_root: Digest = rand::rand_array().into();
     let note_root: Digest = note_root.unwrap_or(rand::rand_array().into());
     let batch_root: Digest = rand::rand_array().into();
     let proof_hash: Digest = rand::rand_array().into();
 
     BlockHeader::new(
-        prev_hash, block_num, chain_root, state_root, note_root, batch_root, proof_hash,
+        prev_hash,
+        block_num,
+        chain_root,
+        acct_root,
+        nullifier_root,
+        note_root,
+        batch_root,
+        proof_hash,
     )
 }
 
@@ -89,19 +120,16 @@ pub fn mock_chain_data(consumed_notes: &mut [Note]) -> ChainMmr {
 
     // create a dummy chain of block headers
     let block_chain = vec![
-        mock_block_header(Felt::ZERO, None, Some(note_trees[0].root())),
-        mock_block_header(Felt::ONE, None, Some(note_trees[1].root())),
-        mock_block_header(Felt::new(2), None, None),
-        mock_block_header(Felt::new(3), None, None),
+        mock_block_header(Felt::ZERO, None, Some(note_trees[0].root()), &[]),
+        mock_block_header(Felt::ONE, None, Some(note_trees[1].root()), &[]),
+        mock_block_header(Felt::new(2), None, None, &[]),
+        mock_block_header(Felt::new(3), None, None, &[]),
     ];
-
-    // convert block hashes into words
-    let block_hashes: Vec<Digest> = block_chain.iter().map(|h| h.hash()).collect();
 
     // instantiate and populate MMR
     let mut chain_mmr = ChainMmr::default();
-    for hash in block_hashes.iter() {
-        chain_mmr.mmr_mut().add(*hash)
+    for block_header in block_chain.iter() {
+        chain_mmr.mmr_mut().add(block_header.hash())
     }
 
     // set origin for consumed notes using chain and block data
@@ -139,15 +167,7 @@ fn mock_account_vault() -> AccountVault {
     AccountVault::new(&[fungible_asset, non_fungible_asset]).unwrap()
 }
 
-pub fn mock_account(
-    nonce: Option<Felt>,
-    code: Option<AccountCode>,
-    assembler: &mut Assembler,
-) -> Account {
-    // Create account id
-    let account_id =
-        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
-
+fn mock_account_storage() -> AccountStorage {
     // Create an account merkle store
     let mut account_merkle_store = MerkleStore::new();
     let child_smt =
@@ -156,7 +176,7 @@ pub fn mock_account(
     account_merkle_store.extend(child_smt.inner_nodes());
 
     // create account storage
-    let account_storage = AccountStorage::new(
+    AccountStorage::new(
         vec![
             STORAGE_ITEM_0,
             STORAGE_ITEM_1,
@@ -164,12 +184,11 @@ pub fn mock_account(
         ],
         account_merkle_store,
     )
-    .unwrap();
+    .unwrap()
+}
 
-    let account_code = match code {
-        Some(code) => code,
-        None => {
-            let account_code = "\
+fn mock_account_code(account_id: &AccountId, assembler: &mut Assembler) -> AccountCode {
+    let account_code = "\
             use.miden::sat::account
 
             export.incr_nonce
@@ -206,9 +225,38 @@ pub fn mock_account(
                 sub
             end
             ";
-            let account_module_ast = ModuleAst::parse(account_code).unwrap();
-            AccountCode::new(account_id, account_module_ast, assembler).unwrap()
-        }
+    let account_module_ast = ModuleAst::parse(account_code).unwrap();
+    AccountCode::new(*account_id, account_module_ast, assembler).unwrap()
+}
+
+fn mock_new_account(assembler: &mut Assembler) -> Account {
+    let account_storage = mock_account_storage();
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+    let account_code = mock_account_code(&account_id, assembler);
+    let account_seed: Word = ACCOUNT_SEED_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN
+        .iter()
+        .map(|x| Felt::new(*x))
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    let account_id =
+        AccountId::new(account_seed, account_code.root(), account_storage.root()).unwrap();
+    Account::new(account_id, AccountVault::default(), account_storage, account_code, Felt::ZERO)
+}
+
+pub fn mock_account(nonce: Felt, code: Option<AccountCode>, assembler: &mut Assembler) -> Account {
+    // Create account id
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+
+    // mock account storage
+    let account_storage = mock_account_storage();
+
+    // mock account code
+    let account_code = match code {
+        Some(code) => code,
+        None => mock_account_code(&account_id, assembler),
     };
 
     // Create account vault
@@ -217,21 +265,25 @@ pub fn mock_account(
     // Create an account with storage items
     let account_id =
         AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
-    Account::new(
-        account_id,
-        account_vault,
-        account_storage,
-        account_code,
-        nonce.unwrap_or(Felt::ZERO),
-    )
+    Account::new(account_id, account_vault, account_storage, account_code, nonce)
 }
 
-pub fn mock_inputs() -> (Account, BlockHeader, ChainMmr, Vec<Note>) {
+#[derive(Debug, PartialEq)]
+pub enum AccountStatus {
+    New,
+    Existing,
+}
+
+pub fn mock_inputs(account_status: AccountStatus) -> (Account, BlockHeader, ChainMmr, Vec<Note>) {
     // Create assembler and assembler context
     let mut assembler = assembler();
 
     // Create an account with storage items
-    let account = mock_account(None, None, &mut assembler);
+    let account = if account_status == AccountStatus::New {
+        mock_new_account(&mut assembler)
+    } else {
+        mock_account(Felt::ONE, None, &mut assembler)
+    };
 
     // Created notes
     let created_notes = mock_created_notes(&mut assembler);
@@ -243,10 +295,11 @@ pub fn mock_inputs() -> (Account, BlockHeader, ChainMmr, Vec<Note>) {
     let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
 
     // Block header
-    let block_header: BlockHeader = mock_block_header(
+    let block_header = mock_block_header(
         Felt::new(4),
         Some(chain_mmr.mmr().accumulator().hash_peaks().into()),
         None,
+        &[account.clone()],
     );
 
     // Transaction inputs
@@ -258,11 +311,11 @@ pub fn mock_executed_tx() -> ExecutedTransaction {
     let mut assembler = assembler();
 
     // Initial Account
-    let initial_account = mock_account(Some(Felt::ZERO), None, &mut assembler);
+    let initial_account = mock_account(Felt::ONE, None, &mut assembler);
 
     // Finial Account (nonce incremented by 1)
     let final_account =
-        mock_account(Some(Felt::ONE), Some(initial_account.code().clone()), &mut assembler);
+        mock_account(Felt::new(2), Some(initial_account.code().clone()), &mut assembler);
 
     // Created notes
     let created_notes = mock_created_notes(&mut assembler);
@@ -274,16 +327,17 @@ pub fn mock_executed_tx() -> ExecutedTransaction {
     let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
 
     // Block header
-    let block_header: BlockHeader = mock_block_header(
+    let block_header = mock_block_header(
         Felt::new(4),
         Some(chain_mmr.mmr().accumulator().hash_peaks().into()),
         None,
+        &[initial_account.clone()],
     );
 
     // Executed Transaction
-
     ExecutedTransaction::new(
         initial_account,
+        None,
         final_account,
         consumed_notes,
         created_notes,
@@ -291,6 +345,7 @@ pub fn mock_executed_tx() -> ExecutedTransaction {
         block_header,
         chain_mmr,
     )
+    .unwrap()
 }
 
 pub fn mock_consumed_notes(assembler: &mut Assembler, created_notes: &[Note]) -> Vec<Note> {

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -2,8 +2,8 @@ use super::{
     notes::{Note, NoteEnvelope, NoteStub},
     Account, AccountDelta, AccountError, AccountId, AccountStorage, AccountStub, AdviceInputs,
     AdviceInputsBuilder, BTreeMap, BlockHeader, ChainMmr, Digest, Felt, Hasher, MerkleStore,
-    StarkField, ToAdviceInputs, TransactionResultError, TransactionWitnessError, TryFromVmResult,
-    Vec, Word, WORD_SIZE,
+    PreparedTransactionError, StarkField, ToAdviceInputs, TransactionResultError,
+    TransactionWitnessError, TryFromVmResult, Vec, Word, WORD_SIZE, ZERO,
 };
 use miden_core::{Program, StackInputs, StackOutputs};
 

--- a/objects/src/transaction/prepared_tx.rs
+++ b/objects/src/transaction/prepared_tx.rs
@@ -1,17 +1,21 @@
 use super::{
-    utils, Account, AdviceInputs, BlockHeader, ChainMmr, ConsumedNotes, Digest, Note, Program,
-    StackInputs, Vec,
+    utils, Account, AdviceInputs, BlockHeader, ChainMmr, ConsumedNotes, Digest, Note,
+    PreparedTransactionError, Program, StackInputs, Vec, Word,
 };
+use crate::validate_account_seed;
 
 /// A struct that contains all of the data required to execute a transaction. This includes:
 /// - account: Account that the transaction is being executed against.
+/// - account_seed: An optional account seed used to create a new account.
 /// - block_header: The header of the latest known block.
 /// - block_chain: The chain mmr associated with the latest known block.
 /// - consumed_notes: A vector of consumed notes.
 /// - tx_script_root: An optional transaction script root.
 /// - tx_program: The transaction program.
+#[derive(Debug)]
 pub struct PreparedTransaction {
     account: Account,
+    account_seed: Option<Word>,
     block_header: BlockHeader,
     block_chain: ChainMmr,
     consumed_notes: ConsumedNotes,
@@ -22,20 +26,23 @@ pub struct PreparedTransaction {
 impl PreparedTransaction {
     pub fn new(
         account: Account,
+        account_seed: Option<Word>,
         block_header: BlockHeader,
         block_chain: ChainMmr,
         consumed_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
         tx_program: Program,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, PreparedTransactionError> {
+        Self::validate_new_account_seed(&account, account_seed)?;
+        Ok(Self {
             account,
+            account_seed,
             block_header,
             block_chain,
             consumed_notes: ConsumedNotes::new(consumed_notes),
             tx_script_root,
             tx_program,
-        }
+        })
     }
 
     // ACCESSORS
@@ -73,9 +80,14 @@ impl PreparedTransaction {
 
     /// Returns the stack inputs required when executing the transaction.
     pub fn stack_inputs(&self) -> StackInputs {
+        let initial_acct_hash = if self.account.is_new() {
+            Digest::default()
+        } else {
+            self.account.hash()
+        };
         utils::generate_stack_inputs(
             &self.account.id(),
-            &self.account.hash(),
+            initial_acct_hash,
             self.consumed_notes.commitment(),
             &self.block_header,
         )
@@ -85,6 +97,7 @@ impl PreparedTransaction {
     pub fn advice_provider_inputs(&self) -> AdviceInputs {
         utils::generate_advice_provider_inputs(
             &self.account,
+            self.account_seed,
             &self.block_header,
             &self.block_chain,
             &self.consumed_notes,
@@ -94,6 +107,22 @@ impl PreparedTransaction {
     /// Returns the consumed notes commitment.
     pub fn consumed_notes_commitment(&self) -> Digest {
         self.consumed_notes.commitment()
+    }
+
+    // HELPERS
+    // --------------------------------------------------------------------------------------------
+    /// Validates that a valid account seed has been provided if the account the transaction is
+    /// being executed against is new.
+    fn validate_new_account_seed(
+        account: &Account,
+        seed: Option<Word>,
+    ) -> Result<(), PreparedTransactionError> {
+        match (account.is_new(), seed) {
+            (true, Some(seed)) => validate_account_seed(account, seed)
+                .map_err(PreparedTransactionError::InvalidAccountIdSeedError),
+            (true, None) => Err(PreparedTransactionError::AccountIdSeedNoteProvided),
+            _ => Ok(()),
+        }
     }
 
     // CONSUMERS

--- a/objects/src/transaction/tx_result.rs
+++ b/objects/src/transaction/tx_result.rs
@@ -61,6 +61,7 @@ impl TransactionResult {
             FinalAccountStub::try_from_vm_result(&stack_outputs, &stack, &map, &store)?;
         let created_notes = CreatedNotes::try_from_vm_result(&stack_outputs, &stack, &map, &store)?;
 
+        // TODO: Fix delta extraction for new account creation
         // extract the account storage delta
         let storage_delta =
             extract_account_storage_delta(&store, &initial_account, &final_account_stub)?;

--- a/objects/src/transaction/tx_witness.rs
+++ b/objects/src/transaction/tx_witness.rs
@@ -27,6 +27,7 @@ pub struct TransactionWitness {
 
 impl TransactionWitness {
     /// Creates a new [TransactionWitness] from the provided data.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         account_id: AccountId,
         initial_account_hash: Digest,


### PR DESCRIPTION
Tests failing due to - https://github.com/0xPolygonMiden/miden-base/pull/185.  Rebasing will fix tests once merged.

Introduces account creation logic in the kernel.

We identify a new account by checking if the nonce is equal to zero. If the account is new then we enforce the condition that the nonce must be incremented in the transaction, this condition is enforced in the epilogue.  We now apply two permutations of the hashing function to compute the seed digest and as such the work has doubled.  To account for the doubling of work I have reduced the required trailing bits by one.  

closes: #87, #84 