### PR TITLE
Nit: Rename `TransactionCompiler`

### DIFF
--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -19,8 +19,7 @@ mod tests;
 ///
 /// In addition to transaction compilation, transaction compiler provides methods which can be
 /// used to compile Miden account code and note scripts.
-#[cfg(not(test))]
-pub struct TransactionComplier {
+pub struct TransactionCompiler {
     assembler: Assembler,
     account_procedures: BTreeMap<AccountId, Vec<Digest>>,
     prologue: CodeBlock,
@@ -29,11 +28,11 @@ pub struct TransactionComplier {
     note_processing_teardown: CodeBlock,
 }
 
-impl TransactionComplier {
+impl TransactionCompiler {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new instance of the [TransactionComplier].
-    pub fn new() -> TransactionComplier {
+    pub fn new() -> TransactionCompiler {
         let assembler = miden_lib::assembler::assembler();
 
         // compile prologue
@@ -76,7 +75,7 @@ impl TransactionComplier {
             )
             .expect("note processing teardown is well formed");
 
-        TransactionComplier {
+        TransactionCompiler {
             assembler,
             account_procedures: BTreeMap::default(),
             prologue,
@@ -357,7 +356,7 @@ impl TransactionComplier {
     }
 }
 
-impl Default for TransactionComplier {
+impl Default for TransactionCompiler {
     fn default() -> Self {
         Self::new()
     }
@@ -445,16 +444,4 @@ fn recursively_collect_call_branches(code_block: &CodeBlock, branches: &mut Vec<
 pub enum NoteTarget {
     AccountId(AccountId),
     Procedures(Vec<Digest>),
-}
-
-// TEST ASSETS
-// ================================================================================================
-#[cfg(test)]
-pub struct TransactionComplier {
-    pub assembler: Assembler,
-    pub account_procedures: BTreeMap<AccountId, Vec<Digest>>,
-    pub prologue: CodeBlock,
-    pub epilogue: CodeBlock,
-    pub note_setup: CodeBlock,
-    pub note_processing_teardown: CodeBlock,
 }

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -1,4 +1,4 @@
-use super::{AccountId, ModuleAst, Note, NoteTarget, Operation, ProgramAst, TransactionComplier};
+use super::{AccountId, ModuleAst, Note, NoteTarget, Operation, ProgramAst, TransactionCompiler};
 use miden_objects::{
     accounts::ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
     assembly::{AssemblyContext, CodeBlock},
@@ -48,7 +48,7 @@ end
 
 #[test]
 fn test_load_account() {
-    let mut tx_compiler = TransactionComplier::new();
+    let mut tx_compiler = TransactionCompiler::new();
     let account_id =
         AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
     let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
@@ -104,7 +104,7 @@ fn test_compile_valid_note_script() {
         ),
     ];
 
-    let mut tx_compiler = TransactionComplier::new();
+    let mut tx_compiler = TransactionCompiler::new();
     let account_id =
         AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
     let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
@@ -130,7 +130,7 @@ fn test_compile_valid_note_script() {
 }
 
 fn mock_consumed_notes(
-    tx_compiler: &mut TransactionComplier,
+    tx_compiler: &mut TransactionCompiler,
     target_account: AccountId,
 ) -> Vec<Note> {
     pub const ACCOUNT_ID_SENDER: u64 = 0b0110111011u64 << 54;
@@ -184,7 +184,7 @@ fn mock_consumed_notes(
 
 #[test]
 fn test_transaction_compilation() {
-    let mut tx_compiler = TransactionComplier::new();
+    let mut tx_compiler = TransactionCompiler::new();
     let account_id =
         AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
     let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
@@ -209,7 +209,7 @@ fn test_transaction_compilation() {
 // ================================================================================================
 
 fn expected_mast_tree(
-    tx_compiler: &mut TransactionComplier,
+    tx_compiler: &mut TransactionCompiler,
     notes: &[Note],
     tx_script: &ProgramAst,
 ) -> CodeBlock {
@@ -240,7 +240,7 @@ fn expected_mast_tree(
     program_root
 }
 
-fn create_note_leafs(tx_compiler: &mut TransactionComplier, note: &Note) -> CodeBlock {
+fn create_note_leafs(tx_compiler: &mut TransactionCompiler, note: &Note) -> CodeBlock {
     let note_code_block = tx_compiler
         .assembler
         .compile_in_context(

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     AccountCode, AccountId, DataStore, Digest, NoteOrigin, NoteScript, NoteTarget,
-    PreparedTransaction, RecAdviceProvider, TransactionComplier, TransactionExecutorError,
+    PreparedTransaction, RecAdviceProvider, TransactionCompiler, TransactionExecutorError,
     TransactionResult,
 };
 use crate::TryFromVmResult;
@@ -28,7 +28,7 @@ use vm_processor::DefaultHost;
 /// executor and produces a [TransactionWitness] for the transaction. The TransactionWitness can
 /// then be used to by the prover to generate a proof transaction execution.
 pub struct TransactionExecutor<D: DataStore> {
-    compiler: TransactionComplier,
+    compiler: TransactionCompiler,
     data_store: D,
 }
 
@@ -37,7 +37,7 @@ impl<D: DataStore> TransactionExecutor<D> {
     // --------------------------------------------------------------------------------------------
     /// Creates a new [TransactionExecutor] instance with the specified [DataStore].
     pub fn new(data_store: D) -> Self {
-        let compiler = TransactionComplier::new();
+        let compiler = TransactionCompiler::new();
         Self {
             compiler,
             data_store,

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -11,7 +11,7 @@ use vm_core::{Operation, Program};
 use vm_processor::{ExecutionError, RecAdviceProvider};
 
 mod compiler;
-pub use compiler::{NoteTarget, TransactionComplier};
+pub use compiler::{NoteTarget, TransactionCompiler};
 
 mod data;
 pub use data::DataStore;

--- a/miden-tx/src/verifier/mod.rs
+++ b/miden-tx/src/verifier/mod.rs
@@ -1,4 +1,4 @@
-use super::{Digest, Hasher, TransactionComplier, TransactionVerifierError};
+use super::{Digest, Hasher, TransactionCompiler, TransactionVerifierError};
 use miden_objects::{
     notes::NoteEnvelope,
     transaction::{ConsumedNoteInfo, ProvenTransaction},
@@ -14,14 +14,14 @@ use vm_core::{stack::STACK_TOP_SIZE, StackInputs, StackOutputs};
 /// the minimum security level that the transaction proof must have in order to be considered
 /// valid.
 pub struct TransactionVerifier {
-    compiler: TransactionComplier,
+    compiler: TransactionCompiler,
     proof_security_level: u32,
 }
 
 impl TransactionVerifier {
     /// Creates a new [TransactionVerifier] object.
     pub fn new(proof_security_level: u32) -> Self {
-        let compiler = TransactionComplier::new();
+        let compiler = TransactionCompiler::new();
         Self {
             compiler,
             proof_security_level,


### PR DESCRIPTION
Fixes typo in `TransactionCompiler`, and removes the duplication of the struct with `#[cfg(test/not(test))]`.

Specifically, the `#[cfg(not(test))]` on a core struct confused rust-analyzer, and I couldn't lookup symbols in the `impl` block.