### PR TITLE
Add `Account::set_nonce()` function

### DIFF
--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -204,13 +204,7 @@ impl Account {
 
         // update nonce
         if let Some(nonce) = delta.nonce() {
-            if self.nonce.as_int() >= nonce.as_int() {
-                return Err(AccountError::NonceNotMonotonicallyIncreasing {
-                    current: self.nonce.as_int(),
-                    new: nonce.as_int(),
-                });
-            }
-            self.nonce = nonce;
+            self.set_nonce(nonce)?;
         }
 
         Ok(())

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -216,6 +216,25 @@ impl Account {
         Ok(())
     }
 
+    /// Sets the nonce of this account to the specified nonce value.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The new nonce is smaller than the actual account nonce
+    /// - The new nonce is equal to the actual account nonce
+    pub fn set_nonce(&mut self, nonce: Felt) -> Result<(), AccountError> {
+        if self.nonce.as_int() >= nonce.as_int() {
+            return Err(AccountError::NonceNotMonotonicallyIncreasing {
+                current: self.nonce.as_int(),
+                new: nonce.as_int(),
+            });
+        }
+
+        self.nonce = nonce;
+
+        Ok(())
+    }
+
     // TEST HELPERS
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
In this PR I propose the addition of `Account::set_nonce()`. For different use cases we will need to manipulate the nonce of accounts. 

Will help us close: https://github.com/0xPolygonMiden/miden-node/issues/223