### PR TITLE
Change `block_num` type to `u32`

### DIFF
--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -170,7 +170,7 @@ fn block_data_memory_assertions<A: AdviceProvider>(
     // The block number should be stored at BLOCK_METADATA_PTR[BLOCK_NUMBER_IDX]
     assert_eq!(
         process.get_mem_value(ContextId::root(), BLOCK_METADATA_PTR).unwrap()[BLOCK_NUMBER_IDX],
-        inputs.block_header().block_num()
+        inputs.block_header().block_num().into()
     );
 
     // The protocol version should be stored at BLOCK_METADATA_PTR[PROTOCOL_VERSION_IDX]

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     assets::{Asset, FungibleAsset},
     notes::RecordedNote,
     transaction::{CreatedNotes, FinalAccountStub},
-    Felt, StarkField, Word,
+    Felt, Word,
 };
 use miden_prover::ProvingOptions;
 use mock::{
@@ -36,7 +36,7 @@ fn test_transaction_executor_witness() {
     let account_id = data_store.account.id();
     executor.load_account(account_id).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -219,7 +219,7 @@ fn test_transaction_result_account_delta() {
     let tx_script_code = ProgramAst::parse(&tx_script).unwrap();
     let tx_script = executor.compile_tx_script(tx_script_code, vec![], vec![]).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -286,7 +286,7 @@ fn test_prove_witness_and_verify() {
     let account_id = data_store.account.id();
     executor.load_account(account_id).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -313,7 +313,7 @@ fn test_prove_and_verify_with_tx_executor() {
     let account_id = data_store.account.id();
     executor.load_account(account_id).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -342,7 +342,7 @@ fn test_tx_script() {
     let account_id = data_store.account.id();
     executor.load_account(account_id).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -422,7 +422,7 @@ impl DataStore for MockDataStore {
     ) -> Result<(Account, BlockHeader, ChainMmr, Vec<RecordedNote>, AdviceInputs), DataStoreError>
     {
         assert_eq!(account_id, self.account.id());
-        assert_eq!(block_num as u64, self.block_header.block_num().as_int());
+        assert_eq!(block_num, self.block_header.block_num());
         assert_eq!(notes.len(), self.notes.len());
         let origins = self.notes.iter().map(|note| note.origin()).collect::<Vec<_>>();
         notes.iter().all(|note| origins.contains(&note));

--- a/miden-tx/tests/common/mod.rs
+++ b/miden-tx/tests/common/mod.rs
@@ -6,7 +6,7 @@ use miden_objects::{
     assets::{Asset, FungibleAsset},
     crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
     notes::{Note, NoteOrigin, NoteScript, RecordedNote},
-    BlockHeader, ChainMmr, Felt, StarkField, Word,
+    BlockHeader, ChainMmr, Felt, Word,
 };
 use miden_tx::{DataStore, DataStoreError};
 use mock::{
@@ -82,7 +82,7 @@ impl DataStore for MockDataStore {
     ) -> Result<(Account, BlockHeader, ChainMmr, Vec<RecordedNote>, AdviceInputs), DataStoreError>
     {
         assert_eq!(account_id, self.account.id());
-        assert_eq!(block_num as u64, self.block_header.block_num().as_int());
+        assert_eq!(block_num, self.block_header.block_num());
         assert_eq!(notes.len(), self.notes.len());
         let origins = self.notes.iter().map(|note| note.origin()).collect::<Vec<_>>();
         notes.iter().all(|note| origins.contains(&note));

--- a/miden-tx/tests/test_miden_faucet_contract.rs
+++ b/miden-tx/tests/test_miden_faucet_contract.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     assets::{Asset, FungibleAsset, TokenSymbol},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
     notes::{NoteMetadata, NoteStub, NoteVault},
-    Felt, StarkField, Word, ZERO,
+    Felt, Word, ZERO,
 };
 use miden_tx::TransactionExecutor;
 use mock::{constants::ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, utils::prepare_word};
@@ -31,7 +31,7 @@ fn test_faucet_contract_mint_fungible_asset_succeeds() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(faucet_account.id()).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -102,7 +102,7 @@ fn test_faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(faucet_account.id()).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -201,7 +201,7 @@ fn test_faucet_contract_burn_fungible_asset_succeeds() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(faucet_account.id()).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 

--- a/miden-tx/tests/test_miden_note_scripts.rs
+++ b/miden-tx/tests/test_miden_note_scripts.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     assembly::ProgramAst,
     assets::{Asset, FungibleAsset},
     utils::collections::Vec,
-    Felt, StarkField,
+    Felt,
 };
 use miden_tx::TransactionExecutor;
 use mock::constants::{
@@ -57,7 +57,7 @@ fn test_p2id_script() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account_id).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -122,7 +122,7 @@ fn test_p2id_script() {
         )
         .unwrap();
 
-    let block_ref = data_store_malicious_account.block_header.block_num().as_int() as u32;
+    let block_ref = data_store_malicious_account.block_header.block_num();
     let note_origins = data_store_malicious_account
         .notes
         .iter()
@@ -182,7 +182,7 @@ fn test_p2id_script_multiple_assets() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account_id).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -247,7 +247,7 @@ fn test_p2id_script_multiple_assets() {
         )
         .unwrap();
 
-    let block_ref = data_store_malicious_account.block_header.block_num().as_int() as u32;
+    let block_ref = data_store_malicious_account.block_header.block_num();
     let note_origins = data_store_malicious_account
         .notes
         .iter()
@@ -351,7 +351,7 @@ fn test_p2idr_script() {
 
     executor_1.load_account(target_account_id).unwrap();
 
-    let block_ref_1 = data_store_1.block_header.block_num().as_int() as u32;
+    let block_ref_1 = data_store_1.block_header.block_num();
     let note_origins =
         data_store_1.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -413,7 +413,7 @@ fn test_p2idr_script() {
         )
         .unwrap();
 
-    let block_ref_2 = data_store_2.block_header.block_num().as_int() as u32;
+    let block_ref_2 = data_store_2.block_header.block_num();
     let note_origins_2 =
         data_store_2.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -446,7 +446,7 @@ fn test_p2idr_script() {
         )
         .unwrap();
 
-    let block_ref_3 = data_store_3.block_header.block_num().as_int() as u32;
+    let block_ref_3 = data_store_3.block_header.block_num();
     let note_origins_3 =
         data_store_3.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -472,7 +472,7 @@ fn test_p2idr_script() {
     let mut executor_4 = TransactionExecutor::new(data_store_4.clone());
     executor_4.load_account(target_account_id).unwrap();
 
-    let block_ref_4 = data_store_4.block_header.block_num().as_int() as u32;
+    let block_ref_4 = data_store_4.block_header.block_num();
     let note_origins_4 =
         data_store_4.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -512,7 +512,7 @@ fn test_p2idr_script() {
 
     executor_5.load_account(sender_account_id).unwrap();
 
-    let block_ref_5 = data_store_5.block_header.block_num().as_int() as u32;
+    let block_ref_5 = data_store_5.block_header.block_num();
     let note_origins =
         data_store_5.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -546,7 +546,7 @@ fn test_p2idr_script() {
 
     executor_6.load_account(malicious_account_id).unwrap();
 
-    let block_ref_6 = data_store_6.block_header.block_num().as_int() as u32;
+    let block_ref_6 = data_store_6.block_header.block_num();
     let note_origins_6 =
         data_store_6.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 

--- a/miden-tx/tests/test_miden_wallet.rs
+++ b/miden-tx/tests/test_miden_wallet.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     assembly::ProgramAst,
     assets::{Asset, FungibleAsset},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
-    Felt, StarkField, Word, ONE, ZERO,
+    Felt, Word, ONE, ZERO,
 };
 use miden_tx::TransactionExecutor;
 use mock::{
@@ -64,7 +64,7 @@ fn test_receive_asset_via_wallet() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account.id()).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 
@@ -132,7 +132,7 @@ fn test_send_asset_via_wallet() {
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(sender_account.id()).unwrap();
 
-    let block_ref = data_store.block_header.block_num().as_int() as u32;
+    let block_ref = data_store.block_header.block_num();
     let note_origins =
         data_store.notes.iter().map(|note| note.origin().clone()).collect::<Vec<_>>();
 

--- a/mock/src/mock/block.rs
+++ b/mock/src/mock/block.rs
@@ -5,7 +5,7 @@ use miden_objects::{
 use miden_test_utils::rand;
 
 pub fn mock_block_header(
-    block_num: Felt,
+    block_num: u32,
     chain_root: Option<Digest>,
     note_root: Option<Digest>,
     accts: &[Account],

--- a/mock/src/mock/chain.rs
+++ b/mock/src/mock/chain.rs
@@ -437,8 +437,7 @@ impl<R: Rng + SeedableRng> MockChain<R> {
     ///
     /// This will also make all the objects currently pending available for use.
     pub fn seal_block(&mut self) -> BlockHeader {
-        let block_num: u64 = self.blocks.len().try_into().expect("usize to u64 failed");
-        let block_num: Felt = block_num.into();
+        let block_num: u32 = self.blocks.len().try_into().expect("usize to u32 failed");
 
         for (account, _seed) in self.pending_objects.accounts.iter() {
             let id: Felt = account.id().into();
@@ -451,11 +450,11 @@ impl<R: Rng + SeedableRng> MockChain<R> {
 
         // TODO:
         // - resetting the nullifier tree once defined at the protocol level.
-        // - insering only nullifier from transactions included in the batches, once the batch
+        // - inserting only nullifier from transactions included in the batches, once the batch
         // kernel has been implemented.
         for nullifier in self.pending_objects.nullifiers.iter() {
             self.nullifiers
-                .insert(*nullifier, [block_num, Felt::ZERO, Felt::ZERO, Felt::ZERO]);
+                .insert(*nullifier, [block_num.into(), Felt::ZERO, Felt::ZERO, Felt::ZERO]);
         }
         let notes = self.pending_objects.build_notes_tree();
 
@@ -617,10 +616,10 @@ pub fn mock_chain_data(consumed_notes: Vec<Note>) -> (ChainMmr, Vec<RecordedNote
 
     // create a dummy chain of block headers
     let block_chain = vec![
-        mock_block_header(Felt::ZERO, None, note_tree_iter.next().map(|x| x.root()), &[]),
-        mock_block_header(Felt::ONE, None, note_tree_iter.next().map(|x| x.root()), &[]),
-        mock_block_header(Felt::new(2), None, note_tree_iter.next().map(|x| x.root()), &[]),
-        mock_block_header(Felt::new(3), None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(0, None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(1, None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(2, None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(3, None, note_tree_iter.next().map(|x| x.root()), &[]),
     ];
 
     // instantiate and populate MMR

--- a/mock/src/mock/transaction.rs
+++ b/mock/src/mock/transaction.rs
@@ -60,7 +60,7 @@ pub fn mock_inputs(
 
     // Block header
     let block_header = mock_block_header(
-        Felt::new(4),
+        4,
         Some(chain_mmr.mmr().peaks(chain_mmr.mmr().forest()).unwrap().hash_peaks()),
         None,
         &[account.clone()],
@@ -119,7 +119,7 @@ pub fn mock_inputs_with_existing(
 
     // Block header
     let block_header = mock_block_header(
-        Felt::new(4),
+        4,
         Some(chain_mmr.mmr().peaks(chain_mmr.mmr().forest()).unwrap().hash_peaks()),
         None,
         &[account.clone()],
@@ -156,7 +156,7 @@ pub fn mock_executed_tx(asset_preservation: AssetPreservationStatus) -> Executed
 
     // Block header
     let block_header = mock_block_header(
-        Felt::new(4),
+        4,
         Some(chain_mmr.mmr().peaks(chain_mmr.mmr().forest()).unwrap().hash_peaks()),
         None,
         &[initial_account.clone()],

--- a/objects/src/block/header.rs
+++ b/objects/src/block/header.rs
@@ -21,7 +21,7 @@ use super::{AdviceInputsBuilder, Digest, Felt, Hasher, ToAdviceInputs, Vec, ZERO
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct BlockHeader {
     prev_hash: Digest,
-    block_num: Felt,
+    block_num: u32,
     chain_root: Digest,
     account_root: Digest,
     nullifier_root: Digest,
@@ -39,7 +39,7 @@ impl BlockHeader {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         prev_hash: Digest,
-        block_num: Felt,
+        block_num: u32,
         chain_root: Digest,
         account_root: Digest,
         nullifier_root: Digest,
@@ -105,7 +105,7 @@ impl BlockHeader {
     }
 
     /// Returns the block number.
-    pub fn block_num(&self) -> Felt {
+    pub fn block_num(&self) -> u32 {
         self.block_num
     }
 
@@ -167,7 +167,7 @@ impl BlockHeader {
         proof_hash: Digest,
         version: Felt,
         timestamp: Felt,
-        block_num: Felt,
+        block_num: u32,
     ) -> Digest {
         let mut elements: Vec<Felt> = Vec::with_capacity(32);
         elements.extend_from_slice(prev_hash.as_elements());
@@ -176,7 +176,7 @@ impl BlockHeader {
         elements.extend_from_slice(nullifier_root.as_elements());
         elements.extend_from_slice(batch_root.as_elements());
         elements.extend_from_slice(proof_hash.as_elements());
-        elements.extend([block_num, version, timestamp, ZERO]);
+        elements.extend([block_num.into(), version, timestamp, ZERO]);
         elements.resize(32, ZERO);
         Hasher::hash_elements(&elements)
     }
@@ -191,7 +191,7 @@ impl ToAdviceInputs for &BlockHeader {
         target.push_onto_stack(self.nullifier_root.as_elements());
         target.push_onto_stack(self.batch_root.as_elements());
         target.push_onto_stack(self.proof_hash.as_elements());
-        target.push_onto_stack(&[self.block_num, self.version, self.timestamp, ZERO]);
+        target.push_onto_stack(&[self.block_num.into(), self.version, self.timestamp, ZERO]);
         target.push_onto_stack(&[ZERO; 4]);
         target.push_onto_stack(self.note_root.as_elements());
     }

--- a/objects/src/notes/origin.rs
+++ b/objects/src/notes/origin.rs
@@ -1,14 +1,14 @@
 use miden_crypto::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use vm_processor::DeserializationError;
 
-use super::{Digest, Felt, NoteError, ToString, NOTE_TREE_DEPTH};
+use super::{Digest, NoteError, ToString, NOTE_TREE_DEPTH};
 use crate::crypto::merkle::{MerklePath, NodeIndex};
 
 /// Contains information about the origin of a note.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteOrigin {
-    pub block_num: Felt,
+    pub block_num: u32,
     pub node_index: NodeIndex,
 }
 
@@ -33,7 +33,7 @@ pub struct NoteInclusionProof {
 impl NoteInclusionProof {
     /// Creates a new note origin.
     pub fn new(
-        block_num: Felt,
+        block_num: u32,
         sub_hash: Digest,
         note_root: Digest,
         index: u64,
@@ -82,14 +82,14 @@ impl NoteInclusionProof {
 
 impl Serializable for NoteOrigin {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.block_num.write_into(target);
+        target.write_u32(self.block_num);
         self.node_index.write_into(target);
     }
 }
 
 impl Deserializable for NoteOrigin {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let block_num = Felt::read_from(source)?;
+        let block_num = source.read_u32()?;
         let node_index = NodeIndex::read_from(source)?;
 
         Ok(Self {

--- a/objects/src/transaction/consumed_notes.rs
+++ b/objects/src/transaction/consumed_notes.rs
@@ -78,7 +78,7 @@ impl ToAdviceInputs for ConsumedNotes {
             note_data.extend(note.vault().to_padded_assets());
             target.insert_into_map(note.vault().hash().into(), note.vault().to_padded_assets());
 
-            note_data.push(proof.origin().block_num);
+            note_data.push(proof.origin().block_num.into());
             note_data.extend(*proof.sub_hash());
             note_data.extend(*proof.note_root());
             note_data.push(Felt::from(proof.origin().node_index.value()));


### PR DESCRIPTION
This PR changes type of `block_num` field in `BlockHeader` to `u32` as block numbers will not exceed this value (at 3-second block intervals, this gives us 400+ years of runway).