### PR TITLE
Event-based procedure index lookups

### DIFF
--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -14,7 +14,6 @@ const.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT=131072
 # Event emitted to signal that an asset is being removed from the account vault.
 const.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT=131073
 
-
 # AUTHENTICATION
 # =================================================================================================
 

--- a/miden-lib/asm/miden/kernels/tx/account.masm
+++ b/miden-lib/asm/miden/kernels/tx/account.masm
@@ -39,8 +39,8 @@ const.MAX_SLOT_TYPE=64
 # EVENTS
 # =================================================================================================
 
-# Event emitted to push index of the account procedure at the top of the operand stack onto the
-# advice stack.
+# Event emitted to push the index of the account procedure at the top of the operand stack onto
+# the advice stack.
 const.PUSH_ACCOUNT_PROCEDURE_INDEX_EVENT=131074
 
 # CONSTANT ACCESSORS
@@ -350,7 +350,7 @@ export.set_item
     # => [V]
 end
 
-#! Authenticates the procedure root is part of the account code Merkle tree. Panics if the
+#! Verifies that the procedure root is part of the account code Merkle tree. Panics if the
 #! procedure root is not part of the account code Merkle tree.
 #!
 #! Stack: [PROC_ROOT]

--- a/miden-lib/asm/miden/kernels/tx/account.masm
+++ b/miden-lib/asm/miden/kernels/tx/account.masm
@@ -36,6 +36,13 @@ const.SLOT_TYPES_COMMITMENT_STORAGE_SLOT=255
 # The maximum value a slot type can take (An array of depth 64).
 const.MAX_SLOT_TYPE=64
 
+# EVENTS
+# =================================================================================================
+
+# Event emitted to push index of the account procedure at the top of the operand stack onto the
+# advice stack.
+const.PUSH_ACCOUNT_PROCEDURE_INDEX_EVENT=131074
+
 # CONSTANT ACCESSORS
 # =================================================================================================
 
@@ -343,7 +350,7 @@ export.set_item
     # => [V]
 end
 
-#! Authenticates the proedcure root is part of the account code Merkle treee. Panics if the
+#! Authenticates the procedure root is part of the account code Merkle tree. Panics if the
 #! procedure root is not part of the account code Merkle tree.
 #!
 #! Stack: [PROC_ROOT]
@@ -355,8 +362,8 @@ export.authenticate_procedure.1
     exec.memory::get_acct_code_root swapw
     # => [PROC_ROOT, CODE_ROOT]
 
-    # load the index of the procedure root onto the advice stack
-    adv.push_mapval adv_push.1 movdn.4
+    # load the index of the procedure root onto the advice stack, and move it to the operand stack
+    emit.PUSH_ACCOUNT_PROCEDURE_INDEX_EVENT adv_push.1 movdn.4
     # => [PROC_ROOT, index, CODE_ROOT]
 
     # push the depth of the code Merkle tree onto the stack

--- a/miden-lib/src/tests/mod.rs
+++ b/miden-lib/src/tests/mod.rs
@@ -1,15 +1,9 @@
 use std::path::PathBuf;
 
-use miden_objects::{
-    transaction::PreparedTransaction,
-    vm::{Program, StackInputs},
-    Felt, Hasher, Word, ONE, ZERO,
-};
-use vm_processor::{
-    AdviceProvider, ContextId, DefaultHost, MemAdviceProvider, Process, ProcessState,
-};
+use miden_objects::{vm::StackInputs, Felt, Hasher, Word, ONE, ZERO};
+use vm_processor::{ContextId, MemAdviceProvider, Process, ProcessState};
 
-use super::{transaction::ToTransactionKernelInputs, Library};
+use super::Library;
 
 mod test_account;
 mod test_asset;
@@ -45,12 +39,6 @@ fn test_compile() {
 
 // HELPER FUNCTIONS
 // ================================================================================================
-
-fn build_tx_inputs(tx: &PreparedTransaction) -> (Program, StackInputs, MemAdviceProvider) {
-    let (stack_inputs, advice_inputs) = tx.get_kernel_inputs();
-    let advice_provider = MemAdviceProvider::from(advice_inputs);
-    (tx.program().clone(), stack_inputs, advice_provider)
-}
 
 fn build_module_path(dir: &str, file: &str) -> PathBuf {
     [env!("CARGO_MANIFEST_DIR"), "asm", dir, file].iter().collect()

--- a/miden-lib/src/tests/test_asset.rs
+++ b/miden-lib/src/tests/test_asset.rs
@@ -9,11 +9,11 @@ use mock::{
     run_tx,
 };
 
-use super::{build_tx_inputs, Hasher, Word, ONE};
+use super::{Hasher, Word, ONE};
 
 #[test]
 fn test_create_fungible_asset_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -44,15 +44,13 @@ fn test_create_fungible_asset_succeeds() {
         "
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction);
 }
 
 #[test]
 fn test_create_non_fungible_asset_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -84,8 +82,6 @@ fn test_create_non_fungible_asset_succeeds() {
         expected_non_fungible_asset = prepare_word(&Word::from(non_fungible_asset))
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider).unwrap();
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction).unwrap();
 }

--- a/miden-lib/src/tests/test_faucet.rs
+++ b/miden-lib/src/tests/test_faucet.rs
@@ -12,7 +12,7 @@ use mock::{
     run_tx,
 };
 
-use super::{build_tx_inputs, ONE};
+use super::ONE;
 use crate::transaction::memory::FAUCET_STORAGE_DATA_SLOT;
 
 // FUNGIBLE FAUCET MINT TESTS
@@ -20,7 +20,7 @@ use crate::transaction::memory::FAUCET_STORAGE_DATA_SLOT;
 
 #[test]
 fn test_mint_fungible_asset_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -43,7 +43,7 @@ fn test_mint_fungible_asset_succeeds() {
             push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
             exec.faucet::mint
 
-            # assert the correct asset is returned
+            # assert the correct asset is returned
             push.{FUNGIBLE_ASSET_AMOUNT}.0.0.{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN}
             assert_eqw
 
@@ -63,15 +63,13 @@ fn test_mint_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider).unwrap();
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_mint_fungible_asset_fails_not_faucet_account() {
-    let (account, block_header, chain, notes) =
+    let tx_inputs =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
@@ -88,16 +86,14 @@ fn test_mint_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
     assert!(process.is_err());
 }
 
 #[test]
 fn test_mint_fungible_asset_inconsistent_faucet_id() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -120,17 +116,15 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
 
 #[test]
 fn test_mint_fungible_asset_fails_saturate_max_amount() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -154,10 +148,8 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() {
         saturating_amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_FAUCET_INITIAL_BALANCE + 1
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
@@ -169,7 +161,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() {
 #[ignore]
 #[test]
 fn test_mint_non_fungible_asset_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -217,15 +209,13 @@ fn test_mint_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider).unwrap();
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_mint_non_fungible_asset_fails_not_faucet_account() {
-    let (account, block_header, chain, notes) =
+    let tx_inputs =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
 
@@ -244,17 +234,15 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
 
 #[test]
 fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
-    let (account, block_header, chain, notes) =
+    let tx_inputs =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1);
 
@@ -273,17 +261,15 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
 
 #[test]
 fn test_mint_non_fungible_asset_fails_asset_already_exists() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -308,10 +294,8 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
@@ -321,7 +305,7 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
 
 #[test]
 fn test_burn_fungible_asset_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
             nonce: ONE,
@@ -365,15 +349,13 @@ fn test_burn_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider).unwrap();
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_burn_fungible_asset_fails_not_faucet_account() {
-    let (account, block_header, chain, notes) =
+    let tx_inputs =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
@@ -390,17 +372,15 @@ fn test_burn_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
 
 #[test]
 fn test_burn_fungible_asset_inconsistent_faucet_id() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -423,16 +403,14 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
     assert!(process.is_err());
 }
 
 #[test]
 fn test_burn_fungible_asset_insufficient_input_amount() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
             nonce: ONE,
@@ -456,10 +434,8 @@ fn test_burn_fungible_asset_insufficient_input_amount() {
         saturating_amount = CONSUMED_ASSET_1_AMOUNT + 1
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
@@ -471,7 +447,7 @@ fn test_burn_fungible_asset_insufficient_input_amount() {
 #[ignore]
 #[test]
 fn test_burn_non_fungible_asset_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -519,15 +495,13 @@ fn test_burn_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider).unwrap();
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_burn_non_fungible_asset_fails_does_not_exist() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -557,17 +531,15 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
 
 #[test]
 fn test_burn_non_fungible_asset_fails_not_faucet_account() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::TooManyNonFungibleInput,
     );
@@ -593,17 +565,15 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
 
 #[test]
 fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -633,10 +603,8 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let process = run_tx(program, stack_inputs, advice_provider);
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let process = run_tx(&transaction);
 
     assert!(process.is_err());
 }
@@ -646,7 +614,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
 
 #[test]
 fn test_get_total_issuance_succeeds() {
-    let (account, block_header, chain, notes) = mock_inputs(
+    let tx_inputs = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -675,8 +643,6 @@ fn test_get_total_issuance_succeeds() {
     ",
     );
 
-    let transaction =
-        prepare_transaction(account, None, block_header, chain, notes, None, &code, "", None);
-    let (program, stack_inputs, advice_provider) = build_tx_inputs(&transaction);
-    let _process = run_tx(program, stack_inputs, advice_provider).unwrap();
+    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let _process = run_tx(&transaction).unwrap();
 }

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -1,5 +1,28 @@
 use core::fmt;
 
+use super::Digest;
+
+// TRANSACTION KERNEL ERROR
+// ================================================================================================
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum TransactionKernelError {
+    UnknownAccountProcedure(Digest),
+}
+
+impl fmt::Display for TransactionKernelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownAccountProcedure(proc_root) => {
+                write!(f, "account procedure with root {proc_root} is not in the advice provider")
+            },
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TransactionKernelError {}
+
 // TRANSACTION EVENT PARSING ERROR
 // ================================================================================================
 

--- a/miden-lib/src/transaction/events.rs
+++ b/miden-lib/src/transaction/events.rs
@@ -17,6 +17,7 @@ use super::TransactionEventParsingError;
 pub enum TransactionEvent {
     AddAssetToAccountVault = 0x2_0000,      // 131072
     RemoveAssetFromAccountVault = 0x2_0001, // 131073
+    PushAccountProcedureIndex = 0x2_0002,   // 131074
 }
 
 impl TransactionEvent {
@@ -41,6 +42,7 @@ impl TryFrom<u32> for TransactionEvent {
         match value {
             0x2_0000 => Ok(TransactionEvent::AddAssetToAccountVault),
             0x2_0001 => Ok(TransactionEvent::RemoveAssetFromAccountVault),
+            0x2_0002 => Ok(TransactionEvent::PushAccountProcedureIndex),
             _ => Err(TransactionEventParsingError::InvalidTransactionEvent(value)),
         }
     }

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -229,13 +229,6 @@ fn add_account_to_advice_inputs(
     // extend the merkle store with account code tree
     inputs.extend_merkle_store(code.procedure_tree().inner_nodes());
 
-    // extend advice map with account proc root |-> proc index
-    inputs.extend_map(
-        code.procedure_tree()
-            .leaves()
-            .map(|(idx, leaf)| (leaf.into_bytes(), vec![idx.into()])),
-    );
-
     // --- account seed -------------------------------------------------------
     if let Some(account_seed) = account_seed {
         inputs.extend_map(vec![(

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -28,7 +28,7 @@ pub use outputs::{
 };
 
 mod errors;
-pub use errors::TransactionEventParsingError;
+pub use errors::{TransactionEventParsingError, TransactionKernelError};
 
 // TRANSACTION KERNEL
 // ================================================================================================

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -144,7 +144,7 @@ impl<D: DataStore> TransactionExecutor<D> {
 
         let (stack_inputs, advice_inputs) = transaction.get_kernel_inputs();
         let advice_recorder: RecAdviceProvider = advice_inputs.into();
-        let mut host = TransactionHost::new(advice_recorder);
+        let mut host = TransactionHost::new(transaction.account().into(), advice_recorder);
 
         let result = vm_processor::execute(
             transaction.program(),

--- a/miden-tx/src/host/account_delta.rs
+++ b/miden-tx/src/host/account_delta.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     utils::collections::{btree_map::Entry, BTreeMap},
     Digest,
 };
-use vm_processor::{ExecutionError, HostResponse, ProcessState};
+use vm_processor::{ExecutionError, ProcessState};
 
 // ACCOUNT VAULT DELTA TRACKER
 // ================================================================================================
@@ -31,10 +31,7 @@ impl AccountVaultDeltaTracker {
 
     /// Extracts the asset that is being added to the account's vault from the process state and
     /// updates the appropriate fungible or non-fungible asset map.
-    pub fn add_asset<S: ProcessState>(
-        &mut self,
-        process: &S,
-    ) -> Result<HostResponse, ExecutionError> {
+    pub fn add_asset<S: ProcessState>(&mut self, process: &S) -> Result<(), ExecutionError> {
         let asset: Asset = process.get_stack_word(0).try_into().map_err(|err| {
             ExecutionError::EventError(format!(
                 "Failed to apply account vault delta - asset is malformed - {err}"
@@ -54,16 +51,13 @@ impl AccountVaultDeltaTracker {
             },
         };
 
-        Ok(HostResponse::None)
+        Ok(())
     }
 
     /// Extracts the asset that is being removed from the account's vault from the process state
     /// and updates the appropriate [AccountVaultDeltaHandler::fungible_assets] or
     /// [AccountVaultDeltaHandler::non_fungible_assets] map.
-    pub fn remove_asset<S: ProcessState>(
-        &mut self,
-        process: &S,
-    ) -> Result<HostResponse, ExecutionError> {
+    pub fn remove_asset<S: ProcessState>(&mut self, process: &S) -> Result<(), ExecutionError> {
         let asset: Asset = process.get_stack_word(0).try_into().map_err(|err| {
             ExecutionError::EventError(format!(
                 "Failed to apply account vault delta - asset is malformed - {err}"
@@ -83,7 +77,7 @@ impl AccountVaultDeltaTracker {
             },
         };
 
-        Ok(HostResponse::None)
+        Ok(())
     }
 
     // CONVERSIONS

--- a/miden-tx/src/host/account_procs.rs
+++ b/miden-tx/src/host/account_procs.rs
@@ -1,0 +1,56 @@
+use miden_lib::transaction::TransactionKernelError;
+use miden_objects::accounts::AccountCode;
+
+use super::{AdviceProvider, BTreeMap, Digest, NodeIndex, ProcessState};
+
+// ACCOUNT PROCEDURE INDEX MAP
+// ================================================================================================
+
+/// A map of proc_root |-> proc_index for all known procedures of an account interface.
+pub struct AccountProcedureIndexMap(BTreeMap<Digest, u8>);
+
+impl AccountProcedureIndexMap {
+    /// Returns a new [AccountProcedureIndexMap] instantiated with account procedures present in
+    /// the provided advice provider.
+    ///
+    /// This function assumes that the account procedure tree (or a part thereof) is loaded into the
+    /// Merkle store of the provided advice provider.
+    pub fn new<A: AdviceProvider>(account_code_root: Digest, adv_provider: &A) -> Self {
+        // get the Merkle store with the procedure tree from the advice provider
+        let proc_store = adv_provider.get_store_subset([account_code_root].iter());
+
+        // iterate over all possible procedure indexes
+        let mut result = BTreeMap::new();
+        for i in 0..AccountCode::MAX_NUM_PROCEDURES {
+            let index = NodeIndex::new(AccountCode::PROCEDURE_TREE_DEPTH, i as u64)
+                .expect("procedure tree index is valid");
+            // if the node at the current index does not exist, skip it and try the next node;this
+            // situation is valid if not all account procedures are loaded into the advice provider
+            if let Ok(proc_root) = proc_store.get_node(account_code_root, index) {
+                // if we got an empty digest, this means we got to the end of the procedure list
+                if proc_root == Digest::default() {
+                    break;
+                }
+                result.insert(proc_root, i as u8);
+            }
+        }
+        Self(result)
+    }
+
+    /// Returns index of the procedure whose root is currently at the top of the operand stack in
+    /// the provided process.
+    ///
+    /// # Errors
+    /// Returns an error if the procedure at the top of the operand stack is not present in this
+    /// map.
+    pub fn get_proc_index<S: ProcessState>(
+        &self,
+        process: &S,
+    ) -> Result<u8, TransactionKernelError> {
+        let proc_root = process.get_stack_word(0).into();
+        self.0
+            .get(&proc_root)
+            .cloned()
+            .ok_or(TransactionKernelError::UnknownAccountProcedure(proc_root))
+    }
+}

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -51,7 +51,7 @@ impl TransactionProver {
         let tx_script_root = tx_witness.tx_script().map(|script| *script.hash());
 
         let advice_provider: MemAdviceProvider = advice_inputs.into();
-        let mut host = TransactionHost::new(advice_provider);
+        let mut host = TransactionHost::new(tx_witness.account().into(), advice_provider);
         let (stack_outputs, proof) =
             prove(tx_witness.program(), stack_inputs, &mut host, self.proof_options.clone())
                 .map_err(TransactionProverError::ProveTransactionProgramFailed)?;

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -49,7 +49,7 @@ fn test_transaction_executor_witness() {
     // use the witness to execute the transaction again
     let (stack_inputs, advice_inputs) = tx_witness.get_kernel_inputs();
     let mem_advice_provider: MemAdviceProvider = advice_inputs.into();
-    let mut host = TransactionHost::new(mem_advice_provider);
+    let mut host = TransactionHost::new(tx_witness.account().into(), mem_advice_provider);
     let result =
         vm_processor::execute(tx_witness.program(), stack_inputs, &mut host, Default::default())
             .unwrap();

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -346,13 +346,14 @@ struct MockDataStore {
 
 impl MockDataStore {
     pub fn new(asset_preservation: AssetPreservationStatus) -> Self {
-        let (account, block_header, block_chain, input_notes) =
-            mock_inputs(MockAccountType::StandardExisting, asset_preservation);
+        let (account, _, block_header, block_chain, notes) =
+            mock_inputs(MockAccountType::StandardExisting, asset_preservation).into_parts();
+
         Self {
             account,
             block_header,
             block_chain,
-            notes: input_notes,
+            notes: notes.into_vec(),
         }
     }
 }

--- a/miden-tx/tests/common/mod.rs
+++ b/miden-tx/tests/common/mod.rs
@@ -32,13 +32,14 @@ pub struct MockDataStore {
 
 impl MockDataStore {
     pub fn new() -> Self {
-        let (account, block_header, block_chain, consumed_notes) =
-            mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
+        let (account, _, block_header, block_chain, notes) =
+            mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved)
+                .into_parts();
         Self {
             account,
             block_header,
             block_chain,
-            notes: consumed_notes,
+            notes: notes.into_vec(),
         }
     }
 

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -1,18 +1,15 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
-use miden_lib::transaction::{memory, TransactionKernel};
+use miden_lib::transaction::{memory, ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
-    accounts::Account,
     notes::NoteAssets,
-    transaction::{
-        ChainMmr, InputNote, InputNotes, OutputNotes, PreparedTransaction, TransactionInputs,
-        TransactionScript,
-    },
-    BlockHeader, Felt, StarkField,
+    transaction::{OutputNotes, PreparedTransaction, TransactionInputs, TransactionScript},
+    Felt, StarkField,
 };
+use mock::host::MockHost;
 use vm_processor::{
-    AdviceProvider, DefaultHost, ExecutionError, ExecutionOptions, Process, Program, StackInputs,
-    Word,
+    AdviceInputs, AdviceProvider, DefaultHost, ExecutionError, ExecutionOptions, Host, Process,
+    StackInputs, Word,
 };
 
 pub mod builders;
@@ -35,18 +32,18 @@ fn load_file_with_code(imports: &str, code: &str, assembly_file: PathBuf) -> Str
 }
 
 /// Inject `code` along side the specified file and run it
-pub fn run_tx<A>(
-    program: Program,
-    stack_inputs: StackInputs,
-    mut adv: A,
-) -> Result<Process<DefaultHost<A>>, ExecutionError>
-where
-    A: AdviceProvider,
-{
-    // mock account method for testing from root context
-    adv.insert_into_map(Word::default(), vec![Felt::new(255)]).unwrap();
+pub fn run_tx(tx: &PreparedTransaction) -> Result<Process<MockHost>, ExecutionError> {
+    run_tx_with_inputs(tx, AdviceInputs::default())
+}
 
-    let host = DefaultHost::new(adv);
+pub fn run_tx_with_inputs(
+    tx: &PreparedTransaction,
+    inputs: AdviceInputs,
+) -> Result<Process<MockHost>, ExecutionError> {
+    let program = tx.program().clone();
+    let (stack_inputs, mut advice_inputs) = tx.get_kernel_inputs();
+    advice_inputs.extend(inputs);
+    let host = MockHost::new(tx.account().into(), advice_inputs);
     let mut process =
         Process::new(program.kernel().clone(), stack_inputs, host, ExecutionOptions::default());
     process.execute(&program)?;
@@ -83,41 +80,46 @@ where
     Ok(process)
 }
 
-// TEST HELPERS
-// ================================================================================================
-pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
-    memory::CONSUMED_NOTE_SECTION_OFFSET + (1 + note_idx) * 1024
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn prepare_transaction(
-    account: Account,
-    account_seed: Option<Word>,
-    block_header: BlockHeader,
-    chain: ChainMmr,
-    notes: Vec<InputNote>,
-    tx_script: Option<TransactionScript>,
-    code: &str,
+/// Inject `code` along side the specified file and run it
+pub fn run_within_host<H: Host>(
     imports: &str,
+    code: &str,
+    stack_inputs: StackInputs,
+    host: H,
     file_path: Option<PathBuf>,
-) -> PreparedTransaction {
+) -> Result<Process<H>, ExecutionError> {
     let assembler = TransactionKernel::assembler();
-
     let code = match file_path {
         Some(file_path) => load_file_with_code(imports, code, file_path),
         None => format!("{imports}{code}"),
     };
 
     let program = assembler.compile(code).unwrap();
+    let mut process =
+        Process::new(program.kernel().clone(), stack_inputs, host, ExecutionOptions::default());
+    process.execute(&program)?;
+    Ok(process)
+}
 
-    let tx_inputs = TransactionInputs::new(
-        account,
-        account_seed,
-        block_header,
-        chain,
-        InputNotes::new(notes).unwrap(),
-    )
-    .unwrap();
+// TEST HELPERS
+// ================================================================================================
+pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
+    memory::CONSUMED_NOTE_SECTION_OFFSET + (1 + note_idx) * 1024
+}
 
+pub fn prepare_transaction(
+    tx_inputs: TransactionInputs,
+    tx_script: Option<TransactionScript>,
+    code: &str,
+    file_path: Option<PathBuf>,
+) -> PreparedTransaction {
+    let assembler = TransactionKernel::assembler();
+
+    let code = match file_path {
+        Some(file_path) => load_file_with_code("", code, file_path),
+        None => code.to_string(),
+    };
+
+    let program = assembler.compile(code).unwrap();
     PreparedTransaction::new(program, tx_script, tx_inputs)
 }

--- a/mock/src/mock/host/account_procs.rs
+++ b/mock/src/mock/host/account_procs.rs
@@ -1,0 +1,61 @@
+use miden_lib::transaction::TransactionKernelError;
+use miden_objects::accounts::AccountCode;
+
+use super::{AdviceProvider, BTreeMap, Digest, NodeIndex, ProcessState};
+
+// ACCOUNT PROCEDURE INDEX MAP
+// ================================================================================================
+
+/// A map of proc_root |-> proc_index for all known procedures of an account interface.
+pub struct AccountProcedureIndexMap(BTreeMap<Digest, u8>);
+
+impl AccountProcedureIndexMap {
+    /// Returns a new [AccountProcedureIndexMap] instantiated with account procedures present in
+    /// the provided advice provider.
+    ///
+    /// This function assumes that the account procedure tree (or a part thereof) is loaded into the
+    /// Merkle store of the provided advice provider.
+    pub fn new<A: AdviceProvider>(account_code_root: Digest, adv_provider: &A) -> Self {
+        // get the Merkle store with the procedure tree from the advice provider
+        let proc_store = adv_provider.get_store_subset([account_code_root].iter());
+
+        // iterate over all possible procedure indexes
+        let mut result = BTreeMap::new();
+        for i in 0..AccountCode::MAX_NUM_PROCEDURES {
+            let index = NodeIndex::new(AccountCode::PROCEDURE_TREE_DEPTH, i as u64)
+                .expect("procedure tree index is valid");
+            // if the node at the current index does not exist, skip it and try the next node;this
+            // situation is valid if not all account procedures are loaded into the advice provider
+            if let Ok(proc_root) = proc_store.get_node(account_code_root, index) {
+                // if we got an empty digest, this means we got to the end of the procedure list
+                if proc_root == Digest::default() {
+                    break;
+                }
+                result.insert(proc_root, i as u8);
+            }
+        }
+        Self(result)
+    }
+
+    /// Returns index of the procedure whose root is currently at the top of the operand stack in
+    /// the provided process.
+    ///
+    /// # Errors
+    /// Returns an error if the procedure at the top of the operand stack is not present in this
+    /// map.
+    pub fn get_proc_index<S: ProcessState>(
+        &self,
+        process: &S,
+    ) -> Result<u8, TransactionKernelError> {
+        let proc_root = process.get_stack_word(0).into();
+        // mock account method for testing from root context
+        // TODO: figure out if we can get rid of this
+        if proc_root == Digest::default() {
+            return Ok(255);
+        }
+        self.0
+            .get(&proc_root)
+            .cloned()
+            .ok_or(TransactionKernelError::UnknownAccountProcedure(proc_root))
+    }
+}

--- a/mock/src/mock/host/mod.rs
+++ b/mock/src/mock/host/mod.rs
@@ -1,0 +1,99 @@
+use miden_lib::transaction::TransactionEvent;
+use miden_objects::{
+    accounts::{delta::AccountVaultDelta, AccountStub},
+    utils::{collections::BTreeMap, string::ToString},
+    Digest,
+};
+use vm_processor::{
+    crypto::NodeIndex, AdviceExtractor, AdviceInjector, AdviceInputs, AdviceProvider, AdviceSource,
+    ContextId, ExecutionError, Host, HostResponse, MemAdviceProvider, ProcessState,
+};
+
+mod account_procs;
+use account_procs::AccountProcedureIndexMap;
+
+// MOCK HOST
+// ================================================================================================
+
+/// This is very similar to the TransactionHost in miden-tx. The differences include:
+/// - We do not track account delta here.
+/// - There is special handling of EMPTY_DIGEST in account procedure index map.
+/// - This host uses `MemAdviceProvider` which is instantiated from the passed in advice inputs.
+pub struct MockHost {
+    adv_provider: MemAdviceProvider,
+    acct_procedure_index_map: AccountProcedureIndexMap,
+}
+
+impl MockHost {
+    /// Returns a new [MockHost] instance with the provided [AdviceInputs].
+    pub fn new(account: AccountStub, advice_inputs: AdviceInputs) -> Self {
+        let adv_provider: MemAdviceProvider = advice_inputs.into();
+        let proc_index_map = AccountProcedureIndexMap::new(account.code_root(), &adv_provider);
+        Self {
+            adv_provider,
+            acct_procedure_index_map: proc_index_map,
+        }
+    }
+
+    /// Consumes this transaction host and returns the advice provider and account vault delta.
+    pub fn into_parts(self) -> (MemAdviceProvider, AccountVaultDelta) {
+        (self.adv_provider, AccountVaultDelta::default())
+    }
+
+    // EVENT HANDLERS
+    // --------------------------------------------------------------------------------------------
+
+    fn on_push_account_procedure_index<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<(), ExecutionError> {
+        let proc_idx = self
+            .acct_procedure_index_map
+            .get_proc_index(process)
+            .map_err(|err| ExecutionError::EventError(err.to_string()))?;
+        self.adv_provider.push_stack(AdviceSource::Value(proc_idx.into()))?;
+        Ok(())
+    }
+}
+
+impl Host for MockHost {
+    fn get_advice<S: ProcessState>(
+        &mut self,
+        process: &S,
+        extractor: AdviceExtractor,
+    ) -> Result<HostResponse, ExecutionError> {
+        self.adv_provider.get_advice(process, &extractor)
+    }
+
+    fn set_advice<S: ProcessState>(
+        &mut self,
+        process: &S,
+        injector: AdviceInjector,
+    ) -> Result<HostResponse, ExecutionError> {
+        self.adv_provider.set_advice(process, &injector)
+    }
+
+    fn on_event<S: ProcessState>(
+        &mut self,
+        process: &S,
+        event_id: u32,
+    ) -> Result<HostResponse, ExecutionError> {
+        let event = TransactionEvent::try_from(event_id)
+            .map_err(|err| ExecutionError::EventError(err.to_string()))?;
+
+        if process.ctx() != ContextId::root() {
+            return Err(ExecutionError::EventError(format!(
+                "{event} event can only be emitted from the root context"
+            )));
+        }
+
+        use TransactionEvent::*;
+        match event {
+            AddAssetToAccountVault => Ok(()),
+            RemoveAssetFromAccountVault => Ok(()),
+            PushAccountProcedureIndex => self.on_push_account_procedure_index(process),
+        }?;
+
+        Ok(HostResponse::None)
+    }
+}

--- a/mock/src/mock/mod.rs
+++ b/mock/src/mock/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod block;
 pub mod chain;
+pub mod host;
 pub mod mmr_peaks;
 pub mod notes;
 pub mod transaction;

--- a/mock/src/mock/transaction.rs
+++ b/mock/src/mock/transaction.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     utils::collections::Vec,
     BlockHeader, Felt, FieldElement,
 };
-use vm_processor::{AdviceInputs, Operation, Program};
+use vm_processor::{AdviceInputs, Operation, Program, Word};
 
 use super::{
     super::TransactionKernel,
@@ -24,7 +24,15 @@ use super::{
 pub fn mock_inputs(
     account_type: MockAccountType,
     asset_preservation: AssetPreservationStatus,
-) -> (Account, BlockHeader, ChainMmr, Vec<InputNote>) {
+) -> TransactionInputs {
+    mock_inputs_with_account_seed(account_type, asset_preservation, None)
+}
+
+pub fn mock_inputs_with_account_seed(
+    account_type: MockAccountType,
+    asset_preservation: AssetPreservationStatus,
+    account_seed: Option<Word>,
+) -> TransactionInputs {
     // Create assembler and assembler context
     let assembler = TransactionKernel::assembler();
 
@@ -51,7 +59,8 @@ pub fn mock_inputs(
         mock_block_header(4, Some(chain_mmr.peaks().hash_peaks()), None, &[account.clone()]);
 
     // Transaction inputs
-    (account, block_header, chain_mmr, recorded_notes)
+    let input_notes = InputNotes::new(recorded_notes).unwrap();
+    TransactionInputs::new(account, account_seed, block_header, chain_mmr, input_notes).unwrap()
 }
 
 pub fn mock_inputs_with_existing(

--- a/objects/src/accounts/stub.rs
+++ b/objects/src/accounts/stub.rs
@@ -79,13 +79,19 @@ impl AccountStub {
 }
 
 impl From<Account> for AccountStub {
-    fn from(value: Account) -> Self {
+    fn from(account: Account) -> Self {
+        (&account).into()
+    }
+}
+
+impl From<&Account> for AccountStub {
+    fn from(account: &Account) -> Self {
         Self {
-            id: value.id(),
-            nonce: value.nonce(),
-            vault_root: value.vault().commitment(),
-            storage_root: value.storage().root(),
-            code_root: value.code().root(),
+            id: account.id(),
+            nonce: account.nonce(),
+            vault_root: account.vault().commitment(),
+            storage_root: account.storage().root(),
+            code_root: account.code().root(),
         }
     }
 }

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -88,6 +88,20 @@ impl TransactionInputs {
     pub fn input_notes(&self) -> &InputNotes {
         &self.input_notes
     }
+
+    // CONVERSIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Consumes these transaction inputs and returns their underlying components.
+    pub fn into_parts(self) -> (Account, Option<Word>, BlockHeader, ChainMmr, InputNotes) {
+        (
+            self.account,
+            self.account_seed,
+            self.block_header,
+            self.block_chain,
+            self.input_notes,
+        )
+    }
 }
 
 // TO NULLIFIER TRAIT
@@ -206,6 +220,14 @@ impl<T: ToNullifier> InputNotes<T> {
     /// Returns an iterator over notes in this [InputNotes].
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.notes.iter()
+    }
+
+    // CONVERSIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Converts self into a vector of input notes.
+    pub fn into_vec(self) -> Vec<T> {
+        self.notes
     }
 }
 


### PR DESCRIPTION
This PR builds on #404 and partially addresses #273. Specifically, we no longer put the `proc_root |-> proc_index` map into the advice provider. Instead, we introduce `PushAccountProcedureIndex` event which the `TransactionHost` uses to populate the advice stack with the index of the relevant procedure.

Also, as a part of this PR I updated the tests to use `MockHost` - this resulted in quite a few changes in existing tests.