### PR TITLE
Refactor: handling of output notes in the advice provider

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/epilogue.masm
+++ b/miden-lib/asm/miden/kernels/tx/epilogue.masm
@@ -10,7 +10,7 @@ use.miden::kernels::tx::asset_vault
 # generating the consumed notes commitment.
 const.CREATED_NOTE_HASHING_MEM_DIFF=1022
 
-# CREATED NOTES PROCEDURES
+# OUTPUT NOTES PROCEDURES
 # =================================================================================================
 
 #! Computes the vault hash of the created note with index i. The hash is computed as a sequential
@@ -104,9 +104,9 @@ end
 #! (note_hash, note_metadata) tuples.
 #!
 #! Stack: []
-#! Output: [CREATED_NOTES_COMMITMENT]
+#! Output: [OUTPUT_NOTES_COMMITMENT]
 #!
-#! - CREATED_NOTES_COMMITMENT is the commitment of the created notes.
+#! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes created by the transaction.
 export.compute_output_notes_hash
     # get the number of created notes from memory
     exec.memory::get_num_created_notes
@@ -144,6 +144,40 @@ export.compute_output_notes_hash
     # drop accessory variables from stack
     movup.4 drop
     movup.4 drop
+end
+
+#! Copies output note data to the advice map. If no notes were created by a transaction, nothing
+#! is copied to the advice map.
+#!
+#! Stack: [OUTPUT_NOTES_COMMITMENT, ...]
+#! Output: [OUTPUT_NOTES_COMMITMENT, ...]
+proc.copy_output_notes_to_advice_map
+    # get the number of notes created by the transaction
+    exec.memory::get_num_created_notes
+    # => [num_notes, OUTPUT_NOTES_COMMITMENT, ...]
+    
+    # if there are created notes, add them to the advice map
+    dup eq.0
+    if.true
+        # drop num_notes
+        drop
+    else
+        # compute the end boundary of the created notes section
+        exec.memory::get_created_note_ptr movdn.4
+        # => [OUTPUT_NOTES_COMMITMENT, created_notes_end_ptr, ...]
+
+        # compute the start boundary of the created notes section
+        exec.memory::get_created_note_data_offset movdn.4
+        # => [OUTPUT_NOTES_COMMITMENT, created_note_ptr, created_notes_end_ptr, ...]
+
+        # insert created data into the advice map
+        adv.insert_mem
+        # => [OUTPUT_NOTES_COMMITMENT, created_note_ptr, created_notes_end_ptr, ...]
+
+        # drop created note pointers
+        movup.4 drop movup.4 drop
+    end
+    # => [OUTPUT_NOTES_COMMITMENT, ...]
 end
 
 # BUILD OUTPUT VAULT
@@ -268,10 +302,10 @@ end
 #! - asserts that the input and output vault roots are equal
 #!
 #! Stack: []
-#! Output: [TX_SCRIPT_ROOT, CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+#! Output: [TX_SCRIPT_ROOT, OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 #!
 #! - TX_SCRIPT_ROOT is the transaction script root
-#! - CREATED_NOTES_COMMITMENT is the commitment of the created notes
+#! - OUTPUT_NOTES_COMMITMENT is the commitment of the created notes
 #! - FINAL_ACCOUNT_HASH is the final account hash
 export.finalize_transaction
     # update account code
@@ -331,33 +365,21 @@ export.finalize_transaction
 
     # compute created note hash
     exec.compute_output_notes_hash
-    # => [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
-    # compute the end boundary of the created notes section
-    exec.memory::get_num_created_notes exec.memory::get_created_note_ptr movdn.4
-    # => [CREATED_NOTES_COMMITMENT, created_notes_end_ptr, FINAL_ACCOUNT_HASH]
-
-    # compute the start boundary of the created notes section
-    exec.memory::get_created_note_data_offset movdn.4
-    # => [CREATED_NOTES_COMMITMENT, created_note_ptr, created_notes_end_ptr, FINAL_ACCOUNT_HASH]
-
-    # insert created data into the advice map
-    adv.insert_mem
-    # => [CREATED_NOTES_COMMITMENT, created_note_ptr, created_notes_end_ptr, FINAL_ACCOUNT_HASH]
-
-    # drop created note pointers
-    movup.4 drop movup.4 drop
-    # => [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # copy output note data to the advice map
+    exec.copy_output_notes_to_advice_map
+    # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
     # load the transaction script root on to the top of the stack
     exec.memory::get_tx_script_root
-    # => [TX_SCRIPT_ROOT, CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # => [TX_SCRIPT_ROOT, OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
     # truncate stack
     swapw.3 dropw swapw.3 dropw swapw.3 dropw
-    # => [TX_SCRIPT_ROOT, CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # => [TX_SCRIPT_ROOT, OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
     # assert no net creation or destruction of assets over the transaction
     exec.memory::get_input_vault_root exec.memory::get_output_vault_root assert_eqw
-    # => [TX_SCRIPT_ROOT, CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # => [TX_SCRIPT_ROOT, OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 end

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -182,28 +182,34 @@ impl TransactionKernel {
 
         // --- parse output notes ---------------------------------------------
 
-        let output_notes_data: &[Word] = group_slice_elements(
-            adv_map
-                .get(output_notes_hash)
-                .ok_or(TransactionOutputError::OutputNoteDataNotFound)?,
-        );
+        // if output_notes_hash is an empty digest, no outputs notes have been created
+        let output_notes = if output_notes_hash == Digest::default() {
+            OutputNotes::default()
+        } else {
+            let output_notes_data: &[Word] = group_slice_elements(
+                adv_map
+                    .get(output_notes_hash)
+                    .ok_or(TransactionOutputError::OutputNoteDataNotFound)?,
+            );
 
-        let mut output_notes = Vec::new();
-        let mut output_note_ptr = 0;
-        while output_note_ptr < output_notes_data.len() {
-            let output_note = notes_try_from_elements(&output_notes_data[output_note_ptr..])
-                .map_err(TransactionOutputError::OutputNoteDataInvalid)?;
-            output_notes.push(output_note);
-            output_note_ptr += memory::NOTE_MEM_SIZE as usize;
-        }
+            let mut output_notes = Vec::new();
+            let mut output_note_ptr = 0;
+            while output_note_ptr < output_notes_data.len() {
+                let output_note = notes_try_from_elements(&output_notes_data[output_note_ptr..])
+                    .map_err(TransactionOutputError::OutputNoteDataInvalid)?;
+                output_notes.push(output_note);
+                output_note_ptr += memory::NOTE_MEM_SIZE as usize;
+            }
 
-        let output_notes = OutputNotes::new(output_notes)?;
-        if output_notes_hash != output_notes.commitment() {
-            return Err(TransactionOutputError::OutputNotesCommitmentInconsistent(
-                output_notes_hash,
-                output_notes.commitment(),
-            ));
-        }
+            let output_notes = OutputNotes::new(output_notes)?;
+            if output_notes_hash != output_notes.commitment() {
+                return Err(TransactionOutputError::OutputNotesCommitmentInconsistent(
+                    output_notes_hash,
+                    output_notes.commitment(),
+                ));
+            }
+            output_notes
+        };
 
         Ok(TransactionOutputs { account, output_notes })
     }

--- a/miden-tx/tests/p2id_script_test.rs
+++ b/miden-tx/tests/p2id_script_test.rs
@@ -68,6 +68,7 @@ fn test_p2id_script() {
         ",
     )
     .unwrap();
+
     let tx_script_target = executor
         .compile_tx_script(
             tx_script_code.clone(),
@@ -77,7 +78,7 @@ fn test_p2id_script() {
         .unwrap();
 
     // Execute the transaction and get the witness
-    let transaction_result = executor
+    let executed_transaction = executor
         .execute_transaction(target_account_id, block_ref, &note_ids, Some(tx_script_target))
         .unwrap();
 
@@ -89,7 +90,7 @@ fn test_p2id_script() {
         target_account.code().clone(),
         Felt::new(2),
     );
-    assert_eq!(transaction_result.final_account().hash(), target_account_after.hash());
+    assert_eq!(executed_transaction.final_account().hash(), target_account_after.hash());
 
     // CONSTRUCT AND EXECUTE TX (Failure)
     // --------------------------------------------------------------------------------------------

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -160,6 +160,12 @@ impl<T: ToEnvelope> PartialEq for OutputNotes<T> {
 
 impl<T: ToEnvelope> Eq for OutputNotes<T> {}
 
+impl Default for OutputNotes {
+    fn default() -> Self {
+        OutputNotes::new(Vec::new()).expect("failed to create empty output notes")
+    }
+}
+
 // SERIALIZATION
 // ------------------------------------------------------------------------------------------------
 
@@ -185,9 +191,13 @@ impl<T: ToEnvelope> Deserializable for OutputNotes<T> {
 
 /// Build a commitment to output notes.
 ///
-/// The commitment is computed as a sequential hash of (hash, metadata) tuples for the notes
-/// created in a transaction.
+/// For a non-empty list of notes, this is a sequential hash of (note_id, metadata) tuples for the
+/// notes created in a transaction. For an empty list, [ZERO; 4] is returned.
 fn build_output_notes_commitment<T: ToEnvelope>(notes: &[T]) -> Digest {
+    if notes.is_empty() {
+        return Digest::default();
+    }
+
     let mut elements: Vec<Felt> = Vec::with_capacity(notes.len() * 8);
     for note in notes.iter() {
         elements.extend_from_slice(note.id().as_elements());


### PR DESCRIPTION
This PR is analogous to #407 but for output notes. The main changes are that if there are no output notes, the epilogue does not put anything under `[ZERO; 4]` into the advice map. This prevents potential collisions over `[ZERO; 4]` key in the advice map.