### PR TITLE
serialization: add serde to more structures

### DIFF
--- a/objects/src/accounts/delta.rs
+++ b/objects/src/accounts/delta.rs
@@ -34,6 +34,7 @@ pub struct AccountDelta {
 /// - slots_delta: a `MerkleTreeDelta` that represents the changes to the account storage slots.
 /// - store_delta: a `MerkleStoreDelta` that represents the changes to the account storage store.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AccountStorageDelta {
     pub slots_delta: MerkleTreeDelta,
     pub store_delta: MerkleStoreDelta,
@@ -57,6 +58,7 @@ impl Default for AccountStorageDelta {
 /// - added_assets: a vector of assets that were added to the account vault.
 /// - removed_assets: a vector of assets that were removed from the account vault.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AccountVaultDelta {
     pub added_assets: Vec<Asset>,
     pub removed_assets: Vec<Asset>,

--- a/objects/src/assets/token_symbol.rs
+++ b/objects/src/assets/token_symbol.rs
@@ -2,6 +2,8 @@ use super::{AssetError, Felt, StarkField, ToString};
 use crate::utils::string::String;
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct TokenSymbol(Felt);
 
 impl TokenSymbol {

--- a/objects/src/transaction/account_stub.rs
+++ b/objects/src/transaction/account_stub.rs
@@ -3,4 +3,6 @@ use crate::accounts::AccountStub;
 // FINAL ACCOUNT STUB
 // ================================================================================================
 /// [FinalAccountStub] represents a stub of an account after a transaction has been executed.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct FinalAccountStub(pub AccountStub);

--- a/objects/src/transaction/consumed_notes.rs
+++ b/objects/src/transaction/consumed_notes.rs
@@ -11,6 +11,7 @@ use super::{
 /// This objects primary use case is to enable all consumed notes to be populated into the advice
 /// provider at once via the [ToAdviceInputs] trait.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ConsumedNotes {
     notes: Vec<RecordedNote>,
     commitment: Digest,
@@ -118,6 +119,7 @@ impl FromIterator<RecordedNote> for ConsumedNotes {
 /// - nullifier: nullifier of the note that was consumed
 /// - script_root: script root of the note that was consumed
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ConsumedNoteInfo {
     nullifier: Digest,
     script_root: Digest,

--- a/objects/src/transaction/created_notes.rs
+++ b/objects/src/transaction/created_notes.rs
@@ -13,6 +13,7 @@ use core::iter::FromIterator;
 /// - notes: a vector of [NoteStub] objects representing the notes created by the transaction.
 /// - commitment: a commitment to the created notes.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CreatedNotes {
     notes: Vec<NoteStub>,
     commitment: Digest,

--- a/objects/src/transaction/event.rs
+++ b/objects/src/transaction/event.rs
@@ -4,6 +4,7 @@ use vm_processor::ExecutionError;
 /// `emit.<event_id>` instruction. The event ID is a 32-bit unsigned integer which is used to
 /// identify the event type.
 #[repr(u32)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Event {
     AddAssetToAccountVault = 131072,
     RemoveAssetFromAccountVault = 131073,

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -10,6 +10,7 @@ use crate::{
 use vm_core::StackOutputs;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ExecutedTransaction {
     initial_account: Account,
     initial_account_seed: Option<Word>,


### PR DESCRIPTION
Enable serde to more structures.

I need the one for the locally proven transaction, otherwise I would have to model each individual item via protobuf.