### PR TITLE
Update `SimpleSmt` usage as per latest crypto crate updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
-miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
-vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }

--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -20,7 +20,7 @@ testing = ["miden-objects/testing"]
 
 [dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 
 [dev-dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false, features = ["testing" ]}

--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -20,7 +20,7 @@ testing = ["miden-objects/testing"]
 
 [dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 
 [dev-dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false, features = ["testing" ]}

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -19,7 +19,7 @@ std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier
 [dependencies]
 miden-lib = { package = "miden-lib", path = "../miden-lib", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-verifier = { workspace = true }
 vm-processor = { workspace = true }
 

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -19,7 +19,7 @@ std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier
 [dependencies]
 miden-lib = { package = "miden-lib", path = "../miden-lib", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 miden-verifier = { workspace = true }
 vm-processor = { workspace = true }
 

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -26,7 +26,7 @@ env_logger = { version = "0.10" }
 hex = "0.4"
 miden-lib = { path = "../miden-lib" }
 miden-objects = { path = "../objects" , features = ["serde", "log", "testing"]}
-miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 postcard = { version = "1.0", features = [ "alloc" ] }
 rand = { version = "0.8" }
 rand_pcg = { version = "0.3", features = ["serde1"] }

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -26,7 +26,7 @@ env_logger = { version = "0.10" }
 hex = "0.4"
 miden-lib = { path = "../miden-lib" }
 miden-objects = { path = "../objects" , features = ["serde", "log", "testing"]}
-miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-test-utils = { package = "miden-test-utils", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 postcard = { version = "1.0", features = [ "alloc" ] }
 rand = { version = "0.8" }
 rand_pcg = { version = "0.3", features = ["serde1"] }

--- a/mock/src/mock/block.rs
+++ b/mock/src/mock/block.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
     accounts::Account, crypto::merkle::SimpleSmt, utils::collections::Vec, BlockHeader, Digest,
-    Felt, StarkField, ZERO,
+    Felt, StarkField, ACCOUNT_TREE_DEPTH, ZERO,
 };
 use miden_test_utils::rand;
 
@@ -10,8 +10,7 @@ pub fn mock_block_header(
     note_root: Option<Digest>,
     accts: &[Account],
 ) -> BlockHeader {
-    let acct_db = SimpleSmt::with_leaves(
-        64,
+    let acct_db = SimpleSmt::<ACCOUNT_TREE_DEPTH>::with_leaves(
         accts
             .iter()
             .flat_map(|acct| {

--- a/mock/src/mock/chain.rs
+++ b/mock/src/mock/chain.rs
@@ -3,11 +3,11 @@ use core::fmt;
 use miden_objects::{
     accounts::{Account, AccountId, AccountType, SlotItem},
     assets::Asset,
-    crypto::merkle::{Mmr, NodeIndex, PartialMmr, SimpleSmt, TieredSmt},
-    notes::{Note, NoteInclusionProof, NOTE_LEAF_DEPTH, NOTE_TREE_DEPTH},
+    crypto::merkle::{LeafIndex, Mmr, PartialMmr, SimpleSmt, TieredSmt},
+    notes::{Note, NoteInclusionProof},
     transaction::{ChainMmr, InputNote},
     utils::collections::Vec,
-    BlockHeader, Digest, Felt, FieldElement, StarkField, Word,
+    BlockHeader, Digest, Felt, FieldElement, Word, ACCOUNT_TREE_DEPTH, NOTE_TREE_DEPTH,
 };
 use rand::{Rng, SeedableRng};
 
@@ -60,7 +60,7 @@ impl<R: Rng> Objects<R> {
         &mut self,
         pending: &mut Objects<R>,
         header: BlockHeader,
-        notes: &SimpleSmt,
+        notes: &SimpleSmt<NOTE_TREE_DEPTH>,
     ) {
         self.accounts.append(&mut pending.accounts);
         self.fungible_faucets.append(&mut pending.fungible_faucets);
@@ -76,7 +76,7 @@ impl<R: Rng> Objects<R> {
     /// The root of the tree is a commitment to all notes created in the block. The commitment
     /// is not for all fields of the [Note] struct, but only for note metadata + core fields of
     /// a note (i.e., vault, inputs, script, and serial number).
-    pub fn build_notes_tree(&self) -> SimpleSmt {
+    pub fn build_notes_tree(&self) -> SimpleSmt<NOTE_TREE_DEPTH> {
         let mut entries = Vec::with_capacity(self.notes.len() * 2);
 
         entries.extend(self.notes.iter().enumerate().map(|(index, note)| {
@@ -88,21 +88,22 @@ impl<R: Rng> Objects<R> {
             (tree_index, note.metadata().into())
         }));
 
-        SimpleSmt::with_leaves(NOTE_LEAF_DEPTH, entries).unwrap()
+        SimpleSmt::with_leaves(entries).unwrap()
     }
 
     /// Given the [BlockHeader] and its notedb's [SimpleSmt], set all the [Note]'s proof.
     ///
     /// Update the [Note]'s proof once the [BlockHeader] has been created.
-    fn finalize_notes(&mut self, header: BlockHeader, notes: &SimpleSmt) -> Vec<InputNote> {
+    fn finalize_notes(
+        &mut self,
+        header: BlockHeader,
+        notes: &SimpleSmt<NOTE_TREE_DEPTH>,
+    ) -> Vec<InputNote> {
         self.notes
             .drain(..)
             .enumerate()
             .map(|(index, note)| {
-                let auth_index =
-                    NodeIndex::new(NOTE_TREE_DEPTH, index as u64).expect("index bigger than 2**20");
-                let note_path =
-                    notes.get_path(auth_index).expect("auth_index outside of SimpleSmt range");
+                let auth_index = LeafIndex::new(index as u64).expect("index bigger than 2**20");
                 InputNote::new(
                     note.clone(),
                     NoteInclusionProof::new(
@@ -110,7 +111,7 @@ impl<R: Rng> Objects<R> {
                         header.sub_hash(),
                         header.note_root(),
                         index as u64,
-                        note_path,
+                        notes.open(&auth_index).path,
                     )
                     .expect("Invalid data provided to proof constructor"),
                 )
@@ -133,8 +134,7 @@ pub struct MockChain<R> {
     nullifiers: TieredSmt,
 
     /// Tree containing the latest hash of each account.
-    // TODO: change this to a TieredSmt with 64bit keys.
-    accounts: SimpleSmt,
+    accounts: SimpleSmt<ACCOUNT_TREE_DEPTH>,
 
     /// RNG used to seed builders.
     ///
@@ -199,7 +199,7 @@ impl<R: Rng + SeedableRng> MockChain<R> {
             chain: Mmr::default(),
             blocks: vec![],
             nullifiers: TieredSmt::default(),
-            accounts: SimpleSmt::new(64).expect("depth too big for SimpleSmt"),
+            accounts: SimpleSmt::<ACCOUNT_TREE_DEPTH>::new().expect("depth too big for SimpleSmt"),
             rng,
             account_id_builder,
             objects: Objects::new(),
@@ -443,12 +443,10 @@ impl<R: Rng + SeedableRng> MockChain<R> {
         let block_num: u32 = self.blocks.len().try_into().expect("usize to u32 failed");
 
         for (account, _seed) in self.pending_objects.accounts.iter() {
-            let id: Felt = account.id().into();
-            self.accounts.update_leaf(id.as_int(), account.hash().into()).unwrap();
+            self.accounts.insert(account.id().into(), account.hash().into());
         }
         for (account, _seed) in self.objects.accounts.iter() {
-            let id: Felt = account.id().into();
-            self.accounts.update_leaf(id.as_int(), account.hash().into()).unwrap();
+            self.accounts.insert(account.id().into(), account.hash().into());
         }
 
         // TODO:
@@ -606,12 +604,8 @@ pub fn mock_chain_data(consumed_notes: Vec<Note>) -> (ChainMmr, Vec<InputNote>) 
     // TODO: Consider how to better represent note authentication data.
     // we use the index for both the block number and the leaf index in the note tree
     for (index, note) in consumed_notes.iter().enumerate() {
-        let tree_index = 2 * index;
-        let smt_entries = vec![
-            (tree_index as u64, note.id().into()),
-            ((tree_index + 1) as u64, note.metadata().into()),
-        ];
-        let smt = SimpleSmt::with_leaves(NOTE_LEAF_DEPTH, smt_entries).unwrap();
+        let smt_entries = vec![(index as u64, note.authentication_hash().into())];
+        let smt = SimpleSmt::<NOTE_TREE_DEPTH>::with_leaves(smt_entries).unwrap();
         note_trees.push(smt);
     }
 
@@ -638,7 +632,7 @@ pub fn mock_chain_data(consumed_notes: Vec<Note>) -> (ChainMmr, Vec<InputNote>) 
         .enumerate()
         .map(|(index, note)| {
             let block_header = &block_chain[index];
-            let auth_index = NodeIndex::new(NOTE_TREE_DEPTH, index as u64).unwrap();
+            let auth_index = LeafIndex::new(index as u64).unwrap();
             InputNote::new(
                 note,
                 NoteInclusionProof::new(
@@ -646,7 +640,7 @@ pub fn mock_chain_data(consumed_notes: Vec<Note>) -> (ChainMmr, Vec<InputNote>) 
                     block_header.sub_hash(),
                     block_header.note_root(),
                     index as u64,
-                    note_trees[index].get_path(auth_index).unwrap(),
+                    note_trees[index].open(&auth_index).path,
                 )
                 .unwrap(),
             )

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -34,10 +34,10 @@ testing = []
 [dependencies]
 assembly = { workspace = true }
 log = { version = "0.4", optional = true }
-miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "plafer-smt-trait", default-features = false }
 miden-verifier = { workspace = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
 vm-processor = { workspace = true }
 
 [dev-dependencies]

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -34,10 +34,10 @@ testing = []
 [dependencies]
 assembly = { workspace = true }
 log = { version = "0.4", optional = true }
-miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "plafer-smt-trait", default-features = false }
+miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 miden-verifier = { workspace = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "plafer-fix-build-smt", default-features = false }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 vm-processor = { workspace = true }
 
 [dev-dependencies]

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -2,10 +2,16 @@ use super::{
     AccountError, AccountStorageDelta, BTreeMap, ByteReader, ByteWriter, Deserializable,
     DeserializationError, Digest, Felt, Hasher, Serializable, String, ToString, Vec, Word,
 };
-use crate::crypto::merkle::{NodeIndex, SimpleSmt};
+use crate::crypto::merkle::{LeafIndex, NodeIndex, SimpleSmt};
 
 mod slot;
 pub use slot::StorageSlotType;
+
+// CONSTANTS
+// ================================================================================================
+
+/// Depth of the storage tree.
+pub const STORAGE_TREE_DEPTH: u8 = 8;
 
 // TYPE ALIASES
 // ================================================================================================
@@ -35,7 +41,7 @@ pub type StorageSlot = (StorageSlotType, Word);
 /// and contains information about slot types of all other slots.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountStorage {
-    slots: SimpleSmt,
+    slots: SimpleSmt<STORAGE_TREE_DEPTH>,
     layout: Vec<StorageSlotType>,
 }
 
@@ -44,7 +50,7 @@ impl AccountStorage {
     // --------------------------------------------------------------------------------------------
 
     /// Depth of the storage tree.
-    pub const STORAGE_TREE_DEPTH: u8 = 8;
+    pub const STORAGE_TREE_DEPTH: u8 = STORAGE_TREE_DEPTH;
 
     /// Total number of storage slots.
     pub const NUM_STORAGE_SLOTS: usize = 256;
@@ -84,7 +90,7 @@ impl AccountStorage {
         ));
 
         // construct storage slots smt and populate the types vector.
-        let slots = SimpleSmt::with_leaves(Self::STORAGE_TREE_DEPTH, entires)
+        let slots = SimpleSmt::<STORAGE_TREE_DEPTH>::with_leaves(entires)
             .map_err(AccountError::DuplicateStorageItems)?;
 
         Ok(Self { slots, layout })
@@ -108,7 +114,7 @@ impl AccountStorage {
     }
 
     /// Returns a reference to the sparse Merkle tree that backs the storage slots.
-    pub fn slots(&self) -> &SimpleSmt {
+    pub fn slots(&self) -> &SimpleSmt<STORAGE_TREE_DEPTH> {
         &self.slots
     }
 
@@ -173,10 +179,8 @@ impl AccountStorage {
         }
 
         // update the slot and return
-        let slot_value = self
-            .slots
-            .update_leaf(index as u64, value)
-            .expect("index is u8 - index within range");
+        let index = LeafIndex::new(index as u64).expect("index is u8 - index within range");
+        let slot_value = self.slots.insert(index, value);
         Ok(slot_value)
     }
 }
@@ -208,7 +212,7 @@ impl Serializable for AccountStorage {
             .leaves()
             .filter(|(idx, &value)| {
                 // TODO: consider checking empty values for complex types as well
-                value != SimpleSmt::EMPTY_VALUE
+                value != SimpleSmt::<STORAGE_TREE_DEPTH>::EMPTY_VALUE
                     && *idx as u8 != AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX
             })
             .collect::<Vec<_>>();

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -52,3 +52,12 @@ pub mod vm {
     pub use vm_core::{code_blocks::CodeBlock, Program, ProgramInfo};
     pub use vm_processor::{AdviceInputs, StackInputs, StackOutputs};
 }
+
+// CONSTANTS
+// ================================================================================================
+
+/// Depth of the account database tree.
+pub const ACCOUNT_TREE_DEPTH: u8 = 64;
+
+/// The depth of the Merkle tree used to commit to notes produced in a block.
+pub const NOTE_TREE_DEPTH: u8 = 20;

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -10,7 +10,7 @@ use super::{
         string::{String, ToString},
     },
     vm::CodeBlock,
-    Digest, Felt, Hasher, NoteError, Word, WORD_SIZE, ZERO,
+    Digest, Felt, Hasher, NoteError, Word, NOTE_TREE_DEPTH, WORD_SIZE, ZERO,
 };
 
 mod envelope;
@@ -39,9 +39,6 @@ pub use assets::NoteAssets;
 
 // CONSTANTS
 // ================================================================================================
-
-/// The depth of the Merkle tree used to commit to notes produced in a block.
-pub const NOTE_TREE_DEPTH: u8 = 20;
 
 /// The depth of the leafs in the note Merkle tree used to commit to notes produced in a block.
 /// This is equal `NOTE_TREE_DEPTH + 1`. In the kernel we do not authenticate leaf data directly


### PR DESCRIPTION
This PR updates `SimpleSmt` usage to be in line with https://github.com/0xPolygonMiden/crypto/pull/245.

This is a replacement for #426.