### PR TITLE
Decorator bug report evidence

### DIFF
--- a/miden-lib/asm/sat/kernel.masm
+++ b/miden-lib/asm/sat/kernel.masm
@@ -5,6 +5,12 @@ use.miden::sat::internal::layout
 use.miden::sat::internal::note
 use.miden::sat::internal::tx
 
+# EVENTS
+# =================================================================================================
+const.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT=0
+const.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT=1
+
+
 # AUTHENTICATION
 # =================================================================================================
 
@@ -233,6 +239,8 @@ end
 #!   - If ASSET is a fungible asset, then ASSET' is the total fungible asset in the account vault
 #!     after ASSET was added to it.
 export.account_vault_add_asset
+    push.1 drop emit.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT
+
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [ASSET]
@@ -258,6 +266,8 @@ end
 #!
 #! - ASSET is the asset to remove from the vault.
 export.account_vault_remove_asset
+    push.1 drop emit.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT
+
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [ASSET]

--- a/miden-lib/asm/sat/kernel.masm
+++ b/miden-lib/asm/sat/kernel.masm
@@ -239,7 +239,7 @@ end
 #!   - If ASSET is a fungible asset, then ASSET' is the total fungible asset in the account vault
 #!     after ASSET was added to it.
 export.account_vault_add_asset
-    push.1 drop emit.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT
+    emit.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT
 
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
@@ -266,7 +266,7 @@ end
 #!
 #! - ASSET is the asset to remove from the vault.
 export.account_vault_remove_asset
-    push.1 drop emit.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT
+    emit.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT
 
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin

--- a/miden-lib/src/event.rs
+++ b/miden-lib/src/event.rs
@@ -1,0 +1,21 @@
+use miden_objects::Word;
+use vm_processor::ExecutionError;
+
+#[repr(u32)]
+pub enum Event {
+    AddAssetToAccountVault = 0,
+    RemoveAssetFromAccountVault = 1,
+}
+
+impl TryFrom<u32> for Event {
+    type Error = ExecutionError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Event::AddAssetToAccountVault),
+            1 => Ok(Event::RemoveAssetFromAccountVault),
+            // TODO: Change to correct error
+            _ => Err(ExecutionError::AdviceMapKeyNotFound(Word::default())),
+        }
+    }
+}

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -12,6 +12,7 @@ mod auth;
 pub use auth::AuthScheme;
 
 pub mod assembler;
+pub mod event;
 pub mod faucets;
 pub mod memory;
 pub mod notes;

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -12,7 +12,8 @@ use miden_objects::{
     TransactionResultError,
 };
 use vm_core::{Program, StackOutputs};
-use vm_processor::DefaultHost;
+
+use super::TransactionHost;
 
 /// The transaction executor is responsible for executing Miden rollup transactions.
 ///
@@ -115,7 +116,7 @@ impl<D: DataStore> TransactionExecutor<D> {
             self.prepare_transaction(account_id, block_ref, note_origins, tx_script)?;
 
         let advice_recorder: RecAdviceProvider = transaction.advice_provider_inputs().into();
-        let mut host = DefaultHost::new(advice_recorder);
+        let mut host = TransactionHost::new(advice_recorder);
         let result = vm_processor::execute(
             transaction.tx_program(),
             transaction.stack_inputs(),
@@ -127,7 +128,8 @@ impl<D: DataStore> TransactionExecutor<D> {
         let (account, block_header, _block_chain, consumed_notes, tx_program, tx_script_root) =
             transaction.into_parts();
 
-        let advice_recorder = host.into_inner();
+        let (advice_recorder, event_handler) = host.into_parts();
+        println!("event_handler: {:?}", event_handler);
         create_transaction_result(
             account,
             consumed_notes,

--- a/miden-tx/src/host/event/mod.rs
+++ b/miden-tx/src/host/event/mod.rs
@@ -1,0 +1,23 @@
+use miden_lib::event::Event;
+use vm_processor::{ExecutionError, HostResponse, ProcessState};
+
+mod vault_delta;
+use vault_delta::VaultDeltaHandler;
+
+#[derive(Default, Debug)]
+pub struct EventHandler {
+    vault_delta_handler: VaultDeltaHandler,
+}
+
+impl EventHandler {
+    pub fn handle_event<S: ProcessState>(
+        &mut self,
+        process: &S,
+        event_id: u32,
+    ) -> Result<HostResponse, ExecutionError> {
+        match Event::try_from(event_id)? {
+            Event::AddAssetToAccountVault => self.vault_delta_handler.add_asset(process),
+            Event::RemoveAssetFromAccountVault => self.vault_delta_handler.remove_asset(process),
+        }
+    }
+}

--- a/miden-tx/src/host/event/vault_delta.rs
+++ b/miden-tx/src/host/event/vault_delta.rs
@@ -1,0 +1,78 @@
+use miden_objects::{
+    assets::Asset,
+    utils::collections::{btree_map::Entry, BTreeMap},
+    Digest,
+};
+use vm_processor::{ExecutionError, HostResponse, ProcessState};
+
+#[derive(Default, Debug)]
+pub struct VaultDeltaHandler {
+    fungible_assets: BTreeMap<u64, i128>,
+    non_fungible_assets: BTreeMap<Digest, i8>,
+}
+
+impl VaultDeltaHandler {
+    pub fn add_asset<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<HostResponse, ExecutionError> {
+        let asset: Asset = process.get_stack_word(0).try_into().unwrap();
+        match asset {
+            Asset::Fungible(asset) => {
+                update_asset_delta(
+                    &mut self.fungible_assets,
+                    asset.faucet_id().into(),
+                    asset.amount() as i128,
+                );
+            }
+            Asset::NonFungible(asset) => {
+                update_asset_delta(&mut self.non_fungible_assets, asset.vault_key().into(), 1)
+            }
+        };
+        Ok(HostResponse::None)
+    }
+
+    pub fn remove_asset<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<HostResponse, ExecutionError> {
+        let asset: Asset = process.get_stack_word(0).try_into().unwrap();
+        match asset {
+            Asset::Fungible(asset) => {
+                update_asset_delta(
+                    &mut self.fungible_assets,
+                    asset.faucet_id().into(),
+                    -(asset.amount() as i128),
+                );
+            }
+            Asset::NonFungible(asset) => {
+                update_asset_delta(&mut self.non_fungible_assets, asset.vault_key().into(), -1)
+            }
+        };
+        Ok(HostResponse::None)
+    }
+}
+
+// HELPERS
+// ================================================================================================
+fn update_asset_delta<K, V>(delta_map: &mut BTreeMap<K, V>, key: K, amount: V)
+where
+    V: core::ops::Neg,
+    V: core::cmp::PartialEq<<V as core::ops::Neg>::Output>,
+    V: core::ops::AddAssign,
+    V: Copy,
+    K: Ord,
+{
+    match delta_map.entry(key) {
+        Entry::Occupied(mut entry) => {
+            if entry.get() == &-amount {
+                entry.remove();
+            } else {
+                *entry.get_mut() += amount;
+            }
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(amount);
+        }
+    }
+}

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -1,0 +1,51 @@
+use vm_processor::{
+    AdviceExtractor, AdviceInjector, AdviceProvider, ExecutionError, Host, HostResponse,
+    ProcessState,
+};
+
+mod event;
+use event::EventHandler;
+
+pub struct TransactionHost<A> {
+    adv_provider: A,
+    event_handler: EventHandler,
+}
+
+impl<A: AdviceProvider> TransactionHost<A> {
+    pub fn new(adv_provider: A) -> Self {
+        Self {
+            adv_provider,
+            event_handler: EventHandler::default(),
+        }
+    }
+
+    pub fn into_parts(self) -> (A, EventHandler) {
+        (self.adv_provider, self.event_handler)
+    }
+}
+
+impl<A: AdviceProvider> Host for TransactionHost<A> {
+    fn get_advice<S: ProcessState>(
+        &mut self,
+        process: &S,
+        extractor: AdviceExtractor,
+    ) -> Result<HostResponse, ExecutionError> {
+        self.adv_provider.get_advice(process, &extractor)
+    }
+
+    fn set_advice<S: ProcessState>(
+        &mut self,
+        process: &S,
+        injector: AdviceInjector,
+    ) -> Result<HostResponse, ExecutionError> {
+        self.adv_provider.set_advice(process, &injector)
+    }
+
+    fn on_event<S: ProcessState>(
+        &mut self,
+        process: &S,
+        event_id: u32,
+    ) -> Result<HostResponse, ExecutionError> {
+        self.event_handler.handle_event(process, event_id)
+    }
+}

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -19,6 +19,9 @@ pub use data::DataStore;
 mod executor;
 pub use executor::TransactionExecutor;
 
+pub mod host;
+pub use host::TransactionHost;
+
 mod prover;
 pub use prover::TransactionProver;
 

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -1,9 +1,9 @@
-use super::TransactionProverError;
+use super::{TransactionHost, TransactionProverError};
 use crate::TryFromVmResult;
 use miden_objects::transaction::{CreatedNotes, FinalAccountStub};
 use miden_objects::transaction::{PreparedTransaction, ProvenTransaction, TransactionWitness};
 use miden_prover::{prove, ProvingOptions};
-use vm_processor::{DefaultHost, MemAdviceProvider};
+use vm_processor::MemAdviceProvider;
 
 /// The [TransactionProver] is a stateless component which is responsible for proving transactions.
 ///
@@ -32,7 +32,7 @@ impl TransactionProver {
     ) -> Result<ProvenTransaction, TransactionProverError> {
         // prove transaction program
         let advice_provider: MemAdviceProvider = transaction.advice_provider_inputs().into();
-        let mut host = DefaultHost::new(advice_provider);
+        let mut host = TransactionHost::new(advice_provider);
         let (outputs, proof) = prove(
             transaction.tx_program(),
             transaction.stack_inputs(),
@@ -42,7 +42,8 @@ impl TransactionProver {
         .map_err(TransactionProverError::ProveTransactionProgramFailed)?;
 
         // extract transaction outputs and process transaction data
-        let (stack, map, store) = host.into_inner().into_parts();
+        let (advice_provider, event_handler) = host.into_parts();
+        let (stack, map, store) = advice_provider.into_parts();
         let final_account_stub =
             FinalAccountStub::try_from_vm_result(&outputs, &stack, &map, &store)
                 .map_err(TransactionProverError::TransactionResultError)?;
@@ -90,13 +91,14 @@ impl TransactionProver {
         ) = tx_witness.into_parts();
 
         let advice_provider: MemAdviceProvider = advice_witness.into();
-        let mut host = DefaultHost::new(advice_provider);
+        let mut host = TransactionHost::new(advice_provider);
         let (outputs, proof) =
             prove(&tx_program, stack_inputs, &mut host, self.proof_options.clone())
                 .map_err(TransactionProverError::ProveTransactionProgramFailed)?;
 
         // extract transaction outputs and process transaction data
-        let (stack, map, store) = host.into_inner().into_parts();
+        let (advice_provider, event_handler) = host.into_parts();
+        let (stack, map, store) = advice_provider.into_parts();
         let final_account_stub =
             FinalAccountStub::try_from_vm_result(&outputs, &stack, &map, &store)
                 .map_err(TransactionProverError::TransactionResultError)?;

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     Account, AccountId, BlockHeader, ChainMmr, DataStore, DataStoreError, Note, NoteOrigin,
-    TransactionExecutor, TransactionProver, TransactionVerifier, TryFromVmResult,
+    TransactionExecutor, TransactionHost, TransactionProver, TransactionVerifier, TryFromVmResult,
 };
 use miden_objects::{
     accounts::AccountCode,
@@ -21,7 +21,7 @@ use mock::{
     mock::{account::MockAccountType, notes::AssetPreservationStatus, transaction::mock_inputs},
     utils::prepare_word,
 };
-use vm_processor::{DefaultHost, MemAdviceProvider};
+use vm_processor::MemAdviceProvider;
 
 // TESTS
 // ================================================================================================
@@ -49,7 +49,7 @@ fn test_transaction_executor_witness() {
 
     // use the witness to execute the transaction again
     let mem_advice_provider: MemAdviceProvider = witness.advice_inputs().clone().into();
-    let mut host = DefaultHost::new(mem_advice_provider);
+    let mut host = TransactionHost::new(mem_advice_provider);
     let result = vm_processor::execute(
         witness.program(),
         witness.get_stack_inputs(),
@@ -58,7 +58,8 @@ fn test_transaction_executor_witness() {
     )
     .unwrap();
 
-    let (stack, map, store) = host.into_inner().into_parts();
+    let (advice_provider, event_handler) = host.into_parts();
+    let (stack, map, store) = advice_provider.into_parts();
     let final_account_stub =
         FinalAccountStub::try_from_vm_result(result.stack_outputs(), &stack, &map, &store).unwrap();
     let created_notes =
@@ -249,6 +250,8 @@ fn test_transaction_result_account_delta() {
         .all(|x| added_assets.contains(x)));
     assert_eq!(added_assets.len(), transaction_result.account_delta().vault.added_assets.len());
 
+    println!("added assets: {:?}", added_assets);
+
     // assert that removed assets are tracked
     assert!(transaction_result
         .account_delta()
@@ -260,6 +263,8 @@ fn test_transaction_result_account_delta() {
         removed_assets.len(),
         transaction_result.account_delta().vault.removed_assets.len()
     );
+
+    println!("removed assets: {:?}", removed_assets);
 }
 
 #[test]


### PR DESCRIPTION
This PR provides evidence for a the decorator bug report.

```
---- tests::test_prologue::test_get_blk_timestamp stdout ----
thread 'tests::test_prologue::test_get_blk_timestamp' panicked at /Users/f/.cargo/git/checkouts/miden-vm-3db6be6805d1979c/10ed3e3/assembly/src/assembler/span_builder.rs:151:13:
internal error: entered unreachable code: decorators in an empty SPAN block
```

See CI tests.

I believe this is caused by procedures which contain a decorator and only call other procedures without executing any operations.  Example given:

```
export.account_vault_add_asset
    emit.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT

    # authenticate that the procedure invocation originates from the account context
    exec.authenticate_account_origin
    # => [ASSET]
    # fetch the vault root
    exec.layout::get_acct_vault_root_ptr movdn.4
    # => [ASSET, acct_vault_root_ptr]
    # add the asset to the account vault
    exec.asset_vault::add_asset
    # => [ASSET']
end
```