### PR TITLE
Add `NoteId::try_from_hex`

### DIFF
--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -76,7 +76,7 @@ impl From<Digest> for NoteId {
 impl NoteId {
     /// Attempts to convert from a hexadecimal string to [NoteId].
     pub fn try_from_hex(hex_value: &str) -> Result<NoteId, HexParseError> {
-        Digest::try_from(hex_value).and_then(|v| Ok(NoteId::from(v)))
+        Digest::try_from(hex_value).map(|h| NoteId::from(h))
     }
 }
 

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -76,7 +76,7 @@ impl From<Digest> for NoteId {
 impl NoteId {
     /// Attempts to convert from a hexadecimal string to [NoteId].
     pub fn try_from_hex(hex_value: &str) -> Result<NoteId, HexParseError> {
-        Digest::try_from(hex_value).map(|h| NoteId::from(h))
+        Digest::try_from(hex_value).map(NoteId::from)
     }
 }
 

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -1,7 +1,6 @@
-use miden_crypto::utils::HexParseError;
-
 use super::{Digest, Felt, Hasher, Note, Word};
 use crate::utils::{
+    HexParseError,
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     string::String,
 };

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -1,8 +1,8 @@
 use super::{Digest, Felt, Hasher, Note, Word};
 use crate::utils::{
-    HexParseError,
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     string::String,
+    HexParseError,
 };
 
 // NOTE ID

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -1,3 +1,5 @@
+use miden_crypto::utils::HexParseError;
+
 use super::{Digest, Felt, Hasher, Note, Word};
 use crate::utils::{
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
@@ -71,6 +73,13 @@ impl From<Digest> for NoteId {
     }
 }
 
+impl NoteId {
+    /// Attempts to convert from a hexadecimal string to [NoteId].
+    pub fn try_from_hex(hex_value: &str) -> Result<NoteId, HexParseError> {
+        Digest::try_from(hex_value).and_then(|v| Ok(NoteId::from(v)))
+    }
+}
+
 // CONVERSIONS FROM NOTE ID
 // ================================================================================================
 
@@ -111,5 +120,18 @@ impl Deserializable for NoteId {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let id = Digest::read_from(source)?;
         Ok(Self(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoteId;
+
+    #[test]
+    fn note_id_try_from_hex() {
+        let note_id_hex = "0xc9d31c82c098e060c9b6e3af2710b3fc5009a1a6f82ef9465f8f35d1f5ba4a80";
+        let note_id = NoteId::try_from_hex(note_id_hex).unwrap();
+
+        assert_eq!(note_id.inner().to_string(), note_id_hex)
     }
 }


### PR DESCRIPTION
As suggested to more easily convert from strings to `NoteId` on the client