### PR TITLE
feat: adding set_nonce to the Account

### DIFF
--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -129,6 +129,11 @@ impl Account {
         self.nonce
     }
 
+    /// Returns nonce for this account.
+    pub fn set_nonce(&mut self, nonce: Felt) {
+        self.nonce = nonce;
+    }
+
     /// Returns true if this account can issue assets.
     pub fn is_faucet(&self) -> bool {
         self.id.is_faucet()


### PR DESCRIPTION
Adding a new `set_nonce()` method to our accounts. We need that to create a mock_chain with existing accounts.