### PR TITLE
Remove unneeded muts

### DIFF
--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -59,7 +59,7 @@ fn test_transaction_prologue() {
     )
     .unwrap();
     let (tx_script, _) =
-        TransactionScript::new(mock_tx_script_code, vec![], &mut TransactionKernel::assembler())
+        TransactionScript::new(mock_tx_script_code, vec![], &TransactionKernel::assembler())
             .unwrap();
 
     let assembly_file = build_module_path(TX_KERNEL_DIR, PROLOGUE_FILE);

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -78,7 +78,7 @@ impl TransactionCompiler {
     /// Compiles the provided program into the [NoteScript] and checks (to the extent possible)
     /// if a note could be executed against all accounts with the specified interfaces.
     pub fn compile_note_script(
-        &mut self,
+        &self,
         note_script_ast: ProgramAst,
         target_account_proc: Vec<ScriptTarget>,
     ) -> Result<NoteScript, TransactionCompilerError> {
@@ -103,7 +103,7 @@ impl TransactionCompiler {
     /// Constructs a [TransactionScript] by compiling the provided source code and checking the
     /// compatibility of the resulting program with the target account interfaces.
     pub fn compile_tx_script<T>(
-        &mut self,
+        &self,
         tx_script_ast: ProgramAst,
         tx_script_inputs: T,
         target_account_proc: Vec<ScriptTarget>,
@@ -112,7 +112,7 @@ impl TransactionCompiler {
         T: IntoIterator<Item = (Word, Vec<Felt>)>,
     {
         let (tx_script, code_block) =
-            TransactionScript::new(tx_script_ast, tx_script_inputs, &mut self.assembler).map_err(
+            TransactionScript::new(tx_script_ast, tx_script_inputs, &self.assembler).map_err(
                 |e| match e {
                     TransactionScriptError::ScriptCompilationError(asm_error) => {
                         TransactionCompilerError::CompileTxScriptFailed(asm_error)
@@ -136,7 +136,7 @@ impl TransactionCompiler {
     ///
     /// The account is assumed to have been previously loaded into this compiler.
     pub fn compile_transaction(
-        &mut self,
+        &self,
         account_id: AccountId,
         notes: &InputNotes,
         tx_script: Option<&ProgramAst>,
@@ -205,7 +205,7 @@ impl TransactionCompiler {
     /// compatible with the target account interfaces. Returns a vector of the compiled note
     /// programs.
     fn compile_notes(
-        &mut self,
+        &self,
         target_account_interface: &[Digest],
         notes: &InputNotes,
         assembly_context: &mut AssemblyContext,
@@ -233,7 +233,7 @@ impl TransactionCompiler {
     ///
     /// The transaction script compatibility is verified against the target account interface.
     fn compile_tx_script_program(
-        &mut self,
+        &self,
         tx_script: &ProgramAst,
         assembly_context: &mut AssemblyContext,
         target_account_interface: Vec<Digest>,

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -86,11 +86,14 @@ impl<D: DataStore> TransactionExecutor<D> {
         self.compiler.load_account_interface(account_id, procedures)
     }
 
+    // COMPILERS
+    // --------------------------------------------------------------------------------------------
+
     /// Compiles the provided program into a [NoteScript] and checks (to the extent possible) if
     /// the specified note program could be executed against all accounts with the specified
     /// interfaces.
     pub fn compile_note_script(
-        &mut self,
+        &self,
         note_script_ast: ProgramAst,
         target_account_procs: Vec<ScriptTarget>,
     ) -> Result<NoteScript, TransactionExecutorError> {
@@ -103,7 +106,7 @@ impl<D: DataStore> TransactionExecutor<D> {
     /// checks (to the extent possible) that the transaction script can be executed against all
     /// accounts with the specified interfaces.
     pub fn compile_tx_script<T>(
-        &mut self,
+        &self,
         tx_script_ast: ProgramAst,
         inputs: T,
         target_account_procs: Vec<ScriptTarget>,
@@ -132,7 +135,7 @@ impl<D: DataStore> TransactionExecutor<D> {
     /// - If the transaction program can not be compiled.
     /// - If the transaction program can not be executed.
     pub fn execute_transaction(
-        &mut self,
+        &self,
         account_id: AccountId,
         block_ref: u32,
         notes: &[NoteId],
@@ -175,7 +178,7 @@ impl<D: DataStore> TransactionExecutor<D> {
     /// - If required data can not be fetched from the [DataStore].
     /// - If the transaction can not be compiled.
     fn prepare_transaction(
-        &mut self,
+        &self,
         account_id: AccountId,
         block_ref: u32,
         notes: &[NoteId],

--- a/objects/src/transaction/tx_script.rs
+++ b/objects/src/transaction/tx_script.rs
@@ -38,7 +38,7 @@ impl TransactionScript {
     pub fn new<T: IntoIterator<Item = (Word, Vec<Felt>)>>(
         code: ProgramAst,
         inputs: T,
-        assembler: &mut Assembler,
+        assembler: &Assembler,
     ) -> Result<(Self, CodeBlock), TransactionScriptError> {
         let code_block = assembler
             .compile_in_context(&code, &mut AssemblyContext::for_program(Some(&code)))


### PR DESCRIPTION
This PR removes unneeded `mut` modifiers from transaction compiler and transaction executor.