### PR TITLE
Introduce account::get_vault_commitment procedure

### DIFF
--- a/miden-lib/asm/sat/account.masm
+++ b/miden-lib/asm/sat/account.masm
@@ -177,3 +177,19 @@ end
 export.remove_asset
     syscall.account_vault_remove_asset
 end
+
+#! Returns a commitment to the account vault.
+#!
+#! Stack: []
+#! Output: [COM]
+#!
+#! - COM is a commitment to the account vault.
+export.get_vault_commitment
+    # pad the stack for syscall invocation
+    padw
+    # => [0, 0, 0, 0]
+
+    # invoke the syscall
+    syscall.get_account_vault_commitment
+    # => [COM]
+end

--- a/miden-lib/asm/sat/kernel.masm
+++ b/miden-lib/asm/sat/kernel.masm
@@ -381,3 +381,19 @@ end
 export.create_note
     exec.tx::create_note
 end
+
+#! Returns a commitment to the account vault the transaction is being executed against.
+#!
+#! Stack: [0, 0, 0, 0]
+#! Outputs: [COM]
+#!
+#! - COM is the commitment to the account vault.
+export.get_account_vault_commitment
+    # fetch the account vault root from memory
+    exec.layout::get_acct_vault_root
+    # => [COM, 0, 0, 0, 0]
+
+    # prepare the stack for return
+    swapw dropw
+    # => [COM]
+end

--- a/miden-lib/tests/test_account.rs
+++ b/miden-lib/tests/test_account.rs
@@ -429,3 +429,36 @@ fn test_authenticate_procedure() {
         }
     }
 }
+
+#[test]
+fn test_get_vault_commitment() {
+    let (account, block_header, chain, notes) = mock_inputs(AccountStatus::Existing);
+
+    let code = format!(
+        "
+    use.miden::sat::account
+    use.miden::sat::internal::prologue
+
+    begin
+        # prepare the transaction
+        exec.prologue::prepare_transaction
+
+        # push the new storage item onto the stack
+        exec.account::get_vault_commitment
+        push.{expected_vault_commitment}
+        assert_eqw
+    end
+    ",
+        expected_vault_commitment = prepare_word(&account.vault().commitment()),
+    );
+
+    let transaction =
+        prepare_transaction(account, None, block_header, chain, notes, &code, "", None, None);
+
+    let _process = run_tx(
+        transaction.tx_program().clone(),
+        StackInputs::from(transaction.stack_inputs()),
+        MemAdviceProvider::from(transaction.advice_provider_inputs()),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
This PR introduces `account::get_vault_commitment` procedure which is the last procedure of the vault interface.

closes: #69 