### PR TITLE
Implement lazy hashing for note assets and inputs

### DIFF
--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -23,7 +23,7 @@ const MODULE_SERDE_OPTIONS: AstSerdeOptions = AstSerdeOptions::new(true);
 // ACCOUNT CODE
 // ================================================================================================
 
-/// Describes the public interface of an account.
+/// A public interface of an account.
 ///
 /// Account's public interface consists of a set of account procedures, each procedure being a Miden
 /// VM program. Thus, MAST root of each procedure commits to the underlying program. We commit to
@@ -71,7 +71,7 @@ impl AccountCode {
     /// Returns a new definition of an account's interface instantiated from the provided
     /// module and list of procedure digests.
     ///
-    /// **Note**: This function assumes that the list of provided procedure digests resulted from
+    /// **Note**: this function assumes that the list of provided procedure digests results from
     /// the compilation of the provided module, but this is not checked.
     ///
     /// # Panics

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -68,14 +68,10 @@ pub const ACCOUNT_ID_INSUFFICIENT_ONES: u64 = 0b1100000110 << 54;
 /// changed). Other components may be mutated throughout the lifetime of the account. However,
 /// account state can be changed only by invoking one of account interface methods.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Account {
     id: AccountId,
-    #[cfg_attr(feature = "serde", serde(with = "vault_serialization"))]
     vault: AccountVault,
-    #[cfg_attr(feature = "serde", serde(with = "storage_serialization"))]
     storage: AccountStorage,
-    #[cfg_attr(feature = "serde", serde(with = "code_serialization"))]
     code: AccountCode,
     nonce: Felt,
 }
@@ -179,11 +175,13 @@ impl Account {
 
 impl Serializable for Account {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.id.write_into(target);
-        self.vault.write_into(target);
-        self.storage.write_into(target);
-        self.code.write_into(target);
-        self.nonce.write_into(target);
+        let Account { id, vault, storage, code, nonce } = self;
+
+        id.write_into(target);
+        vault.write_into(target);
+        storage.write_into(target);
+        code.write_into(target);
+        nonce.write_into(target);
     }
 }
 
@@ -200,68 +198,18 @@ impl Deserializable for Account {
 }
 
 #[cfg(feature = "serde")]
-mod vault_serialization {
-    use super::AccountVault;
-    use crate::utils::serde::{Deserializable, Serializable};
-
-    pub fn serialize<S>(vault: &AccountVault, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let bytes = vault.to_bytes();
+impl serde::Serialize for Account {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let bytes = self.to_bytes();
         serializer.serialize_bytes(&bytes)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<AccountVault, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes: Vec<u8> = <Vec<u8> as serde::Deserialize>::deserialize(deserializer)?;
-        AccountVault::read_from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 
 #[cfg(feature = "serde")]
-mod storage_serialization {
-    use super::AccountStorage;
-    use crate::utils::serde::{Deserializable, Serializable};
-
-    pub fn serialize<S>(storage: &AccountStorage, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let bytes = storage.to_bytes();
-        serializer.serialize_bytes(&bytes)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<AccountStorage, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+impl<'de> serde::Deserialize<'de> for Account {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let bytes: Vec<u8> = <Vec<u8> as serde::Deserialize>::deserialize(deserializer)?;
-        AccountStorage::read_from_bytes(&bytes).map_err(serde::de::Error::custom)
-    }
-}
-
-#[cfg(feature = "serde")]
-mod code_serialization {
-    use super::AccountCode;
-    use crate::utils::serde::{Deserializable, Serializable};
-
-    pub fn serialize<S>(code: &AccountCode, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let bytes = code.to_bytes();
-        serializer.serialize_bytes(&bytes)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<AccountCode, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes: Vec<u8> = <Vec<u8> as serde::Deserialize>::deserialize(deserializer)?;
-        AccountCode::read_from_bytes(&bytes).map_err(serde::de::Error::custom)
+        Self::read_from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -203,7 +203,6 @@ fn build_output_notes_commitment<T: ToEnvelope>(notes: &[T]) -> Digest {
 /// When a note is produced in a transaction, the note's recipient, vault and metadata must be
 /// known. However, other information about the note may or may not be know to the note's producer.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct OutputNote {
     envelope: NoteEnvelope,
     recipient: Digest,


### PR DESCRIPTION
This PR addresses #343 and #345. It also streamlines `serde` serialization of accounts and notes by implementing `Serialize` and `Deserialize` traits directly on these objects rather than providing serilization handlers for different fields.