### PR TITLE
bugfix: ProvenTransaction must be Send

### DIFF
--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -248,3 +248,15 @@ impl Deserializable for ProvenTransaction {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProvenTransaction;
+
+    fn check_if_send<T: Send>() {}
+
+    #[test]
+    fn proven_transaction_is_send() {
+        check_if_send::<ProvenTransaction>();
+    }
+}


### PR DESCRIPTION
This is required by the block_producer, which sends the ProvenTransactions across different tasks.