### PR TITLE
Re-export `ProvingOptions`

### DIFF
--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -23,7 +23,7 @@ pub mod host;
 pub use host::TransactionHost;
 
 mod prover;
-pub use prover::TransactionProver;
+pub use prover::{ProvingOptions, TransactionProver};
 
 mod result;
 pub use result::TryFromVmResult;

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -2,7 +2,8 @@ use super::{TransactionHost, TransactionProverError};
 use crate::TryFromVmResult;
 use miden_objects::transaction::{CreatedNotes, FinalAccountStub};
 use miden_objects::transaction::{PreparedTransaction, ProvenTransaction, TransactionWitness};
-use miden_prover::{prove, ProvingOptions};
+use miden_prover::prove;
+pub use miden_prover::ProvingOptions;
 use vm_processor::MemAdviceProvider;
 
 /// The [TransactionProver] is a stateless component which is responsible for proving transactions.

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -75,7 +75,7 @@ impl ExecutedTransaction {
         &self.tx_script
     }
 
-    /// Returns the block reference.
+    /// Returns the block hash.
     pub fn block_hash(&self) -> Digest {
         self.block_header.hash()
     }


### PR DESCRIPTION
Needed to utilize the prover correctly from the client.