### PR TITLE
Additional conversions for note types

### DIFF
--- a/objects/src/notes/envelope.rs
+++ b/objects/src/notes/envelope.rs
@@ -41,31 +41,49 @@ impl NoteEnvelope {
 }
 
 impl From<NoteEnvelope> for [Felt; 8] {
-    fn from(cni: NoteEnvelope) -> Self {
-        let mut elements: [Felt; 8] = Default::default();
-        elements[..4].copy_from_slice(cni.note_hash.as_elements());
-        elements[4..].copy_from_slice(&Word::from(cni.metadata()));
-        elements
+    fn from(note_envelope: NoteEnvelope) -> Self {
+        (&note_envelope).into()
     }
 }
 
 impl From<NoteEnvelope> for [Word; 2] {
-    fn from(cni: NoteEnvelope) -> Self {
-        let mut elements: [Word; 2] = Default::default();
-        elements[0].copy_from_slice(cni.note_hash.as_elements());
-        elements[1].copy_from_slice(&Word::from(cni.metadata()));
-        elements
+    fn from(note_envelope: NoteEnvelope) -> Self {
+        (&note_envelope).into()
     }
 }
 
 impl From<NoteEnvelope> for [u8; 64] {
-    fn from(cni: NoteEnvelope) -> Self {
+    fn from(note_envelope: NoteEnvelope) -> Self {
+        (&note_envelope).into()
+    }
+}
+
+impl From<&NoteEnvelope> for [Felt; 8] {
+    fn from(note_envelope: &NoteEnvelope) -> Self {
+        let mut elements: [Felt; 8] = Default::default();
+        elements[..4].copy_from_slice(note_envelope.note_hash.as_elements());
+        elements[4..].copy_from_slice(&Word::from(note_envelope.metadata()));
+        elements
+    }
+}
+
+impl From<&NoteEnvelope> for [Word; 2] {
+    fn from(note_envelope: &NoteEnvelope) -> Self {
+        let mut elements: [Word; 2] = Default::default();
+        elements[0].copy_from_slice(note_envelope.note_hash.as_elements());
+        elements[1].copy_from_slice(&Word::from(note_envelope.metadata()));
+        elements
+    }
+}
+
+impl From<&NoteEnvelope> for [u8; 64] {
+    fn from(note_envelope: &NoteEnvelope) -> Self {
         let mut elements: [u8; 64] = [0; 64];
-        let note_metadata_bytes = Word::from(cni.metadata())
+        let note_metadata_bytes = Word::from(note_envelope.metadata())
             .iter()
             .flat_map(|x| x.as_int().to_le_bytes())
             .collect::<Vec<u8>>();
-        elements[..32].copy_from_slice(&cni.note_hash.as_bytes());
+        elements[..32].copy_from_slice(&note_envelope.note_hash.as_bytes());
         elements[32..].copy_from_slice(&note_metadata_bytes);
         elements
     }

--- a/objects/src/notes/envelope.rs
+++ b/objects/src/notes/envelope.rs
@@ -13,7 +13,7 @@ use miden_core::StarkField;
 ///     - tag
 ///     - ZERO
 ///     - ZERO
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteEnvelope {
     note_hash: Digest,

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -39,6 +39,12 @@ impl NoteMetadata {
     }
 }
 
+impl From<NoteMetadata> for Word {
+    fn from(metadata: NoteMetadata) -> Self {
+        (&metadata).into()
+    }
+}
+
 impl From<&NoteMetadata> for Word {
     fn from(metadata: &NoteMetadata) -> Self {
         let mut elements = Word::default();

--- a/objects/src/notes/stub.rs
+++ b/objects/src/notes/stub.rs
@@ -1,4 +1,6 @@
-use super::{Digest, Hasher, NoteEnvelope, NoteError, NoteMetadata, NoteVault, Word, WORD_SIZE};
+use super::{
+    Digest, Hasher, Note, NoteEnvelope, NoteError, NoteMetadata, NoteVault, Word, WORD_SIZE,
+};
 use crypto::StarkField;
 use miden_lib::memory::{
     CREATED_NOTE_ASSETS_OFFSET, CREATED_NOTE_CORE_DATA_SIZE, CREATED_NOTE_HASH_OFFSET,
@@ -110,5 +112,19 @@ impl From<NoteStub> for NoteEnvelope {
 impl From<&NoteStub> for NoteEnvelope {
     fn from(note_stub: &NoteStub) -> Self {
         note_stub.envelope
+    }
+}
+
+impl From<Note> for NoteStub {
+    fn from(note: Note) -> Self {
+        (&note).into()
+    }
+}
+
+impl From<&Note> for NoteStub {
+    fn from(note: &Note) -> Self {
+        let recipient = note.recipient();
+        Self::new(recipient, note.vault.clone(), note.metadata)
+            .expect("Note vault and metadate weren't consistent")
     }
 }

--- a/objects/src/notes/stub.rs
+++ b/objects/src/notes/stub.rs
@@ -106,3 +106,9 @@ impl From<NoteStub> for NoteEnvelope {
         note_stub.envelope
     }
 }
+
+impl From<&NoteStub> for NoteEnvelope {
+    fn from(note_stub: &NoteStub) -> Self {
+        note_stub.envelope
+    }
+}

--- a/objects/src/transaction/consumed_notes.rs
+++ b/objects/src/transaction/consumed_notes.rs
@@ -131,34 +131,58 @@ impl ConsumedNoteInfo {
 }
 
 impl From<ConsumedNoteInfo> for [Felt; 8] {
-    fn from(cni: ConsumedNoteInfo) -> Self {
-        let mut elements: [Felt; 8] = Default::default();
-        elements[..4].copy_from_slice(cni.nullifier.as_elements());
-        elements[4..].copy_from_slice(cni.script_root.as_elements());
-        elements
+    fn from(note_info: ConsumedNoteInfo) -> Self {
+        (&note_info).into()
     }
 }
 
 impl From<ConsumedNoteInfo> for [Word; 2] {
-    fn from(cni: ConsumedNoteInfo) -> Self {
-        let mut elements: [Word; 2] = Default::default();
-        elements[0].copy_from_slice(cni.nullifier.as_elements());
-        elements[1].copy_from_slice(cni.script_root.as_elements());
-        elements
+    fn from(note_info: ConsumedNoteInfo) -> Self {
+        (&note_info).into()
     }
 }
 
 impl From<ConsumedNoteInfo> for [u8; 64] {
-    fn from(cni: ConsumedNoteInfo) -> Self {
-        let mut elements: [u8; 64] = [0; 64];
-        elements[..32].copy_from_slice(&cni.nullifier.as_bytes());
-        elements[32..].copy_from_slice(&cni.script_root.as_bytes());
-        elements
+    fn from(note_info: ConsumedNoteInfo) -> Self {
+        (&note_info).into()
     }
 }
 
 impl From<Note> for ConsumedNoteInfo {
     fn from(note: Note) -> Self {
+        (&note).into()
+    }
+}
+
+impl From<&ConsumedNoteInfo> for [Felt; 8] {
+    fn from(note_info: &ConsumedNoteInfo) -> Self {
+        let mut elements: [Felt; 8] = Default::default();
+        elements[..4].copy_from_slice(note_info.nullifier.as_elements());
+        elements[4..].copy_from_slice(note_info.script_root.as_elements());
+        elements
+    }
+}
+
+impl From<&ConsumedNoteInfo> for [Word; 2] {
+    fn from(note_info: &ConsumedNoteInfo) -> Self {
+        let mut elements: [Word; 2] = Default::default();
+        elements[0].copy_from_slice(note_info.nullifier.as_elements());
+        elements[1].copy_from_slice(note_info.script_root.as_elements());
+        elements
+    }
+}
+
+impl From<&ConsumedNoteInfo> for [u8; 64] {
+    fn from(note_info: &ConsumedNoteInfo) -> Self {
+        let mut elements: [u8; 64] = [0; 64];
+        elements[..32].copy_from_slice(&note_info.nullifier.as_bytes());
+        elements[32..].copy_from_slice(&note_info.script_root.as_bytes());
+        elements
+    }
+}
+
+impl From<&Note> for ConsumedNoteInfo {
+    fn from(note: &Note) -> Self {
         Self::new(note.nullifier(), note.script().hash())
     }
 }

--- a/objects/src/transaction/consumed_notes.rs
+++ b/objects/src/transaction/consumed_notes.rs
@@ -97,6 +97,18 @@ impl From<ConsumedNotes> for Vec<ConsumedNoteInfo> {
     }
 }
 
+impl From<Vec<Note>> for ConsumedNotes {
+    fn from(notes: Vec<Note>) -> Self {
+        Self::new(notes)
+    }
+}
+
+impl FromIterator<Note> for ConsumedNotes {
+    fn from_iter<T: IntoIterator<Item = Note>>(iter: T) -> Self {
+        Self::new(iter.into_iter().collect())
+    }
+}
+
 // CONSUMED NOTE INFO
 // ================================================================================================
 

--- a/objects/src/transaction/created_notes.rs
+++ b/objects/src/transaction/created_notes.rs
@@ -8,7 +8,7 @@ use miden_lib::memory::NOTE_MEM_SIZE;
 // CREATED NOTES
 // ================================================================================================
 /// [CreatedNotes] represents the notes created by a transaction.
-///     
+///
 /// [CreatedNotes] is composed of:
 /// - notes: a vector of [NoteStub] objects representing the notes created by the transaction.
 /// - commitment: a commitment to the created notes.
@@ -104,6 +104,12 @@ pub fn generate_created_notes_stub_commitment(notes: &[NoteStub]) -> Digest {
 
 impl From<CreatedNotes> for Vec<NoteEnvelope> {
     fn from(created_notes: CreatedNotes) -> Self {
-        created_notes.notes.into_iter().map(|note| note.into()).collect::<Vec<_>>()
+        (&created_notes).into()
+    }
+}
+
+impl From<&CreatedNotes> for Vec<NoteEnvelope> {
+    fn from(created_notes: &CreatedNotes) -> Self {
+        created_notes.notes.iter().map(|note| note.into()).collect::<Vec<_>>()
     }
 }

--- a/objects/src/transaction/created_notes.rs
+++ b/objects/src/transaction/created_notes.rs
@@ -1,7 +1,8 @@
 use super::{
-    BTreeMap, Digest, Felt, Hasher, MerkleStore, NoteEnvelope, NoteStub, StackOutputs,
+    BTreeMap, Digest, Felt, Hasher, MerkleStore, Note, NoteEnvelope, NoteStub, StackOutputs,
     TransactionResultError, TryFromVmResult, Vec, Word, WORD_SIZE,
 };
+use core::iter::FromIterator;
 use miden_core::utils::group_slice_elements;
 use miden_lib::memory::NOTE_MEM_SIZE;
 
@@ -111,5 +112,23 @@ impl From<CreatedNotes> for Vec<NoteEnvelope> {
 impl From<&CreatedNotes> for Vec<NoteEnvelope> {
     fn from(created_notes: &CreatedNotes) -> Self {
         created_notes.notes.iter().map(|note| note.into()).collect::<Vec<_>>()
+    }
+}
+
+impl From<Vec<Note>> for CreatedNotes {
+    fn from(notes: Vec<Note>) -> Self {
+        Self::new(notes.into_iter().map(|note| note.into()).collect())
+    }
+}
+
+impl From<Vec<&Note>> for CreatedNotes {
+    fn from(notes: Vec<&Note>) -> Self {
+        Self::new(notes.iter().map(|note| (*note).into()).collect())
+    }
+}
+
+impl FromIterator<Note> for CreatedNotes {
+    fn from_iter<T: IntoIterator<Item = Note>>(iter: T) -> Self {
+        Self::new(iter.into_iter().map(|v| v.into()).collect())
     }
 }


### PR DESCRIPTION
Adds conversions for references in addition to the existing consuming conversions. This makes it easier to create a stubs and envelopes without consuming them, which is useful for testing. Also adds some other useful conversions for consumed and created notes.