### PR TITLE
refactor: handling of input notes in the advice provider

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -404,21 +404,22 @@ proc.process_acct_data
     # => []
 end
 
-# CONSUMED NOTES DATA
+# INPUT NOTES DATA
 # =================================================================================================
 
-#! Authenticate the consumed note data provided via the advice provider is consistent with the
+#! Authenticate the input note data provided via the advice provider is consistent with the
 #! the chain history.  This is achieved by:
 #! - authenticating the MMR leaf associated with the block the note was created in.
 #! - authenticating the note root associated with the block the note was created in.
 #! - authenticating the note and its metadata in the note Merkle tree from the block the note was
 #!   created in.
 #!
-#! Stack: [AUTH_DIGEST]
-#! Advice Stack: [leaf_pos, SUB_HASH, NOTE_ROOT, note_index]
+#! Operand stack: [AUTH_DIGEST]
+#! Advice stack: [leaf_pos, SUB_HASH, NOTE_ROOT, note_index]
 #! Output: []
 #!
-#! - AUTH_DIGEST is the digest of the consumed note data computed as hash(NOTE_HASH, NOTE_METADATA)
+#! Where:
+#! - AUTH_DIGEST is the digest of the input note data computed as hash(NOTE_HASH, NOTE_METADATA)
 #! - leaf_pos is the position of the leaf in the MMR associated with the block the note was created
 #!   in. This is equivalent to the block number.
 #! - SUB_HASH is the sub hash of the block the note was created in.
@@ -466,7 +467,7 @@ proc.authenticate_note.2
     # => []
 end
 
-#! Reads data for consumed note i from the advice provider and stores it in memory at the
+#! Reads data for the input note i from the advice provider and stores it in memory at the
 #! appropriate memory address. This includes computing and storing the nullifier and the
 #! note hash.
 #!
@@ -477,15 +478,16 @@ end
 #!
 #! Output: []
 #!
-#! - i is the index of the consumed note.
-#! - CN1_SN is the serial number of consumed note 1.
-#! - CN1_SR is the script root of consumed note 1.
-#! - CN1_IR is the inputs root of consumed note 1.
-#! - CN1_VR is the vault root of consumed note 1.
-#! - CN1_NA is the number of assets in consumed note 1.
-#! - CN1_A1 is the first asset of consumed note 1.
-#! - CN1_A2 is the second asset of consumed note 1.
-proc.process_consumed_note
+#! Where:
+#! - i is the index of the input note.
+#! - CN1_SN is the serial number of input note 1.
+#! - CN1_SR is the script root of input note 1.
+#! - CN1_IR is the inputs root of input note 1.
+#! - CN1_VR is the vault root of input note 1.
+#! - CN1_NA is the number of assets in input note 1.
+#! - CN1_A1 is the first asset of input note 1.
+#! - CN1_A2 is the second asset of input note 1.
+proc.process_input_note
     # read core note data
     # ---------------------------------------------------------------------------------------------
 
@@ -653,61 +655,68 @@ proc.process_consumed_note
     exec.authenticate_note
 end
 
-#! Process the consumed notes data provided via the advice provider. This involves reading the data
+#! Process the input notes data provided via the advice provider. This involves reading the data
 #! from the advice provider and storing it at the appropriate memory addresses. As each note is
-#! consumed its hash and nullifier is computed. The transaction nullifier commitment is computed
-#! via a sequential hash of all (nullifier, ZERO) pairs for all consumed notes.
+#! processed its hash and nullifier is computed. The transaction nullifier commitment is computed
+#! via a sequential hash of all (nullifier, ZERO) pairs for all input notes.
 #!
 #! Stack: []
-#! Advice stack: [num_cn,
-#!               CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M,
-#!               CN1_A1, CN1_A2, ...
+#! Advice stack: [num_cn, ...],
+#! Advice map: {
+#!               NC: [
+#!                  CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M,
+#!                  CN1_A1, CN1_A2, ...
 #!
-#!               CN2_SN,CN2_SR, CN2_IR, CN2_VR, CN2_M,
-#!               CN2_A1, CN2_A2, ...
-#!               ...]
+#!                  CN2_SN,CN2_SR, CN2_IR, CN2_VR, CN2_M,
+#!                  CN2_A1, CN2_A2, ...
+#!                  ...]
+#!              }
 #! Output: []
 #!
-#! - num_cn is the number of consumed notes.
-#! - CN1_SN is the serial number of consumed note 1.
-#! - CN1_SR is the script root of consumed note 1.
-#! - CN1_IR is the inputs root of consumed note 1.
-#! - CN1_VR is the vault root of consumed note 1.
-#! - CN1_M is the metadata of consumed note 1.
-#! - CN1_A1 is the first asset of consumed note 1.
-#! - CN1_A2 is the second asset of consumed note 1.
-proc.process_consumed_notes_data
-    # load the consumed notes data onto the advice stack
-    exec.memory::get_nullifier_com adv.push_mapval dropw
-    # => [...]
-
-    # read the number of consumed notes from the advice provider
+#! - num_cn is the number of input notes.
+#! - NC is the input note nullifier commitment.
+#! - CN1_SN is the serial number of input note 1.
+#! - CN1_SR is the script root of input note 1.
+#! - CN1_IR is the inputs root of input note 1.
+#! - CN1_VR is the vault root of input note 1.
+#! - CN1_M is the metadata of input note 1.
+#! - CN1_A1 is the first asset of input note 1.
+#! - CN1_A2 is the second asset of input note 1.
+proc.process_input_notes_data
+    # get the number of input notes from the advice stack
     adv_push.1
     # => [num_notes, ...]
 
-    # store the number of consumed notes
-    dup exec.memory::set_total_num_consumed_notes
-    # => [num_notes, ...]
-
-    # assert the number of consumed notes is within limits; since max number of consumed notes is
+    # assert the number of input notes is within limits; since max number of input notes is
     # expected to be smaller than 2^32, we can use a more efficient u32 comparison
     dup exec.constants::get_max_num_consumed_notes u32assert2 u32lte assert
     # => [num_notes, ...]
 
-    # loop over consumed notes and read data
+    # if there are input notes, load input notes data from the advice map onto the advice stack
+    dup neq.0
+    if.true
+        exec.memory::get_nullifier_com adv.push_mapval dropw
+    end
+    # => [num_notes, ...]
+
+    # store the number of input notes into kernel memory
+    dup exec.memory::set_total_num_consumed_notes
+    # => [num_notes, ...]
+
+    # loop over input notes and read data
     # ---------------------------------------------------------------------------------------------
 
     # initialize counter of already processed notes
     push.0
     # => [num_processed_notes = 0, num_notes, ...]
 
-    # check if the number of consumed notes is greater then 0. Conditional for the while loop.
+    # check if the number of input notes is greater then 0. Conditional for the while loop.
     dup.1 dup.1 neq
     # => [has_more_notes, num_processed_notes, num_notes, ...]
 
     # loop and read note data from the advice provider
     while.true
-        dup exec.process_consumed_note
+        dup exec.process_input_note
         # => [num_processed_notes, num_notes, ...]
 
         # increment processed note counter and check if we should loop again
@@ -730,17 +739,17 @@ proc.process_consumed_notes_data
     padw padw padw
     # => [R1, R0, CAP, num_processed_notes, num_notes, ...]
 
-    # check if the number of consumed notes is greater then 0. Conditional for the while loop.
+    # check if the number of input notes is greater then 0. Conditional for the while loop.
     dup.13 dup.13 neq
     # => [has_more_notes, R1, R0, CAP, num_processed_notes, num_notes, ...]
 
-    # loop and sequentially hash hperm(nullifier, ZERO) over all consumed notes
+    # loop and sequentially hash hperm(nullifier, ZERO) over all input notes
     while.true
         # clear hasher rate
         dropw dropw
         # => [CAP, num_processed_notes, num_notes, ...]
 
-        # get consumed note nullifier
+        # get input note nullifier
         dup.4 exec.memory::get_consumed_note_nullifier
         # => [NULLIFIER, CAP, num_processed_notes, num_notes, ...]
 
@@ -761,7 +770,9 @@ proc.process_consumed_notes_data
     dropw swapw dropw
     # => [NULLIFIER_COM, num_processed_notes + 1, num_notes, ...]
 
-    # assert nullifier hash is what we would expect
+    # assert nullifier hash is what we would expect; when there are no input notes, the nullifier
+    # hash should be [ZERO; 4] because the while loop above was not entered and, thus, hperm
+    # instruction was not executed.
     exec.memory::get_nullifier_com assert_eqw
     # => [num_processed_notes + 1, num_notes, ...]
 
@@ -769,7 +780,7 @@ proc.process_consumed_notes_data
     drop drop
     # => [...]
 
-    # set the current consumed note pointer to the first consumed note
+    # set the current input note pointer to the first input note
     push.0 exec.memory::get_consumed_note_ptr exec.memory::set_current_consumed_note_ptr
     # => [...]
 end
@@ -802,24 +813,22 @@ end
 #! 1. "Unhash" inputs, authenticate the data and store it in the root contexts memory.
 #! 2. Build a single vault containing assets of all inputs (input notes combined with current
 #!    account vault).
-#! 3. Verify that all consumed notes are present in the note db.
+#! 3. Verify that all input notes are present in the note db.
 #!
 #! Errors:
 #!  - If data provided by the advice provider does not match global inputs.
 #!  - The account data is invalid.
-#!  - Any of the consumed notes do note exist in the note db.
+#!  - Any of the input notes do note exist in the note db.
 #!
-#! Stack:        [BH, acct_id, IAH, NC]
-#! Advice stack: [NR, PH, CR, SR, BR, PH, BN,
-#!                acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR,
-#!                num_cn,
-#!                CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M,
-#!                CN1_A1, CN1_A2, ...
-#!                CN2_SN,CN2_SR, CN2_IR, CN2_VR, CN2_M,
-#!                CN2_A1, CN2_A2, ...,
-#!                ...,
-#!                TXSR]
-#! Output:       []
+#! Operand stack: [BH, acct_id, IAH, NC]
+#! Advice stack:  [NR, PH, CR, SR, BR, PH, BN,
+#!                  acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR,
+#!                  num_cn, TXSR
+#!                ]
+#! Advice map:  {
+#!                  NC: [NOTE_1_DATA, ..., NOTE_N_DATA],
+#!              }
+#! Output:      []
 #!
 #!
 #! - BH is the latest known block hash at the time of transaction execution.
@@ -838,14 +847,8 @@ end
 #! - AVR is the account vault root.
 #! - ASR is the account storage root.
 #! - ACR is the account code root.
-#! - num_cn is the number of consumed notes.
-#! - CN1_SN is the serial number of consumed note 1.
-#! - CN1_SR is the script root of consumed note 1.
-#! - CN1_IR is the inputs root of consumed note 1.
-#! - CN1_VR is the vault root of consumed note 1.
-#! - CN1_M is the metadata of consumed note 1.
-#! - CN1_A1 is the first asset of consumed note 1.
-#! - CN1_A2 is the second asset of consumed note 1.
+#! - num_cn is the number of input notes.
+#! - NOTE_X_DATA is the data of the x'th note.
 #! - TXSR is the transaction script root.
 export.prepare_transaction
     # process global inputs
@@ -860,8 +863,8 @@ export.prepare_transaction
     # process account data
     exec.process_acct_data
 
-    # process consumed notes data
-    exec.process_consumed_notes_data
+    # process input notes data
+    exec.process_input_notes_data
 
     # process transaction script root
     exec.process_tx_script_root

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -114,7 +114,8 @@ fn extend_advice_inputs(
 ///  elements[40..43]  = account vault root
 ///  elements[44..47]  = account storage root
 ///  elements[48..51]  = account code root
-///  elements[42..56]  = account seed, if one was provided; otherwise [ZERO; 4]
+///  elements[52]      = number of input notes
+///  elements[53..57]  = account seed, if one was provided; otherwise [ZERO; 4]
 fn build_advice_stack(
     tx_inputs: &TransactionInputs,
     tx_script: Option<&TransactionScript>,
@@ -138,6 +139,9 @@ fn build_advice_stack(
     inputs.extend_stack(account.vault().commitment());
     inputs.extend_stack(account.storage().root());
     inputs.extend_stack(account.code().root());
+
+    // push the number of input notes onto the stack
+    inputs.extend_stack([Felt::from(tx_inputs.input_notes().num_notes() as u32)]);
 
     // push tx_script root onto the stack
     if let Some(tx_script) = tx_script {
@@ -272,10 +276,12 @@ fn add_account_to_advice_inputs(
 /// - asset_hash |-> assets
 /// - notes_hash |-> combined note data
 fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInputs) {
-    let mut note_data: Vec<Felt> = Vec::new();
+    // if there are no input notes, nothing is added to the advice inputs
+    if notes.is_empty() {
+        return;
+    }
 
-    note_data.push(Felt::from(notes.num_notes() as u64));
-
+    let mut note_data = Vec::new();
     for input_note in notes.iter() {
         let note = input_note.note();
         let proof = input_note.proof();

--- a/miden-tx/tests/common/mod.rs
+++ b/miden-tx/tests/common/mod.rs
@@ -17,7 +17,6 @@ use mock::{
         transaction::{mock_inputs, mock_inputs_with_existing},
     },
 };
-use vm_processor::AdviceInputs;
 
 // MOCK DATA STORE
 // ================================================================================================
@@ -43,21 +42,14 @@ impl MockDataStore {
         }
     }
 
-    pub fn with_existing(
-        account: Option<Account>,
-        consumed_notes: Option<Vec<Note>>,
-        auxiliary_data: Option<AdviceInputs>,
-    ) -> Self {
-        let (account, block_header, block_chain, consumed_notes, mut auxiliary_data_inputs) =
+    pub fn with_existing(account: Option<Account>, input_notes: Option<Vec<Note>>) -> Self {
+        let (account, block_header, block_chain, consumed_notes, _auxiliary_data_inputs) =
             mock_inputs_with_existing(
                 MockAccountType::StandardExisting,
                 AssetPreservationStatus::Preserved,
                 account,
-                consumed_notes,
+                input_notes,
             );
-        if let Some(auxiliary_data) = auxiliary_data {
-            auxiliary_data_inputs.extend(auxiliary_data);
-        }
         Self {
             account,
             block_header,

--- a/miden-tx/tests/faucet_contract_test.rs
+++ b/miden-tx/tests/faucet_contract_test.rs
@@ -20,6 +20,9 @@ use common::{
     get_new_key_pair_with_advice_map, get_note_with_fungible_asset_and_script, MockDataStore,
 };
 
+// TESTS MINT FUNGIBLE ASSET
+// ================================================================================================
+
 #[test]
 fn test_faucet_contract_mint_fungible_asset_succeeds() {
     let (faucet_pub_key, faucet_keypair_felts) = get_new_key_pair_with_advice_map();
@@ -28,7 +31,7 @@ fn test_faucet_contract_mint_fungible_asset_succeeds() {
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
-    let data_store = MockDataStore::with_existing(Some(faucet_account.clone()), Some(vec![]), None);
+    let data_store = MockDataStore::with_existing(Some(faucet_account.clone()), Some(vec![]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(faucet_account.id()).unwrap();
@@ -59,12 +62,11 @@ fn test_faucet_contract_mint_fungible_asset_succeeds() {
             end
             ",
             recipient = prepare_word(&recipient),
-            tag = tag,
-            amount = amount,
         )
         .as_str(),
     )
     .unwrap();
+
     let tx_script = executor
         .compile_tx_script(tx_script_code, vec![(faucet_pub_key, faucet_keypair_felts)], vec![])
         .unwrap();
@@ -97,7 +99,7 @@ fn test_faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
 
     // CONSTRUCT AND EXECUTE TX (Failure)
     // --------------------------------------------------------------------------------------------
-    let data_store = MockDataStore::with_existing(Some(faucet_account.clone()), Some(vec![]), None);
+    let data_store = MockDataStore::with_existing(Some(faucet_account.clone()), Some(vec![]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(faucet_account.id()).unwrap();
@@ -128,8 +130,6 @@ fn test_faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
             end
             ",
             recipient = prepare_word(&recipient),
-            tag = tag,
-            amount = amount,
         )
         .as_str(),
     )
@@ -144,6 +144,9 @@ fn test_faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
 
     assert!(transaction_result.is_err());
 }
+
+// TESTS BURN FUNGIBLE ASSET
+// ================================================================================================
 
 #[test]
 fn test_faucet_contract_burn_fungible_asset_succeeds() {
@@ -185,7 +188,7 @@ fn test_faucet_contract_burn_fungible_asset_succeeds() {
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
     let data_store =
-        MockDataStore::with_existing(Some(faucet_account.clone()), Some(vec![note.clone()]), None);
+        MockDataStore::with_existing(Some(faucet_account.clone()), Some(vec![note.clone()]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(faucet_account.id()).unwrap();
@@ -202,6 +205,9 @@ fn test_faucet_contract_burn_fungible_asset_succeeds() {
     assert_eq!(transaction_result.account_delta().nonce(), Some(Felt::new(2)));
     assert_eq!(transaction_result.input_notes().get_note(0).id(), note.id());
 }
+
+// TESTS FUNGIBLE CONTRACT CONSTRUCTION
+// ================================================================================================
 
 #[test]
 fn test_faucet_contract_creation() {

--- a/miden-tx/tests/p2id_script_test.rs
+++ b/miden-tx/tests/p2id_script_test.rs
@@ -50,7 +50,7 @@ fn test_p2id_script() {
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
     let data_store =
-        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note.clone()]), None);
+        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note.clone()]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account_id).unwrap();
@@ -102,7 +102,7 @@ fn test_p2id_script() {
         get_account_with_default_account_code(malicious_account_id, malicious_pub_key, None);
 
     let data_store_malicious_account =
-        MockDataStore::with_existing(Some(malicious_account), Some(vec![note]), None);
+        MockDataStore::with_existing(Some(malicious_account), Some(vec![note]));
     let mut executor_2 = TransactionExecutor::new(data_store_malicious_account.clone());
     executor_2.load_account(malicious_account_id).unwrap();
     let tx_script_malicious = executor
@@ -166,7 +166,7 @@ fn test_p2id_script_multiple_assets() {
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
     let data_store =
-        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note.clone()]), None);
+        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note.clone()]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account_id).unwrap();
@@ -218,7 +218,7 @@ fn test_p2id_script_multiple_assets() {
         get_account_with_default_account_code(malicious_account_id, malicious_pub_key, None);
 
     let data_store_malicious_account =
-        MockDataStore::with_existing(Some(malicious_account), Some(vec![note]), None);
+        MockDataStore::with_existing(Some(malicious_account), Some(vec![note]));
     let mut executor_2 = TransactionExecutor::new(data_store_malicious_account.clone());
     executor_2.load_account(malicious_account_id).unwrap();
     let tx_script_malicious = executor

--- a/miden-tx/tests/p2idr_script_test.rs
+++ b/miden-tx/tests/p2idr_script_test.rs
@@ -93,7 +93,6 @@ fn test_p2idr_script() {
     let data_store_1 = MockDataStore::with_existing(
         Some(target_account.clone()),
         Some(vec![note_in_time.clone()]),
-        None,
     );
     let mut executor_1 = TransactionExecutor::new(data_store_1.clone());
 
@@ -145,7 +144,6 @@ fn test_p2idr_script() {
     let data_store_2 = MockDataStore::with_existing(
         Some(sender_account.clone()),
         Some(vec![note_in_time.clone()]),
-        None,
     );
     let mut executor_2 = TransactionExecutor::new(data_store_2.clone());
     executor_2.load_account(sender_account_id).unwrap();
@@ -177,7 +175,6 @@ fn test_p2idr_script() {
     let data_store_3 = MockDataStore::with_existing(
         Some(malicious_account.clone()),
         Some(vec![note_in_time.clone()]),
-        None,
     );
     let mut executor_3 = TransactionExecutor::new(data_store_3.clone());
     executor_3.load_account(malicious_account_id).unwrap();
@@ -209,7 +206,6 @@ fn test_p2idr_script() {
     let data_store_4 = MockDataStore::with_existing(
         Some(target_account.clone()),
         Some(vec![note_reclaimable.clone()]),
-        None,
     );
     let mut executor_4 = TransactionExecutor::new(data_store_4.clone());
     executor_4.load_account(target_account_id).unwrap();
@@ -242,7 +238,6 @@ fn test_p2idr_script() {
     let data_store_5 = MockDataStore::with_existing(
         Some(sender_account.clone()),
         Some(vec![note_reclaimable.clone()]),
-        None,
     );
     let mut executor_5 = TransactionExecutor::new(data_store_5.clone());
 
@@ -275,7 +270,6 @@ fn test_p2idr_script() {
     let data_store_6 = MockDataStore::with_existing(
         Some(malicious_account.clone()),
         Some(vec![note_reclaimable.clone()]),
-        None,
     );
     let mut executor_6 = TransactionExecutor::new(data_store_6.clone());
 

--- a/miden-tx/tests/swap_script_test.rs
+++ b/miden-tx/tests/swap_script_test.rs
@@ -62,7 +62,7 @@ fn test_swap_script() {
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
     let data_store =
-        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note.clone()]), None);
+        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note.clone()]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account_id).unwrap();

--- a/miden-tx/tests/wallet_test.rs
+++ b/miden-tx/tests/wallet_test.rs
@@ -58,8 +58,7 @@ fn test_receive_asset_via_wallet() {
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
-    let data_store =
-        MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note]), None);
+    let data_store = MockDataStore::with_existing(Some(target_account.clone()), Some(vec![note]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(target_account.id()).unwrap();
@@ -126,7 +125,7 @@ fn test_send_asset_via_wallet() {
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
-    let data_store = MockDataStore::with_existing(Some(sender_account.clone()), Some(vec![]), None);
+    let data_store = MockDataStore::with_existing(Some(sender_account.clone()), Some(vec![]));
 
     let mut executor = TransactionExecutor::new(data_store.clone());
     executor.load_account(sender_account.id()).unwrap();

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -282,9 +282,13 @@ impl<T: ToNullifier> Deserializable for InputNotes<T> {
 
 /// Returns the commitment to the input notes represented by the specified nullifiers.
 ///
-/// This is a sequential hash of all (nullifier, ZERO) pairs for the notes consumed in the
-/// transaction.
+/// For a non-empty list of notes, this is a sequential hash of all (nullifier, ZERO) pairs for
+/// the notes consumed in the transaction. For an empty list, [ZERO; 4] is returned.
 pub fn build_input_notes_commitment<T: ToNullifier>(notes: &[T]) -> Digest {
+    if notes.is_empty() {
+        return Digest::default();
+    }
+
     let mut elements: Vec<Felt> = Vec::new();
     for note in notes {
         elements.extend_from_slice(note.nullifier().as_elements());


### PR DESCRIPTION
This PR refactors how we handle input notes in the advice provider and should close #273.

The new approach is to put the number of input notes onto the advice stack, and then read this number first as the part of `process_input_notes_data` procedure in the prologue. Then, if the number of notes is greater than 0, everything works as before, but if the number of notes is 0, we don't make any lookups into the advice map.

One other change, the data in the advice map under the input note key `NC` no longer contains number of notes (because this data is now on the advice stack).

Also, as a part of this PR I updated some docs in the prologue - but more needs to be updated to align with the latest terminology.