### PR TITLE
Adding p2id and p2idr scripts and tests

### DIFF
--- a/miden-lib/asm/note_scripts/basic.masm
+++ b/miden-lib/asm/note_scripts/basic.masm
@@ -1,0 +1,126 @@
+use.miden::sat::account
+use.miden::sat::note
+use.miden::sat::tx
+use.miden::wallets::basic->wallet
+
+#! Helper procedure to add all assets of a note to an account.
+#!
+#! Inputs: []
+#! Outputs: []
+#!
+proc.add_note_assets_to_account
+    push.0 exec.note::get_assets                               
+    # => [num_of_assets, 0 = ptr, ...]
+
+    # compute the pointer at which we should stop iterating
+    dup.1 add
+    # => [end_ptr, ptr, ...]
+
+    # pad the stack and move the pointer to the top
+    padw movup.5
+    # => [ptr, 0, 0, 0, 0, end_ptr, ...]
+
+    # compute the loop latch
+    dup dup.6 neq
+    # => [latch, ptr, 0, 0, 0, 0, end_ptr, ...]
+
+    while.true
+        # => [ptr, 0, 0, 0, 0, end_ptr, ...]
+
+        # save the pointer so that we can use it later
+        dup movdn.5
+        # => [ptr, 0, 0, 0, 0, ptr, end_ptr, ...]
+
+        # load the asset and add it to the account
+        mem_loadw call.wallet::receive_asset
+        # => [ASSET, ptr, end_ptr, ...]
+
+        # increment the pointer and compare it to the end_ptr
+        movup.4 add.1 dup dup.6 neq
+        # => [latch, ptr+1, ASSET, end_ptr, ...]
+    end
+
+    # clear the stack
+    drop dropw drop
+end
+
+
+#! Pay-to-ID script: adds all assets from the note to the account, assuming
+#! ID of the account matches target account ID specified by note inputs.
+#! 
+#! Requires that the account exposes: miden::wallets::basic::receive_asset procedure.
+#!
+#! Inputs: [target_account_id]
+#! Outputs: []
+#!
+#! - ASSET is the asset to be received, can be fungible or non-fungible
+#!
+#! FAILS if: 
+#! - Account does not expose miden::wallets::basic::receive_asset procedure.
+#! - Account ID of executing account is not equal to specified Account ID.
+#! - The same non-fungible asset already exists in the account.
+#! - Adding a fungible asset would result in amount overflow, i.e.,
+#!   the total amount would be greater than 2^63.
+export.p2id                                             
+    # => [note_inputs = target_account_id, ...]                                            
+    
+    exec.account::get_id                                
+    # => [account_id, target_account_id, ...]
+    
+    # ensure account_id = target_account_id, fails otherwise
+    assert_eq                                           
+    # => [...]
+    
+    exec.add_note_assets_to_account
+    # => [...]
+end
+
+#! Pay to ID reclaimable: ensures that note can be consumed only by an account with the provided ID
+#! or after provided block number also by the sender account
+#! 
+#! Inputs: [reclaim_block_height, target_account_id, ...]
+#! Outputs: []
+#!
+#! - ASSET is the asset to be received, can be fungible or non-fungible
+#!
+#! FAILS if: 
+#! - Account does not expose miden::wallets::basic::receive_asset procedure.
+#! - Before reclaim block height: Account ID of executing account is not equal to specified Account ID. 
+#! - At and after reclaim block height: Account ID of executing account is not equal to specified Account ID or Sender Account ID.
+#! - The same non-fungible asset already exists in the account.
+#! - Adding a fungible asset would result in amount overflow, i.e.,
+#!   the total amount would be greater than 2^63.
+export.p2idr
+    # => [reclaim_block_height, target_account_id, ...]                                                                                        
+    
+    exec.account::get_id dup
+    # => [account_id, account_id, reclaim_block_height, target_account_id, ...]
+
+    # determine if the current account is the target account
+    movup.3 eq
+    # => [is_target, account_id, reclaim_block_height, ...]
+
+    if.true
+        # if current account is the target, we don't need to check anything else
+        # and so we just clear the stack
+        drop drop
+
+    else
+        # if current account is not the target, we need to ensure it is the sender
+        exec.note::get_sender
+        # => [sender_account_id, account_id, reclaim_block_height, ...]
+    
+        assert_eq
+        # => [reclaim_block_height, ...]
+
+        # now check that sender is allowed to reclaim, current block >= reclaim block height
+        exec.tx::get_block_number                           
+        # => [current_block_height, reclaim_block_height, ...]    
+    
+        u32checked_lte assert                                                 
+    end 
+
+    exec.add_note_assets_to_account
+    # => [...]
+
+end

--- a/miden-lib/src/tests/mod.rs
+++ b/miden-lib/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod test_asset_vault;
 mod test_epilogue;
 mod test_faucet;
 mod test_note;
+mod test_note_scripts;
 mod test_note_setup;
 mod test_prologue;
 mod test_tx;

--- a/miden-lib/src/tests/test_note_scripts.rs
+++ b/miden-lib/src/tests/test_note_scripts.rs
@@ -1,0 +1,808 @@
+use crate::{MidenLib, SatKernel};
+use assembly::{
+    ast::{ModuleAst, ProgramAst},
+    Assembler,
+};
+use crypto::{Felt, StarkField, Word, ONE};
+use miden_stdlib::StdLibrary;
+
+use miden_objects::{
+    accounts::{Account, AccountCode, AccountId, AccountVault},
+    assets::{Asset, FungibleAsset},
+    block::BlockHeader,
+    chain::ChainMmr,
+    notes::{Note, NoteOrigin, NoteScript},
+};
+
+use mock::{
+    account::{mock_account_storage, MockAccountType, DEFAULT_ACCOUNT_CODE},
+    constants::{
+        ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
+        ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
+        ACCOUNT_ID_SENDER,
+    },
+    notes::AssetPreservationStatus,
+    transaction::mock_inputs_with_existing,
+};
+
+use miden_tx::{DataStore, TransactionExecutor};
+
+#[derive(Clone)]
+pub struct MockDataStore {
+    pub account: Account,
+    pub block_header: BlockHeader,
+    pub block_chain: ChainMmr,
+    pub notes: Vec<Note>,
+}
+
+impl MockDataStore {
+    pub fn with_existing(account: Option<Account>, consumed_notes: Option<Vec<Note>>) -> Self {
+        let (account, block_header, block_chain, consumed_notes) = mock_inputs_with_existing(
+            MockAccountType::StandardExisting,
+            AssetPreservationStatus::Preserved,
+            account,
+            consumed_notes,
+        );
+        Self {
+            account,
+            block_header,
+            block_chain,
+            notes: consumed_notes,
+        }
+    }
+}
+
+impl DataStore for MockDataStore {
+    fn get_transaction_data(
+        &self,
+        account_id: AccountId,
+        block_num: u32,
+        notes: &[NoteOrigin],
+    ) -> Result<(Account, BlockHeader, ChainMmr, Vec<Note>), miden_tx::DataStoreError> {
+        assert_eq!(account_id, self.account.id());
+        assert_eq!(block_num as u64, self.block_header.block_num().as_int());
+        assert_eq!(notes.len(), self.notes.len());
+        let origins = self
+            .notes
+            .iter()
+            .map(|note| note.proof().as_ref().unwrap().origin())
+            .collect::<Vec<_>>();
+        notes.iter().all(|note| origins.contains(&note));
+        Ok((
+            self.account.clone(),
+            self.block_header.clone(),
+            self.block_chain.clone(),
+            self.notes.clone(),
+        ))
+    }
+
+    fn get_account_code(
+        &self,
+        account_id: AccountId,
+    ) -> Result<ModuleAst, miden_tx::DataStoreError> {
+        assert_eq!(account_id, self.account.id());
+        Ok(self.account.code().module().clone())
+    }
+}
+
+// We test the Pay to ID script. So we create a note that can
+// only be consumed by the target account.
+#[test]
+fn test_p2id_script() {
+    // Create assets
+    let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+    let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
+
+    // Create sender and target account
+    let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
+    let target_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+    let target_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let target_account_code_ast = ModuleAst::parse(target_account_code_src).unwrap();
+    let mut account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let target_account_code = AccountCode::new(
+        target_account_id,
+        target_account_code_ast.clone(),
+        &mut account_assembler,
+    )
+    .unwrap();
+
+    let target_account_storage = mock_account_storage();
+    let target_account: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        target_account_storage.clone(),
+        target_account_code.clone(),
+        Felt::new(1),
+    );
+
+    // Create the note
+    let note_script_ast = ProgramAst::parse(
+        format!(
+            "
+        use.miden::note_scripts::basic
+    
+        begin
+            exec.basic::p2id
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let mut note_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let (note_script, _) = NoteScript::new(note_script_ast, &mut note_assembler).unwrap();
+
+    const SERIAL_NUM: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
+
+    let note = Note::new(
+        note_script.clone(),
+        &[target_account_id.into()],
+        &vec![fungible_asset_1],
+        SERIAL_NUM,
+        sender_account_id,
+        ONE,
+        None,
+    )
+    .unwrap();
+
+    // CONSTRUCT AND EXECUTE TX (Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store = MockDataStore::with_existing(Some(target_account), Some(vec![note.clone()]));
+
+    let mut executor = TransactionExecutor::new(data_store.clone());
+    executor.load_account(target_account_id).unwrap();
+
+    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let note_origins = data_store
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    let tx_script = ProgramAst::parse(
+        format!(
+            "
+        use.miden::eoa::basic->auth_tx
+
+        begin
+            call.auth_tx::auth_tx_rpo_falcon512
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    // Execute the transaction and get the witness
+    let transaction_result = executor
+        .execute_transaction(target_account_id, block_ref, &note_origins, Some(tx_script))
+        .unwrap();
+
+    // nonce delta
+    assert!(transaction_result.account_delta().nonce == Some(Felt::new(2)));
+
+    // vault delta
+    let target_account_after: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![fungible_asset_1]).unwrap(),
+        target_account_storage,
+        target_account_code,
+        Felt::new(2),
+    );
+    assert!(transaction_result.final_account_hash() == target_account_after.hash());
+
+    // CONSTRUCT AND EXECUTE TX (Failure)
+    // --------------------------------------------------------------------------------------------
+    // A "malicious" account tries to consume the note, we expect an error
+
+    let malicious_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN + 1).unwrap();
+    let malicious_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let malicious_account_code_ast = ModuleAst::parse(malicious_account_code_src).unwrap();
+    let mut malicious_account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let malicious_account_code = AccountCode::new(
+        malicious_account_id,
+        malicious_account_code_ast.clone(),
+        &mut malicious_account_assembler,
+    )
+    .unwrap();
+
+    let malicious_account_storage = mock_account_storage();
+    let malicious_account: Account = Account::new(
+        malicious_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        malicious_account_storage.clone(),
+        malicious_account_code.clone(),
+        Felt::new(1),
+    );
+
+    let data_store_malicious_account =
+        MockDataStore::with_existing(Some(malicious_account), Some(vec![note]));
+    let mut executor_2 = TransactionExecutor::new(data_store_malicious_account.clone());
+
+    executor_2.load_account(malicious_account_id).unwrap();
+
+    let block_ref = data_store_malicious_account.block_header.block_num().as_int() as u32;
+    let note_origins = data_store_malicious_account
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_2 =
+        executor_2.execute_transaction(malicious_account_id, block_ref, &note_origins, None);
+
+    // Check that we got the expected result - TransactionExecutorError
+    assert!(transaction_result_2.is_err());
+}
+
+// We test the Pay to script with 2 assets to test the loop inside the script.
+// So we create a note containing two assets that can only be consumed by the target account.
+#[test]
+fn test_p2id_script_two_assets() {
+    // Create assets
+    let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1).unwrap();
+    let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
+
+    let faucet_id_2 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2).unwrap();
+    let fungible_asset_2: Asset = FungibleAsset::new(faucet_id_2, 100).unwrap().into();
+
+    // Create sender and target account
+    let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
+    let target_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+    let target_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let target_account_code_ast = ModuleAst::parse(target_account_code_src).unwrap();
+    let mut account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let target_account_code = AccountCode::new(
+        target_account_id,
+        target_account_code_ast.clone(),
+        &mut account_assembler,
+    )
+    .unwrap();
+
+    let target_account_storage = mock_account_storage();
+    let target_account: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        target_account_storage.clone(),
+        target_account_code.clone(),
+        Felt::new(1),
+    );
+
+    // Create the note
+    let note_script_ast = ProgramAst::parse(
+        format!(
+            "
+        use.miden::note_scripts::basic
+    
+        begin
+            exec.basic::p2id
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let mut note_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let (note_script, _) = NoteScript::new(note_script_ast, &mut note_assembler).unwrap();
+
+    const SERIAL_NUM: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
+
+    let note = Note::new(
+        note_script.clone(),
+        &[target_account_id.into()],
+        &vec![fungible_asset_1, fungible_asset_2],
+        SERIAL_NUM,
+        sender_account_id,
+        ONE,
+        None,
+    )
+    .unwrap();
+
+    // CONSTRUCT AND EXECUTE TX (Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store = MockDataStore::with_existing(Some(target_account), Some(vec![note.clone()]));
+
+    let mut executor = TransactionExecutor::new(data_store.clone());
+    executor.load_account(target_account_id).unwrap();
+
+    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let note_origins = data_store
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    let tx_script = ProgramAst::parse(
+        format!(
+            "
+        use.miden::eoa::basic->auth_tx
+
+        begin
+            call.auth_tx::auth_tx_rpo_falcon512
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    // Execute the transaction and get the witness
+    let transaction_result = executor
+        .execute_transaction(target_account_id, block_ref, &note_origins, Some(tx_script))
+        .unwrap();
+
+    // Nonce delta
+    assert!(transaction_result.account_delta().nonce == Some(Felt::new(2)));
+
+    // Vault delta
+    let target_account_after: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![fungible_asset_1, fungible_asset_2]).unwrap(),
+        target_account_storage,
+        target_account_code,
+        Felt::new(2),
+    );
+    assert!(transaction_result.final_account_hash() == target_account_after.hash());
+
+    // CONSTRUCT AND EXECUTE TX (Failure)
+    // --------------------------------------------------------------------------------------------
+    // A "malicious" account tries to consume the note, we expect an error
+
+    let malicious_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN + 1).unwrap();
+    let malicious_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let malicious_account_code_ast = ModuleAst::parse(malicious_account_code_src).unwrap();
+    let mut malicious_account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let malicious_account_code = AccountCode::new(
+        malicious_account_id,
+        malicious_account_code_ast.clone(),
+        &mut malicious_account_assembler,
+    )
+    .unwrap();
+
+    let malicious_account_storage = mock_account_storage();
+    let malicious_account: Account = Account::new(
+        malicious_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        malicious_account_storage.clone(),
+        malicious_account_code.clone(),
+        Felt::new(1),
+    );
+
+    let data_store_malicious_account =
+        MockDataStore::with_existing(Some(malicious_account), Some(vec![note]));
+    let mut executor_2 = TransactionExecutor::new(data_store_malicious_account.clone());
+
+    executor_2.load_account(malicious_account_id).unwrap();
+
+    let block_ref = data_store_malicious_account.block_header.block_num().as_int() as u32;
+    let note_origins = data_store_malicious_account
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_2 =
+        executor_2.execute_transaction(malicious_account_id, block_ref, &note_origins, None);
+
+    // check that we got the expected result - TransactionExecutorError
+    assert!(transaction_result_2.is_err());
+}
+
+// We want to test the Pay to ID Reclaim script, which is a script that allows the user
+// to provide a block height to the P2ID script. Before the block height is reached,
+// the note can only be consumed by the target account. After the block height is reached,
+// the note can also be consumed (reclaimed) by the sender account.
+#[test]
+fn test_p2idr_script() {
+    // Create assets
+    let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+    let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
+
+    // Create sender and target and malicious account
+    let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+    let sender_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let sender_account_code_ast = ModuleAst::parse(sender_account_code_src).unwrap();
+    let mut sender_account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let sender_account_code = AccountCode::new(
+        sender_account_id,
+        sender_account_code_ast.clone(),
+        &mut sender_account_assembler,
+    )
+    .unwrap();
+
+    let sender_account_storage = mock_account_storage();
+
+    // Sender account has an empty vault; this is because we only test note consumption, not creation.
+    let sender_account: Account = Account::new(
+        sender_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        sender_account_storage.clone(),
+        sender_account_code.clone(),
+        Felt::new(1),
+    );
+
+    // Now create the target account
+    let target_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap();
+    let target_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let target_account_code_ast = ModuleAst::parse(target_account_code_src).unwrap();
+    let mut target_account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let target_account_code = AccountCode::new(
+        target_account_id,
+        target_account_code_ast.clone(),
+        &mut target_account_assembler,
+    )
+    .unwrap();
+
+    let target_account_storage = mock_account_storage();
+    let target_account: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        target_account_storage.clone(),
+        target_account_code.clone(),
+        Felt::new(1),
+    );
+
+    let malicious_account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN + 1).unwrap();
+    let malicious_account_code_src = DEFAULT_ACCOUNT_CODE;
+    let malicious_account_code_ast = ModuleAst::parse(malicious_account_code_src).unwrap();
+    let mut malicious_account_assembler = Assembler::default()
+        .with_library(&MidenLib::default())
+        .expect("library is well formed")
+        .with_library(&StdLibrary::default())
+        .expect("library is well formed")
+        .with_kernel(SatKernel::kernel())
+        .expect("kernel is well formed");
+
+    let malicious_account_code = AccountCode::new(
+        malicious_account_id,
+        malicious_account_code_ast.clone(),
+        &mut malicious_account_assembler,
+    )
+    .unwrap();
+
+    let malicious_account_storage = mock_account_storage();
+    let malicious_account: Account = Account::new(
+        malicious_account_id,
+        AccountVault::new(&vec![]).unwrap(),
+        malicious_account_storage.clone(),
+        malicious_account_code.clone(),
+        Felt::new(1),
+    );
+
+    // --------------------------------------------------------------------------------------------
+    // Create notes
+    // Create the reclaim block height (Note: Current block height is 4)
+    let reclaim_block_height_in_time = Felt::new(5);
+    let reclaim_block_height_too_late = Felt::new(3);
+
+    // Create the note with the P2IDR script
+    let note_program_ast = ProgramAst::parse(
+        format!(
+            "
+                use.miden::note_scripts::basic
+    
+                begin
+                    exec.basic::p2idr
+                end
+                ",
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let (note_script, _) =
+        NoteScript::new(note_program_ast, &mut sender_account_assembler).unwrap();
+
+    const SERIAL_NUM: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
+
+    let note_in_time = Note::new(
+        note_script.clone(),
+        &[target_account_id.into(), reclaim_block_height_in_time],
+        &vec![fungible_asset_1],
+        SERIAL_NUM,
+        sender_account_id,
+        ONE,
+        None,
+    )
+    .unwrap();
+
+    let note_too_late = Note::new(
+        note_script.clone(),
+        &[target_account_id.into(), reclaim_block_height_too_late],
+        &vec![fungible_asset_1],
+        SERIAL_NUM,
+        sender_account_id,
+        ONE,
+        None,
+    )
+    .unwrap();
+
+    // --------------------------------------------------------------------------------------------
+    // We have two cases:
+    //  Case "in time": block height is 4, reclaim block height is 5. Only the target account can consume the note.
+    //  Case "too late": block height is 4, reclaim block height is 3. Target and sender account can consume the note.
+    //  The malicious account should never be able to consume the note.
+    // --------------------------------------------------------------------------------------------
+    // CONSTRUCT AND EXECUTE TX (Case "in time" - Target Account Execution Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store_1 = MockDataStore::with_existing(
+        Some(target_account.clone()),
+        Some(vec![note_in_time.clone()]),
+    );
+    let mut executor_1 = TransactionExecutor::new(data_store_1.clone());
+
+    executor_1.load_account(target_account_id).unwrap();
+
+    let block_ref_1 = data_store_1.block_header.block_num().as_int() as u32;
+    let note_origins = data_store_1
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    let tx_script = ProgramAst::parse(
+        format!(
+            "
+        use.miden::eoa::basic->auth_tx
+
+        begin
+            call.auth_tx::auth_tx_rpo_falcon512
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    // Execute the transaction and get the witness
+    let transaction_result_1 = executor_1
+        .execute_transaction(target_account_id, block_ref_1, &note_origins, Some(tx_script.clone()))
+        .unwrap();
+
+    // Assert that the target_account received the funds and the nonce increased by 1
+    // Nonce delta
+    assert!(transaction_result_1.account_delta().nonce == Some(Felt::new(2)));
+
+    // Vault delta
+    let target_account_after: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![fungible_asset_1]).unwrap(),
+        target_account_storage.clone(),
+        target_account_code.clone(),
+        Felt::new(2),
+    );
+    assert!(transaction_result_1.final_account_hash() == target_account_after.hash());
+
+    // CONSTRUCT AND EXECUTE TX (Case "in time" - Sender Account Execution Failure)
+    // --------------------------------------------------------------------------------------------
+    let data_store_2 = MockDataStore::with_existing(
+        Some(sender_account.clone()),
+        Some(vec![note_in_time.clone()]),
+    );
+    let mut executor_2 = TransactionExecutor::new(data_store_2.clone());
+
+    executor_2.load_account(sender_account_id).unwrap();
+
+    let block_ref_2 = data_store_2.block_header.block_num().as_int() as u32;
+    let note_origins_2 = data_store_2
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_2 = executor_2.execute_transaction(
+        sender_account_id,
+        block_ref_2,
+        &note_origins_2,
+        Some(tx_script.clone()),
+    );
+
+    // Check that we got the expected result - TransactionExecutorError and not TransactionResult
+    // Second transaction should not work (sender consumes too early), we expect an error
+    assert!(transaction_result_2.is_err());
+
+    // CONSTRUCT AND EXECUTE TX (Case "in time" - Malicious Target Account Failure)
+    // --------------------------------------------------------------------------------------------
+    let data_store_3 = MockDataStore::with_existing(
+        Some(malicious_account.clone()),
+        Some(vec![note_in_time.clone()]),
+    );
+    let mut executor_3 = TransactionExecutor::new(data_store_3.clone());
+
+    executor_3.load_account(malicious_account_id).unwrap();
+
+    let block_ref_3 = data_store_3.block_header.block_num().as_int() as u32;
+    let note_origins_3 = data_store_3
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_3 = executor_3.execute_transaction(
+        malicious_account_id,
+        block_ref_3,
+        &note_origins_3,
+        Some(tx_script.clone()),
+    );
+
+    // Check that we got the expected result - TransactionExecutorError and not TransactionResult
+    // Third transaction should not work (malicious account can never consume), we expect an error
+    assert!(transaction_result_3.is_err());
+
+    // CONSTRUCT AND EXECUTE TX (Case "too late" - Execution Target Account Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store_4 = MockDataStore::with_existing(
+        Some(target_account.clone()),
+        Some(vec![note_too_late.clone()]),
+    );
+    let mut executor_4 = TransactionExecutor::new(data_store_4.clone());
+
+    executor_4.load_account(target_account_id).unwrap();
+
+    let block_ref_4 = data_store_4.block_header.block_num().as_int() as u32;
+    let note_origins_4 = data_store_4
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_4 = executor_4
+        .execute_transaction(
+            target_account_id,
+            block_ref_4,
+            &note_origins_4,
+            Some(tx_script.clone()),
+        )
+        .unwrap();
+
+    // Check that we got the expected result - TransactionResult
+    // Assert that the target_account received the funds and the nonce increased by 1
+    // Nonce delta
+    assert!(transaction_result_4.account_delta().nonce == Some(Felt::new(2)));
+
+    // Vault delta
+    let target_account_after: Account = Account::new(
+        target_account_id,
+        AccountVault::new(&vec![fungible_asset_1]).unwrap(),
+        target_account_storage,
+        target_account_code,
+        Felt::new(2),
+    );
+    assert!(transaction_result_4.final_account_hash() == target_account_after.hash());
+
+    // CONSTRUCT AND EXECUTE TX (Case "too late" - Execution Sender Account Success)
+    // --------------------------------------------------------------------------------------------
+    let data_store_5 = MockDataStore::with_existing(
+        Some(sender_account.clone()),
+        Some(vec![note_too_late.clone()]),
+    );
+    let mut executor_5 = TransactionExecutor::new(data_store_5.clone());
+
+    executor_5.load_account(sender_account_id).unwrap();
+
+    let block_ref_5 = data_store_5.block_header.block_num().as_int() as u32;
+    let note_origins = data_store_5
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_5 = executor_5
+        .execute_transaction(sender_account_id, block_ref_5, &note_origins, Some(tx_script.clone()))
+        .unwrap();
+
+    // Assert that the sender_account received the funds and the nonce increased by 1
+    // Nonce delta
+    assert!(transaction_result_5.account_delta().nonce == Some(Felt::new(2)));
+
+    // Vault delta (Note: vault was empty before)
+    let sender_account_after: Account = Account::new(
+        sender_account_id,
+        AccountVault::new(&vec![fungible_asset_1]).unwrap(),
+        sender_account_storage,
+        sender_account_code,
+        Felt::new(2),
+    );
+    assert!(transaction_result_5.final_account_hash() == sender_account_after.hash());
+
+    // CONSTRUCT AND EXECUTE TX (Case "too late" - Malicious Account Failure)
+    // --------------------------------------------------------------------------------------------
+    let data_store_6 = MockDataStore::with_existing(
+        Some(malicious_account.clone()),
+        Some(vec![note_too_late.clone()]),
+    );
+    let mut executor_6 = TransactionExecutor::new(data_store_6.clone());
+
+    executor_6.load_account(malicious_account_id).unwrap();
+
+    let block_ref_6 = data_store_6.block_header.block_num().as_int() as u32;
+    let note_origins_6 = data_store_6
+        .notes
+        .iter()
+        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .collect::<Vec<_>>();
+
+    // Execute the transaction and get the witness
+    let transaction_result_6 = executor_6.execute_transaction(
+        malicious_account_id,
+        block_ref_6,
+        &note_origins_6,
+        Some(tx_script.clone()),
+    );
+
+    // Check that we got the expected result - TransactionExecutorError and not TransactionResult
+    // Sixth transaction should not work (malicious account can never consume), we expect an error
+    assert!(transaction_result_6.is_err())
+}


### PR DESCRIPTION
Closing https://github.com/0xPolygonMiden/miden-base/issues/12 (finally)

I created a new folder, `note_scripts`, in which I created a file, `basic.masm`. The file entails the p2id and p2idr scripts. 

Testing is quite complex. But I hope it is well documented. Basically, I had to create three different accounts, and they all tried to consume the note. In the second test, at two different points in time. 

Still left: 
- use commenting style of our other masm files
- check in the p2idr script the account state after the transaction