### PR TITLE
chore: updated code to match latest AssemblyContext API changes

### DIFF
--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -1,7 +1,7 @@
 use super::{
-    AccountCode, AccountId, Assembler, AssemblyContext, AssemblyContextType, BTreeMap, CodeBlock,
-    Digest, MidenLib, ModuleAst, Note, NoteScript, Operation, Program, ProgramAst, SatKernel,
-    StdLibrary, TransactionCompilerError,
+    AccountCode, AccountId, Assembler, AssemblyContext, BTreeMap, CodeBlock, Digest, MidenLib,
+    ModuleAst, Note, NoteScript, Operation, Program, ProgramAst, SatKernel, StdLibrary,
+    TransactionCompilerError,
 };
 use miden_core::ProgramInfo;
 
@@ -46,30 +46,21 @@ impl TransactionComplier {
         let prologue_ast =
             ProgramAst::parse(SatKernel::prologue()).expect("prologue is well formed");
         let prologue = assembler
-            .compile_in_context(
-                &prologue_ast,
-                &mut AssemblyContext::new(AssemblyContextType::Program),
-            )
+            .compile_in_context(&prologue_ast, &mut AssemblyContext::for_program(&prologue_ast))
             .expect("prologue is well formed");
 
         // compile epilogue
         let epilogue_ast =
             ProgramAst::parse(SatKernel::epilogue()).expect("epilogue is well formed");
         let epilogue = assembler
-            .compile_in_context(
-                &epilogue_ast,
-                &mut AssemblyContext::new(AssemblyContextType::Program),
-            )
+            .compile_in_context(&epilogue_ast, &mut AssemblyContext::for_program(&epilogue_ast))
             .expect("epilogue is well formed");
 
         // compile note setup
         let note_setup_ast =
             ProgramAst::parse(SatKernel::note_setup()).expect("note setup is well formed");
         let note_setup = assembler
-            .compile_in_context(
-                &note_setup_ast,
-                &mut AssemblyContext::new(AssemblyContextType::Program),
-            )
+            .compile_in_context(&note_setup_ast, &mut AssemblyContext::for_program(&note_setup_ast))
             .expect("note setup is well formed");
 
         // compile note processing teardown
@@ -78,7 +69,7 @@ impl TransactionComplier {
         let note_processing_teardown = assembler
             .compile_in_context(
                 &note_processing_teardown_ast,
-                &mut AssemblyContext::new(AssemblyContextType::Program),
+                &mut AssemblyContext::for_program(&note_processing_teardown_ast),
             )
             .expect("note processing teardown is well formed");
 
@@ -167,7 +158,8 @@ impl TransactionComplier {
         }
 
         // Create the [AssemblyContext] for compilation of the transaction program
-        let mut assembly_context = AssemblyContext::new(AssemblyContextType::Program);
+        let mut assembly_context =
+            AssemblyContext::for_program(&ProgramAst::parse("begin end").unwrap());
 
         // Create note tree and note [CodeBlock]s
         let (note_tree_root, note_roots) = self.compile_and_build_note_program_tree(

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -46,21 +46,30 @@ impl TransactionComplier {
         let prologue_ast =
             ProgramAst::parse(SatKernel::prologue()).expect("prologue is well formed");
         let prologue = assembler
-            .compile_in_context(&prologue_ast, &mut AssemblyContext::for_program(&prologue_ast))
+            .compile_in_context(
+                &prologue_ast,
+                &mut AssemblyContext::for_program(Some(&prologue_ast)),
+            )
             .expect("prologue is well formed");
 
         // compile epilogue
         let epilogue_ast =
             ProgramAst::parse(SatKernel::epilogue()).expect("epilogue is well formed");
         let epilogue = assembler
-            .compile_in_context(&epilogue_ast, &mut AssemblyContext::for_program(&epilogue_ast))
+            .compile_in_context(
+                &epilogue_ast,
+                &mut AssemblyContext::for_program(Some(&epilogue_ast)),
+            )
             .expect("epilogue is well formed");
 
         // compile note setup
         let note_setup_ast =
             ProgramAst::parse(SatKernel::note_setup()).expect("note setup is well formed");
         let note_setup = assembler
-            .compile_in_context(&note_setup_ast, &mut AssemblyContext::for_program(&note_setup_ast))
+            .compile_in_context(
+                &note_setup_ast,
+                &mut AssemblyContext::for_program(Some(&note_setup_ast)),
+            )
             .expect("note setup is well formed");
 
         // compile note processing teardown
@@ -69,7 +78,7 @@ impl TransactionComplier {
         let note_processing_teardown = assembler
             .compile_in_context(
                 &note_processing_teardown_ast,
-                &mut AssemblyContext::for_program(&note_processing_teardown_ast),
+                &mut AssemblyContext::for_program(Some(&note_processing_teardown_ast)),
             )
             .expect("note processing teardown is well formed");
 
@@ -158,8 +167,7 @@ impl TransactionComplier {
         }
 
         // Create the [AssemblyContext] for compilation of the transaction program
-        let mut assembly_context =
-            AssemblyContext::for_program(&ProgramAst::parse("begin end").unwrap());
+        let mut assembly_context = AssemblyContext::for_program(None);
 
         // Create note tree and note [CodeBlock]s
         let (note_tree_root, note_roots) = self.compile_and_build_note_program_tree(

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -222,10 +222,7 @@ fn expected_mast_tree(
 
     let tx_script_program = tx_compiler
         .assembler
-        .compile_in_context(
-            tx_script,
-            &mut AssemblyContext::new(assembly::AssemblyContextType::Program),
-        )
+        .compile_in_context(tx_script, &mut AssemblyContext::for_program(tx_script))
         .unwrap();
     let tx_script_epilogue_leafs = CodeBlock::new_join([
         CodeBlock::new_call(tx_script_program.hash()),
@@ -248,7 +245,7 @@ fn create_note_leafs(tx_compiler: &mut TransactionComplier, note: &Note) -> Code
         .assembler
         .compile_in_context(
             note.script().code(),
-            &mut AssemblyContext::new(assembly::AssemblyContextType::Program),
+            &mut AssemblyContext::for_program(&note.script().code),
         )
         .unwrap();
     CodeBlock::new_join([

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -222,7 +222,7 @@ fn expected_mast_tree(
 
     let tx_script_program = tx_compiler
         .assembler
-        .compile_in_context(tx_script, &mut AssemblyContext::for_program(tx_script))
+        .compile_in_context(tx_script, &mut AssemblyContext::for_program(Some(tx_script)))
         .unwrap();
     let tx_script_epilogue_leafs = CodeBlock::new_join([
         CodeBlock::new_call(tx_script_program.hash()),
@@ -245,7 +245,7 @@ fn create_note_leafs(tx_compiler: &mut TransactionComplier, note: &Note) -> Code
         .assembler
         .compile_in_context(
             note.script().code(),
-            &mut AssemblyContext::for_program(&note.script().code),
+            &mut AssemblyContext::for_program(Some(&note.script().code())),
         )
         .unwrap();
     CodeBlock::new_join([

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -1,6 +1,6 @@
 use assembly::{
     ast::{ModuleAst, ProgramAst},
-    Assembler, AssemblyContext, AssemblyContextType, AssemblyError,
+    Assembler, AssemblyContext, AssemblyError,
 };
 use crypto::{hash::rpo::Rpo256 as Hasher, hash::rpo::RpoDigest as Digest, merkle::NodeIndex};
 use miden_core::{code_blocks::CodeBlock, utils::collections::BTreeMap, Operation, Program};

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -1,6 +1,6 @@
 use super::{
-    AccountError, AccountId, Assembler, AssemblyContext, AssemblyContextType, Digest, LibraryPath,
-    Module, ModuleAst, Vec,
+    AccountError, AccountId, Assembler, AssemblyContext, Digest, LibraryPath, Module, ModuleAst,
+    Vec,
 };
 use crypto::merkle::SimpleSmt;
 
@@ -59,7 +59,7 @@ impl AccountCode {
 
         // compile the module and make sure the number of exported procedures is within the limit
         let mut procedure_digests = assembler
-            .compile_module(&module, &mut AssemblyContext::new(AssemblyContextType::Module))
+            .compile_module(&module, &mut AssemblyContext::for_module(false))
             .map_err(AccountError::AccountCodeAssemblerError)?;
 
         if procedure_digests.len() > MAX_ACCOUNT_PROCEDURES {

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,8 +1,8 @@
 use super::{
     assets::{Asset, FungibleAsset, NonFungibleAsset},
-    AccountError, AdviceInputsBuilder, Assembler, AssemblyContext, AssemblyContextType, Digest,
-    Felt, Hasher, LibraryPath, Module, ModuleAst, StarkField, TieredSmt, ToAdviceInputs, ToString,
-    Vec, Word, ZERO,
+    AccountError, AdviceInputsBuilder, Assembler, AssemblyContext, Digest, Felt, Hasher,
+    LibraryPath, Module, ModuleAst, StarkField, TieredSmt, ToAdviceInputs, ToString, Vec, Word,
+    ZERO,
 };
 use crypto::{
     merkle::StoreNode,

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use assembly::{
     ast::{ModuleAst, ProgramAst},
-    Assembler, AssemblyContext, AssemblyContextType, LibraryPath, Module,
+    Assembler, AssemblyContext, LibraryPath, Module,
 };
 use crypto::{
     hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest},

--- a/objects/src/mock/chain.rs
+++ b/objects/src/mock/chain.rs
@@ -70,7 +70,7 @@ mod mock {
     use core::fmt;
     use crypto::{
         hash::rpo::RpoDigest as Digest,
-        merkle::{MerkleError, NodeIndex, SimpleSmt, TieredSmt},
+        merkle::{NodeIndex, SimpleSmt, TieredSmt},
     };
     use miden_core::{FieldElement, StarkField};
     use rand::{Rng, SeedableRng};

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    assets::Asset, AccountId, Assembler, AssemblyContext, AssemblyContextType, CodeBlock, Digest,
-    Felt, Hasher, NoteError, ProgramAst, ToString, Vec, Word, WORD_SIZE, ZERO,
+    assets::Asset, AccountId, Assembler, AssemblyContext, CodeBlock, Digest, Felt, Hasher,
+    NoteError, ProgramAst, ToString, Vec, Word, WORD_SIZE, ZERO,
 };
 
 mod envelope;

--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -1,13 +1,11 @@
-use super::{
-    Assembler, AssemblyContext, AssemblyContextType, CodeBlock, Digest, NoteError, ProgramAst,
-};
+use super::{Assembler, AssemblyContext, CodeBlock, Digest, NoteError, ProgramAst};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteScript {
-    hash: Digest,
+    pub hash: Digest,
     #[cfg_attr(feature = "serde", serde(with = "serialization"))]
-    code: ProgramAst,
+    pub code: ProgramAst,
 }
 
 #[cfg(feature = "serde")]
@@ -38,7 +36,7 @@ mod serialization {
 impl NoteScript {
     pub fn new(code: ProgramAst, assembler: &Assembler) -> Result<(Self, CodeBlock), NoteError> {
         let code_block = assembler
-            .compile_in_context(&code, &mut AssemblyContext::new(AssemblyContextType::Program))
+            .compile_in_context(&code, &mut AssemblyContext::for_program(&code))
             .map_err(NoteError::ScriptCompilationError)?;
         Ok((
             Self {

--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -3,9 +3,9 @@ use super::{Assembler, AssemblyContext, CodeBlock, Digest, NoteError, ProgramAst
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteScript {
-    pub hash: Digest,
+    hash: Digest,
     #[cfg_attr(feature = "serde", serde(with = "serialization"))]
-    pub code: ProgramAst,
+    code: ProgramAst,
 }
 
 #[cfg(feature = "serde")]
@@ -36,7 +36,7 @@ mod serialization {
 impl NoteScript {
     pub fn new(code: ProgramAst, assembler: &Assembler) -> Result<(Self, CodeBlock), NoteError> {
         let code_block = assembler
-            .compile_in_context(&code, &mut AssemblyContext::for_program(&code))
+            .compile_in_context(&code, &mut AssemblyContext::for_program(Some(&code)))
             .map_err(NoteError::ScriptCompilationError)?;
         Ok((
             Self {


### PR DESCRIPTION
https://github.com/0xPolygonMiden/miden-vm/pull/1063 changed the AssemblyContext API, so main is no longer compiling. This updates the code to match the new api.