### PR TITLE
Change account procedure ordering

### DIFF
--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -15,13 +15,14 @@ use mock::{
     constants::{
         non_fungible_asset, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
         ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
-        ACCOUNT_PROCEDURE_INCR_NONCE_MAST_ROOT, ACCOUNT_PROCEDURE_SET_CODE_MAST_ROOT,
-        ACCOUNT_PROCEDURE_SET_ITEM_MAST_ROOT, CHILD_ROOT_PARENT_LEAF_INDEX, CHILD_SMT_DEPTH,
+        ACCOUNT_PROCEDURE_INCR_NONCE_PROC_IDX, ACCOUNT_PROCEDURE_SET_CODE_PROC_IDX,
+        ACCOUNT_PROCEDURE_SET_ITEM_PROC_IDX, CHILD_ROOT_PARENT_LEAF_INDEX, CHILD_SMT_DEPTH,
         CHILD_STORAGE_INDEX_0, FUNGIBLE_ASSET_AMOUNT,
     },
     mock::{account::MockAccountType, notes::AssetPreservationStatus, transaction::mock_inputs},
     utils::prepare_word,
 };
+use vm_core::utils::to_hex;
 use vm_processor::MemAdviceProvider;
 
 // TESTS
@@ -102,6 +103,19 @@ fn test_transaction_result_account_delta() {
     let removed_asset_3 = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
     let removed_assets = vec![removed_asset_1, removed_asset_2, removed_asset_3];
 
+    let account_procedure_incr_nonce_mast_root = to_hex(
+        &data_store.account.code().procedures()[ACCOUNT_PROCEDURE_INCR_NONCE_PROC_IDX].as_bytes(),
+    )
+    .unwrap();
+    let account_procedure_set_code_mast_root = to_hex(
+        &data_store.account.code().procedures()[ACCOUNT_PROCEDURE_SET_CODE_PROC_IDX].as_bytes(),
+    )
+    .unwrap();
+    let account_procedure_set_item_mast_root = to_hex(
+        &data_store.account.code().procedures()[ACCOUNT_PROCEDURE_SET_ITEM_PROC_IDX].as_bytes(),
+    )
+    .unwrap();
+
     let tx_script = format!(
         "\
         use.miden::sat::account
@@ -114,12 +128,12 @@ fn test_transaction_result_account_delta() {
             push.0 movdn.5 push.0 movdn.5 push.0 movdn.5
             # => [index, V', 0, 0, 0]
 
-            call.{ACCOUNT_PROCEDURE_SET_ITEM_MAST_ROOT}
+            call.0x{account_procedure_set_item_mast_root}
             # => [R', V]
         end
 
         proc.set_code
-            call.{ACCOUNT_PROCEDURE_SET_CODE_MAST_ROOT}
+            call.0x{account_procedure_set_code_mast_root}
             # => [0, 0, 0, 0]
 
             dropw
@@ -127,7 +141,7 @@ fn test_transaction_result_account_delta() {
         end
 
         proc.incr_nonce
-            call.{ACCOUNT_PROCEDURE_INCR_NONCE_MAST_ROOT}
+            call.0x{account_procedure_incr_nonce_mast_root}
             # => [0]
 
             drop

--- a/mock/src/constants.rs
+++ b/mock/src/constants.rs
@@ -1,3 +1,7 @@
+pub use super::mock::account::{
+    ACCOUNT_PROCEDURE_INCR_NONCE_PROC_IDX, ACCOUNT_PROCEDURE_SET_CODE_PROC_IDX,
+    ACCOUNT_PROCEDURE_SET_ITEM_PROC_IDX,
+};
 use miden_objects::{
     accounts::{AccountId, StorageItem},
     assets::{Asset, NonFungibleAsset, NonFungibleAssetDetails},
@@ -66,13 +70,6 @@ pub const DEFAULT_ACCOUNT_CODE: &str = "
     export.basic_wallet::send_asset
     export.basic_eoa::auth_tx_rpo_falcon512
 ";
-
-pub const ACCOUNT_PROCEDURE_INCR_NONCE_MAST_ROOT: &str =
-    "0xd765111e22479256e87a57eaf3a27479d19cc876c9a715ee6c262e0a0d47a2ac";
-pub const ACCOUNT_PROCEDURE_SET_CODE_MAST_ROOT: &str =
-    "0x9d221abcc386973775499406d126764cdf4530ccf8084e27091f7e9f28177bbe";
-pub const ACCOUNT_PROCEDURE_SET_ITEM_MAST_ROOT: &str =
-    "0x49935297f029f8b229fe86c6c47b9d291d063b8558fe90319128fb60dbda3d1b";
 
 pub const CONSUMED_ASSET_1_AMOUNT: u64 = 100;
 pub const CONSUMED_ASSET_2_AMOUNT: u64 = 200;

--- a/mock/src/mock/account.rs
+++ b/mock/src/mock/account.rs
@@ -58,15 +58,23 @@ pub fn mock_account_storage() -> AccountStorage {
     .unwrap()
 }
 
+// Constants that define the indexes of the account procedures of interest
+pub const ACCOUNT_PROCEDURE_INCR_NONCE_PROC_IDX: usize = 2;
+pub const ACCOUNT_PROCEDURE_SET_ITEM_PROC_IDX: usize = 3;
+pub const ACCOUNT_PROCEDURE_SET_CODE_PROC_IDX: usize = 4;
+
 pub fn mock_account_code(assembler: &Assembler) -> AccountCode {
     let account_code = "\
             use.miden::sat::account
             use.miden::sat::tx
             use.miden::wallets::basic->wallet
 
+            # acct proc 0
             export.wallet::receive_asset
+            # acct proc 1
             export.wallet::send_asset
 
+            # acct proc 2
             export.incr_nonce
                 push.0 swap
                 # => [value, 0]
@@ -75,6 +83,7 @@ pub fn mock_account_code(assembler: &Assembler) -> AccountCode {
                 # => [0]
             end
 
+            # acct proc 3
             export.set_item
                 exec.account::set_item
                 # => [R', V, 0, 0, 0]
@@ -83,6 +92,7 @@ pub fn mock_account_code(assembler: &Assembler) -> AccountCode {
                 # => [R', V]
             end
 
+            # acct proc 4
             export.set_code
                 padw swapw
                 # => [CODE_ROOT, 0, 0, 0, 0]
@@ -91,6 +101,7 @@ pub fn mock_account_code(assembler: &Assembler) -> AccountCode {
                 # => [0, 0, 0, 0]
             end
 
+            # acct proc 5
             export.create_note
                 # apply padding
                 repeat.8
@@ -102,11 +113,13 @@ pub fn mock_account_code(assembler: &Assembler) -> AccountCode {
                 # => [ptr, 0, 0, 0, 0, 0, 0, 0, 0]
             end
 
+            # acct proc 6
             export.account_procedure_1
                 push.1.2
                 add
             end
 
+            # acct proc 7
             export.account_procedure_2
                 push.2.1
                 sub


### PR DESCRIPTION
This PR changes the ordering of account code procedures. Procedures digest are now stored in the order they are defined in the source code module in the `code.procedures` field.  This allows the user to achieve a mapping between procedure index and procedure mast root. 

We then order the procedures when constructing the Merkle tree which is used to commit to the procedures such that we get a standardised commitment for a given set of procedures. 

Using this updated implementation we address the issues in #303.

closes: #303 