### PR TITLE
feat: add DataStoreError double spend variant

### DIFF
--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -111,6 +111,7 @@ pub enum DataStoreError {
     BlockNotFound(u32),
     InvalidTransactionInput(TransactionInputError),
     InternalError(String),
+    NoteAlreadyConsumed(NoteId),
     NoteNotFound(NoteId),
 }
 

--- a/miden-tx/src/executor/data.rs
+++ b/miden-tx/src/executor/data.rs
@@ -22,6 +22,7 @@ pub trait DataStore {
     /// - The account with the specified ID could not be found in the data store.
     /// - The block with the specified number could not be found in the data store.
     /// - Any of the notes with the specified IDs could not be found in the data store.
+    /// - Any of the notes with the specified IDs were already consumed.
     /// - The combination of specified inputs resulted in a transaction input error.
     /// - The data store encountered some internal error
     fn get_transaction_inputs(


### PR DESCRIPTION
after [a discussion](https://github.com/0xPolygonMiden/miden-client/pull/188#discussion_r1503326091) on one of the miden client's PRs we decided to add a variant to the DataStoreError to handle double spend errors (trying to consume an already consumed note) since we're currently using the `DataStoreError::InternalError` variant and it's less descriptive.

Also updated the `get_transaction_inputs` function documentation to consider the new variant.