### PR TITLE
Parallel account id pow

### DIFF
--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -24,6 +24,7 @@ std = ["assembly/std", "crypto/std", "miden-core/std", "miden-lib/std", "miden-p
 testing = ["miden-test-utils", "mock"]
 serde = ["dep:serde", "crypto/serde"]
 mock = ["dep:rand", "testing"]
+concurrent = ["std"]
 
 [dependencies]
 assembly = { workspace = true }

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -10,13 +10,16 @@ use crypto::{
 };
 
 mod account_id;
-pub use account_id::{validate_account_seed, AccountId, AccountType};
+pub use account_id::{compute_digest, digest_pow, validate_account_seed, AccountId, AccountType};
 
 mod code;
 pub use code::AccountCode;
 
 pub mod delta;
 pub use delta::{AccountDelta, AccountStorageDelta};
+
+mod seed;
+pub use seed::get_account_seed;
 
 mod storage;
 pub use storage::{AccountStorage, StorageItem};

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -1,0 +1,244 @@
+use super::{compute_digest, AccountError, AccountId, AccountType, Digest, Felt, Vec, Word};
+
+#[cfg(feature = "concurrent")]
+use std::{
+    sync::{
+        mpsc::{self, Sender},
+        OnceLock,
+    },
+    thread::{self, spawn},
+};
+
+// SEED GENERATORS
+// --------------------------------------------------------------------------------------------
+
+/// Finds and returns a seed suitable for creating an account ID for the specified account type
+/// using the provided initial seed as a starting point.
+#[cfg(feature = "concurrent")]
+pub fn get_account_seed(
+    init_seed: [u8; 32],
+    account_type: AccountType,
+    on_chain: bool,
+    code_root: Digest,
+    storage_root: Digest,
+) -> Result<Word, AccountError> {
+    let thread_count = thread::available_parallelism().map_or(1, |v| v.get());
+
+    let (send, recv) = mpsc::channel();
+    let stop = OnceLock::new();
+
+    for count in 0..thread_count {
+        let send = send.clone();
+        let stop = stop.clone();
+        let mut init_seed = init_seed;
+        init_seed[0] += count as u8;
+        spawn(move || {
+            get_account_seed_inner(
+                send,
+                stop,
+                init_seed,
+                account_type,
+                on_chain,
+                code_root,
+                storage_root,
+            )
+        });
+    }
+
+    #[allow(unused_variables)]
+    let (digest, seed) = recv.recv().unwrap();
+    let _ = stop.set(true);
+
+    #[cfg(feature = "log")]
+    ::log::info!(
+        "Using account seed [pow={}, digest={}, seed={}]",
+        super::digest_pow(digest),
+        log::digest_hex(digest),
+        log::word_hex(seed),
+    );
+
+    Ok(seed)
+}
+
+#[cfg(feature = "concurrent")]
+pub fn get_account_seed_inner(
+    send: Sender<(Digest, Word)>,
+    stop: OnceLock<bool>,
+    init_seed: [u8; 32],
+    account_type: AccountType,
+    on_chain: bool,
+    code_root: Digest,
+    storage_root: Digest,
+) {
+    let init_seed: Vec<[u8; 8]> =
+        init_seed.chunks(8).map(|chunk| chunk.try_into().unwrap()).collect();
+    let mut current_seed: Word = [
+        Felt::from(init_seed[0]),
+        Felt::from(init_seed[1]),
+        Felt::from(init_seed[2]),
+        Felt::from(init_seed[3]),
+    ];
+    let mut current_digest = compute_digest(current_seed, code_root, storage_root);
+
+    #[cfg(feature = "log")]
+    let mut log = log::Log::start(current_digest, current_seed, account_type, on_chain);
+
+    // loop until we have a seed that satisfies the specified account type.
+    let mut count = 0;
+    loop {
+        #[cfg(feature = "log")]
+        log.iteration(current_digest, current_seed);
+
+        // regularly check if another thread found a digest
+        count += 1;
+        if count % 500_000 == 0 && stop.get().is_some() {
+            return;
+        }
+
+        // check if the seed satisfies the specified account type
+        if AccountId::validate_seed_digest(&current_digest).is_ok() {
+            // `validate_seed_digest` already validated it
+            let account_id = AccountId::new_unchecked(current_digest[0]);
+            if account_id.account_type() == account_type && account_id.is_on_chain() == on_chain {
+                #[cfg(feature = "log")]
+                log.done(current_digest, current_seed, account_id);
+
+                let _ = send.send((current_digest, current_seed));
+                return;
+            };
+        }
+        current_seed = current_digest.into();
+        current_digest = compute_digest(current_seed, code_root, storage_root);
+    }
+}
+
+/// Finds and returns a seed suitable for creating an account ID for the specified account type
+/// using the provided initial seed as a starting point.
+#[cfg(not(feature = "concurrent"))]
+pub fn get_account_seed(
+    init_seed: [u8; 32],
+    account_type: AccountType,
+    on_chain: bool,
+    code_root: Digest,
+    storage_root: Digest,
+) -> Result<Word, AccountError> {
+    let init_seed: Vec<[u8; 8]> =
+        init_seed.chunks(8).map(|chunk| chunk.try_into().unwrap()).collect();
+    let mut current_seed: Word = [
+        Felt::from(init_seed[0]),
+        Felt::from(init_seed[1]),
+        Felt::from(init_seed[2]),
+        Felt::from(init_seed[3]),
+    ];
+    let mut current_digest = compute_digest(current_seed, code_root, storage_root);
+
+    #[cfg(feature = "log")]
+    let mut log = log::Log::start(current_digest, current_seed, account_type, on_chain);
+
+    // loop until we have a seed that satisfies the specified account type.
+    loop {
+        #[cfg(feature = "log")]
+        log.iteration(current_digest, current_seed);
+
+        // check if the seed satisfies the specified account type
+        if AccountId::validate_seed_digest(&current_digest).is_ok() {
+            if let Ok(account_id) = AccountId::try_from(current_digest[0]) {
+                if account_id.account_type() == account_type && account_id.is_on_chain() == on_chain
+                {
+                    #[cfg(feature = "log")]
+                    log.done(current_digest, current_seed, account_id);
+
+                    return Ok(current_seed);
+                };
+            }
+        }
+        current_seed = current_digest.into();
+        current_digest = compute_digest(current_seed, code_root, storage_root);
+    }
+}
+
+#[cfg(feature = "log")]
+mod log {
+    use super::{
+        super::{digest_pow, Digest, Word},
+        AccountId, AccountType,
+    };
+    use assembly::utils::to_hex;
+    use crypto::utils::string::String;
+    use crypto::FieldElement;
+
+    /// Keeps track of the best digest found so far and count how many iterations have been done.
+    pub struct Log {
+        digest: Digest,
+        seed: Word,
+        count: usize,
+        pow: u32,
+    }
+
+    /// Given a [Digest] returns its hex representaiton.
+    pub fn digest_hex(digest: Digest) -> String {
+        to_hex(&digest.as_bytes()).expect("hex formatting failed")
+    }
+
+    /// Given a [Word] returns its hex representation.
+    pub fn word_hex(word: Word) -> String {
+        to_hex(FieldElement::elements_as_bytes(&word)).expect("hex formatting failed")
+    }
+
+    impl Log {
+        pub fn start(
+            digest: Digest,
+            seed: Word,
+            account_type: AccountType,
+            on_chain: bool,
+        ) -> Self {
+            log::info!(
+                "Generating new account seed [pow={}, digest={}, seed={} type={:?} onchain={}]",
+                digest_pow(digest),
+                digest_hex(digest),
+                word_hex(seed),
+                account_type,
+                on_chain,
+            );
+
+            Self {
+                digest,
+                seed,
+                count: 0,
+                pow: 0,
+            }
+        }
+
+        pub fn iteration(&mut self, digest: Digest, seed: Word) {
+            self.count += 1;
+
+            let pow = digest_pow(digest);
+            if pow >= self.pow {
+                self.digest = digest;
+                self.seed = seed;
+                self.pow = pow;
+            }
+
+            if self.count % 500_000 == 0 {
+                log::debug!(
+                    "Account seed loop [count={}, pow={}, digest={}, seed={}]",
+                    self.count,
+                    self.pow,
+                    digest_hex(self.digest),
+                    word_hex(self.seed),
+                );
+            }
+        }
+
+        pub fn done(self, digest: Digest, seed: Word, account_id: AccountId) {
+            log::info!(
+                "Found account seed [pow={}, current_digest={}, current_seed={} type={:?} onchain={}]]",
+                digest_pow(digest),
+                digest_hex(digest),
+                word_hex(seed),
+                account_id.account_type(),
+                account_id.is_on_chain(),
+            );
+        }
+    }
+}


### PR DESCRIPTION
~merge/review after #223~

This adds parallel PoW to the account id seed. Notes:

- The original code receives a single seed instead of PRNG, this doesn't change that, it just changes the seeds by adding a constant to the last element. It should be good enough since the inner loop used the RPO digest to get the next seed value.
- Parallelism is enabled by the `std` flag, since this uses the std lib to create threads and for the synchronization primitives

To visualize the logs from the threads an environment variable is needed:

```
RUST_LOG=debug cargo run
```

fixes #35