### PR TITLE
error: delegate display to debug formatting

### DIFF
--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -16,8 +16,8 @@ pub enum TransactionError {
 }
 
 impl fmt::Display for TransactionError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -40,8 +40,8 @@ pub enum TransactionCompilerError {
 }
 
 impl fmt::Display for TransactionCompilerError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -63,8 +63,8 @@ pub enum TransactionExecutorError {
 }
 
 impl fmt::Display for TransactionExecutorError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -81,8 +81,8 @@ pub enum TransactionProverError {
 }
 
 impl fmt::Display for TransactionProverError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -98,8 +98,8 @@ pub enum TransactionVerifierError {
 }
 
 impl fmt::Display for TransactionVerifierError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -115,8 +115,8 @@ pub enum DataStoreError {
 }
 
 impl fmt::Display for DataStoreError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -186,7 +186,7 @@ impl TryFrom<[u8; 32]> for FungibleAsset {
 }
 
 impl fmt::Display for FungibleAsset {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -69,8 +69,8 @@ impl From<ParsingError> for AccountError {
 }
 
 impl fmt::Display for AccountError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -152,8 +152,8 @@ impl AssetError {
 }
 
 impl fmt::Display for AssetError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -208,8 +208,8 @@ impl NoteError {
 }
 
 impl fmt::Display for NoteError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -225,8 +225,8 @@ pub enum PreparedTransactionError {
 }
 
 impl fmt::Display for PreparedTransactionError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -242,8 +242,8 @@ pub enum ExecutedTransactionError {
 }
 
 impl fmt::Display for ExecutedTransactionError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -266,8 +266,8 @@ pub enum TransactionResultError {
 }
 
 impl fmt::Display for TransactionResultError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -283,8 +283,8 @@ pub enum TransactionWitnessError {
 }
 
 impl fmt::Display for TransactionWitnessError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
delegates the formatting to the debug implementation instead of calling `todo!`. Also implements `Debug` and `std::error::Error` for the mock errors.