### PR TITLE
mock: add mock constructor to BlockHeader behind testing feature

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,10 @@ repos:
       args: ["+stable", "check", "--all-targets"]
     - id: cargo
       name: Cargo check --all-targets --no-default-features
-      args: ["+stable", "check", "--all-targets", "--no-default-features"]
+      args: ["+stable", "check", "--no-default-features", "--workspace", "--exclude", "miden-mock"]
     - id: cargo
       name: Cargo check --all-targets --all-features
-      args: ["+stable", "check", "--all-targets", "--all-features","--workspace", "--exclude", "miden-mock"]
+      args: ["+stable", "check", "--all-targets", "--all-features", "--workspace"]
     # Unlike fmt, clippy will not be automatically applied
     - id: cargo
       name: Cargo clippy

--- a/mock/src/mock/block.rs
+++ b/mock/src/mock/block.rs
@@ -1,8 +1,4 @@
-use miden_objects::{
-    accounts::Account, crypto::merkle::SimpleSmt, BlockHeader, Digest, Felt, ACCOUNT_TREE_DEPTH,
-    ZERO,
-};
-use rand_utils as rand;
+use miden_objects::{accounts::Account, BlockHeader, Digest};
 
 pub fn mock_block_header(
     block_num: u32,
@@ -10,39 +6,5 @@ pub fn mock_block_header(
     note_root: Option<Digest>,
     accts: &[Account],
 ) -> BlockHeader {
-    let acct_db = SimpleSmt::<ACCOUNT_TREE_DEPTH>::with_leaves(
-        accts
-            .iter()
-            .flat_map(|acct| {
-                if acct.is_new() {
-                    None
-                } else {
-                    let felt_id: Felt = acct.id().into();
-                    Some((felt_id.as_int(), *acct.hash()))
-                }
-            })
-            .collect::<Vec<_>>(),
-    )
-    .expect("failed to create account db");
-
-    let prev_hash: Digest = rand::rand_array().into();
-    let chain_root: Digest = chain_root.unwrap_or(rand::rand_array().into());
-    let acct_root: Digest = acct_db.root();
-    let nullifier_root: Digest = rand::rand_array().into();
-    let note_root: Digest = note_root.unwrap_or(rand::rand_array().into());
-    let batch_root: Digest = rand::rand_array().into();
-    let proof_hash: Digest = rand::rand_array().into();
-
-    BlockHeader::new(
-        prev_hash,
-        block_num,
-        chain_root,
-        acct_root,
-        nullifier_root,
-        note_root,
-        batch_root,
-        proof_hash,
-        ZERO,
-        rand::rand_value(),
-    )
+    BlockHeader::mock(block_num, chain_root, note_root, accts)
 }

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -23,7 +23,7 @@ default = ["std"]
 concurrent = ["std"]
 serde = ["dep:serde", "miden-crypto/serde"]
 std = ["assembly/std", "miden-crypto/std", "miden-verifier/std", "vm-core/std", "vm-processor/std"]
-testing = []
+testing = ["dep:winter-rand-utils"]
 
 [dependencies]
 assembly = { workspace = true }
@@ -33,6 +33,7 @@ miden-verifier = { workspace = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 vm-core = { workspace = true }
 vm-processor = { workspace = true }
+winter-rand-utils = { version = "0.8", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["html_reports"] }

--- a/objects/src/block/header.rs
+++ b/objects/src/block/header.rs
@@ -186,6 +186,61 @@ impl BlockHeader {
     }
 }
 
+#[cfg(feature = "testing")]
+mod mock {
+    use winter_rand_utils as rand;
+
+    use crate::{
+        accounts::Account, crypto::merkle::SimpleSmt, BlockHeader, Digest, Felt,
+        ACCOUNT_TREE_DEPTH, ZERO,
+    };
+
+    impl BlockHeader {
+        pub fn mock(
+            block_num: u32,
+            chain_root: Option<Digest>,
+            note_root: Option<Digest>,
+            accts: &[Account],
+        ) -> Self {
+            let acct_db = SimpleSmt::<ACCOUNT_TREE_DEPTH>::with_leaves(
+                accts
+                    .iter()
+                    .flat_map(|acct| {
+                        if acct.is_new() {
+                            None
+                        } else {
+                            let felt_id: Felt = acct.id().into();
+                            Some((felt_id.as_int(), *acct.hash()))
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .expect("failed to create account db");
+
+            let prev_hash: Digest = rand::rand_array().into();
+            let chain_root: Digest = chain_root.unwrap_or(rand::rand_array().into());
+            let acct_root: Digest = acct_db.root();
+            let nullifier_root: Digest = rand::rand_array().into();
+            let note_root: Digest = note_root.unwrap_or(rand::rand_array().into());
+            let batch_root: Digest = rand::rand_array().into();
+            let proof_hash: Digest = rand::rand_array().into();
+
+            BlockHeader::new(
+                prev_hash,
+                block_num,
+                chain_root,
+                acct_root,
+                nullifier_root,
+                note_root,
+                batch_root,
+                proof_hash,
+                ZERO,
+                rand::rand_value(),
+            )
+        }
+    }
+}
+
 impl Serializable for BlockHeader {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let Self {


### PR DESCRIPTION
As requested [here](https://github.com/0xPolygonMiden/miden-node/pull/260#discussion_r1514047173).

This should be released, since it is a block to release the `miden-node`.