### PR TITLE
docs: add note about total PoW for faucet id

### DIFF
--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -45,6 +45,11 @@ impl AccountId {
     pub const ON_CHAIN_ACCOUNT_SELECTOR: u64 = 0b001;
 
     /// Specifies a minimum number of trailing zeros required in the last element of the seed digest.
+    ///
+    /// Note: The account id includes 3 bits of metadata, these bits determine the account type
+    /// (normal account, fungible token, non-fungible token), the storage type (on/off chain), and
+    /// for the normal accounts if the code is updatable or not. These metadata bits are also
+    /// checked by the PoW and add to the total work defined below.
     pub const REGULAR_ACCOUNT_SEED_DIGEST_MIN_TRAILING_ZEROS: u32 = 23;
     pub const FAUCET_SEED_DIGEST_MIN_TRAILING_ZEROS: u32 = 31;
 


### PR DESCRIPTION
Adds a paragraph documenting the final PoW for account ids.

With these `3` added bits, a faucet id requires `34` bits of work. At 200k hashes/sec the expected time should be around 23hours of CPU time.