### PR TITLE
docs: fix gif

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+markdown: GFM

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -14,7 +14,7 @@ The [Actor Model](https://en.wikipedia.org/wiki/Actor_model) inspired Miden to a
 In Miden, there are accounts and notes which can hold assets. Accounts consume and produce notes in transactions. Transactions describe account state changes of single accounts. The state model captures all individual states of all accounts and notes. Finally, the execution model describes state progress in a sequence of blocks.
 
 <p align="center">
-    <img src="../diagrams/architecture/miden_architecture.gif" style="width: 80%;">
+    <img src="./diagrams/architecture/miden_architecture.gif" style="width: 80%;">
 </p>
 
 ### Accounts


### PR DESCRIPTION
The cool new gif that captures the gist of Miden can not be rendered with the GitHubPages standard renderer. 

The problem here is that Markdown on GitHub.com is rendered with our [CommonMark-compatible renderer](https://blog.github.com/2017-03-14-a-formal-spec-for-github-flavored-markdown/), but Pages by default uses kramdown. See here https://github.com/github/markup/issues/1215
