### PR TITLE
bugfix: note inputs didn't return error

### DIFF
--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -24,9 +24,9 @@ impl NoteInputs {
     ///
     /// # Errors
     /// Returns an error if the number of provided inputs is greater than 16.
-    pub fn new(inputs: &[Felt]) -> Self {
+    pub fn new(inputs: &[Felt]) -> Result<Self, NoteError> {
         if inputs.len() > Self::NOTE_NUM_INPUTS {
-            NoteError::too_many_inputs(inputs.len());
+            return Err(NoteError::too_many_inputs(inputs.len()));
         }
 
         // pad inputs with ZERO to be constant size (16 elements)
@@ -39,10 +39,10 @@ impl NoteInputs {
         // compute hash from padded inputs.
         let hash = Hasher::hash_elements(&padded_inputs);
 
-        Self {
+        Ok(Self {
             inputs: padded_inputs,
             hash,
-        }
+        })
     }
 
     // PUBLIC ACCESSORS
@@ -85,6 +85,6 @@ fn test_input_ordering() {
         Felt::new(3),
     ]);
 
-    let note_inputs = NoteInputs::new(&inputs);
+    let note_inputs = NoteInputs::new(&inputs).expect("note created should succeed");
     assert_eq!(&expected_ordering, note_inputs.inputs());
 }

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -7,7 +7,7 @@ mod envelope;
 pub use envelope::NoteEnvelope;
 
 mod inputs;
-use inputs::NoteInputs;
+pub use inputs::NoteInputs;
 
 mod metadata;
 pub use metadata::NoteMetadata;
@@ -88,7 +88,7 @@ impl Note {
         let num_assets = vault.num_assets();
         Ok(Self {
             script,
-            inputs: NoteInputs::new(inputs),
+            inputs: NoteInputs::new(inputs)?,
             vault,
             serial_num,
             metadata: NoteMetadata::new(sender, tag, Felt::new(num_assets as u64)),


### PR DESCRIPTION
There was an error check in place, but the value was not being returned. This fixes that, and also re-exports the note structures on top-level (like the rest).

I think we should start annotating error types with `#[must_use]` to caught this. Objections?