### PR TITLE
Introduce `RecordedNote` object

### DIFF
--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -62,15 +62,7 @@ pub fn create_note(
 
     let (note_script, _) = NoteScript::new(note_script_ast, &note_assembler)?;
 
-    Note::new(
-        note_script.clone(),
-        &inputs,
-        &assets,
-        serial_num,
-        sender,
-        tag.unwrap_or(ZERO),
-        None,
-    )
+    Note::new(note_script.clone(), &inputs, &assets, serial_num, sender, tag.unwrap_or(ZERO))
 }
 
 pub fn notes_try_from_elements(elements: &[Word]) -> Result<NoteStub, NoteError> {

--- a/miden-lib/src/tests/test_note.rs
+++ b/miden-lib/src/tests/test_note.rs
@@ -68,7 +68,7 @@ fn test_get_sender() {
     )
     .unwrap();
 
-    let sender = transaction.consumed_notes().notes()[0].metadata().sender().into();
+    let sender = transaction.consumed_notes().notes()[0].note().metadata().sender().into();
     assert_eq!(process.stack.get(0), sender);
 }
 
@@ -107,10 +107,10 @@ fn test_get_vault_data() {
             push.{note_1_num_assets} assert_eq
         end
         ",
-        note_0_vault_root = prepare_word(&notes[0].vault().hash()),
-        note_0_num_assets = notes[0].vault().num_assets(),
-        note_1_vault_root = prepare_word(&notes[1].vault().hash()),
-        note_1_num_assets = notes[1].vault().num_assets(),
+        note_0_vault_root = prepare_word(&notes[0].note().vault().hash()),
+        note_0_num_assets = notes[0].note().vault().num_assets(),
+        note_1_vault_root = prepare_word(&notes[1].note().vault().hash()),
+        note_1_num_assets = notes[1].note().vault().num_assets(),
     );
 
     let transaction =
@@ -217,10 +217,10 @@ fn test_get_assets() {
             call.process_note_1
         end
         ",
-        note_0_num_assets = notes[0].vault().num_assets(),
-        note_1_num_assets = notes[1].vault().num_assets(),
-        NOTE_0_ASSET_ASSERTIONS = construct_asset_assertions(&notes[0]),
-        NOTE_1_ASSET_ASSERTIONS = construct_asset_assertions(&notes[1]),
+        note_0_num_assets = notes[0].note().vault().num_assets(),
+        note_1_num_assets = notes[1].note().vault().num_assets(),
+        NOTE_0_ASSET_ASSERTIONS = construct_asset_assertions(&notes[0].note()),
+        NOTE_1_ASSET_ASSERTIONS = construct_asset_assertions(&notes[1].note()),
     );
 
     let inputs = prepare_transaction(
@@ -302,7 +302,7 @@ fn test_get_inputs() {
             call.process_note_0
         end
         ",
-        NOTE_1_INPUT_ASSERTIONS = construct_input_assertions(&notes[0]),
+        NOTE_1_INPUT_ASSERTIONS = construct_input_assertions(&notes[0].note()),
     );
 
     let inputs = prepare_transaction(
@@ -360,7 +360,7 @@ fn note_setup_stack_assertions<A: AdviceProvider>(
     let mut expected_stack = [ZERO; 16];
 
     // replace the top four elements with the tx script root
-    let mut note_script_root = *inputs.consumed_notes().notes()[0].script().hash();
+    let mut note_script_root = *inputs.consumed_notes().notes()[0].note().script().hash();
     note_script_root.reverse();
     expected_stack[..4].copy_from_slice(&note_script_root);
 

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -247,7 +247,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx)
                 .unwrap(),
-            note.nullifier().as_elements()
+            note.note().nullifier().as_elements()
         );
 
         // The note hash should be computed and stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024)
@@ -255,7 +255,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx))
                 .unwrap(),
-            note.hash().as_elements()
+            note.note().hash().as_elements()
         );
 
         // The note serial num should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 1)
@@ -263,7 +263,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 1)
                 .unwrap(),
-            note.serial_num()
+            note.note().serial_num()
         );
 
         // The note script hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 2)
@@ -271,7 +271,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 2)
                 .unwrap(),
-            note.script().hash().as_elements()
+            note.note().script().hash().as_elements()
         );
 
         // The note input hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 3)
@@ -279,7 +279,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 3)
                 .unwrap(),
-            note.inputs().hash().as_elements()
+            note.note().inputs().hash().as_elements()
         );
 
         // The note vault hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 4)
@@ -287,7 +287,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 4)
                 .unwrap(),
-            note.vault().hash().as_elements()
+            note.note().vault().hash().as_elements()
         );
 
         // The number of assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 5)
@@ -295,11 +295,11 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 5)
                 .unwrap(),
-            Word::from(note.metadata())
+            Word::from(note.note().metadata())
         );
 
         // The assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 6..)
-        for (asset, asset_idx) in note.vault().iter().cloned().zip(0u32..) {
+        for (asset, asset_idx) in note.note().vault().iter().cloned().zip(0u32..) {
             let word: Word = asset.into();
             assert_eq!(
                 process

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -136,9 +136,9 @@ fn test_get_output_notes_hash() {
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // extract input note data
-    let input_note_1 = notes.first().unwrap();
+    let input_note_1 = notes.first().unwrap().note();
     let input_asset_1 = **input_note_1.vault().iter().take(1).collect::<Vec<_>>().first().unwrap();
-    let input_note_2 = notes.last().unwrap();
+    let input_note_2 = notes.last().unwrap().note();
     let input_asset_2 = **input_note_2.vault().iter().take(1).collect::<Vec<_>>().first().unwrap();
 
     // create output note 1
@@ -151,7 +151,6 @@ fn test_get_output_notes_hash() {
         output_serial_no_1,
         account.id(),
         output_tag_1,
-        None,
     )
     .unwrap();
 
@@ -165,7 +164,6 @@ fn test_get_output_notes_hash() {
         output_serial_no_2,
         account.id(),
         output_tag_2,
-        None,
     )
     .unwrap();
 

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -1,7 +1,8 @@
-use super::{AccountId, ModuleAst, Note, NoteTarget, ProgramAst, TransactionCompiler};
+use super::{AccountId, ModuleAst, NoteTarget, ProgramAst, TransactionCompiler};
 use miden_objects::{
     accounts::ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
     assets::{Asset, FungibleAsset},
+    notes::{Note, NoteInclusionProof, RecordedNote},
     Felt, FieldElement, Word,
 };
 
@@ -162,7 +163,6 @@ fn mock_consumed_notes(
         SERIAL_NUM_1,
         sender,
         Felt::ZERO,
-        None,
     )
     .unwrap();
 
@@ -174,7 +174,6 @@ fn mock_consumed_notes(
         SERIAL_NUM_2,
         sender,
         Felt::ZERO,
-        None,
     )
     .unwrap();
 
@@ -190,6 +189,18 @@ fn test_transaction_compilation_succeeds() {
     let _account_code = tx_compiler.load_account(account_id, account_code_ast).unwrap();
 
     let notes = mock_consumed_notes(&mut tx_compiler, account_id);
+    let mock_inclusion_proof = NoteInclusionProof::new(
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        0,
+        Default::default(),
+    )
+    .unwrap();
+    let notes = notes
+        .into_iter()
+        .map(|note| RecordedNote::new(note, mock_inclusion_proof.clone()))
+        .collect::<Vec<_>>();
 
     let tx_script_src = format!("begin call.{ACCT_PROC_2} end");
     let tx_script_ast = ProgramAst::parse(tx_script_src.as_str()).unwrap();

--- a/miden-tx/src/data.rs
+++ b/miden-tx/src/data.rs
@@ -1,5 +1,5 @@
-use super::{Account, AccountId, BlockHeader, ChainMmr, DataStoreError, Note, NoteOrigin};
-use miden_objects::assembly::ModuleAst;
+use super::{Account, AccountId, BlockHeader, ChainMmr, DataStoreError, NoteOrigin};
+use miden_objects::{assembly::ModuleAst, notes::RecordedNote};
 
 /// The [DataStore] trait defines the interface that transaction objects use to fetch data
 /// required for transaction execution.
@@ -11,7 +11,7 @@ pub trait DataStore {
         account_id: AccountId,
         block_num: u32,
         notes: &[NoteOrigin],
-    ) -> Result<(Account, BlockHeader, ChainMmr, Vec<Note>), DataStoreError>;
+    ) -> Result<(Account, BlockHeader, ChainMmr, Vec<RecordedNote>), DataStoreError>;
 
     /// Returns the account code [ModuleAst] associated with the the specified [AccountId].
     fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError>;

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -2,7 +2,7 @@ use miden_lib::SatKernel;
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId},
     assembly::CodeBlock,
-    notes::{Note, NoteOrigin, NoteScript},
+    notes::{NoteOrigin, NoteScript},
     transaction::{PreparedTransaction, TransactionResult},
     utils::collections::BTreeMap,
     AccountError, BlockHeader, ChainMmr, Digest, Hasher, TransactionResultError,

--- a/miden-tx/tests/common/mod.rs
+++ b/miden-tx/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use miden_objects::{
     accounts::{Account, AccountId},
     assembly::ModuleAst,
-    notes::{Note, NoteOrigin},
+    notes::{Note, NoteOrigin, RecordedNote},
     BlockHeader, ChainMmr, StarkField,
 };
 use miden_tx::{DataStore, DataStoreError};
@@ -16,7 +16,7 @@ pub struct MockDataStore {
     pub account: Account,
     pub block_header: BlockHeader,
     pub block_chain: ChainMmr,
-    pub notes: Vec<Note>,
+    pub notes: Vec<RecordedNote>,
 }
 
 impl MockDataStore {
@@ -59,15 +59,11 @@ impl DataStore for MockDataStore {
         account_id: AccountId,
         block_num: u32,
         notes: &[NoteOrigin],
-    ) -> Result<(Account, BlockHeader, ChainMmr, Vec<Note>), DataStoreError> {
+    ) -> Result<(Account, BlockHeader, ChainMmr, Vec<RecordedNote>), DataStoreError> {
         assert_eq!(account_id, self.account.id());
         assert_eq!(block_num as u64, self.block_header.block_num().as_int());
         assert_eq!(notes.len(), self.notes.len());
-        let origins = self
-            .notes
-            .iter()
-            .map(|note| note.proof().as_ref().unwrap().origin())
-            .collect::<Vec<_>>();
+        let origins = self.notes.iter().map(|note| note.origin()).collect::<Vec<_>>();
         notes.iter().all(|note| origins.contains(&note));
         Ok((
             self.account.clone(),

--- a/miden-tx/tests/test_miden_faucet_contract.rs
+++ b/miden-tx/tests/test_miden_faucet_contract.rs
@@ -32,11 +32,8 @@ fn test_faucet_contract_mint_fungible_asset_succeeds() {
     executor.load_account(faucet_account.id()).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let recipient = [Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)];
     let tag = Felt::new(4);
@@ -101,11 +98,8 @@ fn test_faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
     executor.load_account(faucet_account.id()).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let recipient = [Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)];
     let tag = Felt::new(4);
@@ -194,11 +188,8 @@ fn test_faucet_contract_burn_fungible_asset_succeeds() {
     executor.load_account(faucet_account.id()).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
     let transaction_result = executor
@@ -207,7 +198,7 @@ fn test_faucet_contract_burn_fungible_asset_succeeds() {
 
     // check that the account burned the asset
     assert!(transaction_result.account_delta().nonce.unwrap() == Felt::new(2));
-    assert!(transaction_result.consumed_notes().notes()[0].hash() == note.hash());
+    assert!(transaction_result.consumed_notes().notes()[0].note().hash() == note.hash());
 }
 
 #[test]
@@ -297,7 +288,6 @@ fn get_note_with_asset_and_script(fungible_asset: FungibleAsset, note_script: Pr
         SERIAL_NUM,
         sender_id,
         Felt::new(1),
-        None,
     )
     .unwrap()
 }

--- a/miden-tx/tests/test_miden_note_scripts.rs
+++ b/miden-tx/tests/test_miden_note_scripts.rs
@@ -62,11 +62,8 @@ fn test_p2id_script() {
     executor.load_account(target_account_id).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let tx_script = ProgramAst::parse(
         format!(
@@ -116,7 +113,7 @@ fn test_p2id_script() {
     let note_origins = data_store_malicious_account
         .notes
         .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .map(|note| note.origin().clone())
         .collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
@@ -167,11 +164,8 @@ fn test_p2id_script_multiple_assets() {
     executor.load_account(target_account_id).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let tx_script = ProgramAst::parse(
         format!(
@@ -221,7 +215,7 @@ fn test_p2id_script_multiple_assets() {
     let note_origins = data_store_malicious_account
         .notes
         .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
+        .map(|note| note.origin().clone())
         .collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
@@ -307,11 +301,8 @@ fn test_p2idr_script() {
     executor_1.load_account(target_account_id).unwrap();
 
     let block_ref_1 = data_store_1.block_header.block_num().as_int() as u32;
-    let note_origins = data_store_1
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store_1.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let tx_script = ProgramAst::parse(
         format!(
@@ -353,11 +344,8 @@ fn test_p2idr_script() {
     executor_2.load_account(sender_account_id).unwrap();
 
     let block_ref_2 = data_store_2.block_header.block_num().as_int() as u32;
-    let note_origins_2 = data_store_2
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins_2 =
+        data_store_2.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
     let transaction_result_2 = executor_2.execute_transaction(
@@ -382,11 +370,8 @@ fn test_p2idr_script() {
     executor_3.load_account(malicious_account_id).unwrap();
 
     let block_ref_3 = data_store_3.block_header.block_num().as_int() as u32;
-    let note_origins_3 = data_store_3
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins_3 =
+        data_store_3.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
     let transaction_result_3 = executor_3.execute_transaction(
@@ -411,11 +396,8 @@ fn test_p2idr_script() {
     executor_4.load_account(target_account_id).unwrap();
 
     let block_ref_4 = data_store_4.block_header.block_num().as_int() as u32;
-    let note_origins_4 = data_store_4
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins_4 =
+        data_store_4.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
     let transaction_result_4 = executor_4
@@ -453,11 +435,8 @@ fn test_p2idr_script() {
     executor_5.load_account(sender_account_id).unwrap();
 
     let block_ref_5 = data_store_5.block_header.block_num().as_int() as u32;
-    let note_origins = data_store_5
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store_5.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
     let transaction_result_5 = executor_5
@@ -489,11 +468,8 @@ fn test_p2idr_script() {
     executor_6.load_account(malicious_account_id).unwrap();
 
     let block_ref_6 = data_store_6.block_header.block_num().as_int() as u32;
-    let note_origins_6 = data_store_6
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins_6 =
+        data_store_6.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
     let transaction_result_6 = executor_6.execute_transaction(

--- a/miden-tx/tests/test_miden_wallet.rs
+++ b/miden-tx/tests/test_miden_wallet.rs
@@ -64,11 +64,8 @@ fn test_receive_asset_via_wallet() {
     executor.load_account(target_account.id()).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let tx_script = ProgramAst::parse(
         format!(
@@ -124,11 +121,8 @@ fn test_send_asset_via_wallet() {
     executor.load_account(sender_account.id()).unwrap();
 
     let block_ref = data_store.block_header.block_num().as_int() as u32;
-    let note_origins = data_store
-        .notes
-        .iter()
-        .map(|note| note.proof().as_ref().unwrap().origin().clone())
-        .collect::<Vec<_>>();
+    let note_origins =
+        data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
     let recipient = [ZERO, ONE, Felt::new(2), Felt::new(3)];
     let tag = Felt::new(4);
@@ -237,7 +231,6 @@ fn get_note_with_fungible_asset_and_script(
         SERIAL_NUM,
         sender_id,
         Felt::new(1),
-        None,
     )
     .unwrap()
 }

--- a/mock/src/builders/note.rs
+++ b/mock/src/builders/note.rs
@@ -79,14 +79,6 @@ impl NoteBuilder {
         let assembler = assembler();
         let note_ast = ProgramAst::parse(&self.code).unwrap();
         let (note_script, _) = NoteScript::new(note_ast, &assembler)?;
-        Note::new(
-            note_script,
-            &self.inputs,
-            &self.assets,
-            self.serial_num,
-            self.sender,
-            self.tag,
-            self.proof,
-        )
+        Note::new(note_script, &self.inputs, &self.assets, self.serial_num, self.sender, self.tag)
     }
 }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -1,6 +1,8 @@
 use miden_lib::{assembler::assembler, memory};
 use miden_objects::{
-    accounts::Account, notes::Note, notes::NoteVault, transaction::PreparedTransaction,
+    accounts::Account,
+    notes::{Note, NoteVault, RecordedNote},
+    transaction::PreparedTransaction,
     BlockHeader, ChainMmr, Digest, Felt, StarkField,
 };
 use std::{fs::File, io::Read, path::PathBuf};
@@ -89,7 +91,7 @@ pub fn prepare_transaction(
     account_seed: Option<Word>,
     block_header: BlockHeader,
     chain: ChainMmr,
-    notes: Vec<Note>,
+    notes: Vec<RecordedNote>,
     tx_script_root: Option<Digest>,
     code: &str,
     imports: &str,

--- a/mock/src/mock/notes.rs
+++ b/mock/src/mock/notes.rs
@@ -57,7 +57,6 @@ pub fn mock_notes(
         SERIAL_NUM_4,
         sender,
         ZERO,
-        None,
     )
     .unwrap();
 
@@ -69,21 +68,13 @@ pub fn mock_notes(
         SERIAL_NUM_5,
         sender,
         ZERO,
-        None,
     )
     .unwrap();
 
     const SERIAL_NUM_6: Word = [Felt::new(21), Felt::new(22), Felt::new(23), Felt::new(24)];
-    let created_note_3 = Note::new(
-        note_script,
-        &[Felt::new(2)],
-        &[fungible_asset_3],
-        SERIAL_NUM_6,
-        sender,
-        ZERO,
-        None,
-    )
-    .unwrap();
+    let created_note_3 =
+        Note::new(note_script, &[Felt::new(2)], &[fungible_asset_3], SERIAL_NUM_6, sender, ZERO)
+            .unwrap();
 
     let created_notes = vec![created_note_1, created_note_2, created_note_3];
 
@@ -140,16 +131,9 @@ pub fn mock_notes(
 
     // Consumed Notes
     const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-    let consumed_note_1 = Note::new(
-        note_1_script,
-        &[Felt::new(1)],
-        &[fungible_asset_1],
-        SERIAL_NUM_1,
-        sender,
-        ZERO,
-        None,
-    )
-    .unwrap();
+    let consumed_note_1 =
+        Note::new(note_1_script, &[Felt::new(1)], &[fungible_asset_1], SERIAL_NUM_1, sender, ZERO)
+            .unwrap();
 
     const SERIAL_NUM_2: Word = [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)];
     let consumed_note_2 = Note::new(
@@ -159,7 +143,6 @@ pub fn mock_notes(
         SERIAL_NUM_2,
         sender,
         ZERO,
-        None,
     )
     .unwrap();
 
@@ -174,7 +157,6 @@ pub fn mock_notes(
         SERIAL_NUM_3,
         sender,
         ZERO,
-        None,
     )
     .unwrap();
 
@@ -189,7 +171,6 @@ pub fn mock_notes(
         SERIAL_NUM_7,
         sender,
         ZERO,
-        None,
     )
     .unwrap();
 
@@ -236,7 +217,6 @@ pub fn mock_notes(
         SERIAL_NUM_8,
         sender,
         ZERO,
-        None,
     )
     .unwrap();
 

--- a/mock/src/mock/transaction.rs
+++ b/mock/src/mock/transaction.rs
@@ -10,14 +10,17 @@ use super::{
 };
 use miden_lib::assembler::assembler;
 use miden_objects::{
-    accounts::Account, notes::Note, transaction::ExecutedTransaction, utils::collections::Vec,
+    accounts::Account,
+    notes::{Note, RecordedNote},
+    transaction::ExecutedTransaction,
+    utils::collections::Vec,
     BlockHeader, ChainMmr, Felt, FieldElement,
 };
 
 pub fn mock_inputs(
     account_type: MockAccountType,
     asset_preservation: AssetPreservationStatus,
-) -> (Account, BlockHeader, ChainMmr, Vec<Note>) {
+) -> (Account, BlockHeader, ChainMmr, Vec<RecordedNote>) {
     // Create assembler and assembler context
     let assembler = assembler();
 
@@ -39,10 +42,10 @@ pub fn mock_inputs(
     };
 
     // mock notes
-    let (mut consumed_notes, _created_notes) = mock_notes(&assembler, &asset_preservation);
+    let (consumed_notes, _created_notes) = mock_notes(&assembler, &asset_preservation);
 
     // Chain data
-    let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
+    let (chain_mmr, recorded_notes) = mock_chain_data(consumed_notes);
 
     // Block header
     let block_header = mock_block_header(
@@ -53,7 +56,7 @@ pub fn mock_inputs(
     );
 
     // Transaction inputs
-    (account, block_header, chain_mmr, consumed_notes)
+    (account, block_header, chain_mmr, recorded_notes)
 }
 
 pub fn mock_inputs_with_existing(
@@ -61,7 +64,7 @@ pub fn mock_inputs_with_existing(
     asset_preservation: AssetPreservationStatus,
     account: Option<Account>,
     consumed_notes_from: Option<Vec<Note>>,
-) -> (Account, BlockHeader, ChainMmr, Vec<Note>) {
+) -> (Account, BlockHeader, ChainMmr, Vec<RecordedNote>) {
     // Create assembler and assembler context
     let assembler = assembler();
 
@@ -92,7 +95,7 @@ pub fn mock_inputs_with_existing(
     }
 
     // Chain data
-    let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
+    let (chain_mmr, recorded_notes) = mock_chain_data(consumed_notes);
 
     // Block header
     let block_header = mock_block_header(
@@ -103,7 +106,7 @@ pub fn mock_inputs_with_existing(
     );
 
     // Transaction inputs
-    (account, block_header, chain_mmr, consumed_notes)
+    (account, block_header, chain_mmr, recorded_notes)
 }
 
 pub fn mock_executed_tx(asset_preservation: AssetPreservationStatus) -> ExecutedTransaction {
@@ -118,10 +121,10 @@ pub fn mock_executed_tx(asset_preservation: AssetPreservationStatus) -> Executed
         mock_account(Felt::new(2), Some(initial_account.code().clone()), &assembler);
 
     // mock notes
-    let (mut consumed_notes, created_notes) = mock_notes(&assembler, &asset_preservation);
+    let (consumed_notes, created_notes) = mock_notes(&assembler, &asset_preservation);
 
     // Chain data
-    let chain_mmr: ChainMmr = mock_chain_data(&mut consumed_notes);
+    let (chain_mmr, recorded_notes) = mock_chain_data(consumed_notes);
 
     // Block header
     let block_header = mock_block_header(
@@ -136,7 +139,7 @@ pub fn mock_executed_tx(asset_preservation: AssetPreservationStatus) -> Executed
         initial_account,
         None,
         final_account,
-        consumed_notes,
+        recorded_notes,
         created_notes,
         None,
         block_header,

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -2,7 +2,7 @@ use crate::{
     accounts::validate_account_seed,
     transaction::{
         utils, Account, AdviceInputs, BlockHeader, ChainMmr, ConsumedNotes, Digest, Note,
-        StackInputs, Vec, Word,
+        RecordedNote, StackInputs, Vec, Word,
     },
     ExecutedTransactionError,
 };
@@ -27,7 +27,7 @@ impl ExecutedTransaction {
         initial_account: Account,
         initial_account_seed: Option<Word>,
         final_account: Account,
-        consumed_notes: Vec<Note>,
+        consumed_notes: Vec<RecordedNote>,
         created_notes: Vec<Note>,
         tx_script_root: Option<Digest>,
         block_header: BlockHeader,

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     accounts::{Account, AccountId},
-    notes::{Note, NoteEnvelope},
+    notes::{Note, NoteEnvelope, RecordedNote},
     utils::collections::Vec,
     AdviceInputs, AdviceInputsBuilder, BlockHeader, ChainMmr, Digest, Felt, Hasher,
     PreparedTransactionError, StarkField, ToAdviceInputs, TransactionWitnessError, Word, WORD_SIZE,

--- a/objects/src/transaction/prepared_tx.rs
+++ b/objects/src/transaction/prepared_tx.rs
@@ -1,8 +1,8 @@
 use crate::{
     accounts::validate_account_seed,
     transaction::{
-        utils, Account, AdviceInputs, BlockHeader, ChainMmr, ConsumedNotes, Digest, Note,
-        PreparedTransactionError, Program, StackInputs, Vec, Word,
+        utils, Account, AdviceInputs, BlockHeader, ChainMmr, ConsumedNotes, Digest,
+        PreparedTransactionError, Program, RecordedNote, StackInputs, Vec, Word,
     },
 };
 
@@ -31,7 +31,7 @@ impl PreparedTransaction {
         account_seed: Option<Word>,
         block_header: BlockHeader,
         block_chain: ChainMmr,
-        consumed_notes: Vec<Note>,
+        consumed_notes: Vec<RecordedNote>,
         tx_script_root: Option<Digest>,
         tx_program: Program,
     ) -> Result<Self, PreparedTransactionError> {

--- a/objects/src/transaction/utils.rs
+++ b/objects/src/transaction/utils.rs
@@ -1,6 +1,6 @@
 use super::{
     Account, AccountId, AdviceInputs, BlockHeader, ChainMmr, ConsumedNotes, Digest, Felt, Hasher,
-    Note, StackInputs, StackOutputs, ToAdviceInputs, Vec, Word, ZERO,
+    Note, RecordedNote, StackInputs, StackOutputs, ToAdviceInputs, Vec, Word, ZERO,
 };
 use vm_core::utils::IntoBytes;
 
@@ -83,11 +83,11 @@ pub fn generate_advice_provider_inputs(
 /// Returns the consumed notes commitment.
 /// This is a sequential hash of all (nullifier, script_root) pairs for the notes consumed in the
 /// transaction.
-pub fn generate_consumed_notes_commitment(notes: &[Note]) -> Digest {
-    let mut elements: Vec<Felt> = Vec::with_capacity(notes.len() * 8);
-    for note in notes.iter() {
-        elements.extend_from_slice(note.nullifier().as_elements());
-        elements.extend_from_slice(note.script().hash().as_elements());
+pub fn generate_consumed_notes_commitment(recorded_notes: &[RecordedNote]) -> Digest {
+    let mut elements: Vec<Felt> = Vec::with_capacity(recorded_notes.len() * 8);
+    for recorded_note in recorded_notes.iter() {
+        elements.extend_from_slice(recorded_note.note().nullifier().as_elements());
+        elements.extend_from_slice(recorded_note.note().script().hash().as_elements());
     }
     Hasher::hash_elements(&elements)
 }


### PR DESCRIPTION
This PR introduces the a `RecordedNote` object which represents a `Note` which has been been included in the miden notes database. This addresses the points raised in #113. It is structured as follows:

```rust
pub struct RecordedNote {
    note: Note,
    proof: NoteInclusionProof,
}
```

This eliminates the need to have an optional `NoteInclusionProof` in the `Note` struct which then has to be unwrapped in the advice inputs builder logic.  Some changes were required to the `mock` crate.  I would appreciate a review of these changes from @hackaugusto who is most familiar with it.

closes: #113 