### PR TITLE
Set up structure for standard note scripts

### DIFF
--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -3,9 +3,64 @@ use crate::memory::{
     CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_VAULT_HASH_OFFSET,
 };
 use miden_objects::{
-    notes::{NoteMetadata, NoteStub, NoteVault},
+    notes::{NoteMetadata, NoteStub, NoteVault, Note, NoteScript},
+    NoteError, accounts::AccountId, assets::Asset,
     Digest, NoteError, StarkField, Word, WORD_SIZE,
+    assembly::ProgramAst,
+
 };
+use crate::assembler::assembler;
+
+pub enum Script {
+    P2ID { target: AccountId },
+    P2IDR {
+        target: AccountId,
+        recall_height: u32,
+    },
+}
+
+pub fn create_note_with_script(
+    script: Script,
+    assets: Vec<Asset>,
+    sender: AccountId,
+    tag: Option<Felt>,
+    serial_num: Word,
+) -> Result<Note, NoteError> {
+
+    let mut note_assembler = assembler();
+    let (note_script, inputs): (&str, Vec<Felt>) = match script {
+        Script::P2ID { target } => ("p2id", vec![target.into()]), // Convert `target` to a suitable type if necessary
+        Script::P2IDR { target, recall_height } => ("p2idr", vec![target.into(), recall_height.into()]), // Convert both to a suitable type
+    };
+
+    // Create the note
+    let note_script_ast = ProgramAst::parse(
+        format!(
+            "
+        use.miden::note_scripts::basic
+    
+        begin
+            exec.basic::{note_script}
+        end
+        "
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let (note_script, _) = NoteScript::new(note_script_ast, &mut note_assembler).unwrap();
+
+    Note::new(
+        note_script.clone(),
+        &inputs,
+        &assets,
+        serial_num,
+        sender,
+        tag.unwrap_or(Felt::new(0)),
+        None,
+    )
+
+}
 
 pub fn notes_try_from_elements(elements: &[Word]) -> Result<NoteStub, NoteError> {
     if elements.len() < CREATED_NOTE_CORE_DATA_SIZE {

--- a/miden-lib/src/tests/mod.rs
+++ b/miden-lib/src/tests/mod.rs
@@ -9,7 +9,6 @@ mod test_asset_vault;
 mod test_epilogue;
 mod test_faucet;
 mod test_note;
-mod test_note_scripts;
 mod test_note_setup;
 mod test_prologue;
 mod test_tx;

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -48,6 +48,6 @@ pub mod crypto {
 }
 
 pub mod utils {
-    pub use miden_crypto::utils::vec;
+    pub use miden_crypto::utils::{format, vec};
     pub use vm_core::utils::{collections, string};
 }


### PR DESCRIPTION
Closes #259 

This is based on #263 because I use the same integration testing structure. 

I moved `test_note_scripts` to `miden-tx` to test it the same way as the faucet smart contract and the wallet.

I added a `Script` Structure and a `create_note_with_script` in `miden-lib/src/notes/mod.rs`. That seemed to be the best place. 