### PR TITLE
Implement `faucet::get_total_issuance` procedure

### DIFF
--- a/miden-lib/asm/sat/faucet.masm
+++ b/miden-lib/asm/sat/faucet.masm
@@ -38,3 +38,23 @@ export.burn
     syscall.burn_asset
     # => [ASSET]
 end
+
+#! Returns the total issuance of the fungible faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a fungible faucet.
+#!
+#! Stack: []
+#! Outputs: [total_issuance]
+#!
+#! - total_issuance is the total issuance of the fungible faucet the transaction is being executed
+#!   against.
+export.get_total_issuance
+    # add padding to the stack for kernel invocation
+    push.0
+    # => [0]
+
+    # invoke the `get_fungible_faucet_total_issuance` kernel procedure
+    syscall.get_fungible_faucet_total_issuance
+    # => [total_issuance]
+end

--- a/miden-lib/asm/sat/internal/faucet.masm
+++ b/miden-lib/asm/sat/internal/faucet.masm
@@ -87,6 +87,23 @@ proc.burn_fungible_asset
     # => [ASSET]
 end
 
+#! Returns the total issuance of the fungible faucet the transaction is being executed against.
+#!
+#! Stack: []
+#! Outputs: [total_issuance]
+#!
+#! - total_issuance is the total issuance of the fungible faucet the transaction is being executed
+#!   against.
+export.get_total_issuance
+    # fetch the TOTAL_ISSUANCE from storage
+    exec.account::get_faucet_storage_data_slot exec.account::get_item
+    # => [TOTAL_ISSUANCE]
+
+    # extract the total_issuance and purge the padding
+    movdn.3 drop drop drop
+    # => [total_issuance]
+end
+
 # NON-FUNGIBLE ASSETS
 # ==================================================================================================
 

--- a/miden-lib/asm/sat/kernel.masm
+++ b/miden-lib/asm/sat/kernel.masm
@@ -458,3 +458,27 @@ export.burn_asset
     exec.faucet::burn
     # => [ASSET]
 end
+
+#! Returns the total issuance of the fungible faucet the transaction is being executed against.
+#!
+#! Panics:
+#! - If the transaction is not being executed against a fungible faucet.
+#!
+#! Stack: [0]
+#! Outputs: [total_issuance]
+#!
+#! - total_issuance is the total issuance of the fungible faucet the transaction is being executed
+#!   against.
+export.get_fungible_faucet_total_issuance
+    # assert that we are executing a transaction against a fungible faucet (access checks)
+    exec.account::get_id exec.account::is_fungible_faucet assert
+    # => [0]
+
+    # get the total issuance
+    exec.faucet::get_total_issuance
+    # => [total_issuance]
+
+    # drop the padding
+    swap drop
+    # => []
+end


### PR DESCRIPTION
This PR implements the `faucet::get_total_issuance` procedure which allows the user to query the total issuance of the fungible faucet the transaction is being executed against.

Procedure description:

```
#! Returns the total issuance of the fungible faucet the transaction is being executed against.
#!
#! Panics:
#! - If the transaction is not being executed against a fungible faucet.
#!
#! Stack: []
#! Outputs: [total_issuance]
#!
#! - total_issuance is the total issuance of the fungible faucet the transaction is being executed
#!   against.
```

closes: #260 