### PR TITLE
feat: adding a simple masm wallet an eoa

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -22,6 +22,7 @@ assembly = { workspace = true }
 crypto = { workspace = true }
 miden-objects = { package = "miden-objects", path = "../objects", features = ["testing"], default-features = false }
 miden-stdlib = { workspace = true }
+miden-tx = { package = "miden-tx", path = "../miden-tx", default-features = false }
 processor = { workspace = true, features = ["internals"] }
 vm-core = { workspace = true }
 

--- a/miden-lib/asm/eoa/basic.masm
+++ b/miden-lib/asm/eoa/basic.masm
@@ -1,0 +1,32 @@
+use.miden::sat::account
+use.miden::sat::tx
+
+#! Authenticate a transaction using Falcon 
+#! WIP - FALCON VERIFICATION IS MISSING, NOT SURE IF HASHING IN CORRECT ORDER
+#! Stack: []
+#! Output: []
+#!
+#! - ASSET is the non-fungible asset of interest.
+#! - tag is the tag to be included in the note.
+#! - RECIPIENT is the recipient of the note.
+export.auth_tx
+    # update the nonce
+    push.1
+    exec.account::incr_nonce
+
+    # get commitments to consumed and created notes, new nonce, and ID
+    #exec.tx::get_output_notes_hash
+    #exec.tx::get_input_notes_hash
+    #exec.account::get_nonce push.0.0.0
+    #exec.account::get_id push.0.0.0
+
+    # compute the message to be signed
+    # M = h(output_notes_hash, h(input_notes_hash, h(0, 0, 0, id, 0, 0, 0, nonce)))
+    #hmerge hmerge hmerge
+
+    # get public key from account storage (assume index 0) and verify signature
+    #push.0
+    #exec.account::get_item
+    # [PUB_KEY, M]
+    # TODO: sign the message using FALCON
+end

--- a/miden-lib/asm/wallets/basic.masm
+++ b/miden-lib/asm/wallets/basic.masm
@@ -1,0 +1,28 @@
+use.miden::sat::account
+use.miden::sat::tx
+
+#! This procedure adds the given asset to the undelying account.
+#! 
+#! Inputs: [ASSET]
+#! Outputs: [0, 0, 0, 0, ...]
+#!
+#! - ASSET is the asset to be received, can be fungible or non-fungible
+export.receive_asset
+    exec.account::add_asset
+    dropw
+end
+
+#! Creates a note which sends a single asset to the specified recipient.
+#!
+#! Inputs: [ASSET, tag, RECIPIENT, ...]
+#! Outputs: [note_ptr, 0, 0, 0, 0, 0, 0, 0, 0, ...]
+#!
+#! - ASSET is the non-fungible asset of interest.
+#! - tag is the tag to be included in the note.
+#! - RECIPIENT is the recipient of the note.
+#! - note_ptr is the pointer to the memory address in the kernel.
+#!   This cannot directly be accessed from another context. 
+export.send_asset
+    exec.account::remove_asset
+    exec.tx::create_note
+end

--- a/miden-lib/tests/test_miden_wallet.rs
+++ b/miden-lib/tests/test_miden_wallet.rs
@@ -1,0 +1,312 @@
+pub mod common;
+
+use assembly::{
+    ast::{ModuleAst, ProgramAst},
+    Assembler,
+};
+use common::{data::prepare_word, NodeIndex};
+use crypto::{Felt, StarkField, Word, ONE, ZERO};
+use miden_lib::{MidenLib, SatKernel};
+use miden_stdlib::StdLibrary;
+
+use miden_objects::{
+    assets::{Asset, FungibleAsset},
+    builder::DEFAULT_ACCOUNT_CODE,
+    mock::{
+        mock_account_storage, mock_inputs_with_existing, AssetPreservationStatus, MockAccountType,
+        ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
+        ACCOUNT_ID_SENDER,
+    },
+    notes::{Note, NoteOrigin, NoteScript},
+    Account, AccountCode, AccountId, AccountVault, BlockHeader, ChainMmr,
+};
+
+use miden_tx::{data::DataStore, TransactionExecutor};
+
+#[derive(Clone)]
+pub enum DataStoreError {
+    AccountNotFound(AccountId),
+    NoteNotFound(u32, NodeIndex),
+}
+
+#[derive(Clone)]
+
+pub struct MockDataStore {
+    pub account: Account,
+    pub block_header: BlockHeader,
+    pub block_chain: ChainMmr,
+    pub notes: Vec<Note>,
+}
+
+impl MockDataStore {
+    pub fn with_existing(account: Option<Account>, consumed_notes: Option<Vec<Note>>) -> Self {
+        let (account, block_header, block_chain, consumed_notes) = mock_inputs_with_existing(
+            MockAccountType::StandardExisting,
+            AssetPreservationStatus::Preserved,
+            account,
+            consumed_notes,
+        );
+        Self {
+            account,
+            block_header,
+            block_chain,
+            notes: consumed_notes,
+        }
+    }
+}
+
+impl DataStore for MockDataStore {
+    fn get_transaction_data(
+        &self,
+        account_id: AccountId,
+        block_num: u32,
+        notes: &[NoteOrigin],
+    ) -> Result<(Account, BlockHeader, ChainMmr, Vec<Note>), miden_tx::DataStoreError> {
+        assert_eq!(account_id, self.account.id());
+        assert_eq!(block_num as u64, self.block_header.block_num().as_int());
+        assert_eq!(notes.len(), self.notes.len());
+        let origins = self
+            .notes
+            .iter()
+            .map(|note| note.proof().as_ref().unwrap().origin())
+            .collect::<Vec<_>>();
+        notes.iter().all(|note| origins.contains(&note));
+        Ok((
+            self.account.clone(),
+            self.block_header.clone(),
+            self.block_chain.clone(),
+            self.notes.clone(),
+        ))
+    }
+
+    fn get_account_code(
+        &self,
+        account_id: AccountId,
+    ) -> Result<ModuleAst, miden_tx::DataStoreError> {
+        assert_eq!(account_id, self.account.id());
+        Ok(self.account.code().module().clone())
+    }
+}
+
+#[test]
+// Testing the basic Miden wallet - receiving an asset
+fn test_receive_asset_via_wallet() {
+    // Create assets
+    let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+    let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
+
+    // Create sender and target account
+    let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
+    let target_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+    let target_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let target_account_code_ast = ModuleAst::parse(target_account_code_src).unwrap();
+    let mut account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let target_account_code = AccountCode::new(
+        target_account_id,
+        target_account_code_ast.clone(),
+        &mut account_assembler,
+    )
+    .unwrap();
+
+    let target_account_storage = mock_account_storage();
+    let target_account: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        target_account_storage.clone(),
+        target_account_code.clone(),
+        Felt::new(1),
+    );
+
+    // Create the note
+    let note_script_ast = ProgramAst::parse(
+        format!(
+            "
+    use.miden::sat::note
+    use.miden::wallets::basic->wallet
+
+    # add the asset
+    begin
+        exec.note::get_assets drop
+        mem_loadw
+        call.wallet::receive_asset
+        dropw
+    end
+    "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let mut note_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let (note_script, _) = NoteScript::new(note_script_ast, &mut note_assembler).unwrap();
+
+    const SERIAL_NUM: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
+
+    let note = Note::new(
+        note_script.clone(),
+        &[],
+        &vec![fungible_asset_1],
+        SERIAL_NUM,
+        sender_account_id,
+        ONE,
+        None,
+    )
+    .unwrap();
+
+    // CONSTRUCT AND EXECUTE TX (Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store = MockDataStore::with_existing(Some(target_account), Some(vec![note]));
+
+    let mut executor = TransactionExecutor::new(data_store.clone());
+    executor.load_account(target_account_id).unwrap();
+
+    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let note_origins = data_store
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    let tx_script = ProgramAst::parse(
+        format!(
+            "
+        use.miden::eoa::basic->auth_tx
+
+        begin
+            call.auth_tx::auth_tx
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+    // Execute the transaction and get the witness
+    let transaction_result = executor
+        .execute_transaction(target_account_id, block_ref, &note_origins, Some(tx_script))
+        .unwrap();
+
+    // nonce delta
+    assert!(transaction_result.account_delta().nonce == Some(Felt::new(2)));
+
+    // vault delta
+    let target_account_after: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![fungible_asset_1]).unwrap(),
+        target_account_storage,
+        target_account_code,
+        Felt::new(2),
+    );
+    assert!(transaction_result.final_account_hash() == target_account_after.hash());
+}
+
+#[test]
+// Testing the basic Miden wallet - sending an asset
+fn test_send_asset_via_wallet() {
+    // Mock data
+    // We need an asset and an account that owns that asset
+    // Create assets
+    let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+    let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
+
+    // Create sender and target account
+    let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+    let sender_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let sender_account_code_ast = ModuleAst::parse(sender_account_code_src).unwrap();
+    let mut account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let sender_account_code = AccountCode::new(
+        sender_account_id,
+        sender_account_code_ast.clone(),
+        &mut account_assembler,
+    )
+    .unwrap();
+
+    let sender_account_storage = mock_account_storage();
+    let sender_account: Account = Account::new(
+        sender_account_id,
+        AccountVault::new(&vec![fungible_asset_1.clone()]).unwrap(),
+        sender_account_storage.clone(),
+        sender_account_code.clone(),
+        Felt::new(1),
+    );
+
+    // CONSTRUCT AND EXECUTE TX (Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store = MockDataStore::with_existing(Some(sender_account), None);
+
+    let mut executor = TransactionExecutor::new(data_store.clone());
+    executor.load_account(sender_account_id).unwrap();
+
+    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let note_origins = data_store
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    let recipient = [ZERO, ONE, Felt::new(2), Felt::new(3)];
+    let tag = Felt::new(4);
+
+    let tx_script = ProgramAst::parse(
+        format!(
+            "
+        use.miden::eoa::basic->auth_tx
+        use.miden::wallets::basic->wallet
+
+        begin
+            push.{recipient}
+            push.{tag}
+            push.{asset}
+            call.wallet::send_asset drop
+            call.auth_tx::auth_tx
+            dropw dropw 
+        end
+        ",
+            recipient = prepare_word(&recipient),
+            tag = tag,
+            asset = prepare_word(&fungible_asset_1.try_into().unwrap())
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    // Execute the transaction and get the witness
+    let transaction_result = executor
+        .execute_transaction(sender_account_id, block_ref, &note_origins, Some(tx_script))
+        .unwrap();
+
+    // nonce delta
+    assert!(transaction_result.account_delta().nonce == Some(Felt::new(2)));
+
+    // vault delta
+    let sender_account_after: Account = Account::new(
+        sender_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        sender_account_storage,
+        sender_account_code,
+        Felt::new(2),
+    );
+    assert!(transaction_result.final_account_hash() == sender_account_after.hash());
+}

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -15,12 +15,12 @@ use processor::{ExecutionError, RecAdviceProvider};
 
 mod compiler;
 pub use compiler::{NoteTarget, TransactionComplier};
-mod data;
-use data::DataStore;
+pub mod data;
+pub use data::DataStore;
 mod error;
 mod executor;
 pub use error::TransactionError;
-use error::{
+pub use error::{
     DataStoreError, TransactionCompilerError, TransactionExecutorError, TransactionProverError,
     TransactionVerifierError,
 };

--- a/objects/src/builder/mod.rs
+++ b/objects/src/builder/mod.rs
@@ -12,42 +12,13 @@ use assembly::ast::ModuleAst;
 use crypto::merkle::MerkleError;
 use rand::{distributions::Standard, Rng};
 
-pub const DEFAULT_ACCOUNT_CODE: &str = "\
-use.miden::sat::account
+pub const DEFAULT_ACCOUNT_CODE: &str = "
+    use.miden::wallets::basic->basic_wallet
+    use.miden::eoa::basic->basic_eoa
 
-export.incr_nonce
-    push.0 swap
-    # => [value, 0]
-
-    exec.account::incr_nonce
-    # => [0]
-end
-
-export.set_item
-    exec.account::set_item
-    # => [R', V, 0, 0, 0]
-
-    movup.8 drop movup.8 drop movup.8 drop
-    # => [R', V]
-end
-
-export.set_code
-    padw swapw
-    # => [CODE_ROOT, 0, 0, 0, 0]
-
-    exec.account::set_code
-    # => [0, 0, 0, 0]
-end
-
-export.account_procedure_1
-    push.1.2
-    add
-end
-
-export.account_procedure_2
-    push.2.1
-    sub
-end
+    export.basic_wallet::receive_asset
+    export.basic_wallet::send_asset
+    export.basic_eoa::auth_tx
 ";
 
 const DEFAULT_NOTE_CODE: &str = "\

--- a/objects/src/mock/account.rs
+++ b/objects/src/mock/account.rs
@@ -33,7 +33,7 @@ fn mock_account_vault() -> AccountVault {
     AccountVault::new(&[fungible_asset, non_fungible_asset]).unwrap()
 }
 
-fn mock_account_storage() -> AccountStorage {
+pub fn mock_account_storage() -> AccountStorage {
     // Create an account merkle store
     let mut account_merkle_store = MerkleStore::new();
     let child_smt =

--- a/objects/src/mock/chain.rs
+++ b/objects/src/mock/chain.rs
@@ -70,7 +70,7 @@ mod mock {
     use core::fmt;
     use crypto::{
         hash::rpo::RpoDigest as Digest,
-        merkle::{MerkleError, NodeIndex, SimpleSmt, TieredSmt},
+        merkle::{NodeIndex, SimpleSmt, TieredSmt},
     };
     use miden_core::{FieldElement, StarkField};
     use rand::{Rng, SeedableRng};

--- a/objects/src/mock/transaction.rs
+++ b/objects/src/mock/transaction.rs
@@ -25,8 +25,47 @@ pub fn mock_inputs(
         MockAccountType::NonFungibleFaucet => mock_non_fungible_faucet(&mut assembler),
     };
 
-    // mock notes
     let (mut consumed_notes, _created_notes) = mock_notes(&mut assembler, asset_preservation);
+
+    // Chain data
+    let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
+
+    // Block header
+    let block_header = mock_block_header(
+        Felt::new(4),
+        Some(chain_mmr.mmr().accumulator().hash_peaks().into()),
+        None,
+        &[account.clone()],
+    );
+
+    // Transaction inputs
+    (account, block_header, chain_mmr, consumed_notes)
+}
+
+pub fn mock_inputs_with_existing(
+    account_type: MockAccountType,
+    asset_preservation: AssetPreservationStatus,
+    account: Option<Account>,
+    consumed_notes_from: Option<Vec<Note>>,
+) -> (Account, BlockHeader, ChainMmr, Vec<Note>) {
+    // Create assembler and assembler context
+    let mut assembler = assembler();
+
+    // Create an account with storage items
+
+    let account = match account_type {
+        MockAccountType::StandardNew => mock_new_account(&mut assembler),
+        MockAccountType::StandardExisting => {
+            account.unwrap_or(mock_account(Felt::ONE, None, &mut assembler))
+        }
+        MockAccountType::FungibleFaucet(acct_id) => mock_fungible_faucet(acct_id, &mut assembler),
+        MockAccountType::NonFungibleFaucet => mock_non_fungible_faucet(&mut assembler),
+    };
+
+    let (mut consumed_notes, _created_notes) = mock_notes(&mut assembler, asset_preservation);
+    if consumed_notes_from.is_some() {
+        consumed_notes = consumed_notes_from.unwrap();
+    }
 
     // Chain data
     let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);


### PR DESCRIPTION
Closes https://github.com/0xPolygonMiden/miden-base/issues/22 and is a new version of https://github.com/0xPolygonMiden/miden-base/pull/213

This PR implements a basic wallet interface. For now, we only have `receive_asset`, `send_asset`.

- Tests are working and test basic functionality. 
  - The first test tests `receive_asset` and the account in fact has the asset in its vault after the transaction
  - The second test `send_asset` and the account doesn't have the asset in its vault after the transaction [Note: here is missing that we don't actually have a note at the end of the test, the note is stored in memory of the account]
  
 - Also the basic eoa `auth_tx` procedure only increases the nonce. The Falcon signature verification is not there yet. @Al-Kindi-0  