### PR TITLE
Update `SimpleSmt` usage as per latest crypto crate updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }

--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -20,7 +20,7 @@ testing = ["miden-objects/testing"]
 
 [dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 
 [dev-dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false, features = ["testing" ]}

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -19,7 +19,7 @@ std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier
 [dependencies]
 miden-lib = { package = "miden-lib", path = "../miden-lib", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 miden-verifier = { workspace = true }
 vm-processor = { workspace = true }
 

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -26,7 +26,7 @@ env_logger = { version = "0.10" }
 hex = "0.4"
 miden-lib = { path = "../miden-lib" }
 miden-objects = { path = "../objects" , features = ["serde", "log", "testing"]}
-miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 postcard = { version = "1.0", features = [ "alloc" ] }
 rand = { version = "0.8" }
 rand_pcg = { version = "0.3", features = ["serde1"] }

--- a/mock/src/mock/block.rs
+++ b/mock/src/mock/block.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
     accounts::Account, crypto::merkle::SimpleSmt, utils::collections::Vec, BlockHeader, Digest,
-    Felt, StarkField, ZERO,
+    Felt, StarkField, ACCOUNT_TREE_DEPTH, ZERO,
 };
 use miden_test_utils::rand;
 
@@ -10,8 +10,7 @@ pub fn mock_block_header(
     note_root: Option<Digest>,
     accts: &[Account],
 ) -> BlockHeader {
-    let acct_db = SimpleSmt::with_leaves(
-        64,
+    let acct_db = SimpleSmt::<ACCOUNT_TREE_DEPTH>::with_leaves(
         accts
             .iter()
             .flat_map(|acct| {

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -34,10 +34,10 @@ testing = []
 [dependencies]
 assembly = { workspace = true }
 log = { version = "0.4", optional = true }
-miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "plafer-smt-trait", default-features = false }
 miden-verifier = { workspace = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 vm-processor = { workspace = true }
 
 [dev-dependencies]

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -52,3 +52,12 @@ pub mod vm {
     pub use vm_core::{code_blocks::CodeBlock, Program, ProgramInfo};
     pub use vm_processor::{AdviceInputs, StackInputs, StackOutputs};
 }
+
+// CONSTANTS
+// ================================================================================================
+
+/// Depth of the account database tree.
+pub const ACCOUNT_TREE_DEPTH: u8 = 64;
+
+/// The depth of the Merkle tree used to commit to notes produced in a block.
+pub const NOTE_TREE_DEPTH: u8 = 20;

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -10,7 +10,7 @@ use super::{
         string::{String, ToString},
     },
     vm::CodeBlock,
-    Digest, Felt, Hasher, NoteError, Word, WORD_SIZE, ZERO,
+    Digest, Felt, Hasher, NoteError, Word, NOTE_TREE_DEPTH, WORD_SIZE, ZERO,
 };
 
 mod envelope;
@@ -39,9 +39,6 @@ pub use assets::NoteAssets;
 
 // CONSTANTS
 // ================================================================================================
-
-/// The depth of the Merkle tree used to commit to notes produced in a block.
-pub const NOTE_TREE_DEPTH: u8 = 20;
 
 /// The depth of the leafs in the note Merkle tree used to commit to notes produced in a block.
 /// This is equal `NOTE_TREE_DEPTH + 1`. In the kernel we do not authenticate leaf data directly


### PR DESCRIPTION
This PR updates `SimpleSmt` usage to be in line with https://github.com/0xPolygonMiden/crypto/pull/245.