### PR TITLE
Enable variable number of note inputs

### DIFF
--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -308,21 +308,22 @@ export.get_note_vault_info
     # => [VAULT_HASH, num_assets]
 end
 
-#! Returns the note inputs hash of the note currently being processed. Panics if a note is not
-#! being processed.
+#! Returns the number of inputs and inputs hash for the note currently being processed. Panics if
+#! a note is not being processed.
 #!
-#! Inputs: [0, 0, 0, 0]
-#! Outputs: [NOTE_INPUTS_HASH]
+#! Inputs: [0, 0, 0, 0, 0]
+#! Outputs: [NOTE_INPUTS_HASH, num_inputs]
 #!
+#! - num_inputs is the number of inputs associated with the note.
 #! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
-export.get_note_inputs_hash
-    # get the note inputs hash
-    exec.note::get_inputs_hash
-    # => [NOTE_INPUTS_HASH, 0, 0, 0, 0]
+export.get_note_inputs_info
+    # get the number of inputs and the inputs hash
+    exec.note::get_inputs_info
+    # => [NOTE_INPUTS_HASH, num_inputs, 0, 0, 0, 0, 0]
 
     # organize the stack for return
-    swapw dropw
-    # => [NOTE_INPUTS_HASH]
+    movup.5 drop movup.5 drop movup.5 drop movup.5 drop movup.5 drop
+    # => [NOTE_INPUTS_HASH, num_inputs]
 end
 
 #! Returns the sender of the note currently being processed. Panics if a note is not being

--- a/miden-lib/asm/miden/kernels/tx/constants.masm
+++ b/miden-lib/asm/miden/kernels/tx/constants.masm
@@ -4,6 +4,9 @@
 # The number of elements in a Word
 const.WORD_SIZE=4
 
+# The maximum number of input values associated with a single note.
+const.MAX_INPUTS_PER_NOTE=128
+
 # The maximum number of assets that can be stored in a single note.
 const.MAX_ASSETS_PER_NOTE=256
 
@@ -38,6 +41,16 @@ const.FAUCET_ACCOUNT_SEED_DIGEST_MODULUS=2147483648
 #! - word_size is the number of elements in a Word.
 export.get_word_size
     push.WORD_SIZE
+end
+
+#! Returns the max allowed number of input values per note.
+#!
+#! Stack: []
+#! Output: [max_inputs_per_note]
+#!
+#! - max_inputs_per_note is the max inputs per note.
+export.get_max_inputs_per_note
+    push.MAX_INPUTS_PER_NOTE
 end
 
 #! Returns the max allowed number of assets per note.

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -133,8 +133,9 @@ const.CONSUMED_NOTE_SCRIPT_ROOT_OFFSET=2
 const.CONSUMED_NOTE_INPUTS_HASH_OFFSET=3
 const.CONSUMED_NOTE_ASSETS_HASH_OFFSET=4
 const.CONSUMED_NOTE_METADATA_OFFSET=5
-const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=6
-const.CONSUMED_NOTE_ASSETS_OFFSET=7
+const.CONSUMED_NOTE_NUM_INPUTS_OFFSET=6
+const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=7
+const.CONSUMED_NOTE_ASSETS_OFFSET=8
 
 # CREATED NOTES
 # -------------------------------------------------------------------------------------------------
@@ -853,6 +854,30 @@ end
 export.set_consumed_note_metadata
     push.CONSUMED_NOTE_METADATA_OFFSET add
     mem_storew dropw
+end
+
+#! Returns the number of inputs for the consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr]
+#! Output: [num_inputs]
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - num_inputs is the number of inputs defined for the consumed note.
+export.get_consumed_note_num_inputs
+    push.CONSUMED_NOTE_NUM_INPUTS_OFFSET add
+    mem_load
+end
+
+#! Sets the number of inputs for a consumed note located at the specified memory address.
+#!
+#! Stack: [consumed_note_ptr, num_inputs]
+#! Output: []
+#!
+#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! - num_assets is the number of inputs for the consumed note.
+export.set_consumed_note_num_inputs
+    push.CONSUMED_NOTE_NUM_INPUTS_OFFSET add
+    mem_store
 end
 
 #! Returns the number of assets in the consumed note located at the specified memory address.

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -122,6 +122,9 @@ const.ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET=405
 # The memory address at which the consumed note section begins.
 const.CONSUMED_NOTE_SECTION_OFFSET=1048576
 
+# The memory address at which the consumed note data section begins.
+const.CONSUMED_NOTE_DATA_SECTION_OFFSET=1064960
+
 # The memory address at which the number of consumed notes is stored.
 const.CONSUMED_NOTE_NUM_PTR=1048576
 
@@ -756,7 +759,7 @@ end
 #! - i is the index of the consumed note.
 #! - ptr is the memory address of the data segment for consumed note i.
 export.get_consumed_note_ptr
-    add.1 exec.constants::get_note_mem_size mul push.CONSUMED_NOTE_SECTION_OFFSET add
+    exec.constants::get_note_mem_size mul push.CONSUMED_NOTE_DATA_SECTION_OFFSET add
 end
 
 #! Set the hash of the consumed note at the specified memory address.
@@ -874,7 +877,7 @@ end
 #! Output: []
 #!
 #! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - num_assets is the number of inputs for the consumed note.
+#! - num_inputs is the number of inputs for the consumed note.
 export.set_consumed_note_num_inputs
     push.CONSUMED_NOTE_NUM_INPUTS_OFFSET add
     mem_store

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -60,14 +60,15 @@ export.get_vault_info
     # => [VAULT_HASH, num_assets]
 end
 
-#! Returns the note inputs hash of the note currently being processed. Panics if a note is not
-#! being processed.
+#! Returns the number of inputs and inputs hash for the note currently being processed. Panics if
+#! a note is not being processed.
 #!
 #! Inputs: []
-#! Outputs: [NOTE_INPUTS_HASH]
+#! Outputs: [NOTE_INPUTS_HASH, num_inputs]
 #!
+#! - num_inputs is the number of inputs associated with the note.
 #! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
-export.get_inputs_hash
+export.get_inputs_info
     # get the current consumed note pointer
     exec.memory::get_current_consumed_note_ptr
     # => [ptr]
@@ -77,9 +78,13 @@ export.get_inputs_hash
     dup neq.0 assert
     # => [ptr]
 
+    # get the number of inputs for the note
+    dup exec.memory::get_consumed_note_num_inputs
+    # => [num_inputs, ptr]
+
     # get the note inputs hash from the note pointer
-    exec.memory::get_consumed_note_inputs_hash
-    # => [NOTE_INPUTS_HASH]
+    swap exec.memory::get_consumed_note_inputs_hash
+    # => [NOTE_INPUTS_HASH, num_inputs]
 end
 
 #! Increment current consumed note pointer to the next note and returns the pointer value.

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -549,8 +549,8 @@ proc.process_input_note
     exec.memory::set_consumed_note_num_inputs
     # => [num_inputs, note_ptr]
 
-    # TODO: make sure the number of inputs is in the valid range
-    drop
+    # make sure the number of inputs is in the valid range
+    exec.constants::get_max_inputs_per_note lte assert
     # => [note_ptr]
 
     # get the number of assets from the advice provider and store it in memory

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -487,8 +487,7 @@ end
 #!
 #! Stack: [i]
 #! Advice stack: [CN1_SN, CN1_SR, CN1_IR, CN1_VR,
-#!               CN1_NA,
-#!               CN1_A1, CN1_A2, ...]
+#!               C1_NI, CN1_NA, CN1_A1, CN1_A2, ...]
 #!
 #! Output: []
 #!
@@ -498,6 +497,7 @@ end
 #! - CN1_SR is the script root of input note 1.
 #! - CN1_IR is the inputs root of input note 1.
 #! - CN1_VR is the vault root of input note 1.
+#! - CN1_NI is the number of inputs in input note 1.
 #! - CN1_NA is the number of assets in input note 1.
 #! - CN1_A1 is the first asset of input note 1.
 #! - CN1_A2 is the second asset of input note 1.
@@ -534,14 +534,23 @@ proc.process_input_note
     mem_storew dropw
     # => [note_ptr]
 
-    # ingest note assets
+    # ingest note metadata
     # ---------------------------------------------------------------------------------------------
 
-    # read the metadata from the advice provider and store in memory
+    # get the metadata from the advice provider and store in memory
     padw adv_loadw dup.4
     # => [note_ptr, NOTE_META, note_ptr]
 
     exec.memory::set_consumed_note_metadata
+    # => [note_ptr]
+
+    # get the number of inputs from the advice provider and store it in memory
+    adv_push.1 dup dup.2
+    exec.memory::set_consumed_note_num_inputs
+    # => [num_inputs, note_ptr]
+
+    # TODO: make sure the number of inputs is in the valid range
+    drop
     # => [note_ptr]
 
     # get the number of assets from the advice provider and store it in memory
@@ -552,6 +561,9 @@ proc.process_input_note
     # assert the number of assets is within limits
     dup exec.constants::get_max_assets_per_note lte assert
     # => [num_assets, note_ptr]
+
+    # ingest note assets
+    # ---------------------------------------------------------------------------------------------
 
     # round up the number of assets to the next multiple of 2 (simplifies reading of assets)
     dup push.1 u32and add

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -1,6 +1,33 @@
 use.std::crypto::hashes::native
 use.std::mem
 
+#! Writes the data currently on the advice stack into the memory at the specified location and
+#! verifies that the hash of the written data is equal to the provided hash.
+#!
+#! Inputs:  [start_ptr, end_ptr, HASH]
+#! Outputs: []
+proc.write_advice_data_to_memory
+    # prepare the stack for reading from the advice stack
+    padw padw padw
+    # => [PAD, PAD, PAD, start_ptr, end_ptr, HASH]
+
+    # read the data from advice stack to memory
+    exec.mem::pipe_double_words_to_memory
+    # => [PERM, PERM, PERM, end_ptr, HASH]
+
+    # extract the digest
+    exec.native::state_to_digest
+    # => [DIGEST, end_ptr, HASH]
+
+    # drop pointer for reading from memory
+    movup.4 drop
+    # => [DIGEST, HASH]
+
+    # assert the computed hash is equal to the expected hash
+    assert_eqw
+    # => []
+end
+
 #! Writes the assets of the currently executing note into memory starting at the specified address.
 #!
 #! Inputs: [dest_ptr]
@@ -28,61 +55,44 @@ export.get_assets
     dup.6 add dup.6
     # => [start_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
 
-    # prepare the stack for reading from the advice stack
-    padw padw padw
-    # => [PAD, PAD, PAD, start_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
-
-    # read the assets from advice stack to memory
-    exec.mem::pipe_double_words_to_memory
-    # => [PERM, PERM, PERM, end_ptr, VAULT_HASH, num_assets, dest_ptr]
-
-    # extract the digest
-    exec.native::state_to_digest
-    # => [DIGEST, end_ptr, VAULT_HASH, num_assets, dest_ptr]
-
-    # drop pointer for reading from memory
-    movup.4 drop
-    # => [DIGEST, VAULT_HASH, num_assets, dest_ptr]
-
-    # assert the vault hash is what we expect
-    assert_eqw
+    # write the data from the advice stack into memory
+    exec.write_advice_data_to_memory
     # => [num_assets, dest_ptr]
 end
 
 #! Writes the inputs of the currently execute note into memory starting at the specified address.
 #!
 #! Inputs: [dest_ptr]
-#! Outputs: [dest_ptr]
+#! Outputs: [num_inputs, dest_ptr]
 #!
 #! - dest_ptr is the memory address to write the inputs.
 export.get_inputs
-    # duplicate the dest_ptr
-    dup
-    # => [dest_ptr, dest_ptr]
+    padw push.0
+    # => [0, 0, 0, 0, 0, dest_ptr]
 
     # get the current consumed note inputs hash
-    padw syscall.get_note_inputs_hash
-    # => [INPUTS_HASH, dest_ptr, dest_ptr]
+    syscall.get_note_inputs_info
+    # => [INPUTS_HASH, num_inputs, dest_ptr]
 
     # load the inputs from the advice map to the advice stack
     adv.push_mapval
-    # => [INPUTS_HASH, dest_ptr, dest_ptr]
+    # => [INPUTS_HASH, num_inputs, dest_ptr]
 
-    # prepare stack for inputs ingestion
-    movup.4 padw padw padw
-    # => [WORD, WORD, ZERO, addr, INPUTS_HASH, dest_ptr]
+    # calculate the number of words required to store the inputs
+    dup.4 u32divmod.4 neq.0 add
+    # => [num_words, INPUTS_HASH, num_inputs, dest_ptr]
 
-    # load the note inputs from the advice provider
-    adv_pipe hperm adv_pipe hperm
-    # => [PERM, PERM, PERM, addr', INPUTS_HASH, dest_ptr]
+    # round up the number of words the next multiple of 2
+    dup is_odd add
+    # => [even_num_words, INPUTS_HASH, num_inputs, dest_ptr]
 
-    # extract inputs hash and assert it matches commitment stored in memory
-    dropw swapw dropw movup.4 drop
-    # => [DIG, INPUTS_HASH, dest_ptr]
+    # calculate the start and end pointer for reading to memory
+    dup.6 add dup.6
+    # => [start_ptr, end_ptr, INPUTS_HASH, num_inputs, dest_ptr]
 
-    # assert the inputs hash matches the commitment stored in memory
-    assert_eqw
-    # => [dest_ptr]
+    # write the data from the advice stack into memory
+    exec.write_advice_data_to_memory
+    # => [num_inputs, dest_ptr]
 end
 
 #! Returns the sender of the note currently being processed. Panics if a note is not being

--- a/miden-lib/asm/note_scripts/P2ID.masm
+++ b/miden-lib/asm/note_scripts/P2ID.masm
@@ -67,6 +67,10 @@ begin
     
     # store the note inputs to memory starting at address 0
     push.0 exec.note::get_inputs
+    # => [num_inputs, inputs_ptr]
+
+    # make sure the number of inputs is 1
+    eq.1 assert
     # => [inputs_ptr]
 
     # read the target account id from the note inputs

--- a/miden-lib/asm/note_scripts/P2IDR.masm
+++ b/miden-lib/asm/note_scripts/P2IDR.masm
@@ -71,6 +71,10 @@ begin
 
     # store the note inputs to memory starting at address 0
     push.0 exec.note::get_inputs
+    # => [num_inputs, inputs_ptr]
+
+    # make sure the number of inputs is 2
+    eq.2 assert
     # => [inputs_ptr]
 
     # read the reclaim block height and target account id from the note inputs

--- a/miden-lib/asm/note_scripts/SWAP.masm
+++ b/miden-lib/asm/note_scripts/SWAP.masm
@@ -35,6 +35,10 @@ begin
 
     # store note inputs into memory starting at address 0
     push.0 exec.note::get_inputs
+    # => [num_inputs, inputs_ptr]
+
+    # make sure the number of inputs is 9
+    eq.9 assert
     # => [inputs_ptr]
 
     # load recipient

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
     accounts::AccountId, assets::Asset, crypto::rand::FeltRng, notes::Note,
-    utils::collections::Vec, Felt, NoteError, Word, ZERO,
+    utils::collections::Vec, Felt, NoteError, Word,
 };
 
 use self::utils::build_note_script;
@@ -29,7 +29,7 @@ pub fn create_p2id_note<R: FeltRng>(
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
     let note_script = build_note_script(bytes)?;
 
-    let inputs = [target.into(), ZERO, ZERO, ZERO];
+    let inputs = [target.into()];
     let tag: Felt = target.into();
     let serial_num = rng.draw_word();
 
@@ -58,7 +58,7 @@ pub fn create_p2idr_note<R: FeltRng>(
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2IDR.masb"));
     let note_script = build_note_script(bytes)?;
 
-    let inputs = [target.into(), recall_height.into(), ZERO, ZERO];
+    let inputs = [target.into(), recall_height.into()];
     let tag: Felt = target.into();
     let serial_num = rng.draw_word();
 
@@ -96,9 +96,6 @@ pub fn create_swap_note<R: FeltRng>(
         asset_word[2],
         asset_word[3],
         sender.into(),
-        ZERO,
-        ZERO,
-        ZERO,
     ];
 
     let tag: Felt = Felt::new(0);

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -19,11 +19,15 @@ use vm_processor::AdviceInputs;
 use super::{build_module_path, ContextId, Felt, Process, ProcessState, Word, TX_KERNEL_DIR, ZERO};
 use crate::transaction::{
     memory::{
-        ACCT_CODE_ROOT_PTR, ACCT_DB_ROOT_PTR, ACCT_ID_AND_NONCE_PTR, ACCT_ID_PTR,
+        MemoryOffset, ACCT_CODE_ROOT_PTR, ACCT_DB_ROOT_PTR, ACCT_ID_AND_NONCE_PTR, ACCT_ID_PTR,
         ACCT_STORAGE_ROOT_PTR, ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET, ACCT_VAULT_ROOT_PTR,
         BATCH_ROOT_PTR, BLK_HASH_PTR, BLOCK_METADATA_PTR, BLOCK_NUMBER_IDX,
         CHAIN_MMR_NUM_LEAVES_PTR, CHAIN_MMR_PEAKS_PTR, CHAIN_ROOT_PTR,
-        CONSUMED_NOTE_SECTION_OFFSET, INIT_ACCT_HASH_PTR, INIT_NONCE_PTR, NOTE_ROOT_PTR,
+        CONSUMED_NOTE_ASSETS_HASH_OFFSET, CONSUMED_NOTE_ASSETS_OFFSET, CONSUMED_NOTE_ID_OFFSET,
+        CONSUMED_NOTE_INPUTS_HASH_OFFSET, CONSUMED_NOTE_METADATA_OFFSET,
+        CONSUMED_NOTE_NUM_ASSETS_OFFSET, CONSUMED_NOTE_NUM_INPUTS_OFFSET,
+        CONSUMED_NOTE_SCRIPT_ROOT_OFFSET, CONSUMED_NOTE_SECTION_OFFSET,
+        CONSUMED_NOTE_SERIAL_NUM_OFFSET, INIT_ACCT_HASH_PTR, INIT_NONCE_PTR, NOTE_ROOT_PTR,
         NULLIFIER_COM_PTR, NULLIFIER_DB_ROOT_PTR, PREV_BLOCK_HASH_PTR, PROOF_HASH_PTR,
         PROTOCOL_VERSION_IDX, TIMESTAMP_IDX, TX_SCRIPT_ROOT_PTR,
     },
@@ -233,66 +237,72 @@ fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &Prepared
 fn consumed_notes_memory_assertions(process: &Process<MockHost>, inputs: &PreparedTransaction) {
     // The number of consumed notes should be stored at the CONSUMED_NOTES_OFFSET
     assert_eq!(
-        read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET)[0],
-        Felt::new(inputs.input_notes().num_notes() as u64)
+        read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET),
+        [Felt::new(inputs.input_notes().num_notes() as u64), ZERO, ZERO, ZERO],
     );
 
     for (note, note_idx) in inputs.input_notes().iter().zip(0_u32..) {
         let note = note.note();
 
-        // The note nullifier should be computer and stored at (CONSUMED_NOTES_OFFSET + 1 + note_idx)
+        // The note nullifier should be computer and stored at the correct offset
         assert_eq!(
             read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx),
             note.nullifier().as_elements()
         );
 
-        // The ID hash should be computed and stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024)
+        // The ID hash should be computed and stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx)),
+            read_note_element(process, note_idx, CONSUMED_NOTE_ID_OFFSET),
             note.id().as_elements()
         );
 
-        // The note serial num should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 1)
+        // The note serial num should be stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 1),
+            read_note_element(process, note_idx, CONSUMED_NOTE_SERIAL_NUM_OFFSET),
             note.serial_num()
         );
 
-        // The note script hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 2)
+        // The note script hash should be stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 2),
+            read_note_element(process, note_idx, CONSUMED_NOTE_SCRIPT_ROOT_OFFSET),
             note.script().hash().as_elements()
         );
 
-        // The note input hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 3)
+        // The note input hash should be stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 3),
+            read_note_element(process, note_idx, CONSUMED_NOTE_INPUTS_HASH_OFFSET),
             note.inputs().hash().as_elements()
         );
 
-        // The note asset hash should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 4)
+        // The note asset hash should be stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 4),
+            read_note_element(process, note_idx, CONSUMED_NOTE_ASSETS_HASH_OFFSET),
             note.assets().commitment().as_elements()
         );
 
-        // The note metadata should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 5)
+        // The note metadata should be stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 5),
+            read_note_element(process, note_idx, CONSUMED_NOTE_METADATA_OFFSET),
             Word::from(note.metadata())
         );
 
-        // The number of assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 6)
+        // The number of inputs should be stored at the correct offset
         assert_eq!(
-            read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 6),
+            read_note_element(process, note_idx, CONSUMED_NOTE_NUM_INPUTS_OFFSET),
+            [Felt::from(note.inputs().num_inputs() as u32), ZERO, ZERO, ZERO]
+        );
+
+        // The number of assets should be stored at the correct offset
+        assert_eq!(
+            read_note_element(process, note_idx, CONSUMED_NOTE_NUM_ASSETS_OFFSET),
             [Felt::from(note.assets().num_assets() as u32), ZERO, ZERO, ZERO]
         );
 
         // The assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 7..)
-        for (asset, asset_idx) in note.assets().iter().cloned().zip(0u32..) {
+        for (asset, asset_idx) in note.assets().iter().cloned().zip(0_u32..) {
             let word: Word = asset.into();
             assert_eq!(
-                read_root_mem_value(process, consumed_note_data_ptr(note_idx) + 7 + asset_idx),
+                read_note_element(process, note_idx, CONSUMED_NOTE_ASSETS_OFFSET + asset_idx),
                 word
             );
         }
@@ -507,5 +517,10 @@ fn test_get_blk_timestamp() {
 // ================================================================================================
 
 fn read_root_mem_value(process: &Process<MockHost>, addr: u32) -> Word {
+    println!("addr: {addr}");
     process.get_mem_value(ContextId::root(), addr).unwrap()
+}
+
+fn read_note_element(process: &Process<MockHost>, note_idx: u32, offset: MemoryOffset) -> Word {
+    read_root_mem_value(process, consumed_note_data_ptr(note_idx) + offset)
 }

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -271,7 +271,7 @@ fn consumed_notes_memory_assertions(process: &Process<MockHost>, inputs: &Prepar
         // The note input hash should be stored at the correct offset
         assert_eq!(
             read_note_element(process, note_idx, CONSUMED_NOTE_INPUTS_HASH_OFFSET),
-            note.inputs().hash().as_elements()
+            note.inputs().commitment().as_elements()
         );
 
         // The note asset hash should be stored at the correct offset
@@ -289,7 +289,7 @@ fn consumed_notes_memory_assertions(process: &Process<MockHost>, inputs: &Prepar
         // The number of inputs should be stored at the correct offset
         assert_eq!(
             read_note_element(process, note_idx, CONSUMED_NOTE_NUM_INPUTS_OFFSET),
-            [Felt::from(note.inputs().num_inputs() as u32), ZERO, ZERO, ZERO]
+            [Felt::from(note.inputs().num_values() as u32), ZERO, ZERO, ZERO]
         );
 
         // The number of assets should be stored at the correct offset
@@ -517,7 +517,6 @@ fn test_get_blk_timestamp() {
 // ================================================================================================
 
 fn read_root_mem_value(process: &Process<MockHost>, addr: u32) -> Word {
-    println!("addr: {addr}");
     process.get_mem_value(ContextId::root(), addr).unwrap()
 }
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -252,16 +252,17 @@ fn add_account_to_advice_inputs(
 /// A combined note data vector is also constructed that holds core data for all notes. This
 /// combined vector is added to the advice map against the input notes commitment. For each note
 /// the following data items are added to the vector:
-///   out[0..4]    = serial num
-///   out[4..8]    = script root
-///   out[8..12]   = input root
-///   out[12..16]  = asset_hash
+///   out[0..4]    = serial_num
+///   out[4..8]    = script_root
+///   out[8..12]   = inputs_hash
+///   out[12..16]  = assets_hash
 ///   out[16..20]  = metadata
-///   out[20]      = num_assets
-///   out[21..25]  = asset_1
-///   out[25..29]  = asset_2
+///   out[20]      = num_inputs
+///   out[21]      = num_assets
+///   out[22..26]  = asset_1
+///   out[26..30]  = asset_2
 ///   ...
-///   out[20 + num_assets * 4..] = Word::default() (this is conditional padding only applied
+///   out[30 + num_assets * 4..] = Word::default() (this is conditional padding only applied
 ///                                                 if the number of assets is odd)
 ///   out[-10]      = origin.block_number
 ///   out[-9..-5]   = origin.SUB_HASH
@@ -304,6 +305,8 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
         note_data.extend(*note.inputs().hash());
         note_data.extend(*note.assets().commitment());
         note_data.extend(Word::from(note.metadata()));
+
+        note_data.push((note.inputs().num_inputs() as u32).into());
 
         note_data.push((note.assets().num_assets() as u32).into());
         note_data.extend(note.assets().to_padded_assets());

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -288,7 +288,7 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
         let proof = input_note.proof();
 
         // insert note inputs and assets into the advice map
-        inputs.extend_map([(note.inputs().hash().into(), note.inputs().inputs().to_vec())]);
+        inputs.extend_map([(note.inputs().commitment().into(), note.inputs().to_padded_values())]);
         inputs.extend_map([(note.assets().commitment().into(), note.assets().to_padded_assets())]);
 
         // insert note authentication path nodes into the Merkle store
@@ -302,11 +302,11 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
         // add the note elements to the combined vector of note data
         note_data.extend(note.serial_num());
         note_data.extend(*note.script().hash());
-        note_data.extend(*note.inputs().hash());
+        note_data.extend(*note.inputs().commitment());
         note_data.extend(*note.assets().commitment());
         note_data.extend(Word::from(note.metadata()));
 
-        note_data.push((note.inputs().num_inputs() as u32).into());
+        note_data.push(note.inputs().num_values().into());
 
         note_data.push((note.assets().num_assets() as u32).into());
         note_data.extend(note.assets().to_padded_assets());

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -182,16 +182,16 @@ pub const NOTE_MEM_SIZE: MemoryAddress = 512;
 // ------------------------------------------------------------------------------------------------
 // Inputs note section contains data of all notes consumed by a transaction. The section starts at
 // memory offset 1_048_576 with a word containing the total number of input notes and is followed
-// by data of each note like so:
+// by note nullifiers and note data like so:
 //
-// TODO: add nullifiers
+// ┌─────────┬───────────┬───────────┬─────┬───────────┬─────────┬────────┬────────┬─────┬────────┐
+// │   NUM   │  NOTE 0   │  NOTE 1   │ ... │  NOTE n   │ PADDING │ NOTE 0 │ NOTE 1 │ ... │ NOTE n │
+// │  NOTES  │ NULLIFIER │ NULLIFIER │     │ NULLIFIER │         │  DATA  │  DATA  │     │  DATA  │
+// └─────────┴───────────┴───────────┴─────┴───────────┴─────────┴────────┴────────┴─────┴────────┘
+//  1_048_576  1_048_577   1_048_578        1_048_576+n      1_064_960   +512    +1024  +512n
 //
-//    ┌───────────┬─────────────┬─────────────┬───────────────┬─────────────┐
-//    │ NUM NOTES │ NOTE 0 DATA │ NOTE 1 DATA │      ...      │ NOTE n DATA │
-//    └───────────┴─────────────┴─────────────┴───────────────┴─────────────┘
-// 1_048_576     +1           +513          +1025           +1+512n
-//
-// Data section for each note consists of exactly 512 words and is laid out like so:
+// Each nullifier occupies a single word. A data section for each note consists of exactly 512
+// words and is laid out like so:
 //
 // ┌──────┬────────┬────────┬────────┬────────┬──────┬────────┬───────┬─────┬───────┬─────────┐
 // │ NOTE │ SERIAL │ SCRIPT │ INPUTS │ ASSETS │ META │  NUM   │ ASSET │ ... │ ASSET │ PADDING │
@@ -205,8 +205,11 @@ pub const NOTE_MEM_SIZE: MemoryAddress = 512;
 /// The memory address at which the consumed note section begins.
 pub const CONSUMED_NOTE_SECTION_OFFSET: MemoryOffset = 1_048_576;
 
+/// The memory address at which the consumed note data section begins.
+pub const CONSUMED_NOTE_DATA_SECTION_OFFSET: MemoryAddress = 1_064_960;
+
 /// The memory address at which the number of consumed notes is stored.
-pub const CONSUMED_NOTE_NUM_PTR: MemoryAddress = 1_048_576;
+pub const CONSUMED_NOTE_NUM_PTR: MemoryAddress = CONSUMED_NOTE_SECTION_OFFSET;
 
 /// The offsets at which data of a consumed note is stored relative to the start of its data segment.
 pub const CONSUMED_NOTE_ID_OFFSET: MemoryOffset = 0;

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -184,6 +184,8 @@ pub const NOTE_MEM_SIZE: MemoryAddress = 512;
 // memory offset 1_048_576 with a word containing the total number of input notes and is followed
 // by data of each note like so:
 //
+// TODO: add nullifiers
+//
 //    ┌───────────┬─────────────┬─────────────┬───────────────┬─────────────┐
 //    │ NUM NOTES │ NOTE 0 DATA │ NOTE 1 DATA │      ...      │ NOTE n DATA │
 //    └───────────┴─────────────┴─────────────┴───────────────┴─────────────┘
@@ -213,8 +215,9 @@ pub const CONSUMED_NOTE_SCRIPT_ROOT_OFFSET: MemoryOffset = 2;
 pub const CONSUMED_NOTE_INPUTS_HASH_OFFSET: MemoryOffset = 3;
 pub const CONSUMED_NOTE_ASSETS_HASH_OFFSET: MemoryOffset = 4;
 pub const CONSUMED_NOTE_METADATA_OFFSET: MemoryOffset = 5;
-pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 6;
-pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 7;
+pub const CONSUMED_NOTE_NUM_INPUTS_OFFSET: MemoryOffset = 6;
+pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 7;
+pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 8;
 
 // OUTPUT NOTES DATA
 // ------------------------------------------------------------------------------------------------

--- a/mock/src/builders/note.rs
+++ b/mock/src/builders/note.rs
@@ -51,7 +51,7 @@ impl NoteBuilder {
     }
 
     pub fn note_inputs(mut self, inputs: Vec<Felt>) -> Result<Self, NoteError> {
-        NoteInputs::new(&inputs)?;
+        NoteInputs::new(inputs.to_vec())?;
         self.inputs = inputs;
         Ok(self)
     }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -104,7 +104,7 @@ pub fn run_within_host<H: Host>(
 // TEST HELPERS
 // ================================================================================================
 pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
-    memory::CONSUMED_NOTE_SECTION_OFFSET + (1 + note_idx) * memory::NOTE_MEM_SIZE
+    memory::CONSUMED_NOTE_DATA_SECTION_OFFSET + note_idx * memory::NOTE_MEM_SIZE
 }
 
 pub fn prepare_transaction(

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -65,6 +65,12 @@ pub const NOTE_TREE_DEPTH: u8 = 20;
 /// The maximum number of assets that can be stored in a single note.
 pub const MAX_ASSETS_PER_NOTE: usize = 256;
 
+/// The maximum number of inputs that can accompany a single note.
+///
+/// The value is set to 128 so that it can be represented using as a single byte while being
+/// evenly divisible by 8.
+pub const MAX_INPUTS_PER_NOTE: usize = 128;
+
 /// The maximum number of notes that can be consumed by a single transaction.
 pub const MAX_INPUT_NOTES_PER_TX: usize = 1023;
 

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -1,102 +1,120 @@
 use core::cell::OnceCell;
 
-use vm_processor::DeserializationError;
-
 use super::{
-    ByteReader, ByteWriter, Deserializable, Digest, Felt, Hasher, NoteError, Serializable, Vec,
-    ZERO,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher, NoteError,
+    Serializable, Vec, WORD_SIZE, ZERO,
 };
+use crate::MAX_INPUTS_PER_NOTE;
 
 // NOTE INPUTS
 // ================================================================================================
 
-/// Holds the inputs which are placed onto the stack before a note's script is executed.
-/// - inputs are stored in reverse stack order such that when they are pushed onto stack they are
-///   in the correct order
-/// - hash is computed from inputs in the order they are stored (reverse stack order)
+/// An container for note inputs.
+///
+/// A note can be associated with up to 128 input values. Each value is represented by a single
+/// field element. Thus, note input values can contain up to ~1 KB of data.
+///
+/// All inputs associated with a note can be reduced to a single commitment which is computed by
+/// first padding the inputs with ZEROs to the next multiple of 8, and then by computing a
+/// sequential hash of the resulting elements.
 #[derive(Clone, Debug)]
 pub struct NoteInputs {
-    inputs: [Felt; 16],
+    values: Vec<Felt>,
     hash: OnceCell<Digest>,
 }
 
 impl NoteInputs {
-    /// Number of note inputs.
-    const NOTE_NUM_INPUTS: usize = 16;
+    /// Maximum number of input values associated with a single note.
+    const MAX_INPUTS_PER_NOTE: usize = MAX_INPUTS_PER_NOTE;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// Returns NoteInputs created from the provided inputs.
-    ///
-    /// The inputs are padded with ZERO such that they are always of length 16.
+    /// Returns [NoteInputs] instantiated from the provided values.
     ///
     /// # Errors
-    /// Returns an error if the number of provided inputs is greater than 16.
-    pub fn new(inputs: &[Felt]) -> Result<Self, NoteError> {
-        if inputs.len() > Self::NOTE_NUM_INPUTS {
-            return Err(NoteError::too_many_inputs(inputs.len()));
+    /// Returns an error if the number of provided inputs is greater than 128.
+    pub fn new(values: Vec<Felt>) -> Result<Self, NoteError> {
+        if values.len() > Self::MAX_INPUTS_PER_NOTE {
+            return Err(NoteError::too_many_inputs(values.len()));
         }
 
-        // pad inputs with ZERO to be constant size (16 elements)
-        let padded_inputs: [Felt; Self::NOTE_NUM_INPUTS] = inputs
-            .iter()
-            .cloned()
-            .chain(core::iter::repeat(ZERO))
-            .take(Self::NOTE_NUM_INPUTS)
-            .collect::<Vec<_>>()
-            .try_into()
-            .expect("padded are of the correct length");
-
-        Ok(Self {
-            inputs: padded_inputs,
-            hash: OnceCell::new(),
-        })
+        Ok(Self { values, hash: OnceCell::new() })
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a reference to the inputs.
-    pub fn inputs(&self) -> &[Felt] {
-        &self.inputs
-    }
-
-    /// Returns the number of inputs.
-    pub fn num_inputs(&self) -> usize {
-        self.inputs.len()
-    }
-
     /// Returns a commitment to these inputs.
-    pub fn hash(&self) -> Digest {
-        *self.hash.get_or_init(|| Hasher::hash_elements(&self.inputs))
+    pub fn commitment(&self) -> Digest {
+        *self.hash.get_or_init(|| {
+            let padded_values = pad_inputs(&self.values);
+            Hasher::hash_elements(&padded_values)
+        })
+    }
+
+    /// Returns the number of input values.
+    ///
+    /// The returned value is guaranteed to be smaller than or equal to 128.
+    pub fn num_values(&self) -> u8 {
+        self.values.len() as u8
+    }
+
+    /// Returns a reference to the input values.
+    pub fn values(&self) -> &[Felt] {
+        &self.values
+    }
+
+    /// Returns a vector of input values padded with ZEROs to the next multiple of 8.
+    pub fn to_padded_values(&self) -> Vec<Felt> {
+        pad_inputs(&self.values)
+    }
+
+    /// Returns a vector of input values.
+    pub fn to_vec(&self) -> Vec<Felt> {
+        self.values.to_vec()
     }
 }
 
 impl PartialEq for NoteInputs {
     fn eq(&self, other: &Self) -> bool {
-        let NoteInputs { inputs, hash: _ } = self;
-
-        inputs == &other.inputs
+        let NoteInputs { values: inputs, hash: _ } = self;
+        inputs == &other.values
     }
 }
 
 impl Eq for NoteInputs {}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns a vector with built from the provided inputs and padded to the next multiple of 8.
+fn pad_inputs(inputs: &[Felt]) -> Vec<Felt> {
+    const BLOCK_SIZE: usize = WORD_SIZE * 2;
+
+    let padded_len = inputs.len().next_multiple_of(BLOCK_SIZE);
+    let mut padded_inputs = Vec::with_capacity(padded_len);
+    padded_inputs.extend(inputs.iter());
+    padded_inputs.resize(padded_len, ZERO);
+
+    padded_inputs
+}
 
 // SERIALIZATION
 // ================================================================================================
 
 impl Serializable for NoteInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let NoteInputs { inputs, hash: _hash } = self;
-
-        inputs.write_into(target);
+        let NoteInputs { values, hash: _hash } = self;
+        target.write_u8(values.len().try_into().expect("inputs len is not a u8 value"));
+        values.write_into(target);
     }
 }
 
 impl Deserializable for NoteInputs {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let inputs = <[Felt; 16]>::read_from(source)?;
-        Self::new(&inputs).map_err(|v| DeserializationError::InvalidValue(format!("{v}")))
+        let num_values = source.read_u8()? as usize;
+        let values = Felt::read_batch_from(source, num_values)?;
+        Self::new(values).map_err(|v| DeserializationError::InvalidValue(format!("{v}")))
     }
 }
 
@@ -105,35 +123,28 @@ impl Deserializable for NoteInputs {
 
 #[cfg(test)]
 mod tests {
-    use super::{Felt, NoteInputs, ZERO};
+    use miden_crypto::utils::Deserializable;
+
+    use super::{Felt, NoteInputs, Serializable};
 
     #[test]
     fn test_input_ordering() {
-        use super::Vec;
-
         // inputs are provided in reverse stack order
-        let inputs = Vec::from([Felt::new(1), Felt::new(2), Felt::new(3)]);
+        let inputs = vec![Felt::new(1), Felt::new(2), Felt::new(3)];
         // we expect the inputs to be padded to length 16 and to remain in reverse stack order.
-        let expected_ordering = Vec::from([
-            Felt::new(1),
-            Felt::new(2),
-            Felt::new(3),
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-            ZERO,
-        ]);
+        let expected_ordering = vec![Felt::new(1), Felt::new(2), Felt::new(3)];
 
-        let note_inputs = NoteInputs::new(&inputs).expect("note created should succeed");
-        assert_eq!(&expected_ordering, note_inputs.inputs());
+        let note_inputs = NoteInputs::new(inputs).expect("note created should succeed");
+        assert_eq!(&expected_ordering, &note_inputs.values);
+    }
+
+    #[test]
+    fn test_input_serialization() {
+        let inputs = vec![Felt::new(1), Felt::new(2), Felt::new(3)];
+        let note_inputs = NoteInputs::new(inputs).unwrap();
+
+        let bytes = note_inputs.to_bytes();
+        let parsed_note_inputs = NoteInputs::read_from_bytes(&bytes).unwrap();
+        assert_eq!(note_inputs, parsed_note_inputs);
     }
 }

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -61,6 +61,11 @@ impl NoteInputs {
         &self.inputs
     }
 
+    /// Returns the number of inputs.
+    pub fn num_inputs(&self) -> usize {
+        self.inputs.len()
+    }
+
     /// Returns a commitment to these inputs.
     pub fn hash(&self) -> Digest {
         *self.hash.get_or_init(|| Hasher::hash_elements(&self.inputs))

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -95,7 +95,7 @@ impl Note {
     ) -> Result<Self, NoteError> {
         Ok(Self {
             script,
-            inputs: NoteInputs::new(inputs)?,
+            inputs: NoteInputs::new(inputs.to_vec())?,
             assets: NoteAssets::new(assets)?,
             serial_num,
             metadata: NoteMetadata::new(sender, tag),
@@ -157,7 +157,7 @@ impl Note {
     pub fn recipient(&self) -> Digest {
         let serial_num_hash = Hasher::merge(&[self.serial_num.into(), Digest::default()]);
         let merge_script = Hasher::merge(&[serial_num_hash, self.script.hash()]);
-        Hasher::merge(&[merge_script, self.inputs.hash()])
+        Hasher::merge(&[merge_script, self.inputs.commitment()])
     }
 
     /// Returns a unique identifier of this note, which is simultaneously a commitment to the note.

--- a/objects/src/notes/nullifier.rs
+++ b/objects/src/notes/nullifier.rs
@@ -67,7 +67,7 @@ impl From<&Note> for Nullifier {
     fn from(note: &Note) -> Self {
         Self::new(
             note.script.hash(),
-            note.inputs.hash(),
+            note.inputs.commitment(),
             note.assets.commitment(),
             note.serial_num,
         )


### PR DESCRIPTION
This addresses the remaining part of #281 (i.e., enables a variable number of inputs per note). The main changes are:

- Refactored `NoteInputs` struct to support variable number of values.
- Modified transaction kernel (prologue and note sections).
- Fixed an separate issue where nullifier section for consumed notes was previously too small (i.e., could fit only 512 nullifiers without overlapping with other data).
- Fixed new clippy warnings (had to bump up Rust version).

Due to refactoring of the `NoteInput` struct, changes in this PR may affect miden client and node.