### PR TITLE
Implement `ToAdviceInputs` for `MmrPeaks`

### DIFF
--- a/objects/src/advice.rs
+++ b/objects/src/advice.rs
@@ -1,6 +1,7 @@
 use super::{utils::collections::Vec, AdviceInputs, Felt, Word};
 use crate::crypto::merkle::InnerNodeInfo;
 use assembly::utils::IntoBytes;
+use miden_crypto::{merkle::MmrPeaks, ZERO};
 
 /// [AdviceInputsBuilder] trait specifies the interface for building advice inputs.
 /// The trait provides three methods for building advice inputs:
@@ -18,14 +19,6 @@ pub trait AdviceInputsBuilder {
     fn add_merkle_nodes<I: Iterator<Item = InnerNodeInfo>>(&mut self, nodes: I);
 }
 
-/// ToAdviceInputs trait specifies the interface for converting a rust object into advice inputs.
-pub trait ToAdviceInputs {
-    /// Converts the rust object into advice inputs and pushes them onto the given advice inputs
-    /// builder.
-    fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T);
-}
-
-/// Implement the `AdviceInputsBuilder` trait on `AdviceInputs`.
 impl AdviceInputsBuilder for AdviceInputs {
     fn push_onto_stack(&mut self, values: &[Felt]) {
         self.extend_stack(values.iter().copied());
@@ -37,5 +30,31 @@ impl AdviceInputsBuilder for AdviceInputs {
 
     fn add_merkle_nodes<I: Iterator<Item = InnerNodeInfo>>(&mut self, nodes: I) {
         self.extend_merkle_store(nodes);
+    }
+}
+
+/// ToAdviceInputs trait specifies the interface for converting a rust object into advice inputs.
+pub trait ToAdviceInputs {
+    /// Converts the rust object into advice inputs and pushes them onto the given advice inputs
+    /// builder.
+    fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T);
+}
+
+// ToAdviceInputs IMPLEMENTATIONS
+// =================================================================================================
+
+impl ToAdviceInputs for MmrPeaks {
+    fn to_advice_inputs<T: AdviceInputsBuilder>(&self, target: &mut T) {
+        // create the vector of items to insert into the map
+        // The vector is in the following format:
+        //    elements[0]       = number of leaves in the Mmr
+        //    elements[1..4]    = padding ([Felt::ZERO; 3])
+        //    elements[4..]     = Mmr peak roots
+        let mut elements = vec![Felt::new(self.num_leaves() as u64), ZERO, ZERO, ZERO];
+        elements.extend(self.flatten_and_pad_peaks());
+
+        // insert the Mmr accumulator vector into the advice map against the Mmr root, which acts
+        // as the key.
+        target.insert_into_map(self.hash_peaks().into(), elements);
     }
 }

--- a/objects/src/chain/mod.rs
+++ b/objects/src/chain/mod.rs
@@ -1,4 +1,4 @@
-use super::{crypto::merkle::Mmr, AdviceInputsBuilder, Felt, ToAdviceInputs, ZERO};
+use super::{crypto::merkle::Mmr, AdviceInputsBuilder, ToAdviceInputs};
 
 // TODO: Consider using a PartialMmr that only contains the Mmr nodes that are relevant to the
 // transaction being processed.
@@ -35,16 +35,6 @@ impl ToAdviceInputs for &ChainMmr {
         // Extract Mmr accumulator
         let accumulator = self.0.peaks(self.0.forest()).unwrap();
 
-        // create the vector of items to insert into the map
-        // The vector is in the following format:
-        //    elements[0]       = number of leaves in the Mmr
-        //    elements[1..4]    = padding ([Felt::ZERO; 3])
-        //    elements[4..]     = Mmr peak roots
-        let mut elements = vec![Felt::new(accumulator.num_leaves() as u64), ZERO, ZERO, ZERO];
-        elements.extend(accumulator.flatten_and_pad_peaks());
-
-        // insert the Mmr accumulator vector into the advice map against the Mmr root, which acts
-        // as the key.
-        target.insert_into_map(accumulator.hash_peaks().into(), elements);
+        accumulator.to_advice_inputs(target);
     }
 }


### PR DESCRIPTION
Implements `ToAdviceInputs` for `MmrPeaks`. This is necessary for me to be able to reuse that logic in the `miden-node`'s block producer, which was locked in the `ChainMmr::ToAdviceInputs` impl.

Specifically, the store returns the `MmrPeaks` of the chain MMR [as part of the `BlockInputs`](https://github.com/0xPolygonMiden/miden-node/blob/43ab472e1117484cc21fd6627117f7ab9ba9af15/proto/src/domain/mod.rs#L24). that is, the block producer doesn't have access to the full `Mmr`, but still needs to convert the `MmrPeaks` to `AdviceInputs`.

In another PR, I would also remove the type `ChainMmr`, as it is a wrapper that does nothing other than implement `ToAdviceInputs`. I would rather implement `ToAdviceInputs` on `Mmr` directly, in `miden_objects::advice` (next to the implementation for `MmrPeaks`). And ultimately, implement `ToAdviceInputs` for all relevant types there, similar to what the standard library [does with](https://doc.rust-lang.org/std/convert/trait.From.html) `From`.