### PR TITLE
kernel: improve error message

### DIFF
--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -79,7 +79,7 @@ impl TransactionKernel {
             .with_library(&StdLibrary::default())
             .expect("failed to load std-lib")
             .with_kernel(Self::kernel())
-            .expect("kernel is well formed")
+            .expect("kernel must be well formed")
     }
 
     // STACK INPUTS / OUTPUTS


### PR DESCRIPTION
The current error looks like this:

```
---- tests::test_epilogue::test_epilogue stdout ----
thread 'tests::test_epilogue::test_epilogue' panicked at miden-lib/src/transaction/mod.rs:82:14:
kernel is well formed: ParsingError("malformed instruction 'assertz.ERR_FAUCET_RESERVED_DATA_SLOT': expected format `assertz.err=<code>`")
```

This fixes the assert message so it reads better:

```
---- tests::test_epilogue::test_epilogue stdout ----
thread 'tests::test_epilogue::test_epilogue' panicked at miden-lib/src/transaction/mod.rs:82:14:
kernel must be well formed: ParsingError("malformed instruction 'assertz.ERR_FAUCET_RESERVED_DATA_SLOT': expected format `assertz.err=<code>`")
```