### PR TITLE
Introduce faucet mint and burn procedures

### DIFF
--- a/miden-lib/asm/sat/asset.masm
+++ b/miden-lib/asm/sat/asset.masm
@@ -1,0 +1,90 @@
+use.miden::sat::internal::account->internal_account
+use.miden::sat::internal::asset
+use.miden::sat::account
+
+# CONSTANTS
+# =================================================================================================
+
+# Two raised to the power of 32 (2^32)
+const.TWO_POW_32=4294967296
+
+# PROCEDURES
+# =================================================================================================
+
+#! Builds a fungible asset for the specified fungible faucet and amount.
+#!
+#! Stack: [faucet_id, amount]
+#! Output: [ASSET]
+#!
+#! - faucet_id is the faucet to create the asset for.
+#! - amount is the amount of the asset to create.
+#! - ASSET is the built fungible asset.
+export.build_fungible_asset
+    # assert the faucet is a fungible faucet
+    dup exec.internal_account::is_fungible_faucet assert
+    # => [faucet_id, amount]
+
+    # assert the amount is valid
+    dup.1 exec.asset::get_fungible_asset_max_amount lte assert
+    # => [faucet_id, amount]
+
+    # create the asset
+    push.0.0 movup.2
+    # => [ASSET]
+end
+
+#! Creates a fungible asset for the faucet the transaction is being executed against.
+#!
+#! Stack: [amount]
+#! Output: [ASSET]
+#!
+#! - amount is the amount of the asset to create.
+#! - ASSET is the created fungible asset.
+export.create_fungible_asset
+    # fetch the id of the faucet the transaction is being executed against.
+    exec.account::get_id
+    # => [id, amount]
+
+    # build the fungible asset
+    exec.build_fungible_asset
+    # => [ASSET]
+end
+
+#! Builds a non fungible asset for the specified non-fungible faucet and amount.
+#!
+#! Stack: [faucet_id, DATA_HASH]
+#! Output: [ASSET]
+#!
+#! - faucet_id is the faucet to create the asset for.
+#! - DATA_HASH is the data hash of the non-fungible asset to build.
+#! - ASSET is the built non-fungible asset.
+export.build_non_fungible_asset
+    # assert the faucet is a non-fungible faucet
+    dup exec.internal_account::is_non_fungible_faucet assert
+    # => [faucet_id, DATA_HASH]
+
+    # build the asset
+    movup.3 drop movdn.2
+    # => [hash_0, hash_1, faucet_id, hash_3]
+
+    # set the most significant bit of the asset to 0
+    u32split u32wrapping_mul.2 div.2 push.TWO_POW_32 mul add
+    # => [ASSET]
+end
+
+#! Creates a non-fungible asset for the faucet the transaction is being executed against.
+#!
+#! Stack: [DATA_HASH]
+#! Output: [ASSET]
+#!
+#! - DATA_HASH is the data hash of the non-fungible asset to create.
+#! - ASSET is the created non-fungible asset.
+export.create_non_fungible_asset
+    # get the id of the faucet the transaction is being executed against
+    exec.account::get_id
+    # => [id, DATA_HASH]
+
+    # build the non-fungible asset
+    exec.build_non_fungible_asset
+    # => [ASSET]
+end

--- a/miden-lib/asm/sat/faucet.masm
+++ b/miden-lib/asm/sat/faucet.masm
@@ -1,0 +1,40 @@
+#! Mint an asset from the faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a faucet.
+#! - If the asset being minted is not associated with the faucet the transaction is being executed
+#!   against.
+#! - If the asset is not well formed.
+#! - For fungible faucets if the total issuance after minting is greater than the maximum amount 
+#!   allowed.
+#! - For non-fungible faucets if the non-fungible asset being minted already exists.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was minted.
+export.mint
+    syscall.mint_asset
+    # => [ASSET]
+end
+
+#! Burn an asset from the faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a faucet.
+#! - If the asset being burned is not associated with the faucet the transaction is being executed
+#!   against.
+#! - If the asset is not well formed.
+#! - For fungible faucets if the amount being burned is greater than the total input to the 
+#!   transaction.
+#! - For non-fungible faucets if the non-fungible asset being burned does not exist or was not 
+#!   provided as input to the transaction via a note or the accounts vault.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was burned.
+export.burn
+    syscall.burn_asset
+    # => [ASSET]
+end

--- a/miden-lib/asm/sat/internal/account.masm
+++ b/miden-lib/asm/sat/internal/account.masm
@@ -25,6 +25,18 @@ const.STORAGE_TREE_DEPTH=8
 # The depth of the account code tree
 const.ACCOUNT_CODE_TREE_DEPTH=8
 
+# The account storage slot at which faucet data is stored.
+# Fungible faucet: The faucet data consists of [ZERO, ZERO, ZERO, total_issuance]
+# Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
+const.FAUCET_STORAGE_DATA_SLOT=255
+
+# Returns the account storage slot at which faucet data is stored.
+# Fungible faucet: The faucet data consists of [ZERO, ZERO, ZERO, total_issuance]
+# Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
+export.get_faucet_storage_data_slot
+    push.FAUCET_STORAGE_DATA_SLOT
+end
+
 # PROCEDURES
 # =================================================================================================
 
@@ -265,12 +277,11 @@ end
 #! Sets an item in the account storage. Panics if the index is out of bounds.
 #!
 #! Stack: [index, V']
-#! Output: [R', V]
+#! Output: [V]
 #!
 #! - index is the index of the item to set.
 #! - V' is the value to set.
 #! - V is the previous value of the item.
-#! - R' is the new storage root.
 export.set_item
     # get the storage root
     exec.layout::get_acct_storage_root

--- a/miden-lib/asm/sat/internal/asset.masm
+++ b/miden-lib/asm/sat/internal/asset.masm
@@ -117,3 +117,37 @@ export.validate_asset
     end
     # => [ASSET]
 end
+
+#! Validates that a fungible asset is associated with the provided faucet_id.
+#!
+#! Stack: [faucet_id, ASSET]
+#! Output: [ASSET]
+#!
+#! - faucet_id is the account id of the faucet.
+#! - ASSET is the asset to validate.
+export.validate_fungible_asset_origin
+    # assert the origin of the asset is the faucet_id provided via the stack
+    dup.1 assert_eq
+    # => [ASSET]
+
+    # assert the fungible asset is valid
+    exec.validate_fungible_asset
+    # => [ASSET]
+end
+
+#! Validates that a non-fungible asset is associated with the provided faucet_id.
+#!
+#! Stack: [faucet_id, ASSET]
+#! Output: [ASSET]
+#!
+#! - faucet_id is the account id of the faucet.
+#! - ASSET is the asset to validate.
+export.validate_non_fungible_asset_origin
+    # assert the origin of the asset is the faucet_id provided via the stack
+    dup.3 assert_eq
+    # => [ASSET]
+
+    # assert the non-fungible asset is valid
+    exec.validate_non_fungible_asset
+    # => [ASSET]
+end

--- a/miden-lib/asm/sat/internal/asset_vault.masm
+++ b/miden-lib/asm/sat/internal/asset_vault.masm
@@ -88,12 +88,12 @@ end
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #! - ASSET is the fungible asset to add to the vault.
 #! - ASSET' is the total fungible asset in the account vault after ASSET was added to it.
-proc.add_fungible_asset
-    dup.4 movdn.5 push.0 movdn.3
-    # => [ASSET_KEY, amount, vault_root_ptr, vault_root_ptr]
+export.add_fungible_asset
+    dup.4 movdn.5 push.0 movdn.3 dup movdn.4
+    # => [ASSET_KEY, faucet_id, amount, vault_root_ptr, vault_root_ptr]
 
     # get the asset vault root and read asset
-    padw movup.9 mem_loadw swapw exec.smt::get
+    padw movup.10 mem_loadw swapw exec.smt::get drop movup.7
     # => [CUR_ASSET, VAULT_ROOT, amount, vault_root_ptr]
 
     # arrange elements
@@ -114,7 +114,7 @@ proc.add_fungible_asset
 
     # prepare the stack to insert the asset into the vault
     dupw movdnw.2 dupw movup.3 drop push.0 movdn.3 swapw
-    # => [KEY, ASSET', VAULT_ROOT, ASSET', vault_root_ptr]
+    # => [ASSET', KEY, VAULT_ROOT, ASSET', vault_root_ptr]
 
     # update asset in vault
     exec.smt::insert dropw
@@ -135,7 +135,7 @@ end
 #!
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #! - ASSET is the non-fungible asset that is added to the vault.
-proc.add_non_fungible_asset
+export.add_non_fungible_asset
     # prepare the stack to insert the asset into the vault
     dup.4 movdn.5 dupw padw movup.12 mem_loadw swapw dupw
     # => [ASSET, ASSET, VAULT_ROOT, ASSET, vault_root_ptr]
@@ -172,7 +172,7 @@ end
 export.add_asset
     # check if the asset is a fungible asset
     exec.asset::is_fungible_asset
-    # => [is_fungible_asset, ASSET, vault_root_ptr]
+    # => [is_fungible_asset, ASSET]
 
     # add the asset to the asset vault
     if.true
@@ -205,16 +205,16 @@ end
 #!
 #! - ASSET is the fungible asset to remove from the vault.
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
-proc.remove_fungible_asset
-    dup.4 movdn.5 dupw push.0 movdn.3
-    # => [ASSET_KEY, amount, ASSET, vault_root_ptr, vault_root_ptr]
+export.remove_fungible_asset
+    dup.4 movdn.5 dupw push.0 movdn.3 dup movdn.4
+    # => [ASSET_KEY, faucet_id, amount, ASSET, vault_root_ptr, vault_root_ptr]
 
     # get the asset vault root and read asset
-    padw movup.13 mem_loadw swapw exec.smt::get
+    padw movup.14 mem_loadw swapw exec.smt::get drop movup.7
     # => [CUR_ASSET, VAULT_ROOT, amount, ASSET, vault_root_ptr]
 
     # arrange elements
-    movup.3 movup.8 dup dup.3
+    movup.3 movup.8 dup dup.2
     # => [cur_amount, amount, amount, cur_amount, faucet_id, 0, 0, VAULT_ROOT, ASSET, vault_root_ptr]
 
     # assert amount <= cur_amount
@@ -258,7 +258,7 @@ end
 #!
 #! - ASSET is the non-fungible asset to remove from the vault.
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
-proc.remove_non_fungible_asset
+export.remove_non_fungible_asset
     # prepare the stack to insert an EMPTY_WORD into the vault at key associated with the 
     # non-fungible asset
     dup.4 movdn.5 dupw padw movup.12 mem_loadw swapw padw

--- a/miden-lib/asm/sat/internal/faucet.masm
+++ b/miden-lib/asm/sat/internal/faucet.masm
@@ -1,0 +1,252 @@
+use.std::collections::smt
+
+use.miden::sat::internal::account
+use.miden::sat::internal::asset
+use.miden::sat::internal::asset_vault
+use.miden::sat::internal::layout
+
+# FUNGIBLE ASSETS
+# ==================================================================================================
+
+#! Mints a fungible asset associated with the fungible faucet the transaction is being executed
+#! against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a fungible faucet.
+#! - If the fungible asset being minted is not associated with the faucet the transaction is
+#!   being executed against.
+#! - If the asset is not well formed.
+#! - If the total issuance after minting is greater than the maximum amount allowed.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - amount is the amount of the fungible asset to mint.
+#! - ASSET is the asset that was minted.
+export.mint_fungible_asset
+    # assert that the asset is associated with the faucet the transaction is being executed against
+    # and that the asset is valid
+    exec.account::get_id exec.asset::validate_fungible_asset_origin
+    # => [ASSET]
+
+    # get the current total issuance
+    exec.account::get_faucet_storage_data_slot exec.account::get_item 
+    # => [TOTAL_ISSUANCE, ASSET]
+
+    # prepare stack to ensure that minting the asset will not exceed the maximum
+    dup.7 dup exec.asset::get_fungible_asset_max_amount dup.3
+    # => [total_issuance, max_allowed_issuance, amount, amount, TOTAL_ISSUANCE, ASSET]
+
+    # compute difference to ensure that the total issuance will not exceed the maximum
+    sub lte assert
+    # => [amount, TOTAL_ISSUANCE, ASSET]
+
+    # update the total issuance
+    add exec.account::get_faucet_storage_data_slot exec.account::set_item dropw
+    # => [ASSET]
+
+    # add the asset to the input vault for asset preservation checks
+    dupw exec.layout::get_input_vault_root_ptr movdn.4 exec.asset_vault::add_fungible_asset dropw
+    # => [ASSET]
+end
+
+#! Burns a fungible asset associated with the fungible faucet the transaction is being executed
+#! against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a fungible faucet.
+#! - If the fungible asset being burned is not associated with the faucet the transaction is
+#!   being executed against.
+#! - If the asset is not well formed.
+#! - If the amount being burned is greater than the total input to the transaction.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was burned.
+proc.burn_fungible_asset
+    # assert that the asset is associated with the faucet the transaction is being executed against
+    # and that the asset is valid
+    exec.account::get_id exec.asset::validate_fungible_asset_origin
+    # => [ASSET]
+
+    # fetch TOTAL_ISSUANCE such that we can compute the new total issuance
+    exec.account::get_faucet_storage_data_slot exec.account::get_item
+    # => [TOTAL_ISSUANCE, ASSET]
+
+    # assert that the asset amount being burned is less or equal to the total issuance
+    dup.7 dup dup.2 lte assert
+    # => [amount, TOTAL_ISSUANCE, ASSET]
+
+    # compute new total issuance
+    sub exec.account::get_faucet_storage_data_slot exec.account::set_item dropw
+    # => [ASSET]
+
+    # remove the asset from the input vault
+    dupw exec.layout::get_input_vault_root_ptr movdn.4 exec.asset_vault::remove_fungible_asset dropw
+    # => [ASSET]
+end
+
+# NON-FUNGIBLE ASSETS
+# ==================================================================================================
+
+#! Mints a non-fungible asset associated with the non-fungible faucet the transaction is being
+#! executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a non-fungible faucet.
+#! - If the non-fungible asset being minted is not associated with the faucet the transaction is
+#!   being executed against.
+#! - If the non-fungible asset being minted already exists.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was minted.
+proc.mint_non_fungible_asset
+    # assert that the asset is associated with the faucet the transaction is being executed against
+    # and that the asset is valid
+    exec.account::get_id exec.asset::validate_non_fungible_asset_origin
+    # => [ASSET]
+
+    # fetch the root of the TSMT containing the non-fungible assets
+    dupw exec.account::get_faucet_storage_data_slot exec.account::get_item
+    # => [TSMT_ROOT, ASSET, ASSET]
+
+    # prepare stack for insert of non-fungible asset into tracking TSMT
+    swapw dupw
+    # => [ASSET, ASSET, TSMT_ROOT, ASSET]
+
+    # insert the non-fungible asset into the tracking TSMT
+    exec.smt::insert
+    # => [OLD_VAL, TSMT_ROOT', ASSET]
+
+    # assert the `OLD_VAL` is ZERO, indicating that the non-fungible asset did not already exist
+    # we only need to check ASSET[1] as this is always set to the faucet_id and can not be 0.
+    drop drop eq.0 assert drop
+    # => [TSMT_ROOT', ASSET]
+
+    # update the root of the TSMT containing the non-fungible assets
+    exec.account::get_faucet_storage_data_slot exec.account::set_item dropw
+    # => [ASSET]
+
+    # add the non-fungible asset to the input vault for asset preservation checks
+    exec.layout::get_input_vault_root_ptr movdn.4 exec.asset_vault::add_non_fungible_asset
+    # => [ASSET]
+end
+
+#! Burns a non-fungible asset associated with the non-fungible faucet the transaction is being
+#! executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a non-fungible faucet.
+#! - If the non-fungible asset being burned is not associated with the faucet the transaction is
+#!   being executed against.
+#! - If the non-fungible asset being burned does not exist or was not provided as input to the 
+#!   transaction via a note or the accounts vault.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was burned.
+proc.burn_non_fungible_asset
+    # assert that we are executing a transaction against the non-fungible faucet (access checks)
+    exec.account::get_id exec.account::is_non_fungible_faucet assert
+    # => [ASSET]
+
+    # duplicate asset
+    dupw
+    # => [ASSET, ASSET]
+
+    # fetch the root of the TSMT containing the non-fungible assets
+    exec.account::get_faucet_storage_data_slot exec.account::get_item
+    # => [TSMT_ROOT, ASSET, ASSET]
+
+    # prepare stack for removal of non-fungible asset from tracking TSMT
+    swapw padw
+    # => [ZERO, ASSET, TSMT_ROOT, ASSET]
+
+    # remove the non-fungible asset from the tracking TSMT
+    exec.smt::set
+    # => [OLD_VAL, TSMT_ROOT', ASSET]
+
+    # assert the `OLD_VAL` is not ZERO, indicating that the non-fungible asset exists.
+    # we only need to check ASSET[1] as this is always set to the faucet_id and can not be 0.
+    drop drop eq.0 not assert drop
+    # => [TSMT_ROOT', ASSET]
+
+    # update the root of the TSMT containing the non-fungible assets
+    exec.account::get_faucet_storage_data_slot exec.account::set_item dropw
+    # => [ASSET]
+
+    # remove the non-fungible asset from the input vault for asset preservation checks
+    exec.layout::get_input_vault_root_ptr movdn.4 exec.asset_vault::remove_non_fungible_asset
+    # => [ASSET]
+end
+
+# PUBLIC INTERFACE
+# ==================================================================================================
+
+#! Mint an asset from the faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a faucet.
+#! - If the asset being minted is not associated with the faucet the transaction is being executed
+#!   against.
+#! - If the asset is not well formed.
+#! - For fungible faucets if the total issuance after minting is greater than the maximum amount 
+#!   allowed.
+#! - For non-fungible faucets if the non-fungible asset being minted already exists.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was minted.
+export.mint
+    # check if the asset is a fungible asset
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset, ASSET]
+
+    if.true
+        # mint the fungible asset
+        exec.mint_fungible_asset
+        # => [ASSET]
+    else
+        # mint the non-fungible asset
+        exec.mint_non_fungible_asset
+        # => [ASSET]
+    end
+end
+
+#! Burn an asset from the faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a faucet.
+#! - If the asset being burned is not associated with the faucet the transaction is being executed
+#!   against.
+#! - If the asset is not well formed.
+#! - For fungible faucets if the amount being burned is greater than the total input to the 
+#!   transaction.
+#! - For non-fungible faucets if the non-fungible asset being burned does not exist or was not 
+#!   provided as input to the transaction via a note or the accounts vault.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was burned.
+export.burn
+    # check if the asset is a fungible asset
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset, ASSET]
+
+    if.true
+        # burn the fungible asset
+        exec.burn_fungible_asset
+        # => [ASSET]
+    else
+        # burn the non-fungible asset
+        exec.burn_non_fungible_asset
+        # => [ASSET]
+    end
+end
+

--- a/miden-lib/asm/sat/kernel.masm
+++ b/miden-lib/asm/sat/kernel.masm
@@ -1,5 +1,6 @@
 use.miden::sat::internal::account
 use.miden::sat::internal::asset_vault
+use.miden::sat::internal::faucet
 use.miden::sat::internal::layout
 use.miden::sat::internal::note
 use.miden::sat::internal::tx
@@ -119,6 +120,13 @@ end
 export.set_account_item
     # AUTHENTICATION
     # ---------------------------------------------------------------------------------------------
+    # if the transaction is being executed against a faucet account then assert 
+    # index != FAUCET_STORAGE_DATA_SLOT (reserved slot)
+    dup exec.account::get_faucet_storage_data_slot eq
+    exec.account::get_id exec.account::is_faucet
+    and assertz
+    # => [index, V', 0, 0, 0]
+
     # get the hash of the caller
     padw caller
     # => [CALLER, index, V', 0, 0, 0]
@@ -396,4 +404,75 @@ export.get_account_vault_commitment
     # prepare the stack for return
     swapw dropw
     # => [COM]
+end
+
+#! Mint an asset from the faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a faucet.
+#! - If the asset being minted is not associated with the faucet the transaction is being executed
+#!   against.
+#! - If the asset is not well formed.
+#! - For fungible faucets if the total issuance after minting is greater than the maximum amount 
+#!   allowed.
+#! - For non-fungible faucets if the non-fungible asset being minted already exists.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was minted.
+export.mint_asset
+    # AUTHENTICATION
+    # ---------------------------------------------------------------------------------------------
+    # get the hash of the caller
+    padw caller
+    # => [CALLER, ASSET]
+
+    # make sure the caller is a part of the account interface
+    exec.account::authenticate_procedure
+    # => [CALLER, ASSET]
+
+    # drop the caller
+    dropw
+    # => [ASSET]
+
+    # KERNEL LOGIC
+    # ---------------------------------------------------------------------------------------------
+    exec.faucet::mint
+end
+
+#! Burn an asset from the faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a faucet.
+#! - If the asset being burned is not associated with the faucet the transaction is being executed
+#!   against.
+#! - If the asset is not well formed.
+#! - For fungible faucets if the amount being burned is greater than the total input to the 
+#!   transaction.
+#! - For non-fungible faucets if the non-fungible asset being burned does not exist or was not 
+#!   provided as input to the transaction via a note or the accounts vault.
+#!
+#! Stack: [ASSET]
+#! Outputs: [ASSET]
+#!
+#! - ASSET is the asset that was burned.
+export.burn_asset
+    # AUTHENTICATION
+    # ---------------------------------------------------------------------------------------------
+    # get the hash of the caller
+    padw caller
+    # => [CALLER, ASSET]
+
+    # make sure the caller is a part of the account interface
+    exec.account::authenticate_procedure
+    # => [CALLER, ASSET]
+
+    # drop the caller
+    dropw
+    # => [ASSET]
+    
+    # KERNEL LOGIC
+    # ---------------------------------------------------------------------------------------------
+    exec.faucet::burn
 end

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -1,10 +1,22 @@
-// PUBLIC CONSTANTS
+// TYPE ALIASES
 // ================================================================================================
 
 pub type MemoryAddress = u32;
 pub type MemoryOffset = u32;
 pub type DataIndex = usize;
 pub type MemSize = usize;
+pub type StorageSlot = u8;
+
+// PUBLIC CONSTANTS
+// ================================================================================================
+
+// RESERVED ACCOUNT STORAGE SLOTS
+// ------------------------------------------------------------------------------------------------
+
+/// The account storage slot at which faucet data is stored.
+/// Fungible faucet: The faucet data consists of [ZERO, ZERO, ZERO, total_issuance]
+/// Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
+pub const FAUCET_STORAGE_DATA_SLOT: StorageSlot = 255;
 
 // BOOKKEEPING
 // ------------------------------------------------------------------------------------------------

--- a/miden-lib/tests/test_account.rs
+++ b/miden-lib/tests/test_account.rs
@@ -1,7 +1,7 @@
 pub mod common;
 use common::{
     data::{
-        mock_inputs, AccountStatus, AssetPreservationStatus, CHILD_ROOT_PARENT_LEAF_INDEX,
+        mock_inputs, AssetPreservationStatus, MockAccountType, CHILD_ROOT_PARENT_LEAF_INDEX,
         CHILD_SMT_DEPTH, CHILD_STORAGE_INDEX_0, CHILD_STORAGE_VALUE_0, STORAGE_ITEM_0,
         STORAGE_ITEM_1,
     },
@@ -28,7 +28,8 @@ const ACCOUNT_ID_INSUFFICIENT_ONES: u64 = 0b1100000110 << 54;
 
 #[test]
 pub fn test_set_code_is_not_immediate() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = "
         use.miden::sat::internal::prologue
@@ -190,7 +191,8 @@ fn test_validate_id_fails_on_insuficcient_ones() {
 #[test]
 fn test_get_item() {
     for storage_item in [STORAGE_ITEM_0, STORAGE_ITEM_1] {
-        let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+        let (account, block_header, chain, notes) =
+            mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
         let code = format!(
             "
@@ -230,7 +232,8 @@ fn test_get_item() {
 
 #[test]
 fn test_get_child_tree_item() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
         "
@@ -282,7 +285,8 @@ fn test_get_child_tree_item() {
 
 #[test]
 fn test_set_item() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // copy the initial account slots (SMT)
     let mut account_smt = account.storage().slots().clone();
@@ -384,7 +388,8 @@ fn test_is_faucet_procedure() {
 
 #[test]
 fn test_authenticate_procedure() {
-    let (account, _, _, _) = mock_inputs(AccountStatus::Existing);
+    let (account, _, _, _) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let test_cases = vec![
         (account.code().procedure_tree().get_leaf(0).unwrap(), true),
@@ -393,7 +398,8 @@ fn test_authenticate_procedure() {
     ];
 
     for (root, valid) in test_cases.into_iter() {
-        let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+        let (account, block_header, chain, notes) =
+            mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
         let code = format!(
             "\
@@ -432,7 +438,8 @@ fn test_authenticate_procedure() {
 
 #[test]
 fn test_get_vault_commitment() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
         "

--- a/miden-lib/tests/test_asset.rs
+++ b/miden-lib/tests/test_asset.rs
@@ -1,0 +1,91 @@
+pub mod common;
+use common::{
+    data::{
+        mock_inputs, AssetPreservationStatus, MockAccountType, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
+        FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA,
+    },
+    prepare_transaction,
+    procedures::prepare_word,
+    run_tx, Hasher, MemAdviceProvider, Word,
+};
+use miden_objects::mock::{non_fungible_asset, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN};
+
+#[test]
+fn test_create_fungible_asset_succeeds() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::asset
+
+        begin
+            # prepare the transaction
+            exec.prologue::prepare_transaction
+
+            # push asset amount onto stack
+            push.{FUNGIBLE_ASSET_AMOUNT}
+            
+            # create fungible asset
+            exec.asset::create_fungible_asset
+
+            # assert the asset is correctly formed
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            assert_eqw
+        end
+        "
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+}
+
+#[test]
+fn test_create_non_fungible_asset_succeeds() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::NonFungibleFaucet, AssetPreservationStatus::Preserved);
+    let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::asset
+
+        begin
+            # prepare the transaction
+            exec.prologue::prepare_transaction
+
+            # push non-fungible asset data hash onto the stack
+            push.{non_fungible_asset_data_hash}
+            exec.asset::create_non_fungible_asset
+
+            # assert the non-fungible asset is correctly formed
+            push.{expected_non_fungible_asset}
+            assert_eqw
+        end
+        ",
+        non_fungible_asset_data_hash = prepare_word(&*Hasher::hash(&NON_FUNGIBLE_ASSET_DATA)),
+        expected_non_fungible_asset = prepare_word(&Word::from(non_fungible_asset))
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    )
+    .unwrap();
+}

--- a/miden-lib/tests/test_epilogue.rs
+++ b/miden-lib/tests/test_epilogue.rs
@@ -106,9 +106,10 @@ fn test_compute_created_note_hash() {
 
 #[test]
 fn test_epilogue_asset_preservation_violation() {
-    for asset_preservation in
-        [AssetPreservationStatus::TooFewInput, AssetPreservationStatus::TooManyInput]
-    {
+    for asset_preservation in [
+        AssetPreservationStatus::TooFewInput,
+        AssetPreservationStatus::TooManyFungibleInput,
+    ] {
         let executed_transaction = mock_executed_tx(asset_preservation);
 
         let created_notes_data_procedure =

--- a/miden-lib/tests/test_faucet.rs
+++ b/miden-lib/tests/test_faucet.rs
@@ -1,0 +1,652 @@
+pub mod common;
+use common::{
+    data::{
+        mock_inputs, AssetPreservationStatus, MockAccountType, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
+        ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1,
+        CONSUMED_NOTE_1_AMOUNT, FUNGIBLE_ASSET_AMOUNT, FUNGIBLE_FAUCET_INITIAL_BALANCE,
+    },
+    prepare_transaction,
+    procedures::prepare_word,
+    run_tx, MemAdviceProvider,
+};
+use miden_lib::memory::FAUCET_STORAGE_DATA_SLOT;
+use miden_objects::{
+    assets::FungibleAsset,
+    mock::{non_fungible_asset, non_fungible_asset_2, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN},
+};
+
+#[test]
+fn test_mint_fungible_asset_succeeds() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            exec.faucet::mint
+
+            # assert the correct asset is returned
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            assert_eqw
+
+            # assert the input vault has been updated
+            exec.layout::get_input_vault_root_ptr
+            push.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            exec.asset_vault::get_balance
+            push.{FUNGIBLE_ASSET_AMOUNT} assert_eq
+
+            # assert the faucet storage has been updated
+            push.{FAUCET_STORAGE_DATA_SLOT}
+            exec.account::get_item
+            push.{expected_final_storage_amount}
+            assert_eq
+        end
+        ",
+        expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_mint_fungible_asset_fails_not_faucet_account() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            exec.faucet::mint
+        end
+        "
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_mint_fungible_asset_inconsistent_faucet_id() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            exec.faucet::mint
+        end
+        ",
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_mint_fungible_asset_fails_saturate_max_amount() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{saturating_amount}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
+            exec.faucet::mint
+        end
+        ",
+        saturating_amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_FAUCET_INITIAL_BALANCE + 1
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_mint_non_fungible_asset_succeeds() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::NonFungibleFaucet, AssetPreservationStatus::Preserved);
+    let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.std::collections::smt
+
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::mint
+
+            # assert the correct asset is returned
+            push.{non_fungible_asset}
+            assert_eqw
+
+            # assert the input vault has been updated.
+            exec.layout::get_input_vault_root_ptr
+            push.{non_fungible_asset}
+            exec.asset_vault::has_non_fungible_asset
+            assert
+
+            # assert the non-fungible asset has been added to the faucet smt
+            push.{FAUCET_STORAGE_DATA_SLOT}
+            exec.account::get_item
+            push.{non_fungible_asset}
+            exec.smt::get
+            push.{non_fungible_asset}
+            assert_eqw
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_mint_non_fungible_asset_fails_not_faucet_account() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
+    let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::mint
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
+    let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1);
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::mint
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_mint_non_fungible_asset_fails_asset_already_exists() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::NonFungibleFaucet, AssetPreservationStatus::Preserved);
+    let non_fungible_asset = non_fungible_asset_2(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::mint
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_burn_fungible_asset_succeeds() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            exec.faucet::burn
+
+            # assert the correct asset is returned
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            assert_eqw
+
+            # assert the input vault has been updated
+            exec.layout::get_input_vault_root_ptr
+            push.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            exec.asset_vault::get_balance
+            push.{final_input_vault_asset_amount} assert_eq
+
+            # assert the faucet storage has been updated
+            push.{FAUCET_STORAGE_DATA_SLOT}
+            exec.account::get_item
+            push.{expected_final_storage_amount}
+            assert_eq
+        end
+        ",
+        final_input_vault_asset_amount = CONSUMED_NOTE_1_AMOUNT - FUNGIBLE_ASSET_AMOUNT,
+        expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_burn_fungible_asset_fails_not_faucet_account() {
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            exec.faucet::burn
+        end
+        "
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_burn_fungible_asset_inconsistent_faucet_id() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            exec.faucet::burn
+        end
+        ",
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_burn_fungible_asset_insufficient_input_amount() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::FungibleFaucet(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1),
+        AssetPreservationStatus::Preserved,
+    );
+
+    let code = format!(
+        "
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{saturating_amount}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1}
+            exec.faucet::burn
+        end
+        ",
+        saturating_amount = CONSUMED_NOTE_1_AMOUNT + 1
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_burn_non_fungible_asset_succeeds() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::NonFungibleFaucet,
+        AssetPreservationStatus::TooManyNonFungibleInput,
+    );
+    let non_fungible_asset_burnt = non_fungible_asset_2(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.std::collections::smt
+
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::burn
+
+            # assert the correct asset is returned
+            push.{non_fungible_asset}
+            assert_eqw
+
+            # assert the input vault has been updated.
+            exec.layout::get_input_vault_root_ptr
+            push.{non_fungible_asset}
+            exec.asset_vault::has_non_fungible_asset
+            not assert
+
+            # assert the non-fungible asset has been removed from the faucet smt
+            push.{FAUCET_STORAGE_DATA_SLOT}
+            exec.account::get_item
+            push.{non_fungible_asset}
+            exec.smt::get
+            padw
+            assert_eqw
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_burn_non_fungible_asset_fails_doesnt_exist() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::NonFungibleFaucet,
+        AssetPreservationStatus::TooManyNonFungibleInput,
+    );
+    let non_fungible_asset_burnt = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.std::collections::smt
+
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::burn
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_burn_non_fungible_asset_fails_not_faucet_account() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::StandardExisting,
+        AssetPreservationStatus::TooManyNonFungibleInput,
+    );
+    let non_fungible_asset_burnt = non_fungible_asset_2(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
+
+    let code = format!(
+        "
+        use.std::collections::smt
+
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::burn
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}
+
+#[test]
+fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
+    let (account, block_header, chain, notes) = mock_inputs(
+        MockAccountType::NonFungibleFaucet,
+        AssetPreservationStatus::TooManyNonFungibleInput,
+    );
+    let non_fungible_asset_burnt = non_fungible_asset_2(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1);
+
+    let code = format!(
+        "
+        use.std::collections::smt
+
+        use.miden::sat::internal::account
+        use.miden::sat::internal::asset_vault
+        use.miden::sat::internal::layout
+        use.miden::sat::internal::prologue
+        use.miden::sat::faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{non_fungible_asset}
+            exec.faucet::burn
+        end
+        ",
+        non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let mut advice_provider = MemAdviceProvider::from(transaction.advice_provider_inputs());
+    let process = run_tx(
+        transaction.tx_program().clone(),
+        transaction.stack_inputs(),
+        &mut advice_provider,
+    );
+    assert!(process.is_err());
+}

--- a/miden-lib/tests/test_note.rs
+++ b/miden-lib/tests/test_note.rs
@@ -1,6 +1,6 @@
 pub mod common;
 use common::{
-    data::{mock_inputs, AccountStatus},
+    data::{mock_inputs, AssetPreservationStatus, MockAccountType},
     prepare_transaction,
     procedures::prepare_word,
     run_tx, Felt, MemAdviceProvider, Note,
@@ -8,7 +8,8 @@ use common::{
 
 #[test]
 fn test_get_sender_no_sender() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // calling get_sender should return sender
     let code = "
@@ -35,7 +36,8 @@ fn test_get_sender_no_sender() {
 
 #[test]
 fn test_get_sender() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // calling get_sender should return sender
     let code = "
@@ -67,7 +69,8 @@ fn test_get_sender() {
 
 #[test]
 fn test_get_vault_data() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // calling get_vault_info should return vault info
     let code = format!(
@@ -120,7 +123,8 @@ fn test_get_vault_data() {
 
 #[test]
 fn test_get_assets() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     const DEST_POINTER_NOTE_0: u32 = 100000000;
     const DEST_POINTER_NOTE_1: u32 = 200000000;

--- a/miden-lib/tests/test_note_setup.rs
+++ b/miden-lib/tests/test_note_setup.rs
@@ -1,7 +1,7 @@
 pub mod common;
 use common::{
     consumed_note_data_ptr,
-    data::{mock_inputs, AccountStatus},
+    data::{mock_inputs, AssetPreservationStatus, MockAccountType},
     memory::CURRENT_CONSUMED_NOTE_PTR,
     prepare_transaction, run_tx, AdviceProvider, Felt, FieldElement, MemAdviceProvider, Process,
     TX_KERNEL_DIR,
@@ -12,7 +12,8 @@ const NOTE_SETUP_FILE: &str = "note_setup.masm";
 
 #[test]
 fn test_note_setup() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let imports = "use.miden::sat::internal::prologue\n";
     let code = "

--- a/miden-lib/tests/test_prologue.rs
+++ b/miden-lib/tests/test_prologue.rs
@@ -1,7 +1,10 @@
 pub mod common;
 use common::{
     consumed_note_data_ptr,
-    data::{mock_inputs, AccountStatus, ACCOUNT_SEED_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN},
+    data::{
+        mock_inputs, AssetPreservationStatus, MockAccountType,
+        ACCOUNT_SEED_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
+    },
     memory::{
         ACCT_CODE_ROOT_PTR, ACCT_DB_ROOT_PTR, ACCT_ID_AND_NONCE_PTR, ACCT_ID_PTR,
         ACCT_STORAGE_ROOT_PTR, ACCT_VAULT_ROOT_PTR, BATCH_ROOT_PTR, BLK_HASH_PTR,
@@ -19,7 +22,8 @@ const PROLOGUE_FILE: &str = "prologue.masm";
 
 #[test]
 fn test_transaction_prologue() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = "
         begin
@@ -270,7 +274,8 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
 
 #[test]
 pub fn test_prologue_create_account() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::New);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardNew, AssetPreservationStatus::Preserved);
     let code = "
     use.miden::sat::internal::prologue
 
@@ -307,7 +312,8 @@ pub fn test_prologue_create_account() {
 
 #[test]
 pub fn test_prologue_create_account_invalid_seed() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::New);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardNew, AssetPreservationStatus::Preserved);
     let account_seed_key = [account.id().into(), ZERO, ZERO, ZERO];
 
     let code = "
@@ -350,7 +356,8 @@ pub fn test_prologue_create_account_invalid_seed() {
 
 #[test]
 fn test_get_blk_version() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let code = "
     use.miden::sat::internal::layout
     use.miden::sat::internal::prologue
@@ -376,7 +383,8 @@ fn test_get_blk_version() {
 
 #[test]
 fn test_get_blk_timestamp() {
-    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+    let (account, block_header, chain, notes) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let code = "
     use.miden::sat::internal::layout
     use.miden::sat::internal::prologue

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -10,8 +10,8 @@ use crypto::StarkField;
 use miden_core::Felt;
 use miden_objects::{
     mock::{
-        mock_inputs, prepare_word, AccountStatus, CHILD_ROOT_PARENT_LEAF_INDEX, CHILD_SMT_DEPTH,
-        CHILD_STORAGE_INDEX_0,
+        mock_inputs, prepare_word, AssetPreservationStatus, MockAccountType,
+        CHILD_ROOT_PARENT_LEAF_INDEX, CHILD_SMT_DEPTH, CHILD_STORAGE_INDEX_0,
     },
     transaction::{CreatedNotes, FinalAccountStub},
     Account, AccountCode, TryFromVmResult,
@@ -30,7 +30,7 @@ pub struct MockDataStore {
 impl MockDataStore {
     pub fn new() -> Self {
         let (account, block_header, block_chain, consumed_notes) =
-            mock_inputs(AccountStatus::Existing);
+            mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
         Self {
             account,
             block_header,

--- a/objects/src/accounts/storage.rs
+++ b/objects/src/accounts/storage.rs
@@ -4,6 +4,8 @@ use crypto::merkle::{MerkleStore, NodeIndex, SimpleSmt, StoreNode};
 // TYPE ALIASES
 // ================================================================================================
 
+/// A type that represents a single storage item. The tuple contains the slot index of the item and
+/// the value of the item.
 pub type StorageItem = (u8, Word);
 
 // ACCOUNT STORAGE

--- a/objects/src/mock/chain.rs
+++ b/objects/src/mock/chain.rs
@@ -27,8 +27,8 @@ pub fn mock_chain_data(consumed_notes: &mut [Note]) -> ChainMmr {
     let block_chain = vec![
         mock_block_header(Felt::ZERO, None, note_tree_iter.next().map(|x| x.root()), &[]),
         mock_block_header(Felt::ONE, None, note_tree_iter.next().map(|x| x.root()), &[]),
-        mock_block_header(Felt::new(2), None, None, &[]),
-        mock_block_header(Felt::new(3), None, None, &[]),
+        mock_block_header(Felt::new(2), None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(Felt::new(3), None, note_tree_iter.next().map(|x| x.root()), &[]),
     ];
 
     // instantiate and populate MMR

--- a/objects/src/mock/constants.rs
+++ b/objects/src/mock/constants.rs
@@ -1,19 +1,24 @@
+use crate::{
+    assets::Asset,
+    assets::{NonFungibleAsset, NonFungibleAssetDetails},
+    AccountId, Felt, StorageItem,
+};
 use miden_core::FieldElement;
 
-use super::{Felt, StorageItem};
-
 pub const ACCOUNT_SEED_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: [u64; 4] = [
-    5950491586293629690,
-    3173174058297886549,
-    16553747801483039178,
-    11841717777847436894,
+    17703295116126138860,
+    4543943952737162398,
+    12131811259770615661,
+    8392414916091377456,
 ];
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = 3972335011818762557;
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = 4537530468170077009;
 pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
 
-pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010011100 << 54;
+pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1010111100 << 54;
 pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0b1110011100 << 54;
-pub const FUNGIBLE_ASSET_AMOUNT: u64 = 1000;
+pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1: u64 = 0b1110011101 << 54;
+pub const FUNGIBLE_ASSET_AMOUNT: u64 = 100;
+pub const FUNGIBLE_FAUCET_INITIAL_BALANCE: u64 = 50000;
 
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1: u64 =
     0b1010010001111111010110100011011110101011010001101111110110111100u64;
@@ -22,7 +27,12 @@ pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2: u64 =
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_3: u64 =
     0b1010011001011010101101000110111101010110100011011101000110111100u64;
 
+pub const CONSUMED_NOTE_1_AMOUNT: u64 = 100;
+pub const CONSUMED_NOTE_2_AMOUNT: u64 = 200;
+pub const CONSUMED_NOTE_3_AMOUNT: u64 = 300;
+
 pub const NON_FUNGIBLE_ASSET_DATA: [u8; 4] = [1, 2, 3, 4];
+pub const NON_FUNGIBLE_ASSET_DATA_2: [u8; 4] = [5, 6, 7, 8];
 
 pub const NONCE: Felt = Felt::ZERO;
 
@@ -38,3 +48,24 @@ pub const CHILD_SMT_DEPTH: u8 = 64;
 pub const CHILD_STORAGE_INDEX_0: u64 = 40;
 pub const CHILD_STORAGE_VALUE_0: [Felt; 4] =
     [Felt::new(11), Felt::new(12), Felt::new(13), Felt::new(14)];
+
+pub fn non_fungible_asset(account_id: u64) -> Asset {
+    let non_fungible_asset_details = NonFungibleAssetDetails::new(
+        AccountId::try_from(account_id).unwrap(),
+        NON_FUNGIBLE_ASSET_DATA.to_vec(),
+    )
+    .unwrap();
+    let non_fungible_asset = NonFungibleAsset::new(&non_fungible_asset_details).unwrap();
+    Asset::NonFungible(non_fungible_asset)
+}
+
+pub fn non_fungible_asset_2(account_id: u64) -> Asset {
+    let non_fungible_asset_2_details: NonFungibleAssetDetails = NonFungibleAssetDetails::new(
+        AccountId::try_from(account_id).unwrap(),
+        NON_FUNGIBLE_ASSET_DATA_2.to_vec(),
+    )
+    .unwrap();
+    let non_fungible_asset_2: NonFungibleAsset =
+        NonFungibleAsset::new(&non_fungible_asset_2_details).unwrap();
+    Asset::NonFungible(non_fungible_asset_2)
+}

--- a/objects/src/mock/mod.rs
+++ b/objects/src/mock/mod.rs
@@ -1,4 +1,3 @@
-use super::{Felt, StorageItem};
 use assembly::Assembler;
 use miden_lib::{MidenLib, SatKernel};
 use miden_stdlib::StdLibrary;


### PR DESCRIPTION
This PR introduces `mint` and `burn` functionality for faucet accounts.

This PR includes the following:

- Introduction of `faucet` module consisting of `mint` and `burn` kernel procedures.
- Fix bug with `add_fungible_asset` procedure when the vault had no balance for the fungible asset being added to the vault.
- Fix bug with `remove_fungible_asset` procedure to ensure that the vault has sufficient balance for the fungible asset being removed.
- Implement reserved storage slot (255) for faucet accounts.

closes: #118 