### PR TITLE
Add mock function `empty_mmr_peaks()`

### DIFF
--- a/mock/src/mock/mmr_peaks.rs
+++ b/mock/src/mock/mmr_peaks.rs
@@ -1,0 +1,5 @@
+use miden_test_utils::crypto::MmrPeaks;
+
+pub fn empty_mmr_peaks() -> MmrPeaks {
+    MmrPeaks::new(0, Vec::new()).unwrap()
+}

--- a/mock/src/mock/mod.rs
+++ b/mock/src/mock/mod.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod block;
 pub mod chain;
 pub mod notes;
+pub mod mmr_peaks;
 pub mod transaction;
 
 use super::builders;

--- a/mock/src/mock/mod.rs
+++ b/mock/src/mock/mod.rs
@@ -1,8 +1,8 @@
 pub mod account;
 pub mod block;
 pub mod chain;
-pub mod notes;
 pub mod mmr_peaks;
+pub mod notes;
 pub mod transaction;
 
 use super::builders;


### PR DESCRIPTION
Adds a mock function to create an empty `MmrPeaks`.

Outcome of discussion: https://github.com/0xPolygonMiden/crypto/pull/218