### PR TITLE
Expose `ToAdviceInputs`

### DIFF
--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -9,7 +9,8 @@ use vm_processor::AdviceInputs;
 pub mod accounts;
 
 mod advice;
-use advice::{AdviceInputsBuilder, ToAdviceInputs};
+use advice::AdviceInputsBuilder;
+pub use advice::ToAdviceInputs;
 
 pub mod assets;
 pub mod notes;


### PR DESCRIPTION
Expose `ToAdviceInputs` for use in `miden-node` and others