### PR TITLE
Introduce `from_parts` constructor for Note object

### DIFF
--- a/objects/src/notes/envelope.rs
+++ b/objects/src/notes/envelope.rs
@@ -11,7 +11,7 @@ use vm_core::StarkField;
 ///   it is four elements in size (a word). The metadata includes the following elements:
 ///     - sender
 ///     - tag
-///     - ZERO
+///     - num assets
 ///     - ZERO
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -56,7 +56,7 @@ pub const NOTE_LEAF_DEPTH: u8 = NOTE_TREE_DEPTH + 1;
 /// Auxiliary data which is used to verify authenticity and signal additional information:
 /// - A metadata object which contains information about the sender, the tag and the number of
 ///   assets in the note.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Note {
     script: NoteScript,
@@ -93,6 +93,23 @@ impl Note {
             serial_num,
             metadata: NoteMetadata::new(sender, tag, Felt::new(num_assets as u64)),
         })
+    }
+
+    /// Returns a note instance created from the provided parts.
+    pub fn from_parts(
+        script: NoteScript,
+        inputs: NoteInputs,
+        vault: NoteVault,
+        serial_num: Word,
+        metadata: NoteMetadata,
+    ) -> Self {
+        Self {
+            script,
+            inputs,
+            vault,
+            serial_num,
+            metadata,
+        }
     }
 
     // PUBLIC ACCESSORS
@@ -185,7 +202,7 @@ impl Note {
 /// This struct is composed:
 /// - A note which has been recorded.
 /// - The inclusion proof of the note.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RecordedNote {
     note: Note,

--- a/objects/src/notes/origin.rs
+++ b/objects/src/notes/origin.rs
@@ -2,7 +2,7 @@ use super::{Digest, Felt, NoteError, ToString, NOTE_TREE_DEPTH};
 use crate::crypto::merkle::{MerklePath, NodeIndex};
 
 /// Contains information about the origin of a note.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteOrigin {
     pub block_num: Felt,
@@ -18,7 +18,7 @@ pub struct NoteOrigin {
 ///              in.
 /// note_path  - the Merkle path to the note in the note Merkle tree of the block the note was
 ///              created in.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteInclusionProof {
     origin: NoteOrigin,

--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -1,6 +1,6 @@
 use super::{Assembler, AssemblyContext, CodeBlock, Digest, NoteError, ProgramAst};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteScript {
     hash: Digest,


### PR DESCRIPTION
This PR introduces a `from_parts` constructor for the `Note` object.