### PR TITLE
refactor: refactor kernel book keeping memory layout and management

### DIFF
--- a/miden-lib/asm/sat/internal/layout.masm
+++ b/miden-lib/asm/sat/internal/layout.masm
@@ -9,23 +9,17 @@ use.miden::sat::internal::constants
 # The memory address at which the transaction vault root is stored
 const.TX_VAULT_ROOT_PTR=0
 
-# The memory address at which the number of executed notes is stored
-const.NUM_EXECUTED_NOTES_PTR=1
+# The memory address at which a pointer to the consumed note being executed is stored.
+const.CURRENT_CONSUMED_NOTE_PTR=1
 
 # The memory address at which the number of created notes is stored.
 const.NUM_CREATED_NOTES_PTR=2
 
-# The memory address at which a pointer to the consumed note being executed is stored.
-const.CURRENT_CONSUMED_NOTE_PTR=3
-
-# The memory address at which the index of the current consumed note is stored.
-const.CURRENT_CONSUMED_NOTE_IDX=4
-
 # The memory address at which the input vault root is stored
-const.INPUT_VAULT_ROOT_PTR=5
+const.INPUT_VAULT_ROOT_PTR=3
 
 # The memory address at which the output vault root is stored
-const.OUTPUT_VAULT_ROOT_PTR=6
+const.OUTPUT_VAULT_ROOT_PTR=4
 
 # GLOBAL INPUTS
 # -------------------------------------------------------------------------------------------------
@@ -187,22 +181,6 @@ end
 #! Output: []
 export.set_current_consumed_note_ptr
     push.CURRENT_CONSUMED_NOTE_PTR mem_store
-end
-
-#! Returns the index of the consumed note being executed.
-#!
-#! Stack: []
-#! Output: [idx]
-export.get_current_consumed_note_idx
-    push.CURRENT_CONSUMED_NOTE_IDX mem_load
-end
-
-#! Sets the index of the consumed note being executed.
-#!
-#! Stack: [idx]
-#! Output: []
-export.set_current_consumed_note_idx
-    push.CURRENT_CONSUMED_NOTE_IDX mem_store
 end
 
 #! Returns a pointer to the memory address at which the input vault root is stored

--- a/miden-lib/asm/sat/internal/main.masm
+++ b/miden-lib/asm/sat/internal/main.masm
@@ -59,7 +59,7 @@ use.miden::sat::internal::prologue
 #! - CNC is the commitment to the notes created by the transaction.
 #! - FAH is the final account hash of the account that the transaction is being
 #!   executed against.
-export.main
+export.main.1
     # Prologue
     # ---------------------------------------------------------------------------------------------
 
@@ -72,6 +72,11 @@ export.main
 
     # get the total number of consumed notes
     exec.layout::get_total_num_consumed_notes
+    # => [num_consumed_notes]
+
+    # compute the pointer to the consumed note after the last consumed note (i.e. the pointer at
+    # which the looping should terminate)
+    dup exec.layout::get_consumed_note_ptr loc_store.0
     # => [num_consumed_notes]
 
     # check if we have any notes to consume
@@ -93,8 +98,8 @@ export.main
         # => []
 
         # check if we have more notes to consume and should loop again
-        exec.layout::get_total_num_consumed_notes
-        exec.layout::get_current_consumed_note_idx
+        exec.note::increment_current_consumed_note_ptr
+        loc_load.0
         neq
         # => [should_loop]
     end

--- a/miden-lib/asm/sat/internal/note.masm
+++ b/miden-lib/asm/sat/internal/note.masm
@@ -1,3 +1,4 @@
+use.miden::sat::internal::constants
 use.miden::sat::internal::layout
 
 #! Returns the sender of the note currently being processed. Panics if a note is not being
@@ -71,18 +72,24 @@ export.get_inputs_hash
     # => [NOTE_INPUTS_HASH]
 end
 
-#! Increments the number of consumed notes by one. Returns the index of the next note to be consumed.
+#! Increment current consumed note pointer to the next note and returns the pointer value.
 #!
 #! Inputs: []
-#! Outputs: [note_idx]
-export.increment_current_consumed_note_idx
-    # get the current consumed note index
-    exec.layout::get_current_consumed_note_idx
-    # => [note_idx]
+#! Outputs: [current_consumed_note_ptr]
+#!
+#! - current_consumed_note_ptr is the pointer to the next note to be processed.
+export.increment_current_consumed_note_ptr
+    # get the current consumed note pointer
+    exec.layout::get_current_consumed_note_ptr
+    # => [orig_consumed_note_ptr]
 
-    # increment the index of the current consumed note and save back to memory
-    dup add.1 exec.layout::set_current_consumed_note_idx
-    # => [note_idx]
+    # increment the pointer
+    exec.constants::get_note_mem_size add
+    # => [current_consumed_note_ptr]
+
+    # set the current consumed note pointer to the incremented value
+    dup exec.layout::set_current_consumed_note_ptr
+    # => [current_consumed_note_ptr]
 end
 
 #! Sets the current consumed note pointer to 0. This should be called after all consumed notes have
@@ -105,16 +112,8 @@ end
 #!
 #! - NSR is the note script root of the note currently being executed.
 export.prepare_note
-    # load the note index onto the stack
-    exec.increment_current_consumed_note_idx
-    # => [idx]
-
     # convert the index of the consumed note being executed to a pointer and store in memory
-    exec.layout::get_consumed_note_ptr
-    # => [note_ptr]
-
-    # set current consumed note pointer to the note being executed
-    dup exec.layout::set_current_consumed_note_ptr
+    exec.layout::get_current_consumed_note_ptr
     # => [note_ptr]
 
     # read the note script root onto the stack

--- a/miden-lib/asm/sat/internal/prologue.masm
+++ b/miden-lib/asm/sat/internal/prologue.masm
@@ -624,6 +624,10 @@ proc.process_consumed_notes_data
 
     # clear stack
     drop drop
+
+    # set the current consumed note pointer to the first consumed note
+    push.0 exec.layout::get_consumed_note_ptr exec.layout::set_current_consumed_note_ptr
+    # => []
 end
 
 # TRANSACTION SCRIPT

--- a/miden-lib/src/memory.rs
+++ b/miden-lib/src/memory.rs
@@ -24,20 +24,17 @@ pub const FAUCET_STORAGE_DATA_SLOT: StorageSlot = 255;
 /// The memory address at which the transaction vault root is stored.
 pub const TX_VAULT_ROOT_PTR: MemoryAddress = 0;
 
-/// The memory address at which the number of executed notes is stored.
-pub const NUM_EXECUTED_NOTES_PTR: MemoryAddress = 1;
+/// The memory address at which a pointer to the consumed note being executed is stored.
+pub const CURRENT_CONSUMED_NOTE_PTR: MemoryAddress = 1;
 
 /// The memory address at which the number of created notes is stored.
 pub const NUM_CREATED_NOTES_PTR: MemoryAddress = 2;
 
-/// The memory address at which a pointer to the consumed note being executed is stored.
-pub const CURRENT_CONSUMED_NOTE_PTR: MemoryAddress = 3;
-
 /// The memory address at which the input vault root is stored
-pub const INPUT_VAULT_ROOT_PTR: MemoryAddress = 5;
+pub const INPUT_VAULT_ROOT_PTR: MemoryAddress = 3;
 
 /// The memory address at which the output vault root is stored
-pub const OUTPUT_VAULT_ROOT_PTR: MemoryAddress = 6;
+pub const OUTPUT_VAULT_ROOT_PTR: MemoryAddress = 4;
 
 // GLOBAL INPUTS
 // ------------------------------------------------------------------------------------------------

--- a/miden-lib/src/tests/test_note.rs
+++ b/miden-lib/src/tests/test_note.rs
@@ -19,11 +19,17 @@ fn test_get_sender_no_sender() {
 
     // calling get_sender should return sender
     let code = "
+        use.miden::sat::internal::layout
         use.miden::sat::internal::prologue
         use.miden::sat::note
 
         begin
             exec.prologue::prepare_transaction
+
+            # force the current consumed note pointer to 0
+            push.0 exec.layout::set_current_consumed_note_ptr
+
+            # get the sender
             exec.note::get_sender
         end
         ";
@@ -95,6 +101,9 @@ fn test_get_vault_data() {
             # assert the vault data is correct
             push.{note_0_vault_root} assert_eqw
             push.{note_0_num_assets} assert_eq
+
+            # increment current consumed note pointer
+            exec.note::increment_current_consumed_note_ptr
 
             # prepare note 1
             exec.note::prepare_note
@@ -209,6 +218,9 @@ fn test_get_assets() {
 
             # process note 0
             call.process_note_0
+
+            # increment current consumed note pointer
+            exec.note_internal::increment_current_consumed_note_ptr
 
             # prepare note 1
             exec.note_internal::prepare_note


### PR DESCRIPTION
This PR refactors the kernel booking layout as described in #287 and #280. Specifically we remove `CURRENT_CONSUMED_NOTE_IDX` and `NUM_EXECUTED_NOTES_PTR`.  To support this change we have modified the looping login in `main.masm` such that the termination condition is when the current consumed note pointer matches the calculated loop termination pointer.  We initialise the current consumed note pointer in the prologue.

closes: #287, #280