### PR TITLE
Renamed `AccountVault` into `AssetVault`

### DIFF
--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -1,9 +1,7 @@
 use assembly::LibraryPath;
 use miden_objects::{
-    accounts::{
-        Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault, StorageSlotType,
-    },
-    assets::TokenSymbol,
+    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, StorageSlotType},
+    assets::{AssetVault, TokenSymbol},
     utils::{string::ToString, vec},
     AccountError, Felt, StarkField, Word, ZERO,
 };
@@ -72,7 +70,7 @@ pub fn create_basic_fungible_faucet(
         (0, (StorageSlotType::Value { value_arity: 0 }, auth_data)),
         (1, (StorageSlotType::Value { value_arity: 0 }, metadata)),
     ])?;
-    let account_vault = AccountVault::new(&[])?;
+    let account_vault = AssetVault::new(&[]).map_err(AccountError::AssetVaultError)?;
 
     let account_seed = AccountId::get_account_seed(
         init_seed,

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -1,8 +1,7 @@
 use miden_objects::{
-    accounts::{
-        Account, AccountCode, AccountId, AccountStorage, AccountType, AccountVault, StorageSlotType,
-    },
+    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, StorageSlotType},
     assembly::ModuleAst,
+    assets::AssetVault,
     utils::{
         format,
         string::{String, ToString},
@@ -64,7 +63,7 @@ pub fn create_basic_wallet(
         0,
         (StorageSlotType::Value { value_arity: 0 }, storage_slot_0_data),
     )])?;
-    let account_vault = AccountVault::new(&[])?;
+    let account_vault = AssetVault::new(&[]).map_err(AccountError::AssetVaultError)?;
 
     let account_seed = AccountId::get_account_seed(
         init_seed,

--- a/miden-lib/src/tests/test_asset_vault.rs
+++ b/miden-lib/src/tests/test_asset_vault.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    accounts::{AccountId, AccountVault},
+    accounts::AccountId,
     assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     StarkField,
 };
@@ -105,7 +105,7 @@ fn test_has_non_fungible_asset() {
 fn test_add_fungible_asset_success() {
     let (account, block_header, chain, notes) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
-    let mut account_vault: AccountVault = account.vault().clone();
+    let mut account_vault = account.vault().clone();
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_ASSET_AMOUNT;
@@ -146,7 +146,7 @@ fn test_add_fungible_asset_success() {
 fn test_add_non_fungible_asset_fail_overflow() {
     let (account, block_header, chain, notes) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
-    let mut account_vault: AccountVault = account.vault().clone();
+    let mut account_vault = account.vault().clone();
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_ASSET_AMOUNT + 1;
@@ -259,7 +259,7 @@ fn test_add_non_fungible_asset_fail_duplicate() {
 fn test_remove_fungible_asset_success_no_balance_remaining() {
     let (account, block_header, chain, notes) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
-    let mut account_vault: AccountVault = account.vault().clone();
+    let mut account_vault = account.vault().clone();
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FUNGIBLE_ASSET_AMOUNT;
@@ -332,7 +332,7 @@ fn test_remove_fungible_asset_fail_remove_too_much() {
 fn test_remove_fungible_asset_success_balance_remaining() {
     let (account, block_header, chain, notes) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
-    let mut account_vault: AccountVault = account.vault().clone();
+    let mut account_vault = account.vault().clone();
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let amount = FUNGIBLE_ASSET_AMOUNT - 1;

--- a/miden-lib/src/tests/test_epilogue.rs
+++ b/miden-lib/src/tests/test_epilogue.rs
@@ -8,7 +8,7 @@ use super::{
     build_module_path, ContextId, MemAdviceProvider, ProcessState, Word, TX_KERNEL_DIR, ZERO,
 };
 use crate::transaction::{
-    memory::{CREATED_NOTE_SECTION_OFFSET, CREATED_NOTE_VAULT_HASH_OFFSET, NOTE_MEM_SIZE},
+    memory::{CREATED_NOTE_ASSET_HASH_OFFSET, CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE},
     ToTransactionKernelInputs, FINAL_ACCOUNT_HASH_WORD_IDX, OUTPUT_NOTES_COMMITMENT_WORD_IDX,
     TX_SCRIPT_ROOT_WORD_IDX,
 };
@@ -107,13 +107,13 @@ fn test_compute_created_note_id() {
         )
         .unwrap();
 
-        // assert the vault hash is correct
-        let expected_vault_hash = note.vault().hash();
-        let vault_hash_memory_address =
-            CREATED_NOTE_SECTION_OFFSET + i * NOTE_MEM_SIZE + CREATED_NOTE_VAULT_HASH_OFFSET;
-        let actual_vault_hash =
-            process.get_mem_value(ContextId::root(), vault_hash_memory_address).unwrap();
-        assert_eq!(expected_vault_hash.as_elements(), actual_vault_hash);
+        // assert the note asset hash is correct
+        let expected_asset_hash = note.assets().commitment();
+        let asset_hash_memory_address =
+            CREATED_NOTE_SECTION_OFFSET + i * NOTE_MEM_SIZE + CREATED_NOTE_ASSET_HASH_OFFSET;
+        let actual_asset_hash =
+            process.get_mem_value(ContextId::root(), asset_hash_memory_address).unwrap();
+        assert_eq!(expected_asset_hash.as_elements(), actual_asset_hash);
 
         // assert the note ID is correct
         let expected_id = note.id();

--- a/miden-lib/src/tests/test_note.rs
+++ b/miden-lib/src/tests/test_note.rs
@@ -91,7 +91,7 @@ fn test_get_vault_data() {
             exec.note::get_vault_info
 
             # assert the vault data is correct
-            push.{note_0_vault_root} assert_eqw
+            push.{note_0_asset_hash} assert_eqw
             push.{note_0_num_assets} assert_eq
 
             # increment current consumed note pointer
@@ -104,14 +104,14 @@ fn test_get_vault_data() {
             exec.note::get_vault_info
 
             # assert the vault data is correct
-            push.{note_1_vault_root} assert_eqw
+            push.{note_1_asset_hash} assert_eqw
             push.{note_1_num_assets} assert_eq
         end
         ",
-        note_0_vault_root = prepare_word(&notes[0].note().vault().hash()),
-        note_0_num_assets = notes[0].note().vault().num_assets(),
-        note_1_vault_root = prepare_word(&notes[1].note().vault().hash()),
-        note_1_num_assets = notes[1].note().vault().num_assets(),
+        note_0_asset_hash = prepare_word(&notes[0].note().assets().commitment()),
+        note_0_num_assets = notes[0].note().assets().num_assets(),
+        note_1_asset_hash = prepare_word(&notes[1].note().assets().commitment()),
+        note_1_num_assets = notes[1].note().assets().num_assets(),
     );
 
     let transaction =
@@ -130,7 +130,7 @@ fn test_get_assets() {
 
     fn construct_asset_assertions(note: &Note) -> String {
         let mut code = String::new();
-        for asset in note.vault().iter() {
+        for asset in note.assets().iter() {
             code += &format!(
                 "
                 # assert the asset is correct
@@ -215,8 +215,8 @@ fn test_get_assets() {
             call.process_note_1
         end
         ",
-        note_0_num_assets = notes[0].note().vault().num_assets(),
-        note_1_num_assets = notes[1].note().vault().num_assets(),
+        note_0_num_assets = notes[0].note().assets().num_assets(),
+        note_1_num_assets = notes[1].note().assets().num_assets(),
         NOTE_0_ASSET_ASSERTIONS = construct_asset_assertions(notes[0].note()),
         NOTE_1_ASSET_ASSERTIONS = construct_asset_assertions(notes[1].note()),
     );

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -300,12 +300,12 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
             note.note().inputs().hash().as_elements()
         );
 
-        // The note vault hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 4)
+        // The note asset hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 4)
         assert_eq!(
             process
                 .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 4)
                 .unwrap(),
-            note.note().vault().hash().as_elements()
+            note.note().assets().commitment().as_elements()
         );
 
         // The number of assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 5)
@@ -317,7 +317,7 @@ fn consumed_notes_memory_assertions<A: AdviceProvider>(
         );
 
         // The assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 6..)
-        for (asset, asset_idx) in note.note().vault().iter().cloned().zip(0u32..) {
+        for (asset, asset_idx) in note.note().assets().iter().cloned().zip(0u32..) {
             let word: Word = asset.into();
             assert_eq!(
                 process

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -138,9 +138,9 @@ fn test_get_output_notes_hash() {
 
     // extract input note data
     let input_note_1 = notes.first().unwrap().note();
-    let input_asset_1 = **input_note_1.vault().iter().take(1).collect::<Vec<_>>().first().unwrap();
+    let input_asset_1 = **input_note_1.assets().iter().take(1).collect::<Vec<_>>().first().unwrap();
     let input_note_2 = notes.last().unwrap().note();
-    let input_asset_2 = **input_note_2.vault().iter().take(1).collect::<Vec<_>>().first().unwrap();
+    let input_asset_2 = **input_note_2.assets().iter().take(1).collect::<Vec<_>>().first().unwrap();
 
     // create output note 1
     let output_serial_no_1 = [Felt::new(8); 4];
@@ -206,12 +206,12 @@ fn test_get_output_notes_hash() {
         recipient_1 = prepare_word(&output_note_1.recipient()),
         tag_1 = output_note_1.metadata().tag(),
         asset_1 = prepare_word(&Word::from(
-            **output_note_1.vault().iter().take(1).collect::<Vec<_>>().first().unwrap()
+            **output_note_1.assets().iter().take(1).collect::<Vec<_>>().first().unwrap()
         )),
         recipient_2 = prepare_word(&output_note_2.recipient()),
         tag_2 = output_note_2.metadata().tag(),
         asset_2 = prepare_word(&Word::from(
-            **output_note_2.vault().iter().take(1).collect::<Vec<_>>().first().unwrap()
+            **output_note_2.assets().iter().take(1).collect::<Vec<_>>().first().unwrap()
         )),
         expected = prepare_word(&expected_output_notes_hash)
     );

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -251,7 +251,7 @@ fn add_account_to_advice_inputs(
 /// Populates the advice inputs for all input notes.
 ///
 /// For each note the authentication path is populated into the Merkle store, the note inputs
-/// and vault assets are populated in the advice map.
+/// and assets are populated in the advice map.
 ///
 /// A combined note data vector is also constructed that holds core data for all notes. This
 /// combined vector is added to the advice map against the input notes commitment. For each note
@@ -259,7 +259,7 @@ fn add_account_to_advice_inputs(
 ///   out[0..4]    = serial num
 ///   out[4..8]    = script root
 ///   out[8..12]   = input root
-///   out[12..16]  = vault_hash
+///   out[12..16]  = asset_hash
 ///   out[16..20]  = metadata
 ///   out[20..24]  = asset_1
 ///   out[24..28]  = asset_2
@@ -276,7 +276,7 @@ fn add_account_to_advice_inputs(
 ///
 /// Inserts the following entries into the advice map:
 /// - inputs_hash |-> inputs
-/// - vault_hash |-> assets
+/// - asset_hash |-> assets
 /// - notes_hash |-> combined note data
 fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInputs) {
     let mut note_data: Vec<Felt> = Vec::new();
@@ -289,7 +289,7 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
 
         // insert note inputs and assets into the advice map
         inputs.extend_map([(note.inputs().hash().into(), note.inputs().inputs().to_vec())]);
-        inputs.extend_map([(note.vault().hash().into(), note.vault().to_padded_assets())]);
+        inputs.extend_map([(note.assets().commitment().into(), note.assets().to_padded_assets())]);
 
         // insert note authentication path nodes into the Merkle store
         inputs.extend_merkle_store(
@@ -303,10 +303,10 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
         note_data.extend(note.serial_num());
         note_data.extend(*note.script().hash());
         note_data.extend(*note.inputs().hash());
-        note_data.extend(*note.vault().hash());
+        note_data.extend(*note.assets().commitment());
         note_data.extend(Word::from(note.metadata()));
 
-        note_data.extend(note.vault().to_padded_assets());
+        note_data.extend(note.assets().to_padded_assets());
 
         note_data.push(proof.origin().block_num.into());
         note_data.extend(*proof.sub_hash());

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -195,7 +195,7 @@ pub const CONSUMED_NOTE_ID_OFFSET: MemoryOffset = 0;
 pub const CONSUMED_NOTE_SERIAL_NUM_OFFSET: MemoryOffset = 1;
 pub const CONSUMED_NOTE_SCRIPT_ROOT_OFFSET: MemoryOffset = 2;
 pub const CONSUMED_NOTE_INPUTS_HASH_OFFSET: MemoryOffset = 3;
-pub const CONSUMED_NOTE_VAULT_ROOT_OFFSET: MemoryOffset = 4;
+pub const CONSUMED_NOTE_ASSET_HASH_OFFSET: MemoryOffset = 4;
 pub const CONSUMED_NOTE_METADATA_OFFSET: MemoryOffset = 5;
 pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 6;
 
@@ -215,7 +215,7 @@ pub const CREATED_NOTE_SECTION_OFFSET: MemoryOffset = 10000;
 pub const CREATED_NOTE_ID_OFFSET: MemoryOffset = 0;
 pub const CREATED_NOTE_METADATA_OFFSET: MemoryOffset = 1;
 pub const CREATED_NOTE_RECIPIENT_OFFSET: MemoryOffset = 2;
-pub const CREATED_NOTE_VAULT_HASH_OFFSET: MemoryOffset = 3;
+pub const CREATED_NOTE_ASSET_HASH_OFFSET: MemoryOffset = 3;
 pub const CREATED_NOTE_ASSETS_OFFSET: MemoryOffset = 4;
 
 /// The maximum number of created notes that can be produced in a single transaction.

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -1,6 +1,7 @@
 use miden_objects::{
     accounts::{AccountId, AccountStub},
-    notes::{NoteId, NoteMetadata, NoteVault},
+    assets::Asset,
+    notes::{NoteAssets, NoteId, NoteMetadata},
     transaction::OutputNote,
     AccountError, Digest, NoteError, StarkField, Word, WORD_SIZE,
 };
@@ -8,8 +9,8 @@ use miden_objects::{
 use super::memory::{
     ACCT_CODE_ROOT_OFFSET, ACCT_DATA_MEM_SIZE, ACCT_ID_AND_NONCE_OFFSET, ACCT_ID_IDX,
     ACCT_NONCE_IDX, ACCT_STORAGE_ROOT_OFFSET, ACCT_VAULT_ROOT_OFFSET, CREATED_NOTE_ASSETS_OFFSET,
-    CREATED_NOTE_CORE_DATA_SIZE, CREATED_NOTE_ID_OFFSET, CREATED_NOTE_METADATA_OFFSET,
-    CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_VAULT_HASH_OFFSET,
+    CREATED_NOTE_ASSET_HASH_OFFSET, CREATED_NOTE_CORE_DATA_SIZE, CREATED_NOTE_ID_OFFSET,
+    CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET,
 };
 
 // STACK OUTPUTS
@@ -54,7 +55,7 @@ pub fn notes_try_from_elements(elements: &[Word]) -> Result<OutputNote, NoteErro
     let note_id: NoteId = elements[CREATED_NOTE_ID_OFFSET as usize].into();
     let metadata: NoteMetadata = elements[CREATED_NOTE_METADATA_OFFSET as usize].try_into()?;
     let recipient = elements[CREATED_NOTE_RECIPIENT_OFFSET as usize].into();
-    let vault_hash: Digest = elements[CREATED_NOTE_VAULT_HASH_OFFSET as usize].into();
+    let asset_hash: Digest = elements[CREATED_NOTE_ASSET_HASH_OFFSET as usize].into();
 
     if elements.len()
         < (CREATED_NOTE_ASSETS_OFFSET as usize + metadata.num_assets().as_int() as usize)
@@ -63,14 +64,19 @@ pub fn notes_try_from_elements(elements: &[Word]) -> Result<OutputNote, NoteErro
         return Err(NoteError::InvalidStubDataLen(elements.len()));
     }
 
-    let vault: NoteVault = elements[CREATED_NOTE_ASSETS_OFFSET as usize
+    let assets = elements[CREATED_NOTE_ASSETS_OFFSET as usize
         ..(CREATED_NOTE_ASSETS_OFFSET as usize + metadata.num_assets().as_int() as usize)]
-        .try_into()?;
-    if vault.hash() != vault_hash {
-        return Err(NoteError::InconsistentStubVaultHash(vault_hash, vault.hash()));
+        .iter()
+        .map(|word| (*word).try_into())
+        .collect::<Result<Vec<Asset>, _>>()
+        .map_err(NoteError::InvalidAssetData)?;
+
+    let assets = NoteAssets::new(&assets)?;
+    if assets.commitment() != asset_hash {
+        return Err(NoteError::InconsistentStubAssetHash(asset_hash, assets.commitment()));
     }
 
-    let stub = OutputNote::new(recipient, vault, metadata);
+    let stub = OutputNote::new(recipient, assets, metadata);
     if stub.id() != note_id {
         return Err(NoteError::InconsistentStubId(stub.id(), note_id));
     }

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -3,6 +3,7 @@ use miden_objects::{
     assets::Asset,
     notes::{NoteAssets, NoteId, NoteMetadata},
     transaction::OutputNote,
+    utils::collections::Vec,
     AccountError, Digest, NoteError, StarkField, Word, WORD_SIZE,
 };
 

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -232,7 +232,7 @@ fn test_transaction_result_account_delta() {
         .last()
         .unwrap()
         .note()
-        .vault()
+        .assets()
         .iter()
         .cloned()
         .collect::<Vec<_>>();

--- a/miden-tx/tests/common/mod.rs
+++ b/miden-tx/tests/common/mod.rs
@@ -1,8 +1,8 @@
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault, StorageSlotType},
+    accounts::{Account, AccountCode, AccountId, AccountStorage, StorageSlotType},
     assembly::{ModuleAst, ProgramAst},
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, AssetVault, FungibleAsset},
     crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
     notes::{Note, NoteId, NoteScript},
     transaction::{ChainMmr, InputNote, InputNotes, TransactionInputs},
@@ -135,8 +135,8 @@ pub fn get_account_with_default_account_code(
             .unwrap();
 
     let account_vault = match assets {
-        Some(asset) => AccountVault::new(&[asset]).unwrap(),
-        None => AccountVault::new(&[]).unwrap(),
+        Some(asset) => AssetVault::new(&[asset]).unwrap(),
+        None => AssetVault::new(&[]).unwrap(),
     };
 
     Account::new(account_id, account_vault, account_storage, account_code, Felt::new(1))

--- a/miden-tx/tests/faucet_contract_test.rs
+++ b/miden-tx/tests/faucet_contract_test.rs
@@ -4,9 +4,9 @@ use miden_lib::{
     AuthScheme,
 };
 use miden_objects::{
-    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault, StorageSlotType},
+    accounts::{Account, AccountCode, AccountId, AccountStorage, StorageSlotType},
     assembly::{ModuleAst, ProgramAst},
-    assets::{Asset, FungibleAsset, TokenSymbol},
+    assets::{Asset, AssetVault, FungibleAsset, TokenSymbol},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
     notes::{NoteAssets, NoteMetadata},
     transaction::OutputNote,
@@ -273,7 +273,7 @@ fn get_faucet_account_with_max_supply_and_total_issuance(
 
     Account::new(
         faucet_account_id,
-        AccountVault::new(&[]).unwrap(),
+        AssetVault::new(&[]).unwrap(),
         faucet_account_storage.clone(),
         faucet_account_code.clone(),
         Felt::new(1),

--- a/miden-tx/tests/faucet_contract_test.rs
+++ b/miden-tx/tests/faucet_contract_test.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     assembly::{ModuleAst, ProgramAst},
     assets::{Asset, FungibleAsset, TokenSymbol},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
-    notes::{NoteMetadata, NoteVault},
+    notes::{NoteAssets, NoteMetadata},
     transaction::OutputNote,
     Felt, Word, ZERO,
 };
@@ -79,13 +79,13 @@ fn test_faucet_contract_mint_fungible_asset_succeeds() {
 
     let expected_note = OutputNote::new(
         recipient.into(),
-        NoteVault::new(&[fungible_asset]).unwrap(),
+        NoteAssets::new(&[fungible_asset]).unwrap(),
         NoteMetadata::new(faucet_account.id(), tag, Felt::new(1)),
     );
 
     let created_note = transaction_result.output_notes().get_note(0).clone();
     assert_eq!(created_note.recipient(), expected_note.recipient());
-    assert_eq!(created_note.vault(), expected_note.vault());
+    assert_eq!(created_note.assets(), expected_note.assets());
     assert_eq!(created_note.metadata(), expected_note.metadata());
 }
 

--- a/miden-tx/tests/p2id_script_test.rs
+++ b/miden-tx/tests/p2id_script_test.rs
@@ -1,8 +1,8 @@
 use miden_lib::notes::{create_note, Script};
 use miden_objects::{
-    accounts::{Account, AccountId, AccountVault},
+    accounts::{Account, AccountId},
     assembly::ProgramAst,
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, AssetVault, FungibleAsset},
     utils::collections::Vec,
     Felt,
 };
@@ -84,7 +84,7 @@ fn test_p2id_script() {
     // vault delta
     let target_account_after: Account = Account::new(
         target_account.id(),
-        AccountVault::new(&[fungible_asset]).unwrap(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
         target_account.code().clone(),
         Felt::new(2),
@@ -200,7 +200,7 @@ fn test_p2id_script_multiple_assets() {
     // vault delta
     let target_account_after: Account = Account::new(
         target_account.id(),
-        AccountVault::new(&[fungible_asset_1, fungible_asset_2]).unwrap(),
+        AssetVault::new(&[fungible_asset_1, fungible_asset_2]).unwrap(),
         target_account.storage().clone(),
         target_account.code().clone(),
         Felt::new(2),

--- a/miden-tx/tests/p2idr_script_test.rs
+++ b/miden-tx/tests/p2idr_script_test.rs
@@ -1,8 +1,8 @@
 use miden_lib::notes::{create_note, Script};
 use miden_objects::{
-    accounts::{Account, AccountId, AccountVault},
+    accounts::{Account, AccountId},
     assembly::ProgramAst,
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, AssetVault, FungibleAsset},
     utils::collections::Vec,
     Felt,
 };
@@ -133,7 +133,7 @@ fn test_p2idr_script() {
     // Assert that the target_account received the funds and the nonce increased by 1
     let target_account_after: Account = Account::new(
         target_account_id,
-        AccountVault::new(&[fungible_asset]).unwrap(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
         target_account.code().clone(),
         Felt::new(2),
@@ -230,7 +230,7 @@ fn test_p2idr_script() {
     // Vault delta
     let target_account_after: Account = Account::new(
         target_account_id,
-        AccountVault::new(&[fungible_asset]).unwrap(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
         target_account.code().clone(),
         Felt::new(2),
@@ -263,7 +263,7 @@ fn test_p2idr_script() {
     // Vault delta (Note: vault was empty before)
     let sender_account_after: Account = Account::new(
         sender_account_id,
-        AccountVault::new(&[fungible_asset]).unwrap(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
         sender_account.storage().clone(),
         sender_account.code().clone(),
         Felt::new(2),

--- a/miden-tx/tests/swap_script_test.rs
+++ b/miden-tx/tests/swap_script_test.rs
@@ -6,7 +6,7 @@ use miden_objects::{
     accounts::{Account, AccountId, AccountVault, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN},
     assembly::ProgramAst,
     assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
-    notes::{NoteMetadata, NoteVault},
+    notes::{NoteAssets, NoteMetadata},
     transaction::OutputNote,
     Felt,
 };
@@ -115,9 +115,9 @@ fn test_swap_script() {
     let note_metadata =
         NoteMetadata::new(target_account_id, sender_account_id.into(), Felt::new(1));
 
-    let note_vault = NoteVault::new(&[non_fungible_asset]).unwrap();
+    let note_assets = NoteAssets::new(&[non_fungible_asset]).unwrap();
 
-    let requested_note = OutputNote::new(recipient, note_vault, note_metadata);
+    let requested_note = OutputNote::new(recipient, note_assets, note_metadata);
 
     let created_note = transaction_result.output_notes().get_note(0);
 

--- a/miden-tx/tests/swap_script_test.rs
+++ b/miden-tx/tests/swap_script_test.rs
@@ -3,9 +3,9 @@ use common::{
 };
 use miden_lib::notes::{create_note, Script};
 use miden_objects::{
-    accounts::{Account, AccountId, AccountVault, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN},
+    accounts::{Account, AccountId, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN},
     assembly::ProgramAst,
-    assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
+    assets::{Asset, AssetVault, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     notes::{NoteAssets, NoteMetadata},
     transaction::OutputNote,
     Felt,
@@ -92,7 +92,7 @@ fn test_swap_script() {
     // target account vault delta
     let target_account_after: Account = Account::new(
         target_account.id(),
-        AccountVault::new(&[fungible_asset]).unwrap(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
         target_account.code().clone(),
         Felt::new(2),

--- a/miden-tx/tests/wallet_test.rs
+++ b/miden-tx/tests/wallet_test.rs
@@ -1,8 +1,8 @@
 use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
 use miden_objects::{
-    accounts::{Account, AccountId, AccountStorage, AccountVault, StorageSlotType},
+    accounts::{Account, AccountId, AccountStorage, StorageSlotType},
     assembly::ProgramAst,
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, AssetVault, FungibleAsset},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
     Felt, Word, ONE, ZERO,
 };
@@ -99,7 +99,7 @@ fn test_receive_asset_via_wallet() {
     // vault delta
     let target_account_after: Account = Account::new(
         target_account.id(),
-        AccountVault::new(&[fungible_asset_1.into()]).unwrap(),
+        AssetVault::new(&[fungible_asset_1.into()]).unwrap(),
         account_storage,
         account_code,
         Felt::new(2),
@@ -177,7 +177,7 @@ fn test_send_asset_via_wallet() {
     // vault delta
     let sender_account_after: Account = Account::new(
         data_store.account.id(),
-        AccountVault::new(&[]).unwrap(),
+        AssetVault::new(&[]).unwrap(),
         sender_account_storage,
         sender_account_code,
         Felt::new(2),

--- a/mock/src/builders/account.rs
+++ b/mock/src/builders/account.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
-    accounts::{Account, AccountStorage, AccountType, AccountVault, SlotItem},
-    assets::Asset,
+    accounts::{Account, AccountStorage, AccountType, SlotItem},
+    assets::{Asset, AssetVault},
     utils::{
         collections::Vec,
         string::{String, ToString},
@@ -80,7 +80,7 @@ impl<T: Rng> AccountBuilder<T> {
     }
 
     pub fn build(mut self) -> Result<Account, AccountBuilderError> {
-        let vault = AccountVault::new(&self.assets).map_err(AccountBuilderError::AccountError)?;
+        let vault = AssetVault::new(&self.assets).map_err(AccountBuilderError::AssetVaultError)?;
         let storage = self.storage_builder.build();
         self.account_id_builder.code(&self.code);
         self.account_id_builder.storage_root(storage.root());
@@ -92,7 +92,7 @@ impl<T: Rng> AccountBuilder<T> {
 
     /// Build an account using the provided `seed`.
     pub fn with_seed(mut self, seed: Word) -> Result<Account, AccountBuilderError> {
-        let vault = AccountVault::new(&self.assets).map_err(AccountBuilderError::AccountError)?;
+        let vault = AssetVault::new(&self.assets).map_err(AccountBuilderError::AssetVaultError)?;
         let storage = self.storage_builder.build();
         self.account_id_builder.code(&self.code);
         self.account_id_builder.storage_root(storage.root());
@@ -110,7 +110,7 @@ impl<T: Rng> AccountBuilder<T> {
         seed: Word,
         mut storage: AccountStorage,
     ) -> Result<Account, AccountBuilderError> {
-        let vault = AccountVault::new(&self.assets).map_err(AccountBuilderError::AccountError)?;
+        let vault = AssetVault::new(&self.assets).map_err(AccountBuilderError::AssetVaultError)?;
         let inner_storage = self.storage_builder.build();
 
         let slots = storage.slots_mut();

--- a/mock/src/builders/error.rs
+++ b/mock/src/builders/error.rs
@@ -1,10 +1,11 @@
 use core::fmt::Display;
 
-use miden_objects::{crypto::merkle::MerkleError, AccountError};
+use miden_objects::{crypto::merkle::MerkleError, AccountError, AssetVaultError};
 
 #[derive(Debug)]
 pub enum AccountBuilderError {
     AccountError(AccountError),
+    AssetVaultError(AssetVaultError),
     MerkleError(MerkleError),
 
     /// When the created [AccountId] doesn't match the builder's configured [AccountType].

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::Read, path::PathBuf};
 use miden_lib::transaction::{memory, TransactionKernel};
 use miden_objects::{
     accounts::Account,
-    notes::NoteVault,
+    notes::NoteAssets,
     transaction::{
         ChainMmr, InputNote, InputNotes, OutputNotes, PreparedTransaction, TransactionInputs,
         TransactionScript,

--- a/mock/src/mock/account.rs
+++ b/mock/src/mock/account.rs
@@ -1,8 +1,8 @@
 use miden_lib::transaction::memory::FAUCET_STORAGE_DATA_SLOT;
 use miden_objects::{
-    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault, StorageSlotType},
+    accounts::{Account, AccountCode, AccountId, AccountStorage, StorageSlotType},
     assembly::{Assembler, ModuleAst},
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, AssetVault, FungibleAsset},
     crypto::merkle::TieredSmt,
     Felt, FieldElement, Word, ZERO,
 };
@@ -15,7 +15,7 @@ use crate::constants::{
     FUNGIBLE_ASSET_AMOUNT, FUNGIBLE_FAUCET_INITIAL_BALANCE,
 };
 
-fn mock_account_vault() -> AccountVault {
+fn mock_account_vault() -> AssetVault {
     // prepare fungible asset
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
     let fungible_asset =
@@ -33,7 +33,7 @@ fn mock_account_vault() -> AccountVault {
 
     // prepare non fungible asset
     let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
-    AccountVault::new(&[fungible_asset, fungible_asset_1, fungible_asset_2, non_fungible_asset])
+    AssetVault::new(&[fungible_asset, fungible_asset_1, fungible_asset_2, non_fungible_asset])
         .unwrap()
 }
 
@@ -118,7 +118,7 @@ pub fn mock_new_account(assembler: &Assembler) -> Account {
         generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
     let account_storage = mock_account_storage();
     let account_code = mock_account_code(assembler);
-    Account::new(acct_id, AccountVault::default(), account_storage, account_code, Felt::ZERO)
+    Account::new(acct_id, AssetVault::default(), account_storage, account_code, Felt::ZERO)
 }
 
 pub fn mock_account(
@@ -163,7 +163,7 @@ pub fn mock_fungible_faucet(
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
     let account_code = mock_account_code(assembler);
-    Account::new(account_id, AccountVault::default(), account_storage, account_code, nonce)
+    Account::new(account_id, AssetVault::default(), account_storage, account_code, nonce)
 }
 
 pub fn mock_non_fungible_faucet(
@@ -192,7 +192,7 @@ pub fn mock_non_fungible_faucet(
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
     let account_code = mock_account_code(assembler);
-    Account::new(account_id, AccountVault::default(), account_storage, account_code, nonce)
+    Account::new(account_id, AssetVault::default(), account_storage, account_code, nonce)
 }
 
 #[derive(Debug, PartialEq)]

--- a/mock/src/mock/notes.rs
+++ b/mock/src/mock/notes.rs
@@ -105,10 +105,10 @@ pub fn mock_notes(
     ",
         created_note_0_recipient = prepare_word(&created_notes[0].recipient()),
         created_note_0_tag = created_notes[0].metadata().tag(),
-        created_note_0_asset = prepare_assets(created_notes[0].vault())[0],
+        created_note_0_asset = prepare_assets(created_notes[0].assets())[0],
         created_note_1_recipient = prepare_word(&created_notes[1].recipient()),
         created_note_1_tag = created_notes[1].metadata().tag(),
-        created_note_1_asset = prepare_assets(created_notes[1].vault())[0],
+        created_note_1_asset = prepare_assets(created_notes[1].assets())[0],
     );
     let note_1_script_ast = ProgramAst::parse(&note_1_script_src).unwrap();
     let (note_1_script, _) = NoteScript::new(note_1_script_ast, assembler).unwrap();
@@ -128,7 +128,7 @@ pub fn mock_notes(
         ",
         created_note_2_recipient = prepare_word(&created_notes[2].recipient()),
         created_note_2_tag = created_notes[2].metadata().tag(),
-        created_note_2_asset = prepare_assets(created_notes[2].vault())[0],
+        created_note_2_asset = prepare_assets(created_notes[2].assets())[0],
     );
     let note_2_script_ast = ProgramAst::parse(&note_2_script_src).unwrap();
     let (note_2_script, _) = NoteScript::new(note_2_script_ast, assembler).unwrap();

--- a/mock/src/procedures.rs
+++ b/mock/src/procedures.rs
@@ -3,21 +3,21 @@ use super::{
         CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET,
         NOTE_MEM_SIZE, NUM_CREATED_NOTES_PTR,
     },
-    NoteVault, OutputNotes, StarkField, Word,
+    NoteAssets, OutputNotes, StarkField, Word,
 };
 
 pub fn output_notes_data_procedure(notes: &OutputNotes) -> String {
     let note_0_metadata = prepare_word(&notes.get_note(0).metadata().into());
     let note_0_recipient = prepare_word(notes.get_note(0).recipient());
-    let note_0_assets = prepare_assets(notes.get_note(0).vault());
+    let note_0_assets = prepare_assets(notes.get_note(0).assets());
 
     let note_1_metadata = prepare_word(&notes.get_note(1).metadata().into());
     let note_1_recipient = prepare_word(notes.get_note(1).recipient());
-    let note_1_assets = prepare_assets(notes.get_note(1).vault());
+    let note_1_assets = prepare_assets(notes.get_note(1).assets());
 
     let note_2_metadata = prepare_word(&notes.get_note(2).metadata().into());
     let note_2_recipient = prepare_word(notes.get_note(2).recipient());
-    let note_2_assets = prepare_assets(notes.get_note(2).vault());
+    let note_2_assets = prepare_assets(notes.get_note(2).assets());
 
     const NOTE_1_OFFSET: u32 = NOTE_MEM_SIZE;
     const NOTE_2_OFFSET: u32 = NOTE_MEM_SIZE * 2;
@@ -73,9 +73,9 @@ pub fn prepare_word(word: &Word) -> String {
     word.iter().map(|x| x.as_int().to_string()).collect::<Vec<_>>().join(".")
 }
 
-fn prepare_assets(vault: &NoteVault) -> Vec<String> {
+fn prepare_assets(note_assets: &NoteAssets) -> Vec<String> {
     let mut assets = Vec::new();
-    for &asset in vault.iter() {
+    for &asset in note_assets.iter() {
         let asset_word: Word = asset.into();
         let asset_str = prepare_word(&asset_word);
         assets.push(asset_str);

--- a/mock/src/utils.rs
+++ b/mock/src/utils.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    notes::NoteVault,
+    notes::NoteAssets,
     utils::{
         collections::Vec,
         string::{String, ToString},
@@ -12,9 +12,9 @@ pub fn prepare_word(word: &Word) -> String {
     word.iter().map(|x| x.as_int().to_string()).collect::<Vec<_>>().join(".")
 }
 
-pub fn prepare_assets(vault: &NoteVault) -> Vec<String> {
+pub fn prepare_assets(note_assets: &NoteAssets) -> Vec<String> {
     let mut assets = Vec::new();
-    for &asset in vault.iter() {
+    for &asset in note_assets.iter() {
         let asset_word: Word = asset.into();
         let asset_str = prepare_word(&asset_word);
         assets.push(asset_str);

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,7 +1,6 @@
 use super::{
     assembly::{Assembler, AssemblyContext, ModuleAst},
-    assets::{Asset, FungibleAsset, NonFungibleAsset},
-    crypto::merkle::TieredSmt,
+    assets::AssetVault,
     utils::{
         collections::{BTreeMap, Vec},
         serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
@@ -27,9 +26,6 @@ pub use storage::{AccountStorage, SlotItem, StorageSlotType};
 
 mod stub;
 pub use stub::AccountStub;
-
-mod vault;
-pub use vault::AccountVault;
 
 // TESTING CONSTANTS
 // ================================================================================================
@@ -70,7 +66,7 @@ pub const ACCOUNT_ID_INSUFFICIENT_ONES: u64 = 0b1100000110 << 54;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Account {
     id: AccountId,
-    vault: AccountVault,
+    vault: AssetVault,
     storage: AccountStorage,
     code: AccountCode,
     nonce: Felt,
@@ -83,7 +79,7 @@ impl Account {
     /// and nonce.
     pub fn new(
         id: AccountId,
-        vault: AccountVault,
+        vault: AssetVault,
         storage: AccountStorage,
         code: AccountCode,
         nonce: Felt,
@@ -119,13 +115,13 @@ impl Account {
     }
 
     /// Returns a reference to the vault of this account.
-    pub fn vault(&self) -> &AccountVault {
+    pub fn vault(&self) -> &AssetVault {
         &self.vault
     }
 
     #[cfg(test)]
     /// Returns a mutable reference to the vault of this account.
-    pub fn vault_mut(&mut self) -> &mut AccountVault {
+    pub fn vault_mut(&mut self) -> &mut AssetVault {
         &mut self.vault
     }
 
@@ -188,7 +184,7 @@ impl Serializable for Account {
 impl Deserializable for Account {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let id = AccountId::read_from(source)?;
-        let vault = AccountVault::read_from(source)?;
+        let vault = AssetVault::read_from(source)?;
         let storage = AccountStorage::read_from(source)?;
         let code = AccountCode::read_from(source)?;
         let nonce = Felt::read_from(source)?;

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -1,3 +1,5 @@
+use vm_processor::DeserializationError;
+
 use super::{
     accounts::{AccountId, AccountType},
     utils::{collections::Vec, string::ToString},
@@ -13,7 +15,9 @@ pub use nonfungible::{NonFungibleAsset, NonFungibleAssetDetails};
 
 mod token_symbol;
 pub use token_symbol::TokenSymbol;
-use vm_processor::DeserializationError;
+
+mod vault;
+pub use vault::AssetVault;
 
 // ASSET
 // ================================================================================================

--- a/objects/src/assets/vault.rs
+++ b/objects/src/assets/vault.rs
@@ -1,15 +1,15 @@
 use super::{
-    AccountError, AccountId, AccountType, Asset, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Digest, FungibleAsset, NonFungibleAsset, Serializable, TieredSmt,
-    ToString, Vec, ZERO,
+    AccountId, AccountType, Asset, ByteReader, ByteWriter, Deserializable, DeserializationError,
+    FungibleAsset, NonFungibleAsset, Serializable, ToString, Vec, ZERO,
 };
+use crate::{crypto::merkle::TieredSmt, AssetVaultError, Digest};
 
-// ACCOUNT VAULT
+// ASSET VAULT
 // ================================================================================================
 
-/// An asset container for an account.
+/// A container for an unlimited number of assets.
 ///
-/// An account vault can contain an unlimited number of assets. The assets are stored in a Sparse
+/// An asset vault can contain an unlimited number of assets. The assets are stored in a Sparse
 /// Merkle tree as follows:
 /// - For fungible assets, the index of a node is defined by the issuing faucet ID, and the value
 ///   of the node is the asset itself. Thus, for any fungible asset there will be only one node
@@ -17,22 +17,22 @@ use super::{
 /// - For non-fungible assets, the index is defined by the asset itself, and the asset is also
 ///   the value of the node.
 ///
-/// An account vault can be reduced to a single hash which is the root of the Sparse Merkle tree.
+/// An asset vault can be reduced to a single hash which is the root of the Sparse Merkle tree.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AccountVault {
+pub struct AssetVault {
     asset_tree: TieredSmt,
 }
 
-impl AccountVault {
+impl AssetVault {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// Returns a new account vault initialized with the provided assets.
-    pub fn new(assets: &[Asset]) -> Result<Self, AccountError> {
+    /// Returns a new [AssetVault] initialized with the provided assets.
+    pub fn new(assets: &[Asset]) -> Result<Self, AssetVaultError> {
         Ok(Self {
             asset_tree: TieredSmt::with_entries(
                 assets.iter().map(|asset| (asset.vault_key().into(), (*asset).into())),
             )
-            .map_err(AccountError::DuplicateAsset)?,
+            .map_err(AssetVaultError::DuplicateAsset)?,
         })
     }
 
@@ -45,9 +45,9 @@ impl AccountVault {
     }
 
     /// Returns true if the specified non-fungible asset is stored in this vault.
-    pub fn has_non_fungible_asset(&self, asset: Asset) -> Result<bool, AccountError> {
+    pub fn has_non_fungible_asset(&self, asset: Asset) -> Result<bool, AssetVaultError> {
         if asset.is_fungible() {
-            return Err(AccountError::not_a_non_fungible_asset(asset));
+            return Err(AssetVaultError::NotANonFungibleAsset(asset));
         }
 
         // check if the asset is stored in the vault
@@ -62,9 +62,9 @@ impl AccountVault {
     ///
     /// # Errors
     /// Returns an error if the specified ID is not an ID of a fungible asset faucet.
-    pub fn get_balance(&self, faucet_id: AccountId) -> Result<u64, AccountError> {
+    pub fn get_balance(&self, faucet_id: AccountId) -> Result<u64, AssetVaultError> {
         if !matches!(faucet_id.account_type(), AccountType::FungibleFaucet) {
-            return Err(AccountError::not_a_fungible_faucet_id(faucet_id));
+            return Err(AssetVaultError::NotAFungibleFaucetId(faucet_id));
         }
 
         // if the tree value is [0, 0, 0, 0], the asset is not stored in the vault
@@ -79,7 +79,7 @@ impl AccountVault {
         self.asset_tree.iter().map(|x| Asset::new_unchecked(x.1))
     }
 
-    /// Returns a reference to the Sparse Merkle tree underling this account vault.
+    /// Returns a reference to the Sparse Merkle tree underling this asset vault.
     pub fn asset_tree(&self) -> &TieredSmt {
         &self.asset_tree
     }
@@ -94,7 +94,7 @@ impl AccountVault {
     /// # Errors
     /// - If the total value of two fungible assets is greater than or equal to 2^63.
     /// - If the vault already contains the same non-fungible asset.
-    pub fn add_asset(&mut self, asset: Asset) -> Result<Asset, AccountError> {
+    pub fn add_asset(&mut self, asset: Asset) -> Result<Asset, AssetVaultError> {
         Ok(match asset {
             Asset::Fungible(asset) => Asset::Fungible(self.add_fungible_asset(asset)?),
             Asset::NonFungible(asset) => Asset::NonFungible(self.add_non_fungible_asset(asset)?),
@@ -106,13 +106,16 @@ impl AccountVault {
     ///
     /// # Errors
     /// - If the total value of assets is greater than or equal to 2^63.
-    fn add_fungible_asset(&mut self, asset: FungibleAsset) -> Result<FungibleAsset, AccountError> {
+    fn add_fungible_asset(
+        &mut self,
+        asset: FungibleAsset,
+    ) -> Result<FungibleAsset, AssetVaultError> {
         // fetch current asset value from the tree and add the new asset to it.
         let new: FungibleAsset = match self.asset_tree.get_value(asset.vault_key().into()) {
             current if current == TieredSmt::EMPTY_VALUE => asset,
             current => {
                 let current = FungibleAsset::new_unchecked(current);
-                current.add(asset).map_err(AccountError::AddFungibleAssetBalanceError)?
+                current.add(asset).map_err(AssetVaultError::AddFungibleAssetBalanceError)?
             },
         };
         self.asset_tree.insert(new.vault_key().into(), new.into());
@@ -128,13 +131,13 @@ impl AccountVault {
     fn add_non_fungible_asset(
         &mut self,
         asset: NonFungibleAsset,
-    ) -> Result<NonFungibleAsset, AccountError> {
+    ) -> Result<NonFungibleAsset, AssetVaultError> {
         // add non-fungible asset to the vault
         let old = self.asset_tree.insert(asset.vault_key().into(), asset.into());
 
         // if the asset already exists, return an error
         if old != TieredSmt::EMPTY_VALUE {
-            return Err(AccountError::DuplicateNonFungibleAsset(asset));
+            return Err(AssetVaultError::DuplicateNonFungibleAsset(asset));
         }
 
         Ok(asset)
@@ -148,7 +151,7 @@ impl AccountVault {
     /// - The fungible asset is not found in the vault.
     /// - The amount of the fungible asset in the vault is less than the amount to be removed.
     /// - The non-fungible asset is not found in the vault.
-    pub fn remove_asset(&mut self, asset: Asset) -> Result<Asset, AccountError> {
+    pub fn remove_asset(&mut self, asset: Asset) -> Result<Asset, AssetVaultError> {
         Ok(match asset {
             Asset::Fungible(asset) => Asset::Fungible(self.remove_fungible_asset(asset)?),
             Asset::NonFungible(asset) => Asset::NonFungible(self.remove_non_fungible_asset(asset)?),
@@ -163,11 +166,11 @@ impl AccountVault {
     fn remove_fungible_asset(
         &mut self,
         asset: FungibleAsset,
-    ) -> Result<FungibleAsset, AccountError> {
+    ) -> Result<FungibleAsset, AssetVaultError> {
         // fetch the asset from the vault.
         let mut current = match self.asset_tree.get_value(asset.vault_key().into()) {
             current if current == TieredSmt::EMPTY_VALUE => {
-                return Err(AccountError::FungibleAssetNotFound(asset))
+                return Err(AssetVaultError::FungibleAssetNotFound(asset))
             },
             current => FungibleAsset::new_unchecked(current),
         };
@@ -175,7 +178,7 @@ impl AccountVault {
         // subtract the amount of the asset to be removed from the current amount.
         current
             .sub(asset.amount())
-            .map_err(AccountError::SubtractFungibleAssetBalanceError)?;
+            .map_err(AssetVaultError::SubtractFungibleAssetBalanceError)?;
 
         // if the amount of the asset is zero, remove the asset from the vault.
         let new = match current.amount() {
@@ -195,13 +198,13 @@ impl AccountVault {
     fn remove_non_fungible_asset(
         &mut self,
         asset: NonFungibleAsset,
-    ) -> Result<NonFungibleAsset, AccountError> {
+    ) -> Result<NonFungibleAsset, AssetVaultError> {
         // remove the asset from the vault.
         let old = self.asset_tree.insert(asset.vault_key().into(), TieredSmt::EMPTY_VALUE);
 
         // return an error if the asset did not exist in the vault.
         if old == TieredSmt::EMPTY_VALUE {
-            return Err(AccountError::NonFungibleAssetNotFound(asset));
+            return Err(AssetVaultError::NonFungibleAssetNotFound(asset));
         }
 
         // return the asset that was removed.
@@ -212,12 +215,12 @@ impl AccountVault {
 // SERIALIZATION
 // ================================================================================================
 
-impl Serializable for AccountVault {
+impl Serializable for AssetVault {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // TODO: determine total number of assets in the vault without allocating the vector
         let assets = self.assets().collect::<Vec<_>>();
 
-        // TODO: either enforce that number of assets in account vault is never greater than
+        // TODO: either enforce that number of assets in the vault is never greater than
         // u32::MAX or use variable-length encoding for the number of assets
         assert!(assets.len() <= u32::MAX as usize, "too many assets in the vault");
         target.write_u32(assets.len() as u32);
@@ -228,7 +231,7 @@ impl Serializable for AccountVault {
     }
 }
 
-impl Deserializable for AccountVault {
+impl Deserializable for AssetVault {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let num_assets = source.read_u32()? as usize;
         let assets = Asset::read_batch_from(source, num_assets)?;

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -195,17 +195,15 @@ impl std::error::Error for AssetError {}
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum NoteError {
-    NoteDeserializationError(DeserializationError),
     DuplicateFungibleAsset(AccountId),
     DuplicateNonFungibleAsset(NonFungibleAsset),
     EmptyAssetList,
     InconsistentStubId(NoteId, NoteId),
-    InconsistentStubNumAssets(u64, u64),
-    InconsistentStubVaultHash(Digest, Digest),
+    InconsistentStubAssetHash(Digest, Digest),
     InvalidStubDataLen(usize),
     InvalidOriginIndex(String),
-    InvalidVaultDataLen(usize),
-    InvalidVaultAssetData(AssetError),
+    InvalidAssetData(AssetError),
+    NoteDeserializationError(DeserializationError),
     NoteMetadataSenderInvalid(AccountError),
     ScriptCompilationError(AssemblyError),
     TooManyAssets(usize),

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -22,21 +22,15 @@ pub enum AccountError {
     AccountCodeTooManyProcedures { max: usize, actual: usize },
     AccountIdInvalidFieldElement(String),
     AccountIdTooFewOnes,
-    AddFungibleAssetBalanceError(AssetError),
     ApplyStorageSlotsDiffFailed(MerkleError),
     ApplyStorageStoreDiffFailed(MerkleError),
-    DuplicateAsset(MerkleError),
-    DuplicateNonFungibleAsset(NonFungibleAsset),
+    AssetVaultError(AssetVaultError),
     DuplicateStorageItems(MerkleError),
-    FungibleAssetNotFound(FungibleAsset),
     FungibleFaucetIdInvalidFirstBit,
     FungibleFaucetInvalidMetadata(String),
     HexParseError(String),
     InconsistentAccountIdSeed { expected: AccountId, actual: AccountId },
     NonceMustBeMonotonicallyIncreasing(u64, u64),
-    NonFungibleAssetNotFound(NonFungibleAsset),
-    NotAFungibleFaucetId(AccountId),
-    NotANonFungibleAsset(Asset),
     SeedDigestTooFewTrailingZeros { expected: u32, actual: u32 },
     SetStoreNodeFailed(MerkleError),
     StorageArrayRequiresMoreThanOneElement,
@@ -44,7 +38,6 @@ pub enum AccountError {
     StorageSlotArrayTooSmall { actual: u8, min: u8 },
     StorageSlotIsReserved(u8),
     StubDataIncorrectLength(usize, usize),
-    SubtractFungibleAssetBalanceError(AssetError),
 }
 
 impl AccountError {
@@ -62,14 +55,6 @@ impl AccountError {
 
     pub fn fungible_faucet_id_invalid_first_bit() -> Self {
         Self::FungibleFaucetIdInvalidFirstBit
-    }
-
-    pub fn not_a_fungible_faucet_id(account_id: AccountId) -> Self {
-        Self::NotAFungibleFaucetId(account_id)
-    }
-
-    pub fn not_a_non_fungible_asset(asset: Asset) -> Self {
-        Self::NotANonFungibleAsset(asset)
     }
 }
 
@@ -189,6 +174,30 @@ impl fmt::Display for AssetError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for AssetError {}
+
+// ASSET VAULT ERROR
+// ================================================================================================
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AssetVaultError {
+    AddFungibleAssetBalanceError(AssetError),
+    DuplicateAsset(MerkleError),
+    DuplicateNonFungibleAsset(NonFungibleAsset),
+    FungibleAssetNotFound(FungibleAsset),
+    NotANonFungibleAsset(Asset),
+    NotAFungibleFaucetId(AccountId),
+    NonFungibleAssetNotFound(NonFungibleAsset),
+    SubtractFungibleAssetBalanceError(AssetError),
+}
+
+impl fmt::Display for AssetVaultError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AssetVaultError {}
 
 // NOTE ERROR
 // ================================================================================================

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -16,8 +16,8 @@ pub mod transaction;
 
 mod errors;
 pub use errors::{
-    AccountDeltaError, AccountError, AssetError, ChainMmrError, NoteError, TransactionInputError,
-    TransactionOutputError, TransactionScriptError,
+    AccountDeltaError, AccountError, AssetError, AssetVaultError, ChainMmrError, NoteError,
+    TransactionInputError, TransactionOutputError, TransactionScriptError,
 };
 // RE-EXPORTS
 // ================================================================================================

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -67,7 +67,7 @@ impl NoteInputs {
 
 impl PartialEq for NoteInputs {
     fn eq(&self, other: &Self) -> bool {
-        let NoteInputs { inputs, hash: _hash } = self;
+        let NoteInputs { inputs, hash: _ } = self;
 
         inputs == &other.inputs
     }

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -10,7 +10,7 @@ use crate::utils::serde::{
 ///
 /// Note ID is computed as:
 ///
-///   hash(recipient, vault_hash),
+///   hash(recipient, asset_hash),
 ///
 /// where `recipient` is defined as:
 ///   hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
@@ -18,14 +18,14 @@ use crate::utils::serde::{
 /// This achieves the following properties:
 /// - Every note can be reduced to a single unique ID.
 /// - To compute a note ID, we do not need to know the note's serial_num. Knowing the hash
-///   of the serial_num (as well as script hash, input hash, and note vault) is sufficient.
+///   of the serial_num (as well as script hash, input hash, and note assets) is sufficient.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoteId(Digest);
 
 impl NoteId {
     /// Returns a new [NoteId] instantiated from the provided note components.
-    pub fn new(recipient: Digest, vault_commitment: Digest) -> Self {
-        Self(Hasher::merge(&[recipient, vault_commitment]))
+    pub fn new(recipient: Digest, asset_commitment: Digest) -> Self {
+        Self(Hasher::merge(&[recipient, asset_commitment]))
     }
 
     /// Returns the elements representation of this note ID.
@@ -49,7 +49,7 @@ impl NoteId {
 
 impl From<&Note> for NoteId {
     fn from(note: &Note) -> Self {
-        Self::new(note.recipient(), note.vault().hash())
+        Self::new(note.recipient(), note.assets().commitment())
     }
 }
 

--- a/objects/src/notes/nullifier.rs
+++ b/objects/src/notes/nullifier.rs
@@ -8,13 +8,13 @@ use crate::utils::serde::{
 
 /// A note's nullifier.
 ///
-/// A note's nullifier is computed as hash(serial_num, script_hash, input_hash, vault_hash).
+/// A note's nullifier is computed as hash(serial_num, script_hash, input_hash, asset_hash).
 ///
 /// This achieves the following properties:
 /// - Every note can be reduced to a single unique nullifier.
 /// - We cannot derive a note's hash from its nullifier, or a note's nullifier from its hash.
 /// - To compute the nullifier we must know all components of the note: serial_num, script_hash,
-///   input_hash and vault_hash.
+///   input_hash and asset_hash.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Nullifier(Digest);
 
@@ -23,14 +23,14 @@ impl Nullifier {
     pub fn new(
         script_hash: Digest,
         inputs_hash: Digest,
-        vault_hash: Digest,
+        asset_hash: Digest,
         serial_num: Word,
     ) -> Self {
         let mut elements = [ZERO; 4 * WORD_SIZE];
         elements[..4].copy_from_slice(&serial_num);
         elements[4..8].copy_from_slice(script_hash.as_elements());
         elements[8..12].copy_from_slice(inputs_hash.as_elements());
-        elements[12..].copy_from_slice(vault_hash.as_elements());
+        elements[12..].copy_from_slice(asset_hash.as_elements());
         Self(Hasher::hash_elements(&elements))
     }
 
@@ -50,7 +50,12 @@ impl Nullifier {
 
 impl From<&Note> for Nullifier {
     fn from(note: &Note) -> Self {
-        Self::new(note.script.hash(), note.inputs.hash(), note.vault.hash(), note.serial_num)
+        Self::new(
+            note.script.hash(),
+            note.inputs.hash(),
+            note.assets.commitment(),
+            note.serial_num,
+        )
     }
 }
 


### PR DESCRIPTION
This closes #197. The changes are:

- `NoteVault` renamed to `NoteAssets`.
- `AccountVault` renamed to `AssetVault` and moved to the `assets` module.