### PR TITLE
Removed unused import & improved documentation on P2ID & P2IDR scripts

### DIFF
--- a/miden-lib/asm/scripts/P2ID.masm
+++ b/miden-lib/asm/scripts/P2ID.masm
@@ -1,6 +1,5 @@
 use.miden::sat::account
 use.miden::sat::note
-use.miden::sat::tx
 use.miden::wallets::basic->wallet
 
 #! Helper procedure to add all assets of a note to an account.
@@ -49,7 +48,7 @@ end
 #
 # Requires that the account exposes: miden::wallets::basic::receive_asset procedure.
 #
-# Inputs: []
+# Inputs: [SCRIPT_ROOT]
 # Outputs: []
 #
 # Note inputs are assumed to be as follows:

--- a/miden-lib/asm/scripts/P2IDR.masm
+++ b/miden-lib/asm/scripts/P2IDR.masm
@@ -5,7 +5,7 @@ use.miden::wallets::basic->wallet
 
 #! Helper procedure to add all assets of a note to an account.
 #!
-#! Inputs: []
+#! Inputs: [SCRIPT_ROOT]
 #! Outputs: []
 #!
 proc.add_note_assets_to_account

--- a/miden-lib/asm/scripts/P2IDR.masm
+++ b/miden-lib/asm/scripts/P2IDR.masm
@@ -5,7 +5,7 @@ use.miden::wallets::basic->wallet
 
 #! Helper procedure to add all assets of a note to an account.
 #!
-#! Inputs: [SCRIPT_ROOT]
+#! Inputs: []
 #! Outputs: []
 #!
 proc.add_note_assets_to_account
@@ -48,7 +48,7 @@ end
 # matches target account ID specified by the note inputs OR matches the sender ID if the note is
 # consumed after the reclaim block height specified by the note inputs.
 #
-# Inputs: []
+# Inputs: [SCRIPT_ROOT]
 # Outputs: []
 #
 # Note inputs are assumed to be as follows:


### PR DESCRIPTION
During the implementation of the SWAP script I saw that an import wasn't used in P2ID and corrected the documentation relative to the inputs to the script on P2ID & P2IDR scripts.