### PR TITLE
AccountType: derive copy and clone

### DIFF
--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -6,7 +6,7 @@ use crypto::FieldElement;
 // ================================================================================================
 
 /// Specifies the account type.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AccountType {
     FungibleFaucet,
     NonFungibleFaucet,


### PR DESCRIPTION
As the title says. This makes it easier to pass the values around (for example, from a non-consuming builder of an AccountId