### PR TITLE
Added proof generation and verification in tests

### DIFF
--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -12,9 +12,20 @@ edition = "2021"
 rust-version = "1.67"
 
 [features]
-concurrent = ["miden-lib/concurrent", "miden-objects/concurrent", "miden-prover/concurrent", "std"]
+concurrent = [
+    "miden-lib/concurrent",
+    "miden-objects/concurrent",
+    "miden-prover/concurrent",
+    "std",
+]
 default = ["std"]
-std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]
+std = [
+    "miden-lib/std",
+    "miden-objects/std",
+    "miden-prover/std",
+    "miden-verifier/std",
+    "vm-processor/std",
+]
 
 [dependencies]
 miden-lib = { package = "miden-lib", path = "../miden-lib", default-features = false }

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -63,7 +63,7 @@ fn test_transaction_executor_witness() {
 }
 
 #[test]
-fn test_transaction_result_account_delta() {
+fn test_executed_transaction_account_delta() {
     let data_store = MockDataStore::new(AssetPreservationStatus::PreservedWithAccountVaultDelta);
     let mut executor = TransactionExecutor::new(data_store.clone());
     let account_id = data_store.account.id();
@@ -200,20 +200,33 @@ fn test_transaction_result_account_delta() {
     // expected delta
     // --------------------------------------------------------------------------------------------
     // execute the transaction and get the witness
-    let transaction_result = executor
+    let executed_transaction = executor
         .execute_transaction(account_id, block_ref, &note_ids, Some(tx_script))
         .unwrap();
 
+    // Prove the transaction
+    let proof_options = ProvingOptions::default();
+    let prover = TransactionProver::new(proof_options);
+    let proven_transaction = prover.prove_transaction(executed_transaction.clone()).unwrap();
+
+    // Verify that the generated proof is valid
+    let verifier = TransactionVerifier::new(96);
+
+    assert!(verifier.verify(proven_transaction).is_ok());
+
     // nonce delta
     // --------------------------------------------------------------------------------------------
-    assert_eq!(transaction_result.account_delta().nonce(), Some(Felt::new(2)));
+    assert_eq!(executed_transaction.account_delta().nonce(), Some(Felt::new(2)));
 
     // storage delta
     // --------------------------------------------------------------------------------------------
-    assert_eq!(transaction_result.account_delta().storage().updated_items.len(), 1);
-    assert_eq!(transaction_result.account_delta().storage().updated_items[0].0, STORAGE_INDEX_0);
+    assert_eq!(executed_transaction.account_delta().storage().updated_items.len(), 1);
     assert_eq!(
-        transaction_result.account_delta().storage().updated_items[0].1,
+        executed_transaction.account_delta().storage().updated_items[0].0,
+        STORAGE_INDEX_0
+    );
+    assert_eq!(
+        executed_transaction.account_delta().storage().updated_items[0].1,
         updated_slot_value
     );
 
@@ -229,7 +242,7 @@ fn test_transaction_result_account_delta() {
         .iter()
         .cloned()
         .collect::<Vec<_>>();
-    assert!(transaction_result
+    assert!(executed_transaction
         .account_delta()
         .vault()
         .added_assets
@@ -237,11 +250,11 @@ fn test_transaction_result_account_delta() {
         .all(|x| added_assets.contains(x)));
     assert_eq!(
         added_assets.len(),
-        transaction_result.account_delta().vault().added_assets.len()
+        executed_transaction.account_delta().vault().added_assets.len()
     );
 
     // assert that removed assets are tracked
-    assert!(transaction_result
+    assert!(executed_transaction
         .account_delta()
         .vault()
         .removed_assets
@@ -249,7 +262,7 @@ fn test_transaction_result_account_delta() {
         .all(|x| removed_assets.contains(x)));
     assert_eq!(
         removed_assets.len(),
-        transaction_result.account_delta().vault().removed_assets.len()
+        executed_transaction.account_delta().vault().removed_assets.len()
     );
 }
 
@@ -319,11 +332,11 @@ fn test_tx_script() {
         .unwrap();
 
     // execute the transaction
-    let transaction_result =
+    let executed_transaction =
         executor.execute_transaction(account_id, block_ref, &note_ids, Some(tx_script));
 
     // assert the transaction executed successfully
-    assert!(transaction_result.is_ok());
+    assert!(executed_transaction.is_ok());
 }
 
 // MOCK DATA STORE

--- a/miden-tx/tests/p2id_script_test.rs
+++ b/miden-tx/tests/p2id_script_test.rs
@@ -132,7 +132,7 @@ fn test_p2id_script() {
         .collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_2 = executor_2.execute_transaction(
+    let executed_transaction_2 = executor_2.execute_transaction(
         malicious_account_id,
         block_ref,
         &note_ids,
@@ -140,7 +140,7 @@ fn test_p2id_script() {
     );
 
     // Check that we got the expected result - TransactionExecutorError
-    assert!(transaction_result_2.is_err());
+    assert!(executed_transaction_2.is_err());
 }
 
 /// We test the Pay to script with 2 assets to test the loop inside the script.
@@ -256,7 +256,7 @@ fn test_p2id_script_multiple_assets() {
         .collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_2 = executor_2.execute_transaction(
+    let executed_transaction_2 = executor_2.execute_transaction(
         malicious_account_id,
         block_ref,
         &note_origins,
@@ -264,5 +264,5 @@ fn test_p2id_script_multiple_assets() {
     );
 
     // Check that we got the expected result - TransactionExecutorError
-    assert!(transaction_result_2.is_err());
+    assert!(executed_transaction_2.is_err());
 }

--- a/miden-tx/tests/p2idr_script_test.rs
+++ b/miden-tx/tests/p2idr_script_test.rs
@@ -7,7 +7,8 @@ use miden_objects::{
     utils::collections::Vec,
     Felt,
 };
-use miden_tx::TransactionExecutor;
+use miden_prover::ProvingOptions;
+use miden_tx::{TransactionExecutor, TransactionProver, TransactionVerifier};
 use mock::constants::{
     ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
     ACCOUNT_ID_SENDER,
@@ -115,7 +116,7 @@ fn test_p2idr_script() {
         .unwrap();
 
     // Execute the transaction and get the witness
-    let transaction_result_1 = executor_1
+    let executed_transaction_1 = executor_1
         .execute_transaction(
             target_account_id,
             block_ref_1,
@@ -123,6 +124,16 @@ fn test_p2idr_script() {
             Some(tx_script_target.clone()),
         )
         .unwrap();
+
+    // Prove the transaction
+    let proof_options = ProvingOptions::default();
+    let prover = TransactionProver::new(proof_options);
+    let proven_transaction = prover.prove_transaction(executed_transaction_1.clone()).unwrap();
+
+    // Verify that the generated proof is valid
+    let verifier = TransactionVerifier::new(96);
+
+    assert!(verifier.verify(proven_transaction).is_ok());
 
     // Assert that the target_account received the funds and the nonce increased by 1
     let target_account_after: Account = Account::new(
@@ -132,7 +143,7 @@ fn test_p2idr_script() {
         target_account.code().clone(),
         Felt::new(2),
     );
-    assert_eq!(transaction_result_1.final_account().hash(), target_account_after.hash());
+    assert_eq!(executed_transaction_1.final_account().hash(), target_account_after.hash());
 
     // CONSTRUCT AND EXECUTE TX (Case "in time" - Sender Account Execution Failure)
     // --------------------------------------------------------------------------------------------
@@ -154,7 +165,7 @@ fn test_p2idr_script() {
     let note_ids_2 = data_store_2.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_2 = executor_2.execute_transaction(
+    let executed_transaction_2 = executor_2.execute_transaction(
         sender_account_id,
         block_ref_2,
         &note_ids_2,
@@ -163,7 +174,7 @@ fn test_p2idr_script() {
 
     // Check that we got the expected result - TransactionExecutorError and not ExecutedTransaction
     // Second transaction should not work (sender consumes too early), we expect an error
-    assert!(transaction_result_2.is_err());
+    assert!(executed_transaction_2.is_err());
 
     // CONSTRUCT AND EXECUTE TX (Case "in time" - Malicious Target Account Failure)
     // --------------------------------------------------------------------------------------------
@@ -185,7 +196,7 @@ fn test_p2idr_script() {
     let note_ids_3 = data_store_3.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_3 = executor_3.execute_transaction(
+    let executed_transaction_3 = executor_3.execute_transaction(
         malicious_account_id,
         block_ref_3,
         &note_ids_3,
@@ -194,7 +205,7 @@ fn test_p2idr_script() {
 
     // Check that we got the expected result - TransactionExecutorError and not ExecutedTransaction
     // Third transaction should not work (malicious account can never consume), we expect an error
-    assert!(transaction_result_3.is_err());
+    assert!(executed_transaction_3.is_err());
 
     // CONSTRUCT AND EXECUTE TX (Case "reclaimable" - Execution Target Account Success)
     // --------------------------------------------------------------------------------------------
@@ -209,14 +220,24 @@ fn test_p2idr_script() {
     let note_ids_4 = data_store_4.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_4 = executor_4
+    let executed_transaction_4 = executor_4
         .execute_transaction(target_account_id, block_ref_4, &note_ids_4, Some(tx_script_target))
         .unwrap();
+
+    // Prove the transaction
+    let proof_options = ProvingOptions::default();
+    let prover = TransactionProver::new(proof_options);
+    let proven_transaction = prover.prove_transaction(executed_transaction_4.clone()).unwrap();
+
+    // Verify that the generated proof is valid
+    let verifier = TransactionVerifier::new(96);
+
+    assert!(verifier.verify(proven_transaction).is_ok());
 
     // Check that we got the expected result - ExecutedTransaction
     // Assert that the target_account received the funds and the nonce increased by 1
     // Nonce delta
-    assert_eq!(transaction_result_4.account_delta().nonce(), Some(Felt::new(2)));
+    assert_eq!(executed_transaction_4.account_delta().nonce(), Some(Felt::new(2)));
 
     // Vault delta
     let target_account_after: Account = Account::new(
@@ -226,7 +247,7 @@ fn test_p2idr_script() {
         target_account.code().clone(),
         Felt::new(2),
     );
-    assert_eq!(transaction_result_4.final_account().hash(), target_account_after.hash());
+    assert_eq!(executed_transaction_4.final_account().hash(), target_account_after.hash());
 
     // CONSTRUCT AND EXECUTE TX (Case "too late" - Execution Sender Account Success)
     // --------------------------------------------------------------------------------------------
@@ -242,13 +263,23 @@ fn test_p2idr_script() {
     let note_ids_5 = data_store_5.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_5 = executor_5
+    let executed_transaction_5 = executor_5
         .execute_transaction(sender_account_id, block_ref_5, &note_ids_5, Some(tx_script_sender))
         .unwrap();
 
+    // Prove the transaction
+    let proof_options = ProvingOptions::default();
+    let prover = TransactionProver::new(proof_options);
+    let proven_transaction = prover.prove_transaction(executed_transaction_5.clone()).unwrap();
+
+    // Verify that the generated proof is valid
+    let verifier = TransactionVerifier::new(96);
+
+    assert!(verifier.verify(proven_transaction).is_ok());
+
     // Assert that the sender_account received the funds and the nonce increased by 1
     // Nonce delta
-    assert_eq!(transaction_result_5.account_delta().nonce(), Some(Felt::new(2)));
+    assert_eq!(executed_transaction_5.account_delta().nonce(), Some(Felt::new(2)));
 
     // Vault delta (Note: vault was empty before)
     let sender_account_after: Account = Account::new(
@@ -258,7 +289,7 @@ fn test_p2idr_script() {
         sender_account.code().clone(),
         Felt::new(2),
     );
-    assert_eq!(transaction_result_5.final_account().hash(), sender_account_after.hash());
+    assert_eq!(executed_transaction_5.final_account().hash(), sender_account_after.hash());
 
     // CONSTRUCT AND EXECUTE TX (Case "too late" - Malicious Account Failure)
     // --------------------------------------------------------------------------------------------
@@ -274,7 +305,7 @@ fn test_p2idr_script() {
     let note_ids_6 = data_store_6.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
 
     // Execute the transaction and get the witness
-    let transaction_result_6 = executor_6.execute_transaction(
+    let executed_transaction_6 = executor_6.execute_transaction(
         malicious_account_id,
         block_ref_6,
         &note_ids_6,
@@ -283,5 +314,5 @@ fn test_p2idr_script() {
 
     // Check that we got the expected result - TransactionExecutorError and not ExecutedTransaction
     // Sixth transaction should not work (malicious account can never consume), we expect an error
-    assert!(transaction_result_6.is_err())
+    assert!(executed_transaction_6.is_err())
 }


### PR DESCRIPTION
In this PR I propose an addition of proof generation and verification in tests. The miden-base repo has multiple crates that run multiple tests that create and execute transactions. Up to now these transactions were executed but not verified, hence preventing the correct verification of correct flow. 

Now the tests generate a proof and verify the proof of correct execution of generated the transactions.