### PR TITLE
Update code to be compatible with Winterfell 0.8

### DIFF
--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -3,7 +3,7 @@ use miden_objects::{
     assembly::LibraryPath,
     assets::{AssetVault, TokenSymbol},
     utils::{string::ToString, vec},
-    AccountError, Felt, StarkField, Word, ZERO,
+    AccountError, Felt, Word, ZERO,
 };
 
 use super::{AuthScheme, Library, MidenLib, TransactionKernel};

--- a/miden-lib/src/tests/test_asset_vault.rs
+++ b/miden-lib/src/tests/test_asset_vault.rs
@@ -1,7 +1,6 @@
 use miden_objects::{
     accounts::AccountId,
     assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
-    StarkField,
 };
 use mock::{
     constants::{

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -314,7 +314,14 @@ fn add_input_notes_to_advice_inputs(notes: &InputNotes, inputs: &mut AdviceInput
         note_data.push(proof.origin().block_num.into());
         note_data.extend(*proof.sub_hash());
         note_data.extend(*proof.note_root());
-        note_data.push(proof.origin().node_index.value().into());
+        note_data.push(
+            proof
+                .origin()
+                .node_index
+                .value()
+                .try_into()
+                .expect("value is greater than or equal to the field modulus"),
+        );
     }
 
     // insert the combined note data into the advice map

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     notes::{NoteAssets, NoteId, NoteMetadata},
     transaction::OutputNote,
     utils::collections::Vec,
-    AccountError, Digest, NoteError, StarkField, Word, WORD_SIZE,
+    AccountError, Digest, NoteError, Word, WORD_SIZE,
 };
 
 use super::memory::{

--- a/miden-tx/src/host/account_delta.rs
+++ b/miden-tx/src/host/account_delta.rs
@@ -9,7 +9,7 @@ use miden_objects::{
         collections::{btree_map::Entry, BTreeMap},
         string::ToString,
     },
-    Digest, Felt, StarkField, Word, EMPTY_WORD, ZERO,
+    Digest, Felt, Word, EMPTY_WORD, ZERO,
 };
 use vm_processor::{ContextId, ProcessState};
 

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -4,7 +4,7 @@ use miden_lib::transaction::{memory, ToTransactionKernelInputs, TransactionKerne
 use miden_objects::{
     notes::NoteAssets,
     transaction::{OutputNotes, PreparedTransaction, TransactionInputs, TransactionScript},
-    Felt, StarkField,
+    Felt,
 };
 use mock::host::MockHost;
 use vm_processor::{

--- a/mock/src/mock/block.rs
+++ b/mock/src/mock/block.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
     accounts::Account, crypto::merkle::SimpleSmt, utils::collections::Vec, BlockHeader, Digest,
-    Felt, StarkField, ACCOUNT_TREE_DEPTH, ZERO,
+    Felt, ACCOUNT_TREE_DEPTH, ZERO,
 };
 use miden_test_utils::rand;
 

--- a/mock/src/procedures.rs
+++ b/mock/src/procedures.rs
@@ -4,7 +4,7 @@ use super::{
         CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE,
         NUM_CREATED_NOTES_PTR,
     },
-    NoteAssets, OutputNotes, StarkField, Word,
+    NoteAssets, OutputNotes, Word,
 };
 
 pub fn output_notes_data_procedure(notes: &OutputNotes) -> String {

--- a/mock/src/utils.rs
+++ b/mock/src/utils.rs
@@ -4,7 +4,7 @@ use miden_objects::{
         collections::Vec,
         string::{String, ToString},
     },
-    StarkField, Word,
+    Word,
 };
 
 // TODO: These functions are duplicates from miden-lib/test/common/procedures.rs

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use super::{
     get_account_seed, Account, AccountError, ByteReader, Deserializable, DeserializationError,
-    Digest, Felt, FieldElement, Hasher, Serializable, StarkField, String, ToString, Vec, Word,
+    Digest, Felt, FieldElement, Hasher, Serializable, String, ToString, Vec, Word,
 };
 use crate::{crypto::merkle::LeafIndex, utils::hex_to_bytes, ACCOUNT_TREE_DEPTH};
 

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -163,7 +163,7 @@ impl Serializable for AccountCode {
         // since the number of procedures is guaranteed to be between 1 and 256, we can store the
         // number as a single byte - but we do have to subtract 1 to store 256 as 255.
         target.write_u8((self.procedures.len() - 1) as u8);
-        self.procedures.write_into(target);
+        target.write_many(self.procedures());
     }
 }
 
@@ -172,7 +172,7 @@ impl Deserializable for AccountCode {
         let mut module = ModuleAst::read_from(source, MODULE_SERDE_OPTIONS)?;
         module.load_source_locations(source)?;
         let num_procedures = (source.read_u8()? as usize) + 1;
-        let procedures = Digest::read_batch_from(source, num_procedures)?;
+        let procedures = source.read_many::<Digest>(num_procedures)?;
 
         Ok(Self::from_parts(module, procedures))
     }

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -6,7 +6,7 @@ use super::{
         serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
         string::{String, ToString},
     },
-    AccountError, Digest, Felt, FieldElement, Hasher, StarkField, Word, ZERO,
+    AccountError, Digest, Felt, FieldElement, Hasher, Word, ZERO,
 };
 
 mod account_id;

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -75,10 +75,10 @@ pub fn get_account_seed_inner(
     let init_seed: Vec<[u8; 8]> =
         init_seed.chunks(8).map(|chunk| chunk.try_into().unwrap()).collect();
     let mut current_seed: Word = [
-        Felt::from(init_seed[0]),
-        Felt::from(init_seed[1]),
-        Felt::from(init_seed[2]),
-        Felt::from(init_seed[3]),
+        Felt::new(u64::from_le_bytes(init_seed[0])),
+        Felt::new(u64::from_le_bytes(init_seed[1])),
+        Felt::new(u64::from_le_bytes(init_seed[2])),
+        Felt::new(u64::from_le_bytes(init_seed[3])),
     ];
     let mut current_digest = compute_digest(current_seed, code_root, storage_root);
 
@@ -137,10 +137,10 @@ pub fn get_account_seed_single(
     let init_seed: Vec<[u8; 8]> =
         init_seed.chunks(8).map(|chunk| chunk.try_into().unwrap()).collect();
     let mut current_seed: Word = [
-        Felt::from(init_seed[0]),
-        Felt::from(init_seed[1]),
-        Felt::from(init_seed[2]),
-        Felt::from(init_seed[3]),
+        Felt::new(u64::from_le_bytes(init_seed[0])),
+        Felt::new(u64::from_le_bytes(init_seed[1])),
+        Felt::new(u64::from_le_bytes(init_seed[2])),
+        Felt::new(u64::from_le_bytes(init_seed[3])),
     ];
     let mut current_digest = compute_digest(current_seed, code_root, storage_root);
 

--- a/objects/src/accounts/storage/slot.rs
+++ b/objects/src/accounts/storage/slot.rs
@@ -118,15 +118,15 @@ impl From<StorageSlotType> for Felt {
         match slot_type {
             StorageSlotType::Value { value_arity } => {
                 let type_value = (value_arity as u64) << 32;
-                Felt::from(type_value)
+                Felt::new(type_value)
             },
             StorageSlotType::Map { value_arity } => {
                 let type_value = ((value_arity as u64) << 32) | 1_u64;
-                Felt::from(type_value)
+                Felt::new(type_value)
             },
             StorageSlotType::Array { depth, value_arity } => {
                 let type_value = ((value_arity as u64) << 32) | (depth as u64);
-                Felt::from(type_value)
+                Felt::new(type_value)
             },
         }
     }

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 
-use super::{
-    parse_word, AccountId, AccountType, Asset, AssetError, Felt, StarkField, ToString, Word, ZERO,
-};
+use super::{parse_word, AccountId, AccountType, Asset, AssetError, Felt, ToString, Word, ZERO};
 
 // FUNGIBLE ASSET
 // ================================================================================================

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -5,7 +5,7 @@ use super::{
         serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
         string::ToString,
     },
-    AssetError, Felt, Hasher, StarkField, Word, ZERO,
+    AssetError, Felt, Hasher, Word, ZERO,
 };
 
 mod fungible;

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -1,8 +1,7 @@
 use core::fmt;
 
 use super::{
-    parse_word, AccountId, AccountType, Asset, AssetError, Felt, Hasher, StarkField, ToString, Vec,
-    Word,
+    parse_word, AccountId, AccountType, Asset, AssetError, Felt, Hasher, ToString, Vec, Word,
 };
 
 /// Position of the faucet_id inside the [NonFungibleAsset] word.

--- a/objects/src/assets/token_symbol.rs
+++ b/objects/src/assets/token_symbol.rs
@@ -1,4 +1,4 @@
-use super::{AssetError, Felt, StarkField, ToString};
+use super::{AssetError, Felt, ToString};
 use crate::utils::string::String;
 
 #[derive(Clone, Copy, Debug)]

--- a/objects/src/assets/vault.rs
+++ b/objects/src/assets/vault.rs
@@ -224,17 +224,14 @@ impl Serializable for AssetVault {
         // u32::MAX or use variable-length encoding for the number of assets
         assert!(assets.len() <= u32::MAX as usize, "too many assets in the vault");
         target.write_u32(assets.len() as u32);
-
-        for asset in assets {
-            asset.write_into(target);
-        }
+        target.write_many(&assets);
     }
 }
 
 impl Deserializable for AssetVault {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let num_assets = source.read_u32()? as usize;
-        let assets = Asset::read_batch_from(source, num_assets)?;
+        let assets = source.read_many::<Asset>(num_assets)?;
         Self::new(&assets).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }

--- a/objects/src/notes/assets.rs
+++ b/objects/src/notes/assets.rs
@@ -153,15 +153,14 @@ impl Serializable for NoteAssets {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         debug_assert!(self.assets.len() <= NoteAssets::MAX_NUM_ASSETS);
         target.write_u8((self.assets.len() - 1) as u8);
-        self.assets.write_into(target);
+        target.write_many(&self.assets);
     }
 }
 
 impl Deserializable for NoteAssets {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let count = source.read_u8()? + 1;
-        let assets = Asset::read_batch_from(source, count.into())?;
-
+        let assets = source.read_many::<Asset>(count.into())?;
         Self::new(&assets).map_err(|e| DeserializationError::InvalidValue(format!("{e:?}")))
     }
 }

--- a/objects/src/notes/envelope.rs
+++ b/objects/src/notes/envelope.rs
@@ -1,5 +1,3 @@
-use vm_core::StarkField;
-
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Note, NoteId, NoteMetadata,
     Serializable, Vec, Word,

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -106,14 +106,14 @@ impl Serializable for NoteInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let NoteInputs { values, hash: _hash } = self;
         target.write_u8(values.len().try_into().expect("inputs len is not a u8 value"));
-        values.write_into(target);
+        target.write_many(values);
     }
 }
 
 impl Deserializable for NoteInputs {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let num_values = source.read_u8()? as usize;
-        let values = Felt::read_batch_from(source, num_values)?;
+        let values = source.read_many::<Felt>(num_values)?;
         Self::new(values).map_err(|v| DeserializationError::InvalidValue(format!("{v}")))
     }
 }

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -302,14 +302,14 @@ impl<T: ToNullifier> Serializable for InputNotes<T> {
         // assert is OK here because we enforce max number of notes in the constructor
         assert!(self.notes.len() <= u16::MAX.into());
         target.write_u16(self.notes.len() as u16);
-        self.notes.write_into(target);
+        target.write_many(&self.notes);
     }
 }
 
 impl<T: ToNullifier> Deserializable for InputNotes<T> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let num_notes = source.read_u16()?;
-        let notes = T::read_batch_from(source, num_notes.into())?;
+        let notes = source.read_many::<T>(num_notes.into())?;
         Self::new(notes).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -173,14 +173,14 @@ impl<T: ToEnvelope> Serializable for OutputNotes<T> {
         // assert is OK here because we enforce max number of notes in the constructor
         assert!(self.notes.len() <= u16::MAX.into());
         target.write_u16(self.notes.len() as u16);
-        self.notes.write_into(target);
+        target.write_many(&self.notes);
     }
 }
 
 impl<T: ToEnvelope> Deserializable for OutputNotes<T> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let num_notes = source.read_u16()?;
-        let notes = T::read_batch_from(source, num_notes.into())?;
+        let notes = source.read_many::<T>(num_notes.into())?;
         Self::new(notes).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }


### PR DESCRIPTION
This PR updates the code to be compatible with new 0.8 version of the Winterfell.

This update mostly contains changes in `Felt` creation, since casting of `u64` to `FieldElement` was removed. It also updates the serialization and deserialization of the structs, which contain vectors of `Felts` or `RpoDigests`.