### PR TITLE
serde: initial implementation for account objects

### DIFF
--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -22,6 +22,7 @@ bench = false
 default = ["std"]
 std = ["assembly/std", "crypto/std", "miden-core/std", "miden-lib/std", "miden-processor/std", "miden-verifier/std"]
 testing = ["miden-test-utils"]
+serde = ["dep:serde", "crypto/serde"]
 
 [dependencies]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
@@ -32,6 +33,7 @@ miden-processor = { package = "miden-processor", git = "https://github.com/0xPol
 miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", optional = true, default-features = false }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"], default-features = false }

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -27,6 +27,8 @@ pub enum AccountType {
 ///  - 1 - only the account hash is stored on-chain which serves as a commitment to the account state.
 /// As such the three most significant bits fully describes the type of the account.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct AccountId(Felt);
 
 impl AccountId {

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -49,6 +49,7 @@ mod tests;
 /// changed). Other components may be mutated throughout the lifetime of the account. However,
 /// account state can be changed only by invoking one of account interface methods.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Account {
     id: AccountId,
     vault: AccountVault,

--- a/objects/src/accounts/storage.rs
+++ b/objects/src/accounts/storage.rs
@@ -18,6 +18,7 @@ pub type StorageItem = (u8, Word);
 /// Merkle roots of other Merkle structures.  If any Merkle roots are found then the Merkle
 /// structures will be persisted in the `AccountStorage` `MerkleStore`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AccountStorage {
     slots: SimpleSmt,
     store: MerkleStore,

--- a/objects/src/accounts/stub.rs
+++ b/objects/src/accounts/stub.rs
@@ -13,6 +13,7 @@ use super::{hash_account, Account, AccountId, Digest, Felt};
 /// - storage_root: accounts storage root ([AccountStorage]).
 /// - code_root: a commitment to the account's code ([AccountCode]).
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AccountStub {
     id: AccountId,
     nonce: Felt,

--- a/objects/src/accounts/vault.rs
+++ b/objects/src/accounts/vault.rs
@@ -19,6 +19,7 @@ use crypto::merkle::MerkleTreeDelta;
 ///
 /// An account vault can be reduced to a single hash which is the root of the Sparse Merkle tree.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AccountVault {
     asset_tree: TieredSmt,
 }


### PR DESCRIPTION
This adds serde support for the account object.

Note: For the account code, instead of adding serde to the `miden-vm` this is using a custom serializer and encoding it as `[u8]`. I did this because I don't think users will edit the bytecode by hand, and there doesn't seem to be an API to convert the module ast to miden assembly.