### PR TITLE
Change git VM dependency to crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-miden-verifier = { package = "miden-verifier", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+assembly = { package = "miden-assembly", version = "0.8", default-features = false }
+miden-verifier = { package = "miden-verifier", version = "0.8", default-features = false }
+vm-processor = { package = "miden-processor", version = "0.8", default-features = false }

--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -21,7 +21,7 @@ testing = ["miden-objects/testing"]
 
 [dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-stdlib = { package = "miden-stdlib", version = "0.8", default-features = false }
 
 [dev-dependencies]
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false, features = ["testing"]}

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -23,7 +23,7 @@ std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier
 [dependencies]
 miden-lib = { package = "miden-lib", path = "../miden-lib", default-features = false }
 miden-objects = { package = "miden-objects", path = "../objects", default-features = false }
-miden-prover = { package = "miden-prover", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-prover = { package = "miden-prover", version = "0.8", default-features = false }
 miden-verifier = { workspace = true }
 vm-processor = { workspace = true }
 

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -31,7 +31,7 @@ log = { version = "0.4", optional = true }
 miden-crypto = { version = "0.8", default-features = false }
 miden-verifier = { workspace = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+vm-core = { package = "miden-core", version = "0.8", default-features = false }
 vm-processor = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This small PR changes Miden VM crates dependencies from git link to crate version. 