### PR TITLE
Integrate upstream tsmt delete for asset vault masm

### DIFF
--- a/miden-lib/asm/sat/internal/asset_vault.masm
+++ b/miden-lib/asm/sat/internal/asset_vault.masm
@@ -240,7 +240,7 @@ proc.remove_fungible_asset
     end
 
     # update asset in vault
-    exec.smt::insert dropw
+    exec.smt::set dropw
     # => [VAULT_ROOT', ASSET, vault_root_ptr]
 
     # update the vault root
@@ -265,7 +265,7 @@ proc.remove_non_fungible_asset
     # => [EMPTY_WORD, ASSET, VAULT_ROOT, ASSET, vault_root_ptr]
 
     # update asset in vault
-    exec.smt::insert
+    exec.smt::set
     # => [OLD_VAL, VAULT_ROOT', ASSET, vault_root_ptr]
 
     # Assert old value was not empty (we only need to check ASSET[1] which is the faucet id)

--- a/miden-lib/tests/test_asset_vault.rs
+++ b/miden-lib/tests/test_asset_vault.rs
@@ -274,8 +274,6 @@ fn test_add_non_fungible_asset_fail_duplicate() {
     assert!(account_vault.add_asset(non_fungible_asset).is_err());
 }
 
-// we will ignore this test for now as we do not have a way to remove assets from the vault
-#[ignore]
 #[test]
 fn test_remove_fungible_asset_success_no_balance_remaining() {
     let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
@@ -366,8 +364,6 @@ fn test_remove_fungible_asset_success_balance_remaining() {
     );
 }
 
-// we ignore this test for now as we can not remove (insert EMPTY_WORD) an asset yet
-#[ignore]
 #[test]
 fn test_remove_non_fungible_asset_fail_doesnt_exist() {
     let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
@@ -406,8 +402,6 @@ fn test_remove_non_fungible_asset_fail_doesnt_exist() {
     assert!(account_vault.remove_asset(non_existent_non_fungible_asset).is_err());
 }
 
-// we ignore this test for now as we can not remove (insert EMPTY_WORD) an asset yet
-#[ignore]
 #[test]
 fn test_remove_non_fungible_asset_success() {
     let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);


### PR DESCRIPTION
This PR makes minor modifications to the asset vault masm implementation to use the `set` procedure on the SMT for deletions. We also remove the ignore flags for tests related to vault asset deletion.