### PR TITLE
feat: adds method for quick faucet creation

### DIFF
--- a/miden-lib/asm/faucets/basic.masm
+++ b/miden-lib/asm/faucets/basic.masm
@@ -3,10 +3,10 @@
 # This is a basic fungible faucet smart contract. 
 #
 # It allows the owner of the faucet to mint, distribute, and burn tokens. Token metadata is stored 
-# in account storage at position 1 as [token_symbol, decimals, 0, max_supply], where:
-# - token_symbol is expressed as <TODO add explainer>.
-# - decimals are the decimals of the token.
+# in account storage at position 1 as [max_supply, decimals, token_symbol, 0], where:
 # - max_supply is the maximum supply of the token.
+# - decimals are the decimals of the token.
+# - token_symbol as three chars encoded in a Felt.
 use.miden::sat::account
 use.miden::sat::asset
 use.miden::sat::faucet

--- a/miden-lib/asm/faucets/basic.masm
+++ b/miden-lib/asm/faucets/basic.masm
@@ -11,7 +11,7 @@ use.miden::sat::account
 use.miden::sat::asset
 use.miden::sat::faucet
 use.miden::sat::tx
-use.miden::eoa::basic->basic_eoa
+use.miden::eoa::basic
 
 # CONSTANTS
 # =================================================================================================
@@ -20,7 +20,7 @@ use.miden::eoa::basic->basic_eoa
 const.METADATA_SLOT=1
 
 # Basic authentication for the faucet owner.
-export.basic_eoa::auth_tx_rpo_falcon512
+export.basic::auth_tx_rpo_falcon512
 
 #! Distributes freshly minted fungible assets to the provided recipient.
 #! 

--- a/miden-lib/src/auth.rs
+++ b/miden-lib/src/auth.rs
@@ -1,0 +1,7 @@
+use miden_objects::crypto::dsa::rpo_falcon512;
+
+// We define different authentication schemes that can be used by accounts.
+// At the moment we only allow RpoFalcon512.
+pub enum AuthScheme {
+    RpoFalcon512 { pub_key: rpo_falcon512::PublicKey },
+}

--- a/miden-lib/src/auth.rs
+++ b/miden-lib/src/auth.rs
@@ -1,10 +1,10 @@
 use miden_objects::crypto::dsa::rpo_falcon512;
 
 /// Defines authentication schemes available to standard and faucet accounts.
-/// At the moment only RpoFalcon512 exists.
 pub enum AuthScheme {
-    /// RPO Falcon512: a variant of the Falcon signature scheme. This variant differs
-    /// from the standard in that instead of using SHAKE256 hash function in the hash-to-point
-    /// algorithm we use RPO256. This makes the signature more efficient to verify in Miden VM.
+    /// A single-key authentication scheme which relies RPO Falcon512 signatures. RPO Falcon512 is a
+    /// variant of the [Falcon](https://falcon-sign.info/) signature scheme. This variant differs from
+    /// the standard in that instead of using SHAKE256 hash function in the hash-to-point algorithm we
+    /// use RPO256. This makes the signature more efficient to verify in Miden VM.
     RpoFalcon512 { pub_key: rpo_falcon512::PublicKey },
 }

--- a/miden-lib/src/auth.rs
+++ b/miden-lib/src/auth.rs
@@ -1,7 +1,10 @@
 use miden_objects::crypto::dsa::rpo_falcon512;
 
-// We define different authentication schemes that can be used by accounts.
-// At the moment we only allow RpoFalcon512.
+/// Defines authentication schemes available to standard and faucet accounts.
+/// At the moment only RpoFalcon512 exists.
 pub enum AuthScheme {
+    /// RPO Falcon512: a variant of the Falcon signature scheme. This variant differs
+    /// from the standard in that instead of using SHAKE256 hash function in the hash-to-point
+    /// algorithm we use RPO256. This makes the signature more efficient to verify in Miden VM.
     RpoFalcon512 { pub_key: rpo_falcon512::PublicKey },
 }

--- a/miden-lib/src/faucets/mod.rs
+++ b/miden-lib/src/faucets/mod.rs
@@ -1,15 +1,14 @@
-use crate::assembler::assembler;
+use crate::{assembler::assembler, auth::AuthScheme};
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault},
     assembly::ModuleAst,
-    crypto::{dsa::rpo_falcon512, merkle::MerkleStore},
-    utils::vec,
-    AccountError, Word, ZERO,
+    crypto::merkle::MerkleStore,
+    utils::{
+        string::{String, ToString},
+        vec,
+    },
+    AccountError, Felt, StarkField, Word, ZERO,
 };
-
-pub enum AuthScheme {
-    RpoFalcon512 { pub_key: rpo_falcon512::PublicKey },
-}
 
 /// Creates a new faucet account with basic faucet interface, specified authentication scheme,
 /// and provided meta data (token symbol, decimals, max supply).
@@ -20,42 +19,53 @@ pub enum AuthScheme {
 ///
 /// `distribute` requires authentication. The authentication procedure is defined by the specified
 /// authentication scheme.
+/// `burn` does not require authentication and can be called by anyone.
+/// Public key information for the scheme is stored in the account storage at slot 0.
+/// The token metadata is stored in the account storage at slot 1.
 pub fn create_basic_faucet(
     init_seed: [u8; 32],
-    meta_data: Word,
+    symbol: String,
+    decimals: u8,
+    max_supply: Felt,
     auth_scheme: AuthScheme,
 ) -> Result<(Account, Word), AccountError> {
-    let (_auth_scheme_prefix, _auth_scheme_procedure, storage_slot_0): (&str, &str, Word) =
-        match auth_scheme {
-            AuthScheme::RpoFalcon512 { pub_key } => {
-                ("basic", "auth_tx_rpo_falcon512", pub_key.into())
-            }
-        };
+    // Atm we onlt have RpoFalcon512 as authentication scheme and this is also the default in the
+    // faucet contract, so we can just use the public key as storage slot 0.
+    let auth_data: Word = match auth_scheme {
+        AuthScheme::RpoFalcon512 { pub_key } => pub_key.into(),
+    };
 
     let account_code_src = include_str!("../../asm/faucets/basic.masm");
-
-    // When we have more auth schemes, we will need to replace the code below with the code above.
-    // match auth_scheme {
-    //     AuthScheme::RpoFalcon512 { .. } => {
-    //         account_code_src = include_str!("../../asm/faucets/basic.masm").to_string();
-    //     }
-    //     // this code is unreachable as of now, in the future there will be more auth schemes
-    //     _ => {
-    //         let auth_scheme_import: String = format!("use.miden::eoa::{}", auth_scheme_prefix);
-    //         let auth_scheme_export: String = format!("export.{}.{})", auth_scheme_prefix, auth_scheme_procedure);
-    //         account_code_src = account_code_src
-    //             .replace("use.miden::eoa::basic", &auth_scheme_import)
-    //             .replace("export.basic::auth_tx_rpo_falcon512", &auth_scheme_export);
-    //     }
-    // }
-
     let account_code_ast = ModuleAst::parse(account_code_src)
         .map_err(|e| AccountError::AccountCodeAssemblerError(e.into()))?;
     let account_assembler = assembler();
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
 
+    // First check that the metadata is valid.
+    if decimals > 18 {
+        return Err(AccountError::FungibleFaucetInvalidMetadata(
+            "Decimals must be less than 19".to_string(),
+        ));
+    } else if symbol.len() > 3 {
+        return Err(AccountError::FungibleFaucetInvalidMetadata(
+            "Token Symbol must have exactly three characters".to_string(),
+        ));
+    } else if max_supply.as_int() == 0 {
+        return Err(AccountError::FungibleFaucetInvalidMetadata(
+            "Max supply must be > 0".to_string(),
+        ));
+    }
+
+    // Note: order is reversed here to match, the faucet contract assumes to get max_supply by
+    // mem_loadw drop drop drop
+    let metadata =
+        [max_supply, ZERO, Felt::from(decimals), encode_symbol_to_felt(&symbol).unwrap()];
+
+    // We store the authentication data and the token metadata in the account storage:
+    // - slot 0: authentication data
+    // - slot 1: token metadata as [token_symbol, decimals, 0, max_supply]
     let account_storage =
-        AccountStorage::new(vec![(0, storage_slot_0), (1, meta_data)], MerkleStore::new())?;
+        AccountStorage::new(vec![(0, auth_data), (1, metadata)], MerkleStore::new())?;
     let account_vault = AccountVault::new(&[])?;
 
     let account_seed = AccountId::get_account_seed(
@@ -70,4 +80,34 @@ pub fn create_basic_faucet(
         Account::new(account_id, account_vault, account_storage, account_code, ZERO),
         account_seed,
     ))
+}
+
+/// Util to encode and decode the token symbol as a Felt. We allow any three character string as
+/// token symbol, e.g., AAA = 0, ...
+pub fn encode_symbol_to_felt(s: &str) -> Result<Felt, &'static str> {
+    let mut encoded_value = 0;
+    for (i, char) in s.chars().enumerate() {
+        encoded_value += (char as u64 - 'A' as u64) * 26u64.pow((2 - i) as u32);
+    }
+
+    Ok(Felt::new(encoded_value))
+}
+
+pub fn decode_felt_to_symbol(encoded_felt: Felt) -> Result<String, &'static str> {
+    let encoded_value = encoded_felt.as_int();
+    if encoded_value >= 26u64.pow(3) {
+        return Err("Encoded value is out of range");
+    }
+
+    let mut decoded_string = String::new();
+    let mut remaining_value = encoded_value;
+
+    for i in (0..3).rev() {
+        let quotient = remaining_value / 26u64.pow(i as u32);
+        remaining_value %= 26u64.pow(i as u32);
+        let char = ((quotient + 'A' as u64) as u8) as char;
+        decoded_string.push(char);
+    }
+
+    Ok(decoded_string)
 }

--- a/miden-lib/src/faucets/mod.rs
+++ b/miden-lib/src/faucets/mod.rs
@@ -2,13 +2,14 @@ use crate::{assembler::assembler, auth::AuthScheme};
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault},
     assembly::ModuleAst,
+    assets::TokenSymbol,
     crypto::merkle::MerkleStore,
-    utils::{
-        string::{String, ToString},
-        vec,
-    },
+    utils::{string::ToString, vec},
     AccountError, Felt, StarkField, Word, ZERO,
 };
+
+const MAX_MAX_SUPPLY: u64 = 1 << 63;
+const MAX_DECIMALS: u8 = 18;
 
 /// Creates a new faucet account with basic faucet interface, specified authentication scheme,
 /// and provided meta data (token symbol, decimals, max supply).
@@ -18,13 +19,13 @@ use miden_objects::{
 /// - `burn`, which burns the provided asset.
 ///
 /// `distribute` requires authentication. The authentication procedure is defined by the specified
-/// authentication scheme.
-/// `burn` does not require authentication and can be called by anyone.
-/// Public key information for the scheme is stored in the account storage at slot 0.
-/// The token metadata is stored in the account storage at slot 1.
+/// authentication scheme. `burn` does not require authentication and can be called by anyone.
+///
+/// Public key information for the scheme is stored in the account storage at slot 0. The token
+/// metadata is stored in the account storage at slot 1.
 pub fn create_basic_faucet(
     init_seed: [u8; 32],
-    symbol: String,
+    symbol: TokenSymbol,
     decimals: u8,
     max_supply: Felt,
     auth_scheme: AuthScheme,
@@ -42,24 +43,18 @@ pub fn create_basic_faucet(
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
 
     // First check that the metadata is valid.
-    if decimals > 18 {
+    if decimals > MAX_DECIMALS {
         return Err(AccountError::FungibleFaucetInvalidMetadata(
             "Decimals must be less than 19".to_string(),
         ));
-    } else if symbol.len() > 3 {
+    } else if max_supply.as_int() >= MAX_MAX_SUPPLY {
         return Err(AccountError::FungibleFaucetInvalidMetadata(
-            "Token Symbol must have exactly three characters".to_string(),
-        ));
-    } else if max_supply.as_int() == 0 {
-        return Err(AccountError::FungibleFaucetInvalidMetadata(
-            "Max supply must be > 0".to_string(),
+            "Max supply must be < 2^63".to_string(),
         ));
     }
 
-    // Note: order is reversed here to match, the faucet contract assumes to get max_supply by
-    // mem_loadw drop drop drop
-    let metadata =
-        [max_supply, ZERO, Felt::from(decimals), encode_symbol_to_felt(&symbol).unwrap()];
+    // Note: data is stored as [ao, a1, a2, a3] but loaded onto the stack as [a3, a2, a1, a0]
+    let metadata = [max_supply, Felt::from(decimals), symbol.as_felt(), ZERO];
 
     // We store the authentication data and the token metadata in the account storage:
     // - slot 0: authentication data
@@ -80,34 +75,4 @@ pub fn create_basic_faucet(
         Account::new(account_id, account_vault, account_storage, account_code, ZERO),
         account_seed,
     ))
-}
-
-/// Util to encode and decode the token symbol as a Felt. We allow any three character string as
-/// token symbol, e.g., AAA = 0, ...
-pub fn encode_symbol_to_felt(s: &str) -> Result<Felt, &'static str> {
-    let mut encoded_value = 0;
-    for (i, char) in s.chars().enumerate() {
-        encoded_value += (char as u64 - 'A' as u64) * 26u64.pow((2 - i) as u32);
-    }
-
-    Ok(Felt::new(encoded_value))
-}
-
-pub fn decode_felt_to_symbol(encoded_felt: Felt) -> Result<String, &'static str> {
-    let encoded_value = encoded_felt.as_int();
-    if encoded_value >= 26u64.pow(3) {
-        return Err("Encoded value is out of range");
-    }
-
-    let mut decoded_string = String::new();
-    let mut remaining_value = encoded_value;
-
-    for i in (0..3).rev() {
-        let quotient = remaining_value / 26u64.pow(i as u32);
-        remaining_value %= 26u64.pow(i as u32);
-        let char = ((quotient + 'A' as u64) as u8) as char;
-        decoded_string.push(char);
-    }
-
-    Ok(decoded_string)
 }

--- a/miden-lib/src/faucets/mod.rs
+++ b/miden-lib/src/faucets/mod.rs
@@ -46,7 +46,7 @@ pub fn create_basic_faucet(
     // First check that the metadata is valid.
     if decimals > MAX_DECIMALS {
         return Err(AccountError::FungibleFaucetInvalidMetadata(
-            "Decimals must be less than 19".to_string(),
+            "Decimals must be less than 13".to_string(),
         ));
     } else if max_supply.as_int() > MAX_MAX_SUPPLY {
         return Err(AccountError::FungibleFaucetInvalidMetadata(
@@ -54,7 +54,7 @@ pub fn create_basic_faucet(
         ));
     }
 
-    // Note: data is stored as [ao, a1, a2, a3] but loaded onto the stack as [a3, a2, a1, a0, ...]
+    // Note: data is stored as [a0, a1, a2, a3] but loaded onto the stack as [a3, a2, a1, a0, ...]
     let metadata = [max_supply, Felt::from(decimals), symbol.into(), ZERO];
 
     // We store the authentication data and the token metadata in the account storage:

--- a/miden-lib/src/faucets/mod.rs
+++ b/miden-lib/src/faucets/mod.rs
@@ -1,0 +1,73 @@
+use crate::assembler::assembler;
+use miden_objects::{
+    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault},
+    assembly::ModuleAst,
+    crypto::{dsa::rpo_falcon512, merkle::MerkleStore},
+    utils::vec,
+    AccountError, Word, ZERO,
+};
+
+pub enum AuthScheme {
+    RpoFalcon512 { pub_key: rpo_falcon512::PublicKey },
+}
+
+/// Creates a new faucet account with basic faucet interface, specified authentication scheme,
+/// and provided meta data (token symbol, decimals, max supply).
+///
+/// The basic faucet interface exposes two procedures:
+/// - `distribute`, which mints an assets and create a note for the provided recipient.
+/// - `burn`, which burns the provided asset.
+///
+/// `distribute` requires authentication. The authentication procedure is defined by the specified
+/// authentication scheme.
+pub fn create_basic_faucet(
+    init_seed: [u8; 32],
+    meta_data: Word,
+    auth_scheme: AuthScheme,
+) -> Result<(Account, Word), AccountError> {
+    let (_auth_scheme_prefix, _auth_scheme_procedure, storage_slot_0): (&str, &str, Word) =
+        match auth_scheme {
+            AuthScheme::RpoFalcon512 { pub_key } => {
+                ("basic", "auth_tx_rpo_falcon512", pub_key.into())
+            }
+        };
+
+    let account_code_src = include_str!("../../asm/faucets/basic.masm");
+
+    // When we have more auth schemes, we will need to replace the code below with the code above.
+    // match auth_scheme {
+    //     AuthScheme::RpoFalcon512 { .. } => {
+    //         account_code_src = include_str!("../../asm/faucets/basic.masm").to_string();
+    //     }
+    //     // this code is unreachable as of now, in the future there will be more auth schemes
+    //     _ => {
+    //         let auth_scheme_import: String = format!("use.miden::eoa::{}", auth_scheme_prefix);
+    //         let auth_scheme_export: String = format!("export.{}.{})", auth_scheme_prefix, auth_scheme_procedure);
+    //         account_code_src = account_code_src
+    //             .replace("use.miden::eoa::basic", &auth_scheme_import)
+    //             .replace("export.basic::auth_tx_rpo_falcon512", &auth_scheme_export);
+    //     }
+    // }
+
+    let account_code_ast = ModuleAst::parse(account_code_src)
+        .map_err(|e| AccountError::AccountCodeAssemblerError(e.into()))?;
+    let account_assembler = assembler();
+    let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
+
+    let account_storage =
+        AccountStorage::new(vec![(0, storage_slot_0), (1, meta_data)], MerkleStore::new())?;
+    let account_vault = AccountVault::new(&[])?;
+
+    let account_seed = AccountId::get_account_seed(
+        init_seed,
+        AccountType::FungibleFaucet,
+        false,
+        account_code.root(),
+        account_storage.root(),
+    )?;
+    let account_id = AccountId::new(account_seed, account_code.root(), account_storage.root())?;
+    Ok((
+        Account::new(account_id, account_vault, account_storage, account_code, ZERO),
+        account_seed,
+    ))
+}

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -9,6 +9,7 @@ use assembly::{utils::Deserializable, Library, LibraryNamespace, MaslLibrary, Ve
 mod tests;
 
 pub mod assembler;
+pub mod auth;
 pub mod faucets;
 pub mod memory;
 pub mod notes;

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -8,9 +8,10 @@ use assembly::{utils::Deserializable, Library, LibraryNamespace, MaslLibrary, Ve
 #[cfg(test)]
 mod tests;
 
-pub mod assembler;
-pub mod auth;
+mod auth;
 pub use auth::AuthScheme;
+
+pub mod assembler;
 pub mod faucets;
 pub mod memory;
 pub mod notes;

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -9,6 +9,7 @@ use assembly::{utils::Deserializable, Library, LibraryNamespace, MaslLibrary, Ve
 mod tests;
 
 pub mod assembler;
+pub mod faucets;
 pub mod memory;
 pub mod notes;
 pub mod transaction;

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -10,6 +10,7 @@ mod tests;
 
 pub mod assembler;
 pub mod auth;
+pub use auth::AuthScheme;
 pub mod faucets;
 pub mod memory;
 pub mod notes;

--- a/miden-lib/src/wallets/mod.rs
+++ b/miden-lib/src/wallets/mod.rs
@@ -1,15 +1,11 @@
-use crate::assembler::assembler;
+use crate::{assembler::assembler, auth::AuthScheme};
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault},
     assembly::ModuleAst,
-    crypto::{dsa::rpo_falcon512, merkle::MerkleStore},
+    crypto::merkle::MerkleStore,
     utils::{format, string::String, vec},
     AccountError, Word, ZERO,
 };
-
-pub enum AuthScheme {
-    RpoFalcon512 { pub_key: rpo_falcon512::PublicKey },
-}
 
 /// Creates a new account with basic wallet interface and the specified authentication scheme.
 ///

--- a/miden-tx/tests/test_miden_faucet_contract.rs
+++ b/miden-tx/tests/test_miden_faucet_contract.rs
@@ -236,7 +236,7 @@ fn test_faucet_contract_creation() {
     // check that max_supply (slot 1) is 123
     assert!(
         faucet_account.storage().get_item(1)
-            == [Felt::new(123), Felt::new(2), token_symbol.as_felt(), ZERO].into()
+            == [Felt::new(123), Felt::new(2), TokenSymbol::from(token_symbol).into(), ZERO].into()
     );
 
     assert!(faucet_account.is_faucet() == true);

--- a/miden-tx/tests/test_miden_faucet_contract.rs
+++ b/miden-tx/tests/test_miden_faucet_contract.rs
@@ -1,12 +1,8 @@
-use miden_lib::{
-    assembler::assembler,
-    auth::AuthScheme,
-    faucets::{create_basic_faucet, encode_symbol_to_felt},
-};
+use miden_lib::{assembler::assembler, faucets::create_basic_faucet, AuthScheme};
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountVault},
     assembly::{ModuleAst, ProgramAst},
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, FungibleAsset, TokenSymbol},
     crypto::dsa::rpo_falcon512,
     notes::{Note, NoteMetadata, NoteScript, NoteStub, NoteVault},
     Felt, StarkField, Word, ZERO,
@@ -229,16 +225,18 @@ fn test_faucet_contract_creation() {
     ];
 
     let max_supply = Felt::new(123);
-    let token_symbol = "POL".to_string();
+    let token_symbol_string = "POL";
+    let token_symbol = TokenSymbol::try_from(token_symbol_string).unwrap();
     let decimals = 2u8;
 
     let (faucet_account, _) =
-        create_basic_faucet(init_seed, token_symbol, decimals, max_supply, auth_scheme).unwrap();
+        create_basic_faucet(init_seed, token_symbol.clone(), decimals, max_supply, auth_scheme)
+            .unwrap();
 
     // check that max_supply (slot 1) is 123
     assert!(
         faucet_account.storage().get_item(1)
-            == [Felt::new(123), ZERO, Felt::new(2), encode_symbol_to_felt("POL").unwrap()].into()
+            == [Felt::new(123), Felt::new(2), token_symbol.as_felt(), ZERO].into()
     );
 
     assert!(faucet_account.is_faucet() == true);

--- a/miden-tx/tests/test_miden_faucet_contract.rs
+++ b/miden-tx/tests/test_miden_faucet_contract.rs
@@ -1,11 +1,14 @@
-use miden_lib::assembler::assembler;
-
+use miden_lib::{
+    assembler::assembler,
+    faucets::{create_basic_faucet, AuthScheme},
+};
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountVault},
     assembly::{ModuleAst, ProgramAst},
     assets::{Asset, FungibleAsset},
+    crypto::dsa::rpo_falcon512,
     notes::{Note, NoteMetadata, NoteScript, NoteStub, NoteVault},
-    Felt, StarkField, Word,
+    Felt, StarkField, Word, ZERO,
 };
 use mock::{
     constants::{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_SENDER},
@@ -17,6 +20,8 @@ use miden_tx::TransactionExecutor;
 
 mod common;
 use common::MockDataStore;
+
+use vm_core::crypto::dsa::rpo_falcon512::{KeyPair, PublicKey};
 
 #[test]
 fn test_faucet_contract_mint_fungible_asset_succeeds() {
@@ -205,6 +210,44 @@ fn test_faucet_contract_burn_fungible_asset_succeeds() {
     // check that the account burned the asset
     assert!(transaction_result.account_delta().nonce.unwrap() == Felt::new(2));
     assert!(transaction_result.consumed_notes().notes()[0].hash() == note.hash());
+}
+
+#[test]
+fn test_faucet_contract_creation() {
+    // we need a Falcon Public Key to create the wallet account
+    let key_pair: KeyPair = rpo_falcon512::KeyPair::new().unwrap();
+    let pub_key: PublicKey = key_pair.public_key();
+    let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 {
+        pub_key: pub_key.into(),
+    };
+
+    // we need to use an initial seed to create the wallet account
+    let init_seed: [u8; 32] = [
+        90, 110, 209, 94, 84, 105, 250, 242, 223, 203, 216, 124, 22, 159, 14, 132, 215, 85, 183,
+        204, 149, 90, 166, 68, 100, 73, 106, 168, 125, 237, 138, 16,
+    ];
+
+    let faucet_meta_data: Word = [Felt::new(123), ZERO, Felt::new(456), Felt::new(789)];
+
+    let (faucet_account, _) =
+        create_basic_faucet(init_seed, faucet_meta_data, auth_scheme).unwrap();
+
+    // check that max_supply (slot 1) is 123
+    assert!(
+        faucet_account.storage().get_item(1)
+            == [Felt::new(123), ZERO, Felt::new(456), Felt::new(789)].into()
+    );
+
+    assert!(faucet_account.is_faucet() == true);
+
+    let exp_faucet_account_code_src = include_str!("../../miden-lib/asm/faucets/basic.masm");
+    let exp_faucet_account_code_ast = ModuleAst::parse(exp_faucet_account_code_src).unwrap();
+    let mut account_assembler = assembler();
+
+    let exp_faucet_account_code =
+        AccountCode::new(exp_faucet_account_code_ast.clone(), &mut account_assembler).unwrap();
+
+    assert!(faucet_account.code() == &exp_faucet_account_code);
 }
 
 fn get_faucet_account_with_max_supply_and_total_issuance(

--- a/miden-tx/tests/test_miden_faucet_contract.rs
+++ b/miden-tx/tests/test_miden_faucet_contract.rs
@@ -1,6 +1,7 @@
 use miden_lib::{
     assembler::assembler,
-    faucets::{create_basic_faucet, AuthScheme},
+    auth::AuthScheme,
+    faucets::{create_basic_faucet, encode_symbol_to_felt},
 };
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountVault},
@@ -227,15 +228,17 @@ fn test_faucet_contract_creation() {
         204, 149, 90, 166, 68, 100, 73, 106, 168, 125, 237, 138, 16,
     ];
 
-    let faucet_meta_data: Word = [Felt::new(123), ZERO, Felt::new(456), Felt::new(789)];
+    let max_supply = Felt::new(123);
+    let token_symbol = "POL".to_string();
+    let decimals = 2u8;
 
     let (faucet_account, _) =
-        create_basic_faucet(init_seed, faucet_meta_data, auth_scheme).unwrap();
+        create_basic_faucet(init_seed, token_symbol, decimals, max_supply, auth_scheme).unwrap();
 
     // check that max_supply (slot 1) is 123
     assert!(
         faucet_account.storage().get_item(1)
-            == [Felt::new(123), ZERO, Felt::new(456), Felt::new(789)].into()
+            == [Felt::new(123), ZERO, Felt::new(2), encode_symbol_to_felt("POL").unwrap()].into()
     );
 
     assert!(faucet_account.is_faucet() == true);

--- a/miden-tx/tests/test_miden_wallet.rs
+++ b/miden-tx/tests/test_miden_wallet.rs
@@ -1,4 +1,4 @@
-use miden_lib::{assembler::assembler, auth::AuthScheme, wallets::create_basic_wallet};
+use miden_lib::{assembler::assembler, wallets::create_basic_wallet, AuthScheme};
 
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountVault},

--- a/miden-tx/tests/test_miden_wallet.rs
+++ b/miden-tx/tests/test_miden_wallet.rs
@@ -1,7 +1,4 @@
-use miden_lib::{
-    assembler::assembler,
-    wallets::{create_basic_wallet, AuthScheme},
-};
+use miden_lib::{assembler::assembler, auth::AuthScheme, wallets::create_basic_wallet};
 
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountVault},

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -10,6 +10,9 @@ pub use fungible::FungibleAsset;
 mod nonfungible;
 pub use nonfungible::{NonFungibleAsset, NonFungibleAssetDetails};
 
+mod token_symbol;
+pub use token_symbol::TokenSymbol;
+
 // ASSET
 // ================================================================================================
 

--- a/objects/src/assets/token_symbol.rs
+++ b/objects/src/assets/token_symbol.rs
@@ -1,0 +1,79 @@
+use super::{AssetError, Felt, StarkField, ToString};
+use crate::utils::string::String;
+
+const MAX_SUMBOL_LENGHT: usize = 6;
+#[derive(Clone, Copy, Debug)]
+pub struct TokenSymbol(Felt);
+
+impl TokenSymbol {
+    pub fn new(symbol: &str) -> Result<Self, AssetError> {
+        let felt = encode_symbol_to_felt(symbol)?;
+        Ok(Self(felt))
+    }
+
+    pub fn as_felt(&self) -> Felt {
+        self.0
+    }
+
+    pub fn as_symbol(&self) -> Result<String, AssetError> {
+        decode_felt_to_symbol(self.0)
+    }
+}
+
+impl TryFrom<&str> for TokenSymbol {
+    type Error = AssetError;
+
+    fn try_from(symbol: &str) -> Result<Self, Self::Error> {
+        TokenSymbol::new(symbol)
+    }
+}
+
+impl From<TokenSymbol> for Felt {
+    fn from(symbol: TokenSymbol) -> Self {
+        symbol.0
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+// Utils to encode and decode the token symbol as a Felt. Token Symbols can consists of up to 6 characters
+// , e.g., A = 0, ...
+fn encode_symbol_to_felt(s: &str) -> Result<Felt, AssetError> {
+    if s.is_empty() || s.len() > MAX_SUMBOL_LENGHT || s.chars().any(|c| !c.is_ascii_uppercase()) {
+        return Err(AssetError::TokenSymbolError(
+            "Input contains characters outside the valid range".to_string(),
+        ));
+    }
+
+    let mut encoded_value = 0;
+    for char in s.chars() {
+        let digit = char as u64 - b'A' as u64;
+        if digit >= 26 {
+            return Err(AssetError::TokenSymbolError(
+                "Input string contains characters outside the valid range".to_string(),
+            ));
+        }
+        encoded_value = encoded_value * 26 + digit;
+    }
+
+    Ok(Felt::new(encoded_value))
+}
+
+fn decode_felt_to_symbol(encoded_felt: Felt) -> Result<String, AssetError> {
+    let encoded_value = encoded_felt.as_int();
+    if encoded_value >= 26u64.pow(6) {
+        return Err(AssetError::TokenSymbolError("Encoded value is out of range".to_string()));
+    }
+
+    let mut decoded_string = String::new();
+    let mut remaining_value = encoded_value;
+
+    for _ in 0..6 {
+        let digit = (remaining_value % 26) as u8;
+        let char = (digit + b'A') as char;
+        decoded_string.insert(0, char);
+        remaining_value /= 26;
+    }
+
+    Ok(decoded_string)
+}

--- a/objects/src/assets/token_symbol.rs
+++ b/objects/src/assets/token_symbol.rs
@@ -12,6 +12,10 @@ impl TokenSymbol {
         let felt = encode_symbol_to_felt(symbol)?;
         Ok(Self(felt))
     }
+
+    pub fn to_str(&self) -> String {
+        decode_felt_to_symbol(self.0)
+    }
 }
 
 impl From<TokenSymbol> for Felt {
@@ -36,8 +40,7 @@ impl TryFrom<Felt> for TokenSymbol {
         if felt.as_int() >= TokenSymbol::MAX_ENCODED_VALUE {
             return Err(AssetError::TokenSymbolError("Encoded value is too large".to_string()));
         }
-        let symbol = decode_felt_to_symbol(felt);
-        TokenSymbol::new(&symbol)
+        Ok(TokenSymbol(felt))
     }
 }
 
@@ -48,7 +51,7 @@ impl TryFrom<Felt> for TokenSymbol {
 fn encode_symbol_to_felt(s: &str) -> Result<Felt, AssetError> {
     if s.is_empty() || s.len() > TokenSymbol::MAX_SYMBOL_LENGHT {
         return Err(AssetError::TokenSymbolError(
-            "Token Symbol must be of length >0 and <7".to_string(),
+            "Token symbol must be between 1 and 6 characters long.".to_string(),
         ));
     } else if s.chars().any(|c| !c.is_ascii_uppercase()) {
         return Err(AssetError::TokenSymbolError(
@@ -89,8 +92,8 @@ fn decode_felt_to_symbol(encoded_felt: Felt) -> String {
 fn test_token_symbol_decoding_encoding() {
     let symbols = vec!["AAAAAA", "AAAAAB", "AAAAAC", "AAAAAD", "AAAAAE", "AAAAAF", "AAAAAG"];
     for symbol in symbols {
-        let felt = encode_symbol_to_felt(symbol).unwrap();
-        let decoded_symbol = decode_felt_to_symbol(felt);
+        let token_symbol = TokenSymbol::try_from(symbol).unwrap();
+        let decoded_symbol = TokenSymbol::to_str(&token_symbol);
         assert_eq!(symbol, decoded_symbol);
     }
 

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -28,6 +28,7 @@ pub enum AccountError {
     DuplicateStorageItems(MerkleError),
     FungibleAssetNotFound(FungibleAsset),
     FungibleFaucetIdInvalidFirstBit,
+    FungibleFaucetInvalidMetadata(String),
     InconsistentAccountIdSeed {
         expected: AccountId,
         actual: AccountId,

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -99,6 +99,7 @@ pub enum AssetError {
     NotAFungibleFaucetId(AccountId),
     NotANonFungibleFaucetId(AccountId),
     NotAnAsset(Word),
+    TokenSymbolError(String),
 }
 
 impl AssetError {


### PR DESCRIPTION
Adds a new method to `miden-lib` to create a basic faucet account. The user can provide 
- the authentication scheme
- the metadata:
    - max supply
    - token decimals
    - token symbol

I added an integration test in `miden-tx` in `test_miden_faucet_contract`. 

_Note: the other integration tests in that file need to use a different create_faucet function because we need to create an existing faucet, i.e., a faucet with Nonce >0, for tests._ 