### PR TITLE
Update `ChainMmr` constructor to take block headers

### DIFF
--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -259,12 +259,22 @@ impl std::error::Error for NoteError {}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChainMmrError {
-    BlockNumTooBig { chain_length: usize, block_num: usize },
+    BlockNumTooBig { chain_length: usize, block_num: u32 },
+    DuplicateBlock { block_num: u32 },
+    UntrackedBlock { block_num: u32 },
 }
 
 impl ChainMmrError {
-    pub fn block_num_too_big(chain_length: usize, block_num: usize) -> Self {
+    pub fn block_num_too_big(chain_length: usize, block_num: u32) -> Self {
         Self::BlockNumTooBig { chain_length, block_num }
+    }
+
+    pub fn duplicate_block(block_num: u32) -> Self {
+        Self::DuplicateBlock { block_num }
+    }
+
+    pub fn untracked_block(block_num: u32) -> Self {
+        Self::UntrackedBlock { block_num }
     }
 }
 

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -312,6 +312,8 @@ pub enum TransactionInputError {
     AccountSeedNotProvidedForNewAccount,
     AccountSeedProvidedForExistingAccount,
     DuplicateInputNote(Digest),
+    InconsistentChainRoot { expected: Digest, actual: Digest },
+    InputNoteBlockNotInChainMmr(NoteId),
     InvalidAccountSeed(AccountError),
     TooManyInputNotes { max: usize, actual: usize },
 }
@@ -331,7 +333,6 @@ impl std::error::Error for TransactionInputError {}
 #[derive(Debug, Clone, PartialEq)]
 pub enum TransactionOutputError {
     DuplicateOutputNote(NoteId),
-    ExtractAccountStorageSlotsDeltaFailed(MerkleError),
     FinalAccountDataNotFound,
     FinalAccountStubDataInvalid(AccountError),
     OutputNoteDataNotFound,

--- a/objects/src/transaction/chain_mmr.rs
+++ b/objects/src/transaction/chain_mmr.rs
@@ -72,8 +72,13 @@ impl ChainMmr {
         self.mmr.forest()
     }
 
+    /// Returns true if the block is present in this chain MMR.
+    pub fn contains_block(&self, block_num: u32) -> bool {
+        self.blocks.contains_key(&block_num)
+    }
+
     /// Returns the block header for the specified block, or None if the block is not present in
-    /// this partial MMR.
+    /// this chain MMR.
     pub fn get_block(&self, block_num: u32) -> Option<&BlockHeader> {
         self.blocks.get(&block_num)
     }


### PR DESCRIPTION
This PR refactors `ChainMmr` constructor so that it accepts `BlockHeader`'s instead of `(u32, Digest)` tuples. This approach is more convenient for how `ChainMmr` is used by the client.

Also, this PR adds a couple of checks to ensure `InputNotes` struct is constructed correctly (having these checks would have saved us a lot of debugging time last week).