### PR TITLE
Refactor `Makefile` to enable `release` and `concurrent` flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
         os: [ubuntu]
-        args: [--release --features testing]
+        args: [--release --features concurrent]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
         os: [ubuntu]
-        args: [--release --features concurrent]
+        args: [--release --features concurrent,testing]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
         os: [ubuntu]
-        args: [--release --features concurrent,testing]
+        args: [--release --features concurrent testing]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ watch:
 	cargo watch -w miden-lib/asm -x build
 
 test:
-	cargo test --features testing
+	cargo test --release --features concurrent

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ watch:
 	cargo watch -w miden-lib/asm -x build
 
 test:
-	cargo test --release --features concurrent,testing
+	cargo test --release --features concurrent testing

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ watch:
 	cargo watch -w miden-lib/asm -x build
 
 test:
-	cargo test --release --features concurrent
+	cargo test --release --features concurrent,testing

--- a/mock/src/constants.rs
+++ b/mock/src/constants.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    accounts::{AccountId, AccountType, SlotItem, StorageSlotType},
+    accounts::{get_account_seed_single, AccountId, AccountType, SlotItem, StorageSlotType},
     assets::{Asset, NonFungibleAsset, NonFungibleAssetDetails},
     Felt, FieldElement, Word, ZERO,
 };
@@ -148,7 +148,7 @@ pub fn generate_account_seed(account_seed_type: AccountSeedType) -> (AccountId, 
         ),
     };
 
-    let seed = AccountId::get_account_seed(
+    let seed = get_account_seed_single(
         init_seed,
         account_type,
         true,

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -19,7 +19,7 @@ pub mod delta;
 pub use delta::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
 
 mod seed;
-pub use seed::get_account_seed;
+pub use seed::{get_account_seed, get_account_seed_single};
 
 mod storage;
 pub use storage::{AccountStorage, SlotItem, StorageSlotType};

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -13,7 +13,7 @@ use super::{compute_digest, AccountError, AccountId, AccountType, Digest, Felt, 
 // --------------------------------------------------------------------------------------------
 
 /// Finds and returns a seed suitable for creating an account ID for the specified account type
-/// using the provided initial seed as a starting point.
+/// using the provided initial seed as a starting point. Using multi-threading.
 #[cfg(feature = "concurrent")]
 pub fn get_account_seed(
     init_seed: [u8; 32],
@@ -114,10 +114,20 @@ pub fn get_account_seed_inner(
     }
 }
 
-/// Finds and returns a seed suitable for creating an account ID for the specified account type
-/// using the provided initial seed as a starting point.
 #[cfg(not(feature = "concurrent"))]
 pub fn get_account_seed(
+    init_seed: [u8; 32],
+    account_type: AccountType,
+    on_chain: bool,
+    code_root: Digest,
+    storage_root: Digest,
+) -> Result<Word, AccountError> {
+    get_account_seed_single(init_seed, account_type, on_chain, code_root, storage_root)
+}
+
+/// Finds and returns a seed suitable for creating an account ID for the specified account type
+/// using the provided initial seed as a starting point. Using a single thread.
+pub fn get_account_seed_single(
     init_seed: [u8; 32],
     account_type: AccountType,
     on_chain: bool,


### PR DESCRIPTION
In this PR I propose the addition of `release` and `concurrent` flag to the `Makefile` and `CI` of miden-base to enable faster `local` and `CI` test runs

Closes: #433 