### PR TITLE
Update prologue to extend chain MMR with the latest block header

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -101,12 +101,17 @@ end
 # CHAIN DATA
 # =================================================================================================
 
-#! Process the chain data provided via the advice provider. This involves reading the MMR data from
-#! the advice provider and storing it at the appropriate memory addresses. As the MMR peaks are
-#! read from the advice provider, the chain root is computed. It is asserted that the computed
-#! chain root matches the chain root stored in the block data section. The number of words that the
-#! advice provider will send for MMR peaks is variable: it will be at least 16 but could be up to
-#! 63. The actual number will be computed based on num_leaves.
+#! Process the chain data provided via the advice provider.
+#!
+#! This involves reading the MMR data from the advice provider and storing it at the appropriate
+#! memory addresses. As the MMR peaks are read from the advice provider, the chain root is computed.
+#! It is asserted that the computed chain root matches the chain root stored in the block data
+#! section. After the consistency of the chain root has been verified, the block header for the
+#! transaction block is inserted into the MMR. This way, notes created at this block can be
+#! authenticated against the chain MMR.
+#!
+#! The number of words that the advice provider will send for MMR peaks is variable: it will be at
+#! least 16 but could be up to 63. The actual number will be computed based on num_leaves.
 #!
 #! Stack: []
 #! Advice Map: {
@@ -118,16 +123,25 @@ end
 #! - num_leaves is the number of leaves in the MMR.
 #! - P1, P2, ... are the MMR peaks.
 proc.process_chain_data
-    # get a pointer to the chain mmr data
-    exec.memory::get_chain_mmr_ptr
-    # => [chain_mmr_ptr]
+    # get a pointer to the chain MMR data
+    exec.memory::get_chain_mmr_ptr dup
+    # => [chain_mmr_ptr, chain_mmr_ptr]
 
     # get the chain root
     exec.memory::get_chain_root
-    # => [CHAIN_ROOT, chain_mmr_ptr]
+    # => [CHAIN_ROOT, chain_mmr_ptr, chain_mmr_ptr]
 
-    # unpack mmr
+    # load MMR peaks corresponding to CHAIN_ROOT into memory starting at chain_mmr_ptr
     exec.mmr::unpack
+    # => [chain_mmr_ptr]
+
+    # get block hash of the block against which the transaction is being executed
+    exec.memory::get_blk_hash
+    # => [BLOCK_HASH, chain_mmr_ptr]
+
+    # add the block hash to the chain MMR; this updates the MMR to the latest state and enables
+    # authentication of notes created as part of the block defined by the BLOCK_HASH
+    exec.mmr::add
     # => []
 end
 

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -308,8 +308,10 @@ pub enum TransactionInputError {
     AccountSeedNotProvidedForNewAccount,
     AccountSeedProvidedForExistingAccount,
     DuplicateInputNote(Digest),
+    InconsistentChainLength { expected: u32, actual: u32 },
     InconsistentChainRoot { expected: Digest, actual: Digest },
     InputNoteBlockNotInChainMmr(NoteId),
+    InputNoteNotInBlock(NoteId, u32),
     InvalidAccountSeed(AccountError),
     TooManyInputNotes { max: usize, actual: usize },
 }


### PR DESCRIPTION
This PR updates the transaction prologue code to extend the chain MMR with the block header provided to the transaction and fixes #305. This is needed because the chain MMR provided to the transaction is one block behind the block against which transaction is executed. Thus, without this change, we would not be able to consume any notes created at the current block.

As a part of this PR I've also added `ChainMmr::add_block()` method. Even though it is used only for testing, I think it might be valuable to expose it publicly.

One thing that this PR doesn't test is whether authentication paths for the leaves tracked by the chain MMR are extended in the advice provider post update. This is non-trivial to test, and looking at the [mmr::add](https://github.com/0xPolygonMiden/miden-vm/blob/main/stdlib/asm/collections/mmr.masm#L323) code, it seems like this should be happening because we use `mtree_merge` instruction to merge MMR peaks.