### PR TITLE
Remove `num_assets` from note metadata

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/constants.masm
+++ b/miden-lib/asm/miden/kernels/tx/constants.masm
@@ -4,20 +4,20 @@
 # The number of elements in a Word
 const.WORD_SIZE=4
 
-# The maximum number of assets that can be stored in a single note
-const.MAX_ASSETS_PER_NOTE=255
+# The maximum number of assets that can be stored in a single note.
+const.MAX_ASSETS_PER_NOTE=256
 
 # The maximum number of notes that can be consumed in a single transaction.
-const.MAX_NUM_CONSUMED_NOTES=1023
+const.MAX_INPUT_NOTES_PER_TX=1023
 
-# The size of the memory segment allocated to each note
-const.NOTE_MEM_SIZE=1024
+# The size of the memory segment allocated to each note.
+const.NOTE_MEM_SIZE=512
 
 # The depth of the Merkle tree used to commit to notes produced in a block.
 const.NOTE_TREE_DEPTH=20
 
-# The maximum number of notes that can be created in a single transaction (2^12)
-const.MAX_NUM_CREATED_NOTES=4096
+# The maximum number of notes that can be created in a single transaction (2^12).
+const.MAX_OUTPUT_NOTES_PER_TX=4096
 
 # Specifies a modulus used to asses if an account seed digest has the required number of trailing
 # zeros for a regular account (2^23).
@@ -57,7 +57,7 @@ end
 #!
 #! - max_num_consumed_notes is the max number of consumed notes.
 export.get_max_num_consumed_notes
-    push.MAX_NUM_CONSUMED_NOTES
+    push.MAX_INPUT_NOTES_PER_TX
 end
 
 #! Returns the size of the memory segment allocated to each note.
@@ -87,7 +87,7 @@ end
 #!
 #! - max_num_created_notes is the max number of notes that can be created in a single transaction.
 export.get_max_num_created_notes
-    push.MAX_NUM_CREATED_NOTES
+    push.MAX_OUTPUT_NOTES_PER_TX
 end
 
 #! Returns a modulus used to asses if an account seed digest has the required number of trailing

--- a/miden-lib/asm/miden/kernels/tx/epilogue.masm
+++ b/miden-lib/asm/miden/kernels/tx/epilogue.masm
@@ -1,150 +1,11 @@
-use.miden::kernels::tx::constants
-use.miden::kernels::tx::memory
 use.miden::kernels::tx::account
 use.miden::kernels::tx::asset_vault
-
-# CONSTANTS
-# =================================================================================================
-
-# The diff between the memory address after first mem_stream operation and the next target when
-# generating the consumed notes commitment.
-const.CREATED_NOTE_HASHING_MEM_DIFF=1022
+use.miden::kernels::tx::constants
+use.miden::kernels::tx::memory
+use.miden::kernels::tx::note
 
 # OUTPUT NOTES PROCEDURES
 # =================================================================================================
-
-#! Computes the vault hash of the created note with index i. The hash is computed as a sequential
-#! hash of the assets contained in the note. If there are an odd number of assets, then for the
-#! final hashing permutation we pad the last word of the hasher rate with ZERO's.
-#!
-#! Stack: [note_data_ptr]
-#! Output: [VAULT_HASH]
-#!
-#! - note_data_ptr is a pointer to the data section of the created note.
-#! - VAULT_HASH is the vault hash of the created note with index i.
-proc.compute_created_note_vault_hash
-    # duplicate note pointer and fetch num_assets
-    dup dup exec.memory::get_created_note_num_assets
-    # => [num_assets, note_data_ptr, note_data_ptr]
-
-    # calculate the number of pairs of assets (takes ceiling if we have an odd number)
-    add.1 u32assert u32div.2
-    # => [num_asset_pairs, note_data_ptr, note_data_ptr]
-
-    # initiate counter for assets
-    push.0
-    # => [asset_counter, num_asset_pairs, note_data_ptr, note_data_ptr]
-
-    # prepare address and stack for reading assets
-    movup.2 exec.memory::get_created_note_asset_data_ptr padw padw padw
-    # => [PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
-
-    # check if we should loop
-    dup.14 dup.14 neq
-    # => [should_loop, PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
-
-    # loop and read assets from memory
-    while.true
-        # read assets from memory.
-        # if this is the last permutation of the loop and we have an odd number of assets then we
-        # implicitly pad the last word of the hasher rate with ZERO's by reading from empty memory.
-        mem_stream hperm
-        # => [PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
-
-        # check if we should loop again
-        movup.13 add.1 dup movdn.14 dup.15 neq
-        # => [should_loop, PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs,
-        #     note_data_ptr]
-    end
-
-    # extract digest from hasher rate elements (h_0, ..., h_3)
-    dropw swapw dropw
-    # => [VAULT_HASH, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
-
-    # drop accessory variables from stack
-    movup.4 drop
-    movup.4 drop
-    movup.4 drop
-    # => [VAULT_HASH, note_data_ptr]
-
-    # save vault hash to memory
-    movup.4 exec.memory::set_created_note_assets_hash
-    # => []
-end
-
-#! Computes the hash of a created note with index i. This is computed as follows:
-#! - we define, recipient =
-#!       hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
-#! - we then compute the created note hash as:
-#!       hash(recipient, vault_hash)
-#!
-#! Stack: [note_data_ptr]
-#! Output: [CREATED_NOTE_HASH]
-#!
-#! - note_data_ptr is a pointer to the data section of the created note.
-#! - CREATED_NOTE_HASH is the hash of the created note with index i.
-proc.compute_created_note_hash
-    # pad capacity elements of hasher
-    padw
-
-    # insert created note recipient into the first four elements of the hasher rate
-    dup.4 exec.memory::get_created_note_recipient
-
-    # populate the last four elements of the hasher rate with the created note vault hash
-    dup.8 exec.compute_created_note_vault_hash
-
-    # compute created note hash and extract digest
-    hperm dropw swapw dropw
-
-    # save created note hash to memory
-    movup.4 mem_storew
-end
-
-#! Computes a commitment to the created notes. This is computed as a sequential hash of
-#! (note_hash, note_metadata) tuples.
-#!
-#! Stack: []
-#! Output: [OUTPUT_NOTES_COMMITMENT]
-#!
-#! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes created by the transaction.
-export.compute_output_notes_hash
-    # get the number of created notes from memory
-    exec.memory::get_num_created_notes
-
-    # calculate the address at which we should stop looping
-    exec.memory::get_created_note_ptr
-
-    # compute pointer for first address
-    push.0 exec.memory::get_created_note_ptr
-
-    # prepare stack for hashing
-    padw padw padw
-
-    # check if the number of created notes is greater then 0. Conditional for the while loop.
-    dup.13 dup.13 neq
-
-    # loop and hash created notes
-    while.true
-        # compute created note hash (this also computes created not vault hash)
-        dup.12 exec.compute_created_note_hash
-
-        # drop created note hash from stack
-        dropw
-
-        # permute over (note_hash, note_metadata)
-        mem_stream hperm
-
-        # increment created note pointer and check if we should loop again
-        movup.12 push.CREATED_NOTE_HASHING_MEM_DIFF add dup movdn.13 dup.14 neq
-    end
-
-    # extract digest from hasher rate elements (h_0, ..., h_3)
-    dropw swapw dropw
-
-    # drop accessory variables from stack
-    movup.4 drop
-    movup.4 drop
-end
 
 #! Copies output note data to the advice map. If no notes were created by a transaction, nothing
 #! is copied to the advice map.
@@ -364,7 +225,7 @@ export.finalize_transaction
     # => [FINAL_ACCOUNT_HASH]
 
     # compute created note hash
-    exec.compute_output_notes_hash
+    exec.note::compute_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
     # copy output note data to the advice map

--- a/miden-lib/asm/miden/kernels/tx/epilogue.masm
+++ b/miden-lib/asm/miden/kernels/tx/epilogue.masm
@@ -68,7 +68,7 @@ proc.compute_created_note_vault_hash
     # => [VAULT_HASH, note_data_ptr]
 
     # save vault hash to memory
-    movup.4 exec.memory::set_created_note_vault_hash
+    movup.4 exec.memory::set_created_note_assets_hash
     # => []
 end
 

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -131,9 +131,10 @@ const.CONSUMED_NOTE_CORE_DATA_OFFSET=1
 const.CONSUMED_NOTE_SERIAL_NUM_OFFSET=1
 const.CONSUMED_NOTE_SCRIPT_ROOT_OFFSET=2
 const.CONSUMED_NOTE_INPUTS_HASH_OFFSET=3
-const.CONSUMED_NOTE_VAULT_ROOT_OFFSET=4
+const.CONSUMED_NOTE_ASSETS_HASH_OFFSET=4
 const.CONSUMED_NOTE_METADATA_OFFSET=5
-const.CONSUMED_NOTE_ASSETS_OFFSET=6
+const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=6
+const.CONSUMED_NOTE_ASSETS_OFFSET=7
 
 # CREATED NOTES
 # -------------------------------------------------------------------------------------------------
@@ -145,8 +146,9 @@ const.CREATED_NOTE_SECTION_OFFSET=10000
 const.CREATED_NOTE_HASH_OFFSET=0
 const.CREATED_NOTE_METADATA_OFFSET=1
 const.CREATED_NOTE_RECIPIENT_OFFSET=2
-const.CREATED_NOTE_VAULT_HASH_OFFSET=3
-const.CREATED_NOTE_ASSETS_OFFSET=4
+const.CREATED_NOTE_ASSETS_HASH_OFFSET=3
+const.CREATED_NOTE_NUM_ASSETS_OFFSET=4
+const.CREATED_NOTE_ASSETS_OFFSET=5
 
 # MEMORY PROCEDURES
 # =================================================================================================
@@ -828,7 +830,7 @@ export.get_consumed_note_inputs_hash
     mem_loadw
 end
 
-#! Returns the metatdata of a consumed note located at the specified memory address.
+#! Returns the metadata of a consumed note located at the specified memory address.
 #!
 #! Stack: [consumed_note_ptr]
 #! Output: [M]
@@ -841,7 +843,7 @@ export.get_consumed_note_metadata
     mem_loadw
 end
 
-#! Sets the metadata of a consumed note located at the specified memory address.
+#! Sets the metadata for a consumed note located at the specified memory address.
 #!
 #! Stack: [consumed_note_ptr, M]
 #! Output: []
@@ -861,11 +863,23 @@ end
 #! - consumed_note_ptr is the memory address at which the consumed note data begins.
 #! - num_assets is the number of assets in the consumed note.
 export.get_consumed_note_num_assets
-    push.CONSUMED_NOTE_METADATA_OFFSET add
+    push.CONSUMED_NOTE_NUM_ASSETS_OFFSET add
     mem_load
 end
 
-#! Returns a pointer pointer to the start of the assets segment for the consumed note located at
+#! Sets the number of assets for a consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr, num_assets]
+#! Output: []
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - num_assets is the number of assets in the consumed note.
+export.set_consumed_note_num_assets
+    push.CONSUMED_NOTE_NUM_ASSETS_OFFSET add
+    mem_store
+end
+
+#! Returns a pointer to the start of the assets segment for the consumed note located at
 #! the specified memory address.
 #!
 #! Stack: [consumed_note_ptr]
@@ -877,16 +891,16 @@ export.get_consumed_note_assets_ptr
     push.CONSUMED_NOTE_ASSETS_OFFSET add
 end
 
-#! Returns the vault root for the consumed note located at the specified memory address.
+#! Returns the assets hash for the consumed note located at the specified memory address.
 #!
 #! Stack: [consumed_note_ptr]
-#! Output: [V]
+#! Output: [AH]
 #!
 #! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - V is the vault root for the consumed note.
-export.get_consumed_note_vault_root
+#! - AH is the assets root for the consumed note.
+export.get_consumed_note_assets_hash
     padw
-    movup.4 push.CONSUMED_NOTE_VAULT_ROOT_OFFSET add
+    movup.4 push.CONSUMED_NOTE_ASSETS_HASH_OFFSET add
     mem_loadw
 end
 
@@ -914,9 +928,9 @@ export.get_consumed_note_sender
     padw
     movup.4 push.CONSUMED_NOTE_METADATA_OFFSET add
     mem_loadw
-    # => [0, sender, tag, num_assets]
+    # => [0, 0, sender, tag]
 
-    drop movdn.2 drop drop
+    drop drop swap drop
     # => [sender]
 end
 
@@ -964,7 +978,7 @@ end
 #! Output: []
 #!
 #! - recipient is the recipient of the note
-#! - note_ptr is a pointer to the memory address at which the created note is stored
+#! - note_ptr is the memory address at which the created note data begins.
 export.set_created_note_recipient
     push.CREATED_NOTE_RECIPIENT_OFFSET add mem_storew dropw
 end
@@ -975,20 +989,20 @@ end
 #! Output: []
 #!
 #! - METADATA is the note metadata
-#! - note_ptr is a pointer to the memory address at which the created note is stored
+#! - note_ptr is the memory address at which the created note data begins.
 export.set_created_note_metadata
     push.CREATED_NOTE_METADATA_OFFSET add mem_storew dropw
 end
 
 #! Returns the number of assets in the created note
 #!
-#! Stack: [created_note_data_ptr]
+#! Stack: [note_ptr]
 #! Output: [num_assets]
 #!
-#! - created_note_data_ptr is the memory address at which the created note data begins.
+#! - note_ptr is a pointer to the memory address at which the created note is stored.
 #! - num_assets is the number of assets in the created note.
 export.get_created_note_num_assets
-    push.CREATED_NOTE_METADATA_OFFSET add mem_load
+    push.CREATED_NOTE_NUM_ASSETS_OFFSET add mem_load
 end
 
 #! Sets the number of assets in the created note
@@ -999,7 +1013,7 @@ end
 #! - note_ptr is the memory address at which the created note data begins.
 #! - num_assets is the number of assets in the created note.
 export.set_created_note_num_assets
-    push.CREATED_NOTE_METADATA_OFFSET add mem_store
+    push.CREATED_NOTE_NUM_ASSETS_OFFSET add mem_store
 end
 
 #! Returns a pointer to the created note asset data
@@ -1013,13 +1027,13 @@ export.get_created_note_asset_data_ptr
     push.CREATED_NOTE_ASSETS_OFFSET add
 end
 
-#! Sets the created note vault hash
+#! Sets the created note assets hash.
 #!
-#! Stack: [created_note_data_ptr, V]
+#! Stack: [created_note_data_ptr, AH]
 #! Output: []
 #!
 #! - created_note_data_ptr is the memory address at which the created note data begins.
-#! - V is the vault hash of the created note.
-export.set_created_note_vault_hash
-    push.CREATED_NOTE_VAULT_HASH_OFFSET add mem_storew
+#! - AH is the assets hash of the created note.
+export.set_created_note_assets_hash
+    push.CREATED_NOTE_ASSETS_HASH_OFFSET add mem_storew
 end

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -119,11 +119,11 @@ const.ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET=405
 # CONSUMED NOTES DATA
 # -------------------------------------------------------------------------------------------------
 
-# The memory address at which the consumed note section begins
-const.CONSUMED_NOTE_SECTION_OFFSET=1000
+# The memory address at which the consumed note section begins.
+const.CONSUMED_NOTE_SECTION_OFFSET=1048576
 
-# The memory address at which the number of consumed notes is stored
-const.CONSUMED_NOTE_NUM_PTR=1000
+# The memory address at which the number of consumed notes is stored.
+const.CONSUMED_NOTE_NUM_PTR=1048576
 
 # The offsets at which data of a consumed note is stored relative to the start of its data segment
 const.CONSUMED_NOTE_HASH_OFFSET=0
@@ -140,7 +140,7 @@ const.CONSUMED_NOTE_ASSETS_OFFSET=7
 # -------------------------------------------------------------------------------------------------
 
 # The memory address at which the created notes section begins.
-const.CREATED_NOTE_SECTION_OFFSET=10000
+const.CREATED_NOTE_SECTION_OFFSET=4194304
 
 # The offsets at which data of a created note is stored relative to the start of its data segment.
 const.CREATED_NOTE_HASH_OFFSET=0

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -46,7 +46,7 @@ export.get_vault_info
     # => [num_assets, ptr]
 
     # get the vault hash from the note pointer
-    swap exec.memory::get_consumed_note_vault_root
+    swap exec.memory::get_consumed_note_assets_hash
     # => [VAULT_HASH, num_assets]
 end
 

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -1,6 +1,16 @@
 use.miden::kernels::tx::constants
 use.miden::kernels::tx::memory
 
+# CONSTANTS
+# =================================================================================================
+
+# The diff between the memory address after first mem_stream operation and the next target when
+# generating the consumed notes commitment. Must be NOTE_MEM_SIZE - 2;
+const.OUTPUT_NOTE_HASHING_MEM_DIFF=510
+
+# INPUT NOTE PROCEDURES
+# =================================================================================================
+
 #! Returns the sender of the note currently being processed. Panics if a note is not being
 #! processed.
 #!
@@ -119,4 +129,158 @@ export.prepare_note
     # read the note script root onto the stack
     exec.memory::get_consumed_note_script_root
     # => [NOTE_SCRIPT_ROOT]
+end
+
+# OUTPUT NOTE PROCEDURES
+# =================================================================================================
+
+#! Computes the assets hash of the output note located at the specified memory address. The hash
+#! is computed as a sequential hash of the assets contained in the note. If there is an odd number
+#! of assets, then for the final hashing permutation we pad the last word of the hasher rate with
+#! ZERO's.
+#!
+#! Stack: [note_data_ptr]
+#! Output: [ASSETS_HASH]
+#!
+#! - note_data_ptr is a pointer to the data section of the output note.
+#! - ASSETS_HASH is the hash of the assets of the output note located at note_data_ptr.
+proc.compute_output_note_assets_hash
+    # duplicate note pointer and fetch num_assets
+    dup dup exec.memory::get_created_note_num_assets
+    # => [num_assets, note_data_ptr, note_data_ptr]
+
+    # calculate the number of pairs of assets (takes ceiling if we have an odd number)
+    add.1 u32assert u32div.2
+    # => [num_asset_pairs, note_data_ptr, note_data_ptr]
+
+    # initiate counter for assets
+    push.0
+    # => [asset_counter, num_asset_pairs, note_data_ptr, note_data_ptr]
+
+    # prepare address and stack for reading assets
+    movup.2 exec.memory::get_created_note_asset_data_ptr padw padw padw
+    # => [PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
+
+    # check if we should loop
+    dup.14 dup.14 neq
+    # => [should_loop, PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
+
+    # loop and read assets from memory
+    while.true
+        # read assets from memory.
+        # if this is the last permutation of the loop and we have an odd number of assets then we
+        # implicitly pad the last word of the hasher rate with ZERO's by reading from empty memory.
+        mem_stream hperm
+        # => [PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
+
+        # check if we should loop again
+        movup.13 add.1 dup movdn.14 dup.15 neq
+        # => [should_loop, PERM, PERM, PERM, asset_data_ptr, asset_counter, num_asset_pairs,
+        #     note_data_ptr]
+    end
+
+    # extract digest from hasher rate elements (h_0, ..., h_3)
+    dropw swapw dropw
+    # => [ASSETS_HASH, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
+
+    # drop accessory variables from stack
+    movup.4 drop
+    movup.4 drop
+    movup.4 drop
+    # => [ASSETS_HASH, note_data_ptr]
+
+    # save vault hash to memory
+    movup.4 exec.memory::set_created_note_assets_hash
+    # => []
+end
+
+#! Computes the hash of an output note located at the specified memory address.
+#!
+#! The hash is computed as follows:
+#! - we define, recipient =
+#!       hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
+#! - we then compute the output note hash as:
+#!       hash(recipient, assets_hash)
+#!
+#! Stack: [note_data_ptr]
+#! Output: [OUTPUT_NOTE_HASH]
+#!
+#! - note_data_ptr is a pointer to the data section of the output note.
+#! - OUTPUT_NOTE_HASH is the hash of the output note located at note_data_ptr.
+proc.compute_output_note_hash
+    # pad capacity elements of hasher
+    padw
+
+    # insert output note recipient into the first four elements of the hasher rate
+    dup.4 exec.memory::get_created_note_recipient
+
+    # populate the last four elements of the hasher rate with the output note's asset hash
+    dup.8 exec.compute_output_note_assets_hash
+
+    # compute output note hash and extract digest
+    hperm dropw swapw dropw
+
+    # save output note hash to memory
+    movup.4 mem_storew
+end
+
+#! Computes a commitment to the output notes. This is computed as a sequential hash of
+#! (note_hash, note_metadata) tuples.
+#!
+#! Stack: []
+#! Output: [OUTPUT_NOTES_COMMITMENT]
+#!
+#! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes created by the transaction.
+export.compute_output_notes_commitment
+    # get the number of output notes from memory
+    exec.memory::get_num_created_notes
+    # => [num_notes, ...]
+
+    # calculate the address at which we should stop looping
+    exec.memory::get_created_note_ptr
+    # => [end_ptr, ...]
+
+    # compute pointer for first address
+    push.0 exec.memory::get_created_note_ptr
+    # => [first_note_ptr, end_ptr, ...]
+
+    # prepare stack for hashing
+    padw padw padw
+    # => [PERM, PERM, PERM, first_note_ptr, end_ptr, ...]
+
+    # check if the number of output notes is greater then 0. Conditional for the while loop.
+    dup.13 dup.13 neq
+    # => [PERM, PERM, PERM, first_note_ptr, end_ptr, ...]
+
+    # loop and hash output notes
+    while.true
+        # compute output note hash (this also computes the note's asset hash)
+        dup.12 exec.compute_output_note_hash
+        # => [NOTE_HASH, PERM, PERM, PERM, note_ptr, end_ptr, ...]
+
+        # drop output note hash from stack
+        dropw
+        # => [PERM, PERM, PERM, note_ptr, end_ptr, ...]
+
+        # permute over (note_hash, note_metadata)
+        mem_stream hperm
+        # => [PERM, PERM, PERM, note_ptr + 2, end_ptr, ...]
+
+        # increment output note pointer
+        movup.12 push.OUTPUT_NOTE_HASHING_MEM_DIFF add
+        # => [note_ptr + 512, PERM, PERM, PERM, end_ptr, ...]
+
+        # check if we should loop again
+        dup movdn.13 dup.14 neq
+        # => [should_loop, PERM, PERM, PERM, note_ptr + 512, end_ptr, ...]
+    end
+
+    # extract digest from hasher rate elements (h_0, ..., h_3)
+    dropw swapw dropw
+    # => [OUTPUT_NOTES_COMMITMENT, end_ptr, end_ptr, ...]
+
+    # drop accessory variables from stack
+    movup.4 drop
+    movup.4 drop
+    # => [OUTPUT_NOTES_COMMITMENT, ...]
 end

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -544,8 +544,9 @@ proc.process_input_note
     exec.memory::set_consumed_note_metadata
     # => [note_ptr]
 
-    # get the number of assets
-    dup exec.memory::get_consumed_note_num_assets
+    # get the number of assets from the advice provider and store it in memory
+    adv_push.1 dup dup.2
+    exec.memory::set_consumed_note_num_assets
     # => [num_assets, note_ptr]
 
     # assert the number of assets is within limits
@@ -589,12 +590,14 @@ proc.process_input_note
     # => [note_ptr, DIG, note_ptr]
 
     # get expected note vault from memory
-    exec.memory::get_consumed_note_vault_root
+    exec.memory::get_consumed_note_assets_hash
     # => [V, DIG, note_ptr]
 
     # assert that the computed hash matches the expected hash
     assert_eqw
     # => [note_ptr]
+
+    # TODO: make sure the last asset is not [ZERO; 4]?
 
     # insert note assets into the input vault
     # ---------------------------------------------------------------------------------------------
@@ -651,7 +654,7 @@ proc.process_input_note
     # => [RECIPIENT, note_ptr]
 
     # hash recipient with vault hash - note_hash = hmerge(recipient, vault_hash)
-    dup.4 exec.memory::get_consumed_note_vault_root hmerge
+    dup.4 exec.memory::get_consumed_note_assets_hash hmerge
     # => [NOTE_HASH, note_ptr]
 
     # store note hash in memory and clear stack

--- a/miden-lib/asm/miden/kernels/tx/tx.masm
+++ b/miden-lib/asm/miden/kernels/tx/tx.masm
@@ -79,11 +79,15 @@ export.create_note
     # => [note_ptr, ASSET, tag, RECIPIENT]
 
     # populate the metadata
-    push.1 movup.6 exec.account::get_id push.0
-    # => [1, acct_id, tag, 0, note_ptr, ASSET,  RECIPIENT]
+    movup.5 exec.account::get_id push.0.0
+    # => [0, 0, acct_id, tag, note_ptr, ASSET,  RECIPIENT]
 
     # set the metadata for the new created note
     dup.4 exec.memory::set_created_note_metadata
+    # => [note_ptr, ASSET, RECIPIENT]
+
+    # set the number of assets for the note to 1
+    push.1 dup.1 exec.memory::set_created_note_num_assets
     # => [note_ptr, ASSET, RECIPIENT]
 
     movdn.4 padw swapw movup.8

--- a/miden-lib/asm/miden/kernels/tx/tx.masm
+++ b/miden-lib/asm/miden/kernels/tx/tx.masm
@@ -1,8 +1,8 @@
 use.miden::kernels::tx::account
 use.miden::kernels::tx::asset
 use.miden::kernels::tx::constants
-use.miden::kernels::tx::epilogue
 use.miden::kernels::tx::memory
+use.miden::kernels::tx::note
 
 #! Returns the block hash of the last known block at the time of transaction execution.
 #!
@@ -36,7 +36,7 @@ export.memory::get_nullifier_com->get_input_notes_hash
 #! Outputs: [COM]
 #!
 #! COM is the output notes hash.
-export.epilogue::compute_output_notes_hash->get_output_notes_hash
+export.note::compute_output_notes_commitment->get_output_notes_hash
 
 #! Increments the number of created notes by one. Returns the index of the next note to be created.
 #!

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -32,6 +32,9 @@ use crate::transaction::{
 
 const PROLOGUE_FILE: &str = "prologue.masm";
 
+// TESTS
+// ================================================================================================
+
 #[test]
 fn test_transaction_prologue() {
     let tx_inputs =
@@ -69,37 +72,31 @@ fn test_transaction_prologue() {
 fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &PreparedTransaction) {
     // The block hash should be stored at the BLK_HASH_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), BLK_HASH_PTR).unwrap(),
+        read_root_mem_value(process, BLK_HASH_PTR),
         inputs.block_header().hash().as_elements()
     );
 
     // The account ID should be stored at the ACCT_ID_PTR
-    assert_eq!(
-        process.get_mem_value(ContextId::root(), ACCT_ID_PTR).unwrap()[0],
-        inputs.account().id().into()
-    );
+    assert_eq!(read_root_mem_value(process, ACCT_ID_PTR)[0], inputs.account().id().into());
 
     // The account commitment should be stored at the ACCT_HASH_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), INIT_ACCT_HASH_PTR).unwrap(),
+        read_root_mem_value(process, INIT_ACCT_HASH_PTR),
         inputs.account().hash().as_elements()
     );
 
     // The nullifier commitment should be stored at the NULLIFIER_COM_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), NULLIFIER_COM_PTR).unwrap(),
+        read_root_mem_value(process, NULLIFIER_COM_PTR),
         inputs.input_notes().commitment().as_elements()
     );
 
     // The initial nonce should be stored at the INIT_NONCE_PTR
-    assert_eq!(
-        process.get_mem_value(ContextId::root(), INIT_NONCE_PTR).unwrap()[0],
-        inputs.account().nonce()
-    );
+    assert_eq!(read_root_mem_value(process, INIT_NONCE_PTR)[0], inputs.account().nonce());
 
     // The transaction script root should be stored at the TX_SCRIPT_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), TX_SCRIPT_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, TX_SCRIPT_ROOT_PTR),
         **inputs.tx_script().as_ref().unwrap().hash()
     );
 }
@@ -107,67 +104,67 @@ fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &Prepared
 fn block_data_memory_assertions(process: &Process<MockHost>, inputs: &PreparedTransaction) {
     // The block hash should be stored at the BLK_HASH_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), BLK_HASH_PTR).unwrap(),
+        read_root_mem_value(process, BLK_HASH_PTR),
         inputs.block_header().hash().as_elements()
     );
 
     // The previous block hash should be stored at the PREV_BLK_HASH_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), PREV_BLOCK_HASH_PTR).unwrap(),
+        read_root_mem_value(process, PREV_BLOCK_HASH_PTR),
         inputs.block_header().prev_hash().as_elements()
     );
 
     // The chain root should be stored at the CHAIN_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), CHAIN_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, CHAIN_ROOT_PTR),
         inputs.block_header().chain_root().as_elements()
     );
 
     // The account db root should be stored at the ACCT_DB_ROOT_PRT
     assert_eq!(
-        process.get_mem_value(ContextId::root(), ACCT_DB_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, ACCT_DB_ROOT_PTR),
         inputs.block_header().account_root().as_elements()
     );
 
     // The nullifier db root should be stored at the NULLIFIER_DB_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), NULLIFIER_DB_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, NULLIFIER_DB_ROOT_PTR),
         inputs.block_header().nullifier_root().as_elements()
     );
 
     // The batch root should be stored at the BATCH_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), BATCH_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, BATCH_ROOT_PTR),
         inputs.block_header().batch_root().as_elements()
     );
 
     // The note root should be stored at the NOTE_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), NOTE_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, NOTE_ROOT_PTR),
         inputs.block_header().note_root().as_elements()
     );
 
     // The proof hash should be stored at the PROOF_HASH_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), PROOF_HASH_PTR).unwrap(),
+        read_root_mem_value(process, PROOF_HASH_PTR),
         inputs.block_header().proof_hash().as_elements()
     );
 
     // The block number should be stored at BLOCK_METADATA_PTR[BLOCK_NUMBER_IDX]
     assert_eq!(
-        process.get_mem_value(ContextId::root(), BLOCK_METADATA_PTR).unwrap()[BLOCK_NUMBER_IDX],
+        read_root_mem_value(process, BLOCK_METADATA_PTR)[BLOCK_NUMBER_IDX],
         inputs.block_header().block_num().into()
     );
 
     // The protocol version should be stored at BLOCK_METADATA_PTR[PROTOCOL_VERSION_IDX]
     assert_eq!(
-        process.get_mem_value(ContextId::root(), BLOCK_METADATA_PTR).unwrap()[PROTOCOL_VERSION_IDX],
+        read_root_mem_value(process, BLOCK_METADATA_PTR)[PROTOCOL_VERSION_IDX],
         inputs.block_header().version()
     );
 
     // The timestamp should be stored at BLOCK_METADATA_PTR[TIMESTAMP_IDX]
     assert_eq!(
-        process.get_mem_value(ContextId::root(), BLOCK_METADATA_PTR).unwrap()[TIMESTAMP_IDX],
+        read_root_mem_value(process, BLOCK_METADATA_PTR)[TIMESTAMP_IDX],
         inputs.block_header().timestamp()
     );
 }
@@ -179,7 +176,7 @@ fn chain_mmr_memory_assertions(process: &Process<MockHost>, prepared_tx: &Prepar
 
     // The number of leaves should be stored at the CHAIN_MMR_NUM_LEAVES_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), CHAIN_MMR_NUM_LEAVES_PTR).unwrap()[0],
+        read_root_mem_value(process, CHAIN_MMR_NUM_LEAVES_PTR)[0],
         Felt::new(chain_mmr.chain_length() as u64)
     );
 
@@ -188,35 +185,32 @@ fn chain_mmr_memory_assertions(process: &Process<MockHost>, prepared_tx: &Prepar
         let i: u32 = i.try_into().expect(
             "Number of peaks is log2(number_of_leaves), this value won't be larger than 2**32",
         );
-        assert_eq!(
-            process.get_mem_value(ContextId::root(), CHAIN_MMR_PEAKS_PTR + i).unwrap(),
-            Word::from(peak)
-        );
+        assert_eq!(read_root_mem_value(process, CHAIN_MMR_PEAKS_PTR + i), Word::from(peak));
     }
 }
 
 fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &PreparedTransaction) {
     // The account id should be stored at ACCT_ID_AND_NONCE_PTR[0]
     assert_eq!(
-        process.get_mem_value(ContextId::root(), ACCT_ID_AND_NONCE_PTR).unwrap(),
+        read_root_mem_value(process, ACCT_ID_AND_NONCE_PTR),
         [inputs.account().id().into(), ZERO, ZERO, inputs.account().nonce()]
     );
 
     // The account vault root commitment should be stored at ACCT_VAULT_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), ACCT_VAULT_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, ACCT_VAULT_ROOT_PTR),
         inputs.account().vault().commitment().as_elements()
     );
 
     // The account storage root commitment should be stored at ACCT_STORAGE_ROOT_PTR
     assert_eq!(
-        process.get_mem_value(ContextId::root(), ACCT_STORAGE_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, ACCT_STORAGE_ROOT_PTR),
         Word::from(inputs.account().storage().root())
     );
 
     // The account code commitment should be stored at (ACCOUNT_DATA_OFFSET + 4)
     assert_eq!(
-        process.get_mem_value(ContextId::root(), ACCT_CODE_ROOT_PTR).unwrap(),
+        read_root_mem_value(process, ACCT_CODE_ROOT_PTR),
         inputs.account().code().root().as_elements()
     );
 
@@ -230,7 +224,7 @@ fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &Prepared
         .zip(ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET..)
     {
         assert_eq!(
-            process.get_mem_value(ContextId::root(), types_ptr).unwrap(),
+            read_root_mem_value(process, types_ptr),
             Word::try_from(types.iter().map(Felt::from).collect::<Vec<_>>()).unwrap()
         );
     }
@@ -239,77 +233,66 @@ fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &Prepared
 fn consumed_notes_memory_assertions(process: &Process<MockHost>, inputs: &PreparedTransaction) {
     // The number of consumed notes should be stored at the CONSUMED_NOTES_OFFSET
     assert_eq!(
-        process.get_mem_value(ContextId::root(), CONSUMED_NOTE_SECTION_OFFSET).unwrap()[0],
+        read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET)[0],
         Felt::new(inputs.input_notes().num_notes() as u64)
     );
 
     for (note, note_idx) in inputs.input_notes().iter().zip(0_u32..) {
+        let note = note.note();
+
         // The note nullifier should be computer and stored at (CONSUMED_NOTES_OFFSET + 1 + note_idx)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx)
-                .unwrap(),
-            note.note().nullifier().as_elements()
+            read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx),
+            note.nullifier().as_elements()
         );
 
         // The ID hash should be computed and stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx))
-                .unwrap(),
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx)),
             note.id().as_elements()
         );
 
         // The note serial num should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 1)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 1)
-                .unwrap(),
-            note.note().serial_num()
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 1),
+            note.serial_num()
         );
 
         // The note script hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 2)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 2)
-                .unwrap(),
-            note.note().script().hash().as_elements()
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 2),
+            note.script().hash().as_elements()
         );
 
         // The note input hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 3)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 3)
-                .unwrap(),
-            note.note().inputs().hash().as_elements()
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 3),
+            note.inputs().hash().as_elements()
         );
 
         // The note asset hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 4)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 4)
-                .unwrap(),
-            note.note().assets().commitment().as_elements()
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 4),
+            note.assets().commitment().as_elements()
         );
 
-        // The number of assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 5)
+        // The note metadata should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 5)
         assert_eq!(
-            process
-                .get_mem_value(ContextId::root(), consumed_note_data_ptr(note_idx) + 5)
-                .unwrap(),
-            Word::from(note.note().metadata())
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 5),
+            Word::from(note.metadata())
         );
 
-        // The assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 6..)
-        for (asset, asset_idx) in note.note().assets().iter().cloned().zip(0u32..) {
+        // The number of assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 6)
+        assert_eq!(
+            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 6),
+            [Felt::from(note.assets().num_assets() as u32), ZERO, ZERO, ZERO]
+        );
+
+        // The assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 7..)
+        for (asset, asset_idx) in note.assets().iter().cloned().zip(0u32..) {
             let word: Word = asset.into();
             assert_eq!(
-                process
-                    .get_mem_value(
-                        ContextId::root(),
-                        consumed_note_data_ptr(note_idx) + 6 + asset_idx
-                    )
-                    .unwrap(),
+                read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 7 + asset_idx),
                 word
             );
         }
@@ -518,4 +501,11 @@ fn test_get_blk_timestamp() {
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(process.stack.get(0), tx_inputs.block_header().timestamp());
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn read_root_mem_value(process: &Process<MockHost>, addr: u32) -> Word {
+    process.get_mem_value(ContextId::root(), addr).unwrap()
 }

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -4,16 +4,21 @@ use miden_objects::{
 };
 use mock::{
     constants::ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
-    mock::{account::MockAccountType, notes::AssetPreservationStatus, transaction::mock_inputs},
+    mock::{
+        account::MockAccountType, host::MockHost, notes::AssetPreservationStatus,
+        transaction::mock_inputs,
+    },
     prepare_transaction,
     procedures::prepare_word,
     run_tx, run_within_tx_kernel,
 };
 
-use super::{ContextId, Felt, MemAdviceProvider, ProcessState, StackInputs, Word, ONE, ZERO};
+use super::{
+    ContextId, Felt, MemAdviceProvider, Process, ProcessState, StackInputs, Word, ONE, ZERO,
+};
 use crate::transaction::memory::{
-    CREATED_NOTE_ASSETS_OFFSET, CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET,
-    CREATED_NOTE_SECTION_OFFSET, NUM_CREATED_NOTES_PTR,
+    CREATED_NOTE_ASSETS_OFFSET, CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_NUM_ASSETS_OFFSET,
+    CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET, NUM_CREATED_NOTES_PTR,
 };
 
 #[test]
@@ -57,34 +62,25 @@ fn test_create_note() {
 
     // assert the recipient is stored at the correct memory location.
     assert_eq!(
-        process
-            .get_mem_value(
-                ContextId::root(),
-                CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_RECIPIENT_OFFSET
-            )
-            .unwrap(),
+        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_RECIPIENT_OFFSET),
         recipient
     );
 
     // assert the metadata is stored at the correct memory location.
     assert_eq!(
-        process
-            .get_mem_value(
-                ContextId::root(),
-                CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_METADATA_OFFSET
-            )
-            .unwrap(),
-        [ONE, tag, Felt::from(account_id), ZERO]
+        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_METADATA_OFFSET),
+        [tag, Felt::from(account_id), ZERO, ZERO]
+    );
+
+    // assert the number of assets is stored at the correct memory location.
+    assert_eq!(
+        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_NUM_ASSETS_OFFSET),
+        [ONE, ZERO, ZERO, ZERO]
     );
 
     // assert the asset is stored at the correct memory location.
     assert_eq!(
-        process
-            .get_mem_value(
-                ContextId::root(),
-                CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET
-            )
-            .unwrap(),
+        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
         asset
     );
 
@@ -214,4 +210,11 @@ fn test_get_output_notes_hash() {
 
     let transaction = prepare_transaction(tx_inputs, None, &code, None);
     let _process = run_tx(&transaction).unwrap();
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn read_root_mem_value(process: &Process<MockHost>, addr: u32) -> Word {
+    process.get_mem_value(ContextId::root(), addr).unwrap()
 }

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -85,7 +85,8 @@ fn test_create_note() {
     );
 
     // assert there top item on the stack is a pointer to the created note.
-    assert_eq!(process.stack.get(0), Felt::new(10000));
+    let note_ptr = CREATED_NOTE_SECTION_OFFSET;
+    assert_eq!(process.stack.get(0), Felt::from(note_ptr));
 }
 
 #[test]

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -258,8 +258,9 @@ fn add_account_to_advice_inputs(
 ///   out[8..12]   = input root
 ///   out[12..16]  = asset_hash
 ///   out[16..20]  = metadata
-///   out[20..24]  = asset_1
-///   out[24..28]  = asset_2
+///   out[20]      = num_assets
+///   out[21..25]  = asset_1
+///   out[25..29]  = asset_2
 ///   ...
 ///   out[20 + num_assets * 4..] = Word::default() (this is conditional padding only applied
 ///                                                 if the number of assets is odd)
@@ -305,6 +306,7 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
         note_data.extend(*note.assets().commitment());
         note_data.extend(Word::from(note.metadata()));
 
+        note_data.push((note.assets().num_assets() as u32).into());
         note_data.extend(note.assets().to_padded_assets());
 
         note_data.push(proof.origin().block_num.into());

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -181,8 +181,21 @@ pub const MAX_ASSETS_PER_NOTE: u32 = 256;
 /// The size of the memory segment allocated to each note
 pub const NOTE_MEM_SIZE: MemoryAddress = 1024;
 
-// CONSUMED NOTES DATA
+// INPUT NOTES DATA
 // ------------------------------------------------------------------------------------------------
+// Inputs note section contains data for all notes consumed by a transaction. It starts with a word
+// containing the total number of input notes and is followed by data of each note like so:
+//
+// ┌───────────┬─────────────┬─────┬─────────────┐
+// │ NUM NOTES │ NOTE 1 DATA │ ... │ NOTE n DATA │
+// └───────────┴─────────────┴─────┴─────────────┘
+//
+// Data section for each note consists of exactly 1024 words and is laid out like so:
+//
+// ┌──────┬────────┬────────┬────────┬────────┬──────┬────────┬───────┬─────┬───────┐
+// │ NOTE │ SERIAL │ SCRIPT │ INPUTS │ ASSETS │ META │  NUM   │ ASSET │ ... │ ASSET │
+// │  ID  │  NUM   │  ROOT  │  HASH  │  HASH  │ DATA │ ASSETS │   1   │     │   n   │
+// └──────┴────────┴────────┴────────┴────────┴──────┴────────┴───────┴─────┴───────┘
 
 /// The memory address at which the consumed note section begins.
 pub const CONSUMED_NOTE_SECTION_OFFSET: MemoryOffset = 1000;
@@ -195,15 +208,20 @@ pub const CONSUMED_NOTE_ID_OFFSET: MemoryOffset = 0;
 pub const CONSUMED_NOTE_SERIAL_NUM_OFFSET: MemoryOffset = 1;
 pub const CONSUMED_NOTE_SCRIPT_ROOT_OFFSET: MemoryOffset = 2;
 pub const CONSUMED_NOTE_INPUTS_HASH_OFFSET: MemoryOffset = 3;
-pub const CONSUMED_NOTE_ASSET_HASH_OFFSET: MemoryOffset = 4;
+pub const CONSUMED_NOTE_ASSETS_HASH_OFFSET: MemoryOffset = 4;
 pub const CONSUMED_NOTE_METADATA_OFFSET: MemoryOffset = 5;
-pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 6;
+pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 6;
+pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 7;
 
 /// The maximum number of consumed notes that can be processed in a single transaction.
 pub const MAX_NUM_CONSUMED_NOTES: u32 = 1023;
 
-// CREATED NOTES DATA
+// OUTPUT NOTES DATA
 // ------------------------------------------------------------------------------------------------
+//
+// ┌─────────┬──────────┬───────────┬─────────────┬────────────┬─────────┬─────┬─────────┐
+// │ NOTE ID │ METADATA │ RECIPIENT │ ASSETS HASH │ NUM ASSETS │ ASSET 1 │ ... │ ASSET n │
+// └─────────┴──────────┴───────────┴─────────────┴────────────┴─────────┴─────┴─────────┘
 
 /// The size of the core created note data segment.
 pub const CREATED_NOTE_CORE_DATA_SIZE: MemSize = 4;
@@ -216,7 +234,8 @@ pub const CREATED_NOTE_ID_OFFSET: MemoryOffset = 0;
 pub const CREATED_NOTE_METADATA_OFFSET: MemoryOffset = 1;
 pub const CREATED_NOTE_RECIPIENT_OFFSET: MemoryOffset = 2;
 pub const CREATED_NOTE_ASSET_HASH_OFFSET: MemoryOffset = 3;
-pub const CREATED_NOTE_ASSETS_OFFSET: MemoryOffset = 4;
+pub const CREATED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 4;
+pub const CREATED_NOTE_ASSETS_OFFSET: MemoryOffset = 5;
 
 /// The maximum number of created notes that can be produced in a single transaction.
 pub const MAX_NUM_CREATED_NOTES: u32 = 4096;

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -11,7 +11,7 @@ use super::memory::{
     ACCT_CODE_ROOT_OFFSET, ACCT_DATA_MEM_SIZE, ACCT_ID_AND_NONCE_OFFSET, ACCT_ID_IDX,
     ACCT_NONCE_IDX, ACCT_STORAGE_ROOT_OFFSET, ACCT_VAULT_ROOT_OFFSET, CREATED_NOTE_ASSETS_OFFSET,
     CREATED_NOTE_ASSET_HASH_OFFSET, CREATED_NOTE_CORE_DATA_SIZE, CREATED_NOTE_ID_OFFSET,
-    CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET,
+    CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_NUM_ASSETS_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET,
 };
 
 // STACK OUTPUTS
@@ -56,17 +56,17 @@ pub fn notes_try_from_elements(elements: &[Word]) -> Result<OutputNote, NoteErro
     let note_id: NoteId = elements[CREATED_NOTE_ID_OFFSET as usize].into();
     let metadata: NoteMetadata = elements[CREATED_NOTE_METADATA_OFFSET as usize].try_into()?;
     let recipient = elements[CREATED_NOTE_RECIPIENT_OFFSET as usize].into();
+    let num_assets = elements[CREATED_NOTE_NUM_ASSETS_OFFSET as usize][0];
     let asset_hash: Digest = elements[CREATED_NOTE_ASSET_HASH_OFFSET as usize].into();
 
     if elements.len()
-        < (CREATED_NOTE_ASSETS_OFFSET as usize + metadata.num_assets().as_int() as usize)
-            * WORD_SIZE
+        < (CREATED_NOTE_ASSETS_OFFSET as usize + num_assets.as_int() as usize) * WORD_SIZE
     {
         return Err(NoteError::InvalidStubDataLen(elements.len()));
     }
 
     let assets = elements[CREATED_NOTE_ASSETS_OFFSET as usize
-        ..(CREATED_NOTE_ASSETS_OFFSET as usize + metadata.num_assets().as_int() as usize)]
+        ..(CREATED_NOTE_ASSETS_OFFSET as usize + num_assets.as_int() as usize)]
         .iter()
         .map(|word| (*word).try_into())
         .collect::<Result<Vec<Asset>, _>>()

--- a/miden-tx/tests/assets/test.masm
+++ b/miden-tx/tests/assets/test.masm
@@ -1,5 +1,5 @@
 use.miden::kernels::prologue
-use.miden::kernels::epilogue
+use.miden::kernels::note
 use.miden::kernels::utils
 
 # CONSTANTS
@@ -76,5 +76,5 @@ begin
     exec.prologue::prepare_transaction
     exec.create_mock_notes
     breakpoint
-    exec.epilogue::compute_output_notes_hash
+    exec.note::compute_output_notes_commitment
 end

--- a/miden-tx/tests/faucet_contract_test.rs
+++ b/miden-tx/tests/faucet_contract_test.rs
@@ -82,7 +82,7 @@ fn test_faucet_contract_mint_fungible_asset_succeeds() {
     let expected_note = OutputNote::new(
         recipient.into(),
         NoteAssets::new(&[fungible_asset]).unwrap(),
-        NoteMetadata::new(faucet_account.id(), tag, Felt::new(1)),
+        NoteMetadata::new(faucet_account.id(), tag),
     );
 
     let created_note = transaction_result.output_notes().get_note(0).clone();

--- a/miden-tx/tests/swap_script_test.rs
+++ b/miden-tx/tests/swap_script_test.rs
@@ -101,8 +101,7 @@ fn test_swap_script() {
     // Check if the created `Note` is what we expect
     let recipient = build_p2id_recipient(sender_account_id, repay_serial_num).unwrap();
 
-    let note_metadata =
-        NoteMetadata::new(target_account_id, sender_account_id.into(), Felt::new(1));
+    let note_metadata = NoteMetadata::new(target_account_id, sender_account_id.into());
 
     let note_assets = NoteAssets::new(&[non_fungible_asset]).unwrap();
 

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -44,8 +44,8 @@ pub fn run_tx_with_inputs(
     let (stack_inputs, mut advice_inputs) = tx.get_kernel_inputs();
     advice_inputs.extend(inputs);
     let host = MockHost::new(tx.account().into(), advice_inputs);
-    let mut process =
-        Process::new(program.kernel().clone(), stack_inputs, host, ExecutionOptions::default());
+    let exec_options = ExecutionOptions::default().with_tracing();
+    let mut process = Process::new(program.kernel().clone(), stack_inputs, host, exec_options);
     process.execute(&program)?;
     Ok(process)
 }
@@ -74,8 +74,8 @@ where
     let program = assembler.compile(code).unwrap();
 
     let host = DefaultHost::new(adv);
-    let mut process =
-        Process::new(program.kernel().clone(), stack_inputs, host, ExecutionOptions::default());
+    let exec_options = ExecutionOptions::default().with_tracing();
+    let mut process = Process::new(program.kernel().clone(), stack_inputs, host, exec_options);
     process.execute(&program)?;
     Ok(process)
 }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -104,7 +104,7 @@ pub fn run_within_host<H: Host>(
 // TEST HELPERS
 // ================================================================================================
 pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
-    memory::CONSUMED_NOTE_SECTION_OFFSET + (1 + note_idx) * 1024
+    memory::CONSUMED_NOTE_SECTION_OFFSET + (1 + note_idx) * memory::NOTE_MEM_SIZE
 }
 
 pub fn prepare_transaction(

--- a/mock/src/mock/notes.rs
+++ b/mock/src/mock/notes.rs
@@ -91,7 +91,7 @@ pub fn mock_notes(
             push.{created_note_0_tag}
             push.{created_note_0_asset}
             # MAST root of the `create_note` mock account procedure
-            call.0x63a658fd415eab326824c1cc14916f071cccf63aba8f0104247eb66a64687581
+            call.0xbda092a816f2d979ecf67e0f39215c9f08b56823f41e3ad568db11dea63304e3
             drop dropw dropw
 
             # create note 1
@@ -99,7 +99,7 @@ pub fn mock_notes(
             push.{created_note_1_tag}
             push.{created_note_1_asset}
             # MAST root of the `create_note` mock account procedure
-            call.0x63a658fd415eab326824c1cc14916f071cccf63aba8f0104247eb66a64687581
+            call.0xbda092a816f2d979ecf67e0f39215c9f08b56823f41e3ad568db11dea63304e3
             drop dropw dropw
         end
     ",
@@ -122,7 +122,7 @@ pub fn mock_notes(
             push.{created_note_2_tag}
             push.{created_note_2_asset}
             # MAST root of the `create_note` mock account procedure
-            call.0x63a658fd415eab326824c1cc14916f071cccf63aba8f0104247eb66a64687581
+            call.0xbda092a816f2d979ecf67e0f39215c9f08b56823f41e3ad568db11dea63304e3
             drop dropw dropw
         end
         ",

--- a/mock/src/mock/notes.rs
+++ b/mock/src/mock/notes.rs
@@ -91,7 +91,7 @@ pub fn mock_notes(
             push.{created_note_0_tag}
             push.{created_note_0_asset}
             # MAST root of the `create_note` mock account procedure
-            call.0xeba65b5e6276e2c2f8e52f8ab8ce0c039bdfba127961826ff7d125c32d6d2458
+            call.0x63a658fd415eab326824c1cc14916f071cccf63aba8f0104247eb66a64687581
             drop dropw dropw
 
             # create note 1
@@ -99,7 +99,7 @@ pub fn mock_notes(
             push.{created_note_1_tag}
             push.{created_note_1_asset}
             # MAST root of the `create_note` mock account procedure
-            call.0xeba65b5e6276e2c2f8e52f8ab8ce0c039bdfba127961826ff7d125c32d6d2458
+            call.0x63a658fd415eab326824c1cc14916f071cccf63aba8f0104247eb66a64687581
             drop dropw dropw
         end
     ",
@@ -122,7 +122,7 @@ pub fn mock_notes(
             push.{created_note_2_tag}
             push.{created_note_2_asset}
             # MAST root of the `create_note` mock account procedure
-            call.0xeba65b5e6276e2c2f8e52f8ab8ce0c039bdfba127961826ff7d125c32d6d2458
+            call.0x63a658fd415eab326824c1cc14916f071cccf63aba8f0104247eb66a64687581
             drop dropw dropw
         end
         ",

--- a/mock/src/procedures.rs
+++ b/mock/src/procedures.rs
@@ -1,7 +1,8 @@
 use super::{
     memory::{
-        CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET,
-        NOTE_MEM_SIZE, NUM_CREATED_NOTES_PTR,
+        CREATED_NOTE_ASSETS_OFFSET, CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_NUM_ASSETS_OFFSET,
+        CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE,
+        NUM_CREATED_NOTES_PTR,
     },
     NoteAssets, OutputNotes, StarkField, Word,
 };
@@ -10,14 +11,17 @@ pub fn output_notes_data_procedure(notes: &OutputNotes) -> String {
     let note_0_metadata = prepare_word(&notes.get_note(0).metadata().into());
     let note_0_recipient = prepare_word(notes.get_note(0).recipient());
     let note_0_assets = prepare_assets(notes.get_note(0).assets());
+    let note_0_num_assets = 1;
 
     let note_1_metadata = prepare_word(&notes.get_note(1).metadata().into());
     let note_1_recipient = prepare_word(notes.get_note(1).recipient());
     let note_1_assets = prepare_assets(notes.get_note(1).assets());
+    let note_1_num_assets = 1;
 
     let note_2_metadata = prepare_word(&notes.get_note(2).metadata().into());
     let note_2_recipient = prepare_word(notes.get_note(2).recipient());
     let note_2_assets = prepare_assets(notes.get_note(2).assets());
+    let note_2_num_assets = 1;
 
     const NOTE_1_OFFSET: u32 = NOTE_MEM_SIZE;
     const NOTE_2_OFFSET: u32 = NOTE_MEM_SIZE * 2;
@@ -35,8 +39,11 @@ pub fn output_notes_data_procedure(notes: &OutputNotes) -> String {
         push.{note_0_recipient}
         push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add mem_storew dropw
 
+        push.{note_0_num_assets}
+        push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add mem_store
+
         push.{}
-        push.{CREATED_NOTE_SECTION_OFFSET}.4 add mem_storew dropw
+        push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_ASSETS_OFFSET} add mem_storew dropw
 
         # populate note 1
         push.{note_1_metadata}
@@ -45,8 +52,11 @@ pub fn output_notes_data_procedure(notes: &OutputNotes) -> String {
         push.{note_1_recipient}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
 
+        push.{note_1_num_assets}
+        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add add mem_store
+
         push.{}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.4 add add mem_storew dropw
+        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_ASSETS_OFFSET} add add mem_storew dropw
 
         # populate note 2
         push.{note_2_metadata}
@@ -55,8 +65,11 @@ pub fn output_notes_data_procedure(notes: &OutputNotes) -> String {
         push.{note_2_recipient}
         push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
 
+        push.{note_2_num_assets}
+        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add add mem_store
+
         push.{}
-        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.4 add add mem_storew dropw
+        push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_ASSETS_OFFSET} add add mem_storew dropw
 
         # set num created notes
         push.{}.{NUM_CREATED_NOTES_PTR} mem_store

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -61,3 +61,12 @@ pub const ACCOUNT_TREE_DEPTH: u8 = 64;
 
 /// The depth of the Merkle tree used to commit to notes produced in a block.
 pub const NOTE_TREE_DEPTH: u8 = 20;
+
+/// The maximum number of assets that can be stored in a single note.
+pub const MAX_ASSETS_PER_NOTE: usize = 256;
+
+/// The maximum number of notes that can be consumed by a single transaction.
+pub const MAX_INPUT_NOTES_PER_TX: usize = 1023;
+
+/// The maximum number of new notes created by a single transaction.
+pub const MAX_OUTPUT_NOTES_PER_TX: usize = 4096;

--- a/objects/src/notes/assets.rs
+++ b/objects/src/notes/assets.rs
@@ -4,13 +4,14 @@ use super::{
     Asset, ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher,
     NoteError, Serializable, Vec, Word, WORD_SIZE, ZERO,
 };
+use crate::MAX_ASSETS_PER_NOTE;
 
 // NOTE ASSETS
 // ================================================================================================
 /// An asset container for a note.
 ///
-/// A note can contain up to 255 assets. No duplicates are allowed, but the order of assets is
-/// unspecified.
+/// A note must contain at least 1 asset and can contain up to 256 assets. No duplicates are
+/// allowed, but the order of assets is unspecified.
 ///
 /// All the assets in a note can be reduced to a single commitment which is computed by
 /// sequentially hashing the assets. Note that the same list of assets can result in two different
@@ -25,7 +26,7 @@ impl NoteAssets {
     // CONSTANTS
     // --------------------------------------------------------------------------------------------
     /// The maximum number of assets which can be carried by a single note.
-    pub const MAX_NUM_ASSETS: usize = 255;
+    pub const MAX_NUM_ASSETS: usize = MAX_ASSETS_PER_NOTE;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -34,7 +35,7 @@ impl NoteAssets {
     /// # Errors
     /// Returns an error if:
     /// - The asset list is empty.
-    /// - The list contains more than 255 assets.
+    /// - The list contains more than 256 assets.
     /// - There are duplicate assets in the list.
     pub fn new(assets: &[Asset]) -> Result<Self, NoteError> {
         if assets.is_empty() {

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -11,7 +11,7 @@ use super::{
 ///
 /// The metadata consists of:
 /// - sender is the account which created the note.
-/// - tag is a tag which can be used to identify the target account for the note.
+/// - tag is a value which can be used by the recipient(s) to identify notes intended for them.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteMetadata {

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -4,23 +4,25 @@ use super::{
     AccountId, ByteReader, ByteWriter, Deserializable, Felt, NoteError, Serializable, Word,
 };
 
-/// Represents metadata associated with a note. This includes the sender, tag, and number of assets.
+// NOTE METADATA
+// ================================================================================================
+
+/// Represents metadata associated with a note.
+///
+/// The metadata consists of:
 /// - sender is the account which created the note.
 /// - tag is a tag which can be used to identify the target account for the note.
-/// - num_assets is the number of assets in the note.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteMetadata {
     sender: AccountId,
     tag: Felt,
-    num_assets: Felt,
 }
 
 impl NoteMetadata {
-    /// Returns a new note metadata object created with the specified parameters.
-    pub fn new(sender: AccountId, tag: Felt, num_assets: Felt) -> Self {
-        // TODO: Assert num assets is valid
-        Self { sender, tag, num_assets }
+    /// Returns a new [NoteMetadata] instantiated with the specified parameters.
+    pub fn new(sender: AccountId, tag: Felt) -> Self {
+        Self { sender, tag }
     }
 
     /// Returns the account which created the note.
@@ -31,11 +33,6 @@ impl NoteMetadata {
     /// Returns the tag associated with the note.
     pub fn tag(&self) -> Felt {
         self.tag
-    }
-
-    /// Returns the number of assets in the note.
-    pub fn num_assets(&self) -> Felt {
-        self.num_assets
     }
 }
 
@@ -48,9 +45,8 @@ impl From<NoteMetadata> for Word {
 impl From<&NoteMetadata> for Word {
     fn from(metadata: &NoteMetadata) -> Self {
         let mut elements = Word::default();
-        elements[0] = metadata.num_assets;
-        elements[1] = metadata.tag;
-        elements[2] = metadata.sender.into();
+        elements[0] = metadata.tag;
+        elements[1] = metadata.sender.into();
         elements
     }
 }
@@ -59,11 +55,9 @@ impl TryFrom<Word> for NoteMetadata {
     type Error = NoteError;
 
     fn try_from(elements: Word) -> Result<Self, Self::Error> {
-        // TODO: Assert num assets is valid
         Ok(Self {
-            sender: elements[2].try_into().map_err(NoteError::NoteMetadataSenderInvalid)?,
-            tag: elements[1],
-            num_assets: elements[0],
+            sender: elements[1].try_into().map_err(NoteError::NoteMetadataSenderInvalid)?,
+            tag: elements[0],
         })
     }
 }
@@ -75,7 +69,6 @@ impl Serializable for NoteMetadata {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.sender.write_into(target);
         self.tag.write_into(target);
-        self.num_assets.write_into(target);
     }
 }
 
@@ -83,8 +76,7 @@ impl Deserializable for NoteMetadata {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let sender = AccountId::read_from(source)?;
         let tag = Felt::read_from(source)?;
-        let num_assets = Felt::read_from(source)?;
 
-        Ok(Self { sender, tag, num_assets })
+        Ok(Self { sender, tag })
     }
 }

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -93,14 +93,12 @@ impl Note {
         sender: AccountId,
         tag: Felt,
     ) -> Result<Self, NoteError> {
-        let assets = NoteAssets::new(assets)?;
-        let num_assets = assets.num_assets();
         Ok(Self {
             script,
             inputs: NoteInputs::new(inputs)?,
-            assets,
+            assets: NoteAssets::new(assets)?,
             serial_num,
-            metadata: NoteMetadata::new(sender, tag, Felt::new(num_assets as u64)),
+            metadata: NoteMetadata::new(sender, tag),
             id: OnceCell::new(),
             nullifier: OnceCell::new(),
         })

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use super::{BlockHeader, ChainMmr, Digest, Felt, Hasher, Word, MAX_INPUT_NOTES_PER_TRANSACTION};
+use super::{BlockHeader, ChainMmr, Digest, Felt, Hasher, Word};
 use crate::{
     accounts::{validate_account_seed, Account},
     notes::{Note, NoteId, NoteInclusionProof, NoteOrigin, Nullifier},
@@ -9,7 +9,7 @@ use crate::{
         serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
         string::ToString,
     },
-    TransactionInputError,
+    TransactionInputError, MAX_INPUT_NOTES_PER_TX,
 };
 
 // TRANSACTION INPUTS
@@ -209,9 +209,9 @@ impl<T: ToNullifier> InputNotes<T> {
     /// - The total number of notes is greater than 1024.
     /// - The vector of notes contains duplicates.
     pub fn new(notes: Vec<T>) -> Result<Self, TransactionInputError> {
-        if notes.len() > MAX_INPUT_NOTES_PER_TRANSACTION {
+        if notes.len() > MAX_INPUT_NOTES_PER_TX {
             return Err(TransactionInputError::TooManyInputNotes {
-                max: MAX_INPUT_NOTES_PER_TRANSACTION,
+                max: MAX_INPUT_NOTES_PER_TX,
                 actual: notes.len(),
             });
         }

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -24,12 +24,3 @@ pub use proven_tx::ProvenTransaction;
 pub use transaction_id::TransactionId;
 pub use tx_script::TransactionScript;
 pub use tx_witness::TransactionWitness;
-
-// CONSTANTS
-// ================================================================================================
-
-/// Maximum number of notes consumed in a single transaction.
-const MAX_INPUT_NOTES_PER_TRANSACTION: usize = 1024;
-
-/// Maximum number of notes created in a single transaction.
-const MAX_OUTPUT_NOTES_PER_TRANSACTION: usize = 1024;

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -9,7 +9,7 @@ use crate::{
         serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
         string::ToString,
     },
-    Digest, Felt, Hasher, StarkField, TransactionOutputError, Word,
+    Digest, Felt, Hasher, TransactionOutputError, Word,
 };
 
 // TRANSACTION OUTPUTS
@@ -226,9 +226,6 @@ impl OutputNote {
     // --------------------------------------------------------------------------------------------
     /// Returns a new [OutputNote] instantiated from the provided parameters.
     pub fn new(recipient: Digest, assets: NoteAssets, metadata: NoteMetadata) -> Self {
-        // assert is OK here because we'll eventually remove `num_assets` from the metadata
-        assert_eq!(assets.num_assets() as u64, metadata.num_assets().as_int());
-
         let note_id = NoteId::new(recipient, assets.commitment());
         Self {
             envelope: NoteEnvelope::new(note_id, metadata),

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -1,6 +1,5 @@
 use core::fmt::Debug;
 
-use super::MAX_OUTPUT_NOTES_PER_TRANSACTION;
 use crate::{
     accounts::AccountStub,
     notes::{Note, NoteAssets, NoteEnvelope, NoteId, NoteMetadata},
@@ -9,7 +8,7 @@ use crate::{
         serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
         string::ToString,
     },
-    Digest, Felt, Hasher, TransactionOutputError, Word,
+    Digest, Felt, Hasher, TransactionOutputError, Word, MAX_OUTPUT_NOTES_PER_TX,
 };
 
 // TRANSACTION OUTPUTS
@@ -90,9 +89,9 @@ impl<T: ToEnvelope> OutputNotes<T> {
     /// - The total number of notes is greater than 1024.
     /// - The vector of notes contains duplicates.
     pub fn new(notes: Vec<T>) -> Result<Self, TransactionOutputError> {
-        if notes.len() > MAX_OUTPUT_NOTES_PER_TRANSACTION {
+        if notes.len() > MAX_OUTPUT_NOTES_PER_TX {
             return Err(TransactionOutputError::TooManyOutputNotes {
-                max: MAX_OUTPUT_NOTES_PER_TRANSACTION,
+                max: MAX_OUTPUT_NOTES_PER_TX,
                 actual: notes.len(),
             });
         }


### PR DESCRIPTION
This PR removes `num_assets` from `NoteMetadata` as described in #281. As a side effect, it will also close #342.

Other small changes in this PR:
- Fixed an issue with note memory layout where input notes could have overlapped with output notes.
- Updated terminology to "input" and "output" notes in some places (a more comprehensive update will come later).
- Consolidated constants.
- Moved procedures related to output notes from the `epilogue` to `note` module in the kernel.