### PR TITLE
Add note builder

### DIFF
--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -30,8 +30,6 @@ mod advice;
 use advice::{AdviceInputsBuilder, ToAdviceInputs};
 
 pub mod assets;
-pub use assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
-
 pub mod notes;
 
 pub mod block;

--- a/objects/src/notes/envelope.rs
+++ b/objects/src/notes/envelope.rs
@@ -1,4 +1,4 @@
-use super::{Digest, Felt, NoteMetadata, Vec, Word};
+use super::{Digest, Felt, Note, NoteMetadata, Vec, Word};
 use miden_core::StarkField;
 
 // NOTE ENVELOPE
@@ -86,5 +86,20 @@ impl From<&NoteEnvelope> for [u8; 64] {
         elements[..32].copy_from_slice(&note_envelope.note_hash.as_bytes());
         elements[32..].copy_from_slice(&note_metadata_bytes);
         elements
+    }
+}
+
+impl From<Note> for NoteEnvelope {
+    fn from(note: Note) -> Self {
+        (&note).into()
+    }
+}
+
+impl From<&Note> for NoteEnvelope {
+    fn from(note: &Note) -> Self {
+        Self {
+            note_hash: note.hash(),
+            note_metadata: *note.metadata(),
+        }
     }
 }


### PR DESCRIPTION
This PR does:

- Add a builder for `Note`s
- Add a conversion from `Note` to `NoteEnvelope`
- Removed top-level re-exports (as discussed on https://github.com/0xPolygonMiden/miden-base/pull/207)