### PR TITLE
Move account storage delta tracking into transaction host

### DIFF
--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -9,10 +9,10 @@ use.miden::kernels::tx::tx
 # =================================================================================================
 
 # Event emitted to signal that an asset is being added to the account vault.
-const.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT=131072
+const.ACCOUNT_VAULT_ADD_ASSET_EVENT=131072
 
 # Event emitted to signal that an asset is being removed from the account vault.
-const.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT=131073
+const.ACCOUNT_VAULT_REMOVE_ASSET_EVENT=131073
 
 # AUTHENTICATION
 # =================================================================================================
@@ -245,7 +245,7 @@ export.account_vault_add_asset
     # TODO: we execute `push.1 drop` before `emit` as decorators are not supported without other
     #       instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
     # emit event to signal that an asset is being added to the account vault
-    push.1 drop emit.ADD_ASSET_TO_ACCOUNT_VAULT_EVENT
+    push.1 drop emit.ACCOUNT_VAULT_ADD_ASSET_EVENT
 
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
@@ -275,7 +275,7 @@ export.account_vault_remove_asset
     # TODO: we execute `push.1 drop` before `emit` as decorators are not supported without other
     #       instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
     # emit event to signal that an asset is being removed from the account vault
-    push.1 drop emit.REMOVE_ASSET_FROM_ACCOUNT_VAULT_EVENT
+    push.1 drop emit.ACCOUNT_VAULT_REMOVE_ASSET_EVENT
 
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin

--- a/miden-lib/asm/miden/kernels/tx/account.masm
+++ b/miden-lib/asm/miden/kernels/tx/account.masm
@@ -39,9 +39,15 @@ const.MAX_SLOT_TYPE=64
 # EVENTS
 # =================================================================================================
 
+# Event emitted to signal that an account storage item is being updated.
+const.ACCOUNT_STORAGE_SET_ITEM_EVENT=131074
+
+# Event emitted to signal that account nonce is being incremented.
+const.ACCOUNT_INCREMENT_NONCE_EVENT=131075
+
 # Event emitted to push the index of the account procedure at the top of the operand stack onto
 # the advice stack.
-const.PUSH_ACCOUNT_PROCEDURE_INDEX_EVENT=131074
+const.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT=131076
 
 # CONSTANT ACCESSORS
 # =================================================================================================
@@ -111,6 +117,9 @@ end
 #! - value is the value to increment the nonce by. value can be at most 2^32 - 1 otherwise this
 #!   procedure panics.
 export.incr_nonce
+    # emit event to signal that account nonce is being incremented
+    emit.ACCOUNT_INCREMENT_NONCE_EVENT
+
     u32assert
     exec.memory::get_acct_nonce add
     exec.memory::set_acct_nonce
@@ -337,6 +346,11 @@ end
 #! - V' is the value to set.
 #! - V is the previous value of the item.
 export.set_item
+    # TODO: we execute `push.1 drop` before `emit` as decorators are not supported without other
+    #       instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
+    # emit event to signal that an account storage item is being updated
+    push.1 drop emit.ACCOUNT_STORAGE_SET_ITEM_EVENT
+    
     # get the storage root
     exec.memory::get_acct_storage_root
     # => [R, index, V']
@@ -363,7 +377,7 @@ export.authenticate_procedure.1
     # => [PROC_ROOT, CODE_ROOT]
 
     # load the index of the procedure root onto the advice stack, and move it to the operand stack
-    emit.PUSH_ACCOUNT_PROCEDURE_INDEX_EVENT adv_push.1 movdn.4
+    emit.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT adv_push.1 movdn.4
     # => [PROC_ROOT, index, CODE_ROOT]
 
     # push the depth of the code Merkle tree onto the stack

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -1,18 +1,31 @@
 use core::fmt;
 
-use super::Digest;
+use miden_objects::{accounts::AccountStorage, utils::string::String, AssetError, Digest};
 
 // TRANSACTION KERNEL ERROR
 // ================================================================================================
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionKernelError {
+    InvalidStorageSlotIndex(u64),
+    MalformedAssetOnAccountVaultUpdate(AssetError),
+    MissingStorageSlotValue(u8, String),
     UnknownAccountProcedure(Digest),
 }
 
 impl fmt::Display for TransactionKernelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidStorageSlotIndex(index) => {
+                let num_slots = AccountStorage::NUM_STORAGE_SLOTS;
+                write!(f, "storage slot index {index} is invalid, must be smaller than {num_slots}")
+            },
+            Self::MalformedAssetOnAccountVaultUpdate(err) => {
+                write!(f, "malformed asset during account vault update: {err}")
+            },
+            Self::MissingStorageSlotValue(index, err) => {
+                write!(f, "value for storage slot {index} could not be found: {err}")
+            },
             Self::UnknownAccountProcedure(proc_root) => {
                 write!(f, "account procedure with root {proc_root} is not in the advice provider")
             },

--- a/miden-lib/src/transaction/events.rs
+++ b/miden-lib/src/transaction/events.rs
@@ -15,9 +15,11 @@ use super::TransactionEventParsingError;
 #[repr(u32)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionEvent {
-    AddAssetToAccountVault = 0x2_0000,      // 131072
-    RemoveAssetFromAccountVault = 0x2_0001, // 131073
-    PushAccountProcedureIndex = 0x2_0002,   // 131074
+    AccountVaultAddAsset = 0x2_0000,      // 131072
+    AccountVaultRemoveAsset = 0x2_0001,   // 131073
+    AccountStorageSetItem = 0x2_0002,     // 131074
+    AccountIncrementNonce = 0x2_0003,     // 131075
+    AccountPushProcedureIndex = 0x2_0004, // 131076
 }
 
 impl TransactionEvent {
@@ -40,9 +42,11 @@ impl TryFrom<u32> for TransactionEvent {
         }
 
         match value {
-            0x2_0000 => Ok(TransactionEvent::AddAssetToAccountVault),
-            0x2_0001 => Ok(TransactionEvent::RemoveAssetFromAccountVault),
-            0x2_0002 => Ok(TransactionEvent::PushAccountProcedureIndex),
+            0x2_0000 => Ok(TransactionEvent::AccountVaultAddAsset),
+            0x2_0001 => Ok(TransactionEvent::AccountVaultRemoveAsset),
+            0x2_0002 => Ok(TransactionEvent::AccountStorageSetItem),
+            0x2_0003 => Ok(TransactionEvent::AccountIncrementNonce),
+            0x2_0004 => Ok(TransactionEvent::AccountPushProcedureIndex),
             _ => Err(TransactionEventParsingError::InvalidTransactionEvent(value)),
         }
     }

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use miden_objects::{
-    assembly::AssemblyError, crypto::merkle::NodeIndex, NoteError, TransactionInputError,
+    assembly::AssemblyError, crypto::merkle::NodeIndex, Felt, NoteError, TransactionInputError,
     TransactionOutputError,
 };
 use miden_verifier::VerificationError;
@@ -48,8 +48,12 @@ pub enum TransactionExecutorError {
         input_id: AccountId,
         output_id: AccountId,
     },
-    LoadAccountFailed(TransactionCompilerError),
+    InconsistentAccountNonceDelta {
+        expected: Option<Felt>,
+        actual: Option<Felt>,
+    },
     InvalidTransactionOutput(TransactionOutputError),
+    LoadAccountFailed(TransactionCompilerError),
 }
 
 impl fmt::Display for TransactionExecutorError {

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -1,11 +1,9 @@
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
-    accounts::{Account, AccountDelta, AccountStorage, AccountStorageDelta, AccountStub},
     assembly::ProgramAst,
-    crypto::merkle::{merkle_tree_delta, MerkleStore},
     transaction::{TransactionInputs, TransactionScript},
     vm::{Program, StackOutputs},
-    Felt, TransactionOutputError, Word,
+    Felt, Word, ZERO,
 };
 use vm_processor::ExecutionOptions;
 
@@ -204,7 +202,7 @@ impl<D: DataStore> TransactionExecutor<D> {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Creates a new [ExecutedTransaction] from the provided data, advice provider and stack outputs.
+/// Creates a new [ExecutedTransaction] from the provided data.
 fn build_executed_transaction(
     program: Program,
     tx_script: Option<TransactionScript>,
@@ -212,10 +210,10 @@ fn build_executed_transaction(
     stack_outputs: StackOutputs,
     host: TransactionHost<RecAdviceProvider>,
 ) -> Result<ExecutedTransaction, TransactionExecutorError> {
-    let (advice_recorder, vault_delta) = host.into_parts();
+    let (advice_recorder, account_delta) = host.into_parts();
 
     // finalize the advice recorder
-    let (advice_witness, _, map, store) = advice_recorder.finalize();
+    let (advice_witness, _, map, _store) = advice_recorder.finalize();
 
     // parse transaction results
     let tx_outputs = TransactionKernel::parse_transaction_outputs(&stack_outputs, &map.into())
@@ -231,23 +229,21 @@ fn build_executed_transaction(
         });
     }
 
-    // build account delta
-
-    // TODO: Fix delta extraction for new account creation
-    // extract the account storage delta
-    let storage_delta = extract_account_storage_delta(&store, initial_account, final_account)
-        .map_err(TransactionExecutorError::InvalidTransactionOutput)?;
-
-    // extract the nonce delta
-    let nonce_delta = if initial_account.nonce() != final_account.nonce() {
-        Some(final_account.nonce())
-    } else {
-        None
-    };
-
-    // construct the account delta
-    let account_delta =
-        AccountDelta::new(storage_delta, vault_delta, nonce_delta).expect("invalid account delta");
+    // make sure nonce delta was computed correctly
+    let nonce_delta = final_account.nonce() - initial_account.nonce();
+    if nonce_delta == ZERO {
+        if account_delta.nonce().is_some() {
+            return Err(TransactionExecutorError::InconsistentAccountNonceDelta {
+                expected: None,
+                actual: account_delta.nonce(),
+            });
+        }
+    } else if final_account.nonce() != account_delta.nonce().unwrap_or_default() {
+        return Err(TransactionExecutorError::InconsistentAccountNonceDelta {
+            expected: Some(final_account.nonce()),
+            actual: account_delta.nonce(),
+        });
+    }
 
     Ok(ExecutedTransaction::new(
         program,
@@ -257,35 +253,4 @@ fn build_executed_transaction(
         tx_script,
         advice_witness,
     ))
-}
-
-/// Extracts account storage delta between the `initial_account` and `final_account_stub` from the
-/// provided `MerkleStore`
-fn extract_account_storage_delta(
-    store: &MerkleStore,
-    initial_account: &Account,
-    final_account_stub: &AccountStub,
-) -> Result<AccountStorageDelta, TransactionOutputError> {
-    // extract storage slots delta
-    let tree_delta = merkle_tree_delta(
-        initial_account.storage().root(),
-        final_account_stub.storage_root(),
-        AccountStorage::STORAGE_TREE_DEPTH,
-        store,
-    )
-    .map_err(TransactionOutputError::ExtractAccountStorageSlotsDeltaFailed)?;
-
-    // map tree delta to cleared/updated slots; we can cast indexes to u8 because the
-    // the number of storage slots cannot be greater than 256
-    let cleared_items = tree_delta.cleared_slots().iter().map(|idx| *idx as u8).collect();
-    let updated_items = tree_delta
-        .updated_slots()
-        .iter()
-        .map(|(idx, value)| (*idx as u8, *value))
-        .collect();
-
-    // construct storage delta
-    let storage_delta = AccountStorageDelta { cleared_items, updated_items };
-
-    Ok(storage_delta)
 }

--- a/miden-tx/src/host/account_delta.rs
+++ b/miden-tx/src/host/account_delta.rs
@@ -1,10 +1,197 @@
+use miden_lib::transaction::{memory::ACCT_STORAGE_ROOT_PTR, TransactionKernelError};
 use miden_objects::{
-    accounts::{AccountId, AccountVaultDelta},
+    accounts::{
+        AccountDelta, AccountId, AccountStorage, AccountStorageDelta, AccountStub,
+        AccountVaultDelta,
+    },
     assets::{Asset, FungibleAsset, NonFungibleAsset},
-    utils::collections::{btree_map::Entry, BTreeMap},
-    Digest,
+    utils::{
+        collections::{btree_map::Entry, BTreeMap},
+        string::ToString,
+    },
+    Digest, Felt, StarkField, Word, EMPTY_WORD, ZERO,
 };
-use vm_processor::{ExecutionError, ProcessState};
+use vm_processor::{ContextId, ProcessState};
+
+use super::{AdviceProvider, TransactionHost};
+
+// CONSTANTS
+// ================================================================================================
+
+const STORAGE_TREE_DEPTH: Felt = Felt::new(AccountStorage::STORAGE_TREE_DEPTH as u64);
+
+// ACCOUNT DELTA TRACKER
+// ================================================================================================
+
+/// Keeps track of changes made to the account during transaction execution.
+///
+/// Currently, this tracks:
+/// - Changes to the account storage slots.
+/// - Changes to the account vault.
+/// - Changes to the account nonce.
+///
+/// TODO: implement tracking of:
+/// - all account storage changes.
+/// - account code changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountDeltaTracker {
+    storage: AccountStorageDeltaTracker,
+    vault: AccountVaultDeltaTracker,
+    init_nonce: Felt,
+    nonce_delta: Felt,
+}
+
+impl AccountDeltaTracker {
+    /// Returns a new [AccountDeltaTracker] instantiated for the specified account.
+    pub fn new(account: &AccountStub) -> Self {
+        Self {
+            storage: AccountStorageDeltaTracker::default(),
+            vault: AccountVaultDeltaTracker::default(),
+            init_nonce: account.nonce(),
+            nonce_delta: ZERO,
+        }
+    }
+
+    /// Consumes `self` and returns the resulting [AccountDelta].
+    pub fn into_delta(self) -> AccountDelta {
+        let storage_delta = self.storage.into_delta();
+        let vault_delta = self.vault.into_delta();
+        let nonce_delta = if self.nonce_delta == ZERO {
+            None
+        } else {
+            Some(self.init_nonce + self.nonce_delta)
+        };
+
+        AccountDelta::new(storage_delta, vault_delta, nonce_delta).expect("invalid account delta")
+    }
+}
+
+// EVENT HANDLERS
+// ================================================================================================
+
+impl<A: AdviceProvider> TransactionHost<A> {
+    /// Extracts the nonce increment from the process state and adds it to the nonce delta tracker.
+    pub(super) fn on_account_increment_nonce<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<(), TransactionKernelError> {
+        let value = process.get_stack_item(0);
+        self.account_delta.nonce_delta += value;
+        Ok(())
+    }
+
+    // ACCOUNT STORAGE UPDATE HANDLERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Extracts information from the process state about the storage slot being updated and
+    /// records the latest value of this storage slot.
+    pub(super) fn on_account_storage_set_item<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<(), TransactionKernelError> {
+        let storage_root = process
+            .get_mem_value(ContextId::root(), ACCT_STORAGE_ROOT_PTR)
+            .expect("no storage root");
+
+        // get slot index from the stack and make sure it is valid
+        let slot_index = process.get_stack_item(0);
+        if slot_index.as_int() as usize >= AccountStorage::NUM_STORAGE_SLOTS {
+            return Err(TransactionKernelError::InvalidStorageSlotIndex(slot_index.as_int()));
+        }
+
+        // get the value to which the slot is being updated
+        let new_slot_value = [
+            process.get_stack_item(4),
+            process.get_stack_item(3),
+            process.get_stack_item(2),
+            process.get_stack_item(1),
+        ];
+
+        // try to get the current value for the slot from the advice provider
+        let current_slot_value = self
+            .adv_provider
+            .get_tree_node(storage_root, &STORAGE_TREE_DEPTH, &slot_index)
+            .map_err(|err| {
+                TransactionKernelError::MissingStorageSlotValue(
+                    slot_index.as_int() as u8,
+                    err.to_string(),
+                )
+            })?;
+
+        // update the delta tracker only if the current and new values are different
+        if current_slot_value != new_slot_value {
+            let slot_index = slot_index.as_int() as u8;
+            self.account_delta.storage.slot_updates.insert(slot_index, new_slot_value);
+        }
+
+        Ok(())
+    }
+
+    // ACCOUNT VAULT UPDATE HANDLERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Extracts the asset that is being added to the account's vault from the process state and
+    /// updates the appropriate fungible or non-fungible asset map.
+    pub(super) fn on_account_vault_add_asset<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<(), TransactionKernelError> {
+        let asset: Asset = process
+            .get_stack_word(0)
+            .try_into()
+            .map_err(TransactionKernelError::MalformedAssetOnAccountVaultUpdate)?;
+
+        self.account_delta.vault.add_asset(asset);
+        Ok(())
+    }
+
+    /// Extracts the asset that is being removed from the account's vault from the process state
+    /// and updates the appropriate fungible or non-fungible asset map.
+    pub(super) fn on_account_vault_remove_asset<S: ProcessState>(
+        &mut self,
+        process: &S,
+    ) -> Result<(), TransactionKernelError> {
+        let asset: Asset = process
+            .get_stack_word(0)
+            .try_into()
+            .map_err(TransactionKernelError::MalformedAssetOnAccountVaultUpdate)?;
+
+        self.account_delta.vault.remove_asset(asset);
+        Ok(())
+    }
+}
+
+// ACCOUNT STORAGE DELTA TRACKER
+// ================================================================================================
+
+/// The account storage delta tracker is responsible for tracking changes to the storage of the
+/// account the transaction is being executed against.
+///
+/// The delta tracker is composed of:
+/// - A map which records the latest states for the updated storage slots.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+struct AccountStorageDeltaTracker {
+    slot_updates: BTreeMap<u8, Word>,
+}
+
+impl AccountStorageDeltaTracker {
+    /// Consumes `self` and returns the [AccountStorageDelta] that represents the changes to
+    /// the account's storage.
+    pub fn into_delta(self) -> AccountStorageDelta {
+        let mut cleared_items = Vec::new();
+        let mut updated_items = Vec::new();
+
+        for (idx, value) in self.slot_updates {
+            if value == EMPTY_WORD {
+                cleared_items.push(idx);
+            } else {
+                updated_items.push((idx, value));
+            }
+        }
+
+        AccountStorageDelta { cleared_items, updated_items }
+    }
+}
 
 // ACCOUNT VAULT DELTA TRACKER
 // ================================================================================================
@@ -12,32 +199,24 @@ use vm_processor::{ExecutionError, ProcessState};
 /// The account vault delta tracker is responsible for tracking changes to the vault of the account
 /// the transaction is being executed against.
 ///
-/// It is composed of two maps:
+/// The delta tracker is composed of two maps:
 /// - Fungible asset map: tracks changes to the vault's fungible assets, where the key is the
 ///   faucet ID of the asset, and the value is the amount of the asset being added or removed from
 ///   the vault (positive value for added assets, negative value for removed assets).
 /// - Non-fungible asset map: tracks changes to the vault's non-fungible assets, where the key is
 ///   the non-fungible asset, and the value is either 1 or -1 depending on whether the asset is
 ///   being added or removed from the vault.
-#[derive(Default, Debug)]
-pub struct AccountVaultDeltaTracker {
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+struct AccountVaultDeltaTracker {
     fungible_assets: BTreeMap<AccountId, i128>,
     non_fungible_assets: BTreeMap<Digest, i8>,
 }
 
 impl AccountVaultDeltaTracker {
-    // MODIFIERS
+    // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Extracts the asset that is being added to the account's vault from the process state and
-    /// updates the appropriate fungible or non-fungible asset map.
-    pub fn add_asset<S: ProcessState>(&mut self, process: &S) -> Result<(), ExecutionError> {
-        let asset: Asset = process.get_stack_word(0).try_into().map_err(|err| {
-            ExecutionError::EventError(format!(
-                "Failed to apply account vault delta - asset is malformed - {err}"
-            ))
-        })?;
-
+    pub fn add_asset(&mut self, asset: Asset) {
         match asset {
             Asset::Fungible(asset) => {
                 update_asset_delta(
@@ -49,21 +228,10 @@ impl AccountVaultDeltaTracker {
             Asset::NonFungible(asset) => {
                 update_asset_delta(&mut self.non_fungible_assets, asset.vault_key().into(), 1)
             },
-        };
-
-        Ok(())
+        }
     }
 
-    /// Extracts the asset that is being removed from the account's vault from the process state
-    /// and updates the appropriate [AccountVaultDeltaHandler::fungible_assets] or
-    /// [AccountVaultDeltaHandler::non_fungible_assets] map.
-    pub fn remove_asset<S: ProcessState>(&mut self, process: &S) -> Result<(), ExecutionError> {
-        let asset: Asset = process.get_stack_word(0).try_into().map_err(|err| {
-            ExecutionError::EventError(format!(
-                "Failed to apply account vault delta - asset is malformed - {err}"
-            ))
-        })?;
-
+    pub fn remove_asset(&mut self, asset: Asset) {
         match asset {
             Asset::Fungible(asset) => {
                 update_asset_delta(
@@ -75,17 +243,15 @@ impl AccountVaultDeltaTracker {
             Asset::NonFungible(asset) => {
                 update_asset_delta(&mut self.non_fungible_assets, asset.vault_key().into(), -1)
             },
-        };
-
-        Ok(())
+        }
     }
 
     // CONVERSIONS
     // --------------------------------------------------------------------------------------------
 
-    /// Consumes this delta tracker and returns the [AccountVaultDelta] that represents the changes
-    /// to the account's vault.
-    pub fn into_vault_delta(self) -> AccountVaultDelta {
+    /// Consumes `self` and returns the [AccountVaultDelta] that represents the changes to the
+    /// account's vault.
+    pub fn into_delta(self) -> AccountVaultDelta {
         let mut added_assets = Vec::new();
         let mut removed_assets = Vec::new();
 

--- a/mock/src/mock/host/mod.rs
+++ b/mock/src/mock/host/mod.rs
@@ -35,7 +35,7 @@ impl MockHost {
         }
     }
 
-    /// Consumes this transaction host and returns the advice provider and account vault delta.
+    /// Consumes `self` and returns the advice provider and account vault delta.
     pub fn into_parts(self) -> (MemAdviceProvider, AccountVaultDelta) {
         (self.adv_provider, AccountVaultDelta::default())
     }
@@ -89,9 +89,8 @@ impl Host for MockHost {
 
         use TransactionEvent::*;
         match event {
-            AddAssetToAccountVault => Ok(()),
-            RemoveAssetFromAccountVault => Ok(()),
-            PushAccountProcedureIndex => self.on_push_account_procedure_index(process),
+            AccountPushProcedureIndex => self.on_push_account_procedure_index(process),
+            _ => Ok(()),
         }?;
 
         Ok(HostResponse::None)

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -46,6 +46,9 @@ impl AccountStorage {
     /// Depth of the storage tree.
     pub const STORAGE_TREE_DEPTH: u8 = 8;
 
+    /// Total number of storage slots.
+    pub const NUM_STORAGE_SLOTS: usize = 256;
+
     /// The storage slot at which the slot types commitment is stored.
     pub const SLOT_TYPES_COMMITMENT_INDEX: u8 = 255;
 
@@ -54,7 +57,7 @@ impl AccountStorage {
     /// Returns a new instance of account storage initialized with the provided items.
     pub fn new(items: Vec<SlotItem>) -> Result<AccountStorage, AccountError> {
         // initialize slot types vector
-        let mut types = vec![StorageSlotType::default(); 256];
+        let mut types = vec![StorageSlotType::default(); Self::NUM_STORAGE_SLOTS];
 
         // set the slot type for the types commitment
         types[Self::SLOT_TYPES_COMMITMENT_INDEX as usize] =


### PR DESCRIPTION
This PR completes the move of account delta tracking into `TransactionHost` and closes #400.

As a part of this PR, I've refactored event handling in the `TransactionHost` and introduced `AccountDeltaTracker` struct.