### PR TITLE
remove Deref impl from non smart pointers

### DIFF
--- a/miden-lib/tests/test_account.rs
+++ b/miden-lib/tests/test_account.rs
@@ -84,7 +84,7 @@ pub fn test_set_code_succeeds() {
             exec.account::set_code
 
             exec.create_mock_notes
-            
+
             push.1
             exec.account::incr_nonce
 
@@ -366,7 +366,7 @@ fn test_is_faucet_procedure() {
             eq.{expected} assert
         end
     ",
-            account_id = *account_id,
+            account_id = account_id,
             expected = if account_id.is_faucet() { 1 } else { 0 },
         );
 

--- a/miden-lib/tests/test_asset_vault.rs
+++ b/miden-lib/tests/test_asset_vault.rs
@@ -115,7 +115,8 @@ fn test_add_fungible_asset_success() {
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_ASSET_AMOUNT;
-    let add_fungible_asset = Asset::try_from([Felt::new(amount), ZERO, ZERO, *faucet_id]).unwrap();
+    let add_fungible_asset =
+        Asset::try_from([Felt::new(amount), ZERO, ZERO, faucet_id.into()]).unwrap();
 
     let code = format!(
         "
@@ -159,7 +160,8 @@ fn test_add_non_fungible_asset_fail_overflow() {
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_ASSET_AMOUNT + 1;
-    let add_fungible_asset = Asset::try_from([Felt::new(amount), ZERO, ZERO, *faucet_id]).unwrap();
+    let add_fungible_asset =
+        Asset::try_from([Felt::new(amount), ZERO, ZERO, faucet_id.into()]).unwrap();
 
     let code = format!(
         "
@@ -284,7 +286,7 @@ fn test_remove_fungible_asset_success_no_balance_remaining() {
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FUNGIBLE_ASSET_AMOUNT;
     let remove_fungible_asset =
-        Asset::try_from([Felt::new(amount), ZERO, ZERO, *faucet_id]).unwrap();
+        Asset::try_from([Felt::new(amount), ZERO, ZERO, faucet_id.into()]).unwrap();
 
     let code = format!(
         "
@@ -329,7 +331,7 @@ fn test_remove_fungible_asset_success_balance_remaining() {
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FUNGIBLE_ASSET_AMOUNT - 1;
     let remove_fungible_asset =
-        Asset::try_from([Felt::new(amount), ZERO, ZERO, *faucet_id]).unwrap();
+        Asset::try_from([Felt::new(amount), ZERO, ZERO, faucet_id.into()]).unwrap();
 
     let code = format!(
         "

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -308,7 +308,7 @@ pub fn test_prologue_create_account() {
 #[test]
 pub fn test_prologue_create_account_invalid_seed() {
     let (account, block_header, chain, notes) = mock_inputs(AccountStatus::New);
-    let account_seed_key = [*account.id(), ZERO, ZERO, ZERO];
+    let account_seed_key = [account.id().into(), ZERO, ZERO, ZERO];
 
     let code = "
     use.miden::sat::internal::prologue

--- a/miden-tx/src/verifier/mod.rs
+++ b/miden-tx/src/verifier/mod.rs
@@ -87,7 +87,7 @@ impl TransactionVerifier {
             Self::compute_consumed_notes_hash(transaction.consumed_notes()).as_elements(),
         );
         stack_inputs.extend_from_slice(transaction.initial_account_hash().as_elements());
-        stack_inputs.push(*transaction.account_id());
+        stack_inputs.push(transaction.account_id().into());
         stack_inputs.extend_from_slice(transaction.block_ref().as_elements());
         StackInputs::new(stack_inputs)
     }

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -1,5 +1,5 @@
 use super::{Account, AccountError, Digest, Felt, Hasher, StarkField, ToString, Vec, Word};
-use core::{fmt, ops::Deref};
+use core::fmt;
 use crypto::FieldElement;
 
 // ACCOUNT ID
@@ -212,14 +212,6 @@ impl AccountId {
     }
 }
 
-impl Deref for AccountId {
-    type Target = Felt;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl From<AccountId> for Felt {
     fn from(id: AccountId) -> Self {
         id.0
@@ -270,7 +262,7 @@ impl TryFrom<u64> for AccountId {
 
 impl fmt::Display for AccountId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "0x{:02x}", self.as_int())
+        write!(f, "0x{:02x}", self.0.as_int())
     }
 }
 

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -158,7 +158,7 @@ impl ToAdviceInputs for Account {
     ///    elements[12..16]  = code root
     fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T) {
         // push core items onto the stack
-        target.push_onto_stack(&[*self.id, ZERO, ZERO, self.nonce]);
+        target.push_onto_stack(&[self.id.into(), ZERO, ZERO, self.nonce]);
         target.push_onto_stack(self.vault.commitment().as_elements());
         target.push_onto_stack(&*self.storage.root());
         target.push_onto_stack(self.code.root().as_elements());
@@ -194,7 +194,7 @@ pub fn hash_account(
     code_root: Digest,
 ) -> Digest {
     let mut elements = [ZERO; 16];
-    elements[0] = *id;
+    elements[0] = id.into();
     elements[3] = nonce;
     elements[4..8].copy_from_slice(&*vault_root);
     elements[8..12].copy_from_slice(&*storage_root);

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -69,7 +69,7 @@ impl FungibleAsset {
     /// Returns the key which is used to store this asset in the account vault.
     pub fn vault_key(&self) -> Word {
         let mut key = Word::default();
-        key[3] = *self.faucet_id;
+        key[3] = self.faucet_id.into();
         key
     }
 
@@ -140,7 +140,7 @@ impl From<FungibleAsset> for Word {
     fn from(asset: FungibleAsset) -> Self {
         let mut result = Word::default();
         result[0] = Felt::new(asset.amount);
-        result[3] = *asset.faucet_id;
+        result[3] = asset.faucet_id.into();
         result
     }
 }

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -2,7 +2,7 @@ use super::{
     parse_word, AccountId, AccountType, Asset, AssetError, Felt, Hasher, StarkField, ToString, Vec,
     Word,
 };
-use core::{fmt, ops::Deref};
+use core::fmt;
 
 // NON-FUNGIBLE ASSET
 // ================================================================================================
@@ -46,7 +46,7 @@ impl NonFungibleAsset {
             return Err(AssetError::not_a_non_fungible_faucet_id(faucet_id));
         }
         // set the element 1 to the faucet_id
-        data_hash[1] = *faucet_id;
+        data_hash[1] = faucet_id.into();
 
         // set the first bit of the asset to 0; we can do this because setting the first bit to 0
         // will always result in a valid field element.
@@ -90,14 +90,6 @@ impl NonFungibleAsset {
         }
 
         Ok(())
-    }
-}
-
-impl Deref for NonFungibleAsset {
-    type Target = Word;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/objects/src/mock/block.rs
+++ b/objects/src/mock/block.rs
@@ -16,7 +16,8 @@ pub fn mock_block_header(
                 if acct.is_new() {
                     None
                 } else {
-                    Some(((*acct.id()).as_int(), *acct.hash()))
+                    let felt_id: Felt = acct.id().into();
+                    Some((felt_id.as_int(), *acct.hash()))
                 }
             })
             .collect::<Vec<_>>(),

--- a/objects/src/transaction/tx_witness.rs
+++ b/objects/src/transaction/tx_witness.rs
@@ -134,7 +134,7 @@ impl TransactionWitness {
         let mut inputs: Vec<Felt> = Vec::with_capacity(13);
         inputs.extend(*self.consumed_notes_hash);
         inputs.extend(*self.initial_account_hash);
-        inputs.push(*self.account_id);
+        inputs.push(self.account_id.into());
         inputs.extend(*self.block_hash);
         StackInputs::new(inputs)
     }

--- a/objects/src/transaction/utils.rs
+++ b/objects/src/transaction/utils.rs
@@ -67,8 +67,10 @@ pub fn generate_advice_provider_inputs(
 
     // insert account id seed into advice map
     if let Some(seed) = account_id_seed {
-        advice_inputs
-            .extend_map(vec![([*account.id(), ZERO, ZERO, ZERO].into_bytes(), seed.to_vec())]);
+        advice_inputs.extend_map(vec![(
+            [account.id().into(), ZERO, ZERO, ZERO].into_bytes(),
+            seed.to_vec(),
+        )]);
     }
 
     advice_inputs
@@ -106,7 +108,7 @@ pub fn generate_stack_inputs(
     let mut inputs: Vec<Felt> = Vec::with_capacity(13);
     inputs.extend(*consumed_notes_commitment);
     inputs.extend_from_slice(account_hash.as_elements());
-    inputs.push(**account_id);
+    inputs.push((*account_id).into());
     inputs.extend_from_slice(block_header.hash().as_elements());
     StackInputs::new(inputs)
 }


### PR DESCRIPTION
This is not strictly necessary, I think it is just a nice to have.

From the stdlib docs:

![image](https://github.com/0xPolygonMiden/miden-base/assets/310139/68b1a7da-75e8-4c66-ba57-616df2ff37b4)


The idea is that `Deref` should be implemented by classes that manage resources (i.e. a smart pointer). Which is not the case for the `Felt` values we have here, these are copyable types which should fit in a register.

This PR removes the `Deref` implementation to follow the recommendation of the stdlib.

