### PR TITLE
Replaced `serial_num` with `rng` for note creation

### DIFF
--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -12,8 +12,11 @@ pub mod utils;
 
 /// Generates a P2ID note - pay to id note.
 ///
-/// This script enables the transfer of assets from the `sender` account to the `target` account.
-/// The passed-in `rng` is used to generate a serial number for the note.
+/// This script enables the transfer of assets from the `sender` account to the `target` account
+/// by specifying the target's account ID.
+///
+/// The passed-in `rng` is used to generate a serial number for the note. The returned note's tag
+/// is set to the target's account ID.
 ///
 /// # Errors
 /// Returns an error if deserialization or compilation of the `P2ID` script fails.
@@ -35,9 +38,13 @@ pub fn create_p2id_note<R: FeltRng>(
 
 /// Generates a P2IDR note - pay to id with recall after a certain block height.
 ///
-/// This script enables the transfer of assets from one account `sender` to another account `target`
-/// additionally it adds the possibility of a recall window enabling reclaiming of assets if the
-/// note has not been consumed by the `target` in the inputed timeframe
+/// This script enables the transfer of assets from the sender `sender` account to the `target`
+/// account by specifying the target's account ID. Additionally it adds the possibility for the
+/// sender to reclaiming the assets if the note has not been consumed by the target within the
+/// specified timeframe.
+///
+/// The passed-in `rng` is used to generate a serial number for the note. The returned note's tag
+/// is set to the target's account ID.
 ///
 /// # Errors
 /// Returns an error if deserialization or compilation of the `P2IDR` script fails.
@@ -60,9 +67,9 @@ pub fn create_p2idr_note<R: FeltRng>(
 
 /// Generates a SWAP note - swap of assets between two accounts.
 ///
-/// This script enables a swap of 2 assets between one account `sender` and any other account that
+/// This script enables a swap of 2 assets between the `sender` account and any other account that
 /// is willing to consume the note. The consumer will receive the `offered_asset` and will create a
-/// new P2ID note with `sender` as target, containing the `requested_asset`
+/// new P2ID note with `sender` as target, containing the `requested_asset`.
 ///
 /// # Errors
 /// Returns an error if deserialization or compilation of the `SWAP` script fails.

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -21,7 +21,7 @@ pub fn create_p2id_note<R: FeltRng>(
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
     let note_script = build_note_script(bytes)?;
 
-    let inputs = vec![target.into(), ZERO, ZERO, ZERO];
+    let inputs = [target.into(), ZERO, ZERO, ZERO];
     let tag: Felt = target.into();
     let serial_num = rng.draw_word();
 
@@ -42,7 +42,7 @@ pub fn create_p2idr_note<R: FeltRng>(
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2IDR.masb"));
     let note_script = build_note_script(bytes)?;
 
-    let inputs = vec![target.into(), recall_height.into(), ZERO, ZERO];
+    let inputs = [target.into(), recall_height.into(), ZERO, ZERO];
     let tag: Felt = target.into();
     let serial_num = rng.draw_word();
 
@@ -66,7 +66,7 @@ pub fn create_swap_note<R: FeltRng>(
     let recipient = utils::build_p2id_recipient(sender, repay_serial_num)?;
     let asset_word: Word = requested_asset.into();
 
-    let inputs = vec![
+    let inputs = [
         recipient[0],
         recipient[1],
         recipient[2],

--- a/miden-lib/src/notes/utils.rs
+++ b/miden-lib/src/notes/utils.rs
@@ -1,0 +1,41 @@
+use assembly::ast::ProgramAst;
+use miden_objects::{
+    accounts::AccountId, notes::NoteScript, Digest, Hasher, NoteError, Word, ZERO,
+};
+
+use crate::transaction::TransactionKernel;
+
+/// Creates the note_script from inputs
+pub fn build_note_script(bytes: &[u8]) -> Result<NoteScript, NoteError> {
+    let note_assembler = TransactionKernel::assembler();
+
+    let script_ast = ProgramAst::from_bytes(bytes).map_err(NoteError::NoteDeserializationError)?;
+    let (note_script, _) = NoteScript::new(script_ast, &note_assembler)?;
+
+    Ok(note_script)
+}
+
+/// Creates the RECIPIENT for the P2ID note script created by the SWAP script
+pub fn build_p2id_recipient(target: AccountId, serial_num: Word) -> Result<Digest, NoteError> {
+    // TODO: add lazy_static initialization or compile-time optimization instead of re-generating
+    // the script hash every time we call the SWAP script
+    let assembler = TransactionKernel::assembler();
+
+    let p2id_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
+
+    let note_script_ast =
+        ProgramAst::from_bytes(p2id_bytes).map_err(NoteError::NoteDeserializationError)?;
+
+    let (note_script, _) = NoteScript::new(note_script_ast, &assembler)?;
+
+    let script_hash = note_script.hash();
+
+    let serial_num_hash = Hasher::merge(&[serial_num.into(), Digest::default()]);
+
+    let merge_script = Hasher::merge(&[serial_num_hash, script_hash]);
+
+    Ok(Hasher::merge(&[
+        merge_script,
+        Hasher::hash_elements(&[target.into(), ZERO, ZERO, ZERO]),
+    ]))
+}

--- a/miden-lib/src/notes/utils.rs
+++ b/miden-lib/src/notes/utils.rs
@@ -19,14 +19,8 @@ pub fn build_note_script(bytes: &[u8]) -> Result<NoteScript, NoteError> {
 pub fn build_p2id_recipient(target: AccountId, serial_num: Word) -> Result<Digest, NoteError> {
     // TODO: add lazy_static initialization or compile-time optimization instead of re-generating
     // the script hash every time we call the SWAP script
-    let assembler = TransactionKernel::assembler();
-
-    let p2id_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
-
-    let note_script_ast =
-        ProgramAst::from_bytes(p2id_bytes).map_err(NoteError::NoteDeserializationError)?;
-
-    let (note_script, _) = NoteScript::new(note_script_ast, &assembler)?;
+    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
+    let note_script = build_note_script(bytes)?;
 
     let script_hash = note_script.hash();
 

--- a/miden-tx/tests/p2id_script_test.rs
+++ b/miden-tx/tests/p2id_script_test.rs
@@ -1,8 +1,9 @@
-use miden_lib::notes::{create_note, Script};
+use miden_lib::notes::create_p2id_note;
 use miden_objects::{
     accounts::{Account, AccountId},
     assembly::ProgramAst,
     assets::{Asset, AssetVault, FungibleAsset},
+    crypto::rand::RpoRandomCoin,
     utils::collections::Vec,
     Felt,
 };
@@ -37,13 +38,11 @@ fn test_p2id_script() {
         get_account_with_default_account_code(target_account_id, target_pub_key, None);
 
     // Create the note
-    let p2id_script = Script::P2ID { target: target_account_id };
-    let note = create_note(
-        p2id_script,
-        vec![fungible_asset],
+    let note = create_p2id_note(
         sender_account_id,
-        None,
-        [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)],
+        target_account_id,
+        vec![fungible_asset],
+        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 
@@ -154,13 +153,11 @@ fn test_p2id_script_multiple_assets() {
         get_account_with_default_account_code(target_account_id, target_pub_key, None);
 
     // Create the note
-    let p2id_script = Script::P2ID { target: target_account_id };
-    let note = create_note(
-        p2id_script,
-        vec![fungible_asset_1, fungible_asset_2],
+    let note = create_p2id_note(
         sender_account_id,
-        None,
-        [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)],
+        target_account_id,
+        vec![fungible_asset_1, fungible_asset_2],
+        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 

--- a/miden-tx/tests/p2idr_script_test.rs
+++ b/miden-tx/tests/p2idr_script_test.rs
@@ -1,8 +1,9 @@
-use miden_lib::notes::{create_note, Script};
+use miden_lib::notes::create_p2idr_note;
 use miden_objects::{
     accounts::{Account, AccountId},
     assembly::ProgramAst,
     assets::{Asset, AssetVault, FungibleAsset},
+    crypto::rand::RpoRandomCoin,
     utils::collections::Vec,
     Felt,
 };
@@ -56,29 +57,23 @@ fn test_p2idr_script() {
     let reclaim_block_height_reclaimable = 3_u32;
 
     // Create the notes with the P2IDR script
-    let p2idr_script_in_time = Script::P2IDR {
-        target: target_account_id,
-        recall_height: reclaim_block_height_in_time,
-    };
-    let note_in_time = create_note(
-        p2idr_script_in_time,
-        vec![fungible_asset],
+    // Create the note_in_time
+    let note_in_time = create_p2idr_note(
         sender_account_id,
-        None,
-        [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)],
+        target_account_id,
+        vec![fungible_asset],
+        reclaim_block_height_in_time,
+        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 
-    let p2idr_script_reclaimable = Script::P2IDR {
-        target: target_account_id,
-        recall_height: reclaim_block_height_reclaimable,
-    };
-    let note_reclaimable = create_note(
-        p2idr_script_reclaimable,
-        vec![fungible_asset],
+    // Create the reclaimable_note
+    let note_reclaimable = create_p2idr_note(
         sender_account_id,
-        None,
-        [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)],
+        target_account_id,
+        vec![fungible_asset],
+        reclaim_block_height_reclaimable,
+        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -32,7 +32,7 @@ pub mod assembly {
 }
 
 pub mod crypto {
-    pub use miden_crypto::{dsa, merkle, utils};
+    pub use miden_crypto::{dsa, merkle, rand, utils};
 }
 
 pub mod utils {


### PR DESCRIPTION
Enables generation of random word for note serial_num inside of the create_note function.

In this PR I propose:
- The addition of `rng` replacing the `serial_num` parameter in the `create_note` function enabling a better interface and internal randomness management.
- The splitting of the `create_note` function into multiple functions. One function for each note script. For now: `create_p2id_note()`, `create_p2idr_note()`, `create_swap_note()`. Making the function more modular.
- A refactor of the swap note return values from `Note` to `(Note, Word)` with `Word` being the serial_number used to generate the recipient, hence enabling consumption of the consumer generated `p2id` note.

Closing #368

New PR opened from #380 to follow code addition convention.