### PR TITLE
Use dedicated storage slot constructors whenever possible

### DIFF
--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -1,7 +1,6 @@
 use miden_objects::{
     accounts::{
         Account, AccountCode, AccountId, AccountStorage, AccountType, SlotItem, StorageSlot,
-        StorageSlotType,
     },
     assembly::LibraryPath,
     assets::{AssetVault, TokenSymbol},
@@ -72,17 +71,11 @@ pub fn create_basic_fungible_faucet(
     let account_storage = AccountStorage::new(vec![
         SlotItem {
             index: 0,
-            slot: StorageSlot {
-                slot_type: StorageSlotType::Value { value_arity: 0 },
-                value: auth_data,
-            },
+            slot: StorageSlot::new_value(auth_data),
         },
         SlotItem {
             index: 1,
-            slot: StorageSlot {
-                slot_type: StorageSlotType::Value { value_arity: 0 },
-                value: metadata,
-            },
+            slot: StorageSlot::new_value(metadata),
         },
     ])?;
     let account_vault = AssetVault::new(&[]).expect("error on empty vault");

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -1,7 +1,5 @@
 use miden_objects::{
-    accounts::{
-        Account, AccountCode, AccountId, AccountStorage, AccountType, StorageSlot, StorageSlotType,
-    },
+    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, StorageSlot},
     assembly::ModuleAst,
     assets::AssetVault,
     utils::format,
@@ -60,10 +58,7 @@ pub fn create_basic_wallet(
 
     let account_storage = AccountStorage::new(vec![miden_objects::accounts::SlotItem {
         index: 0,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: storage_slot_0_data,
-        },
+        slot: StorageSlot::new_value(storage_slot_0_data),
     }])?;
     let account_vault = AssetVault::new(&[]).expect("error on empty vault");
 

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -3,9 +3,7 @@ mod wallet;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    accounts::{
-        Account, AccountCode, AccountId, AccountStorage, SlotItem, StorageSlot, StorageSlotType,
-    },
+    accounts::{Account, AccountCode, AccountId, AccountStorage, SlotItem, StorageSlot},
     assembly::{ModuleAst, ProgramAst},
     assets::{Asset, AssetVault, FungibleAsset},
     crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
@@ -157,10 +155,7 @@ pub fn get_account_with_default_account_code(
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
     let account_storage = AccountStorage::new(vec![SlotItem {
         index: 0,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: public_key,
-        },
+        slot: StorageSlot::new_value(public_key),
     }])
     .unwrap();
 

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -4,9 +4,7 @@ use miden_lib::{
     AuthScheme,
 };
 use miden_objects::{
-    accounts::{
-        Account, AccountCode, AccountId, AccountStorage, SlotItem, StorageSlot, StorageSlotType,
-    },
+    accounts::{Account, AccountCode, AccountId, AccountStorage, SlotItem, StorageSlot},
     assembly::{ModuleAst, ProgramAst},
     assets::{Asset, AssetVault, FungibleAsset, TokenSymbol},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
@@ -279,17 +277,11 @@ fn get_faucet_account_with_max_supply_and_total_issuance(
     let mut faucet_account_storage = AccountStorage::new(vec![
         SlotItem {
             index: 0,
-            slot: StorageSlot {
-                slot_type: StorageSlotType::Value { value_arity: 0 },
-                value: public_key,
-            },
+            slot: StorageSlot::new_value(public_key),
         },
         SlotItem {
             index: 1,
-            slot: StorageSlot {
-                slot_type: StorageSlotType::Value { value_arity: 0 },
-                value: faucet_storage_slot_1,
-            },
+            slot: StorageSlot::new_value(faucet_storage_slot_1),
         },
     ])
     .unwrap();

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -1,6 +1,6 @@
 use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
 use miden_objects::{
-    accounts::{Account, AccountId, AccountStorage, SlotItem, StorageSlot, StorageSlotType},
+    accounts::{Account, AccountId, AccountStorage, SlotItem, StorageSlot},
     assembly::ProgramAst,
     assets::{Asset, AssetVault, FungibleAsset},
     crypto::dsa::rpo_falcon512::{KeyPair, PublicKey},
@@ -87,10 +87,7 @@ fn prove_receive_asset_via_wallet() {
     // clone account info
     let account_storage = AccountStorage::new(vec![SlotItem {
         index: 0,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: target_pub_key,
-        },
+        slot: StorageSlot::new_value(target_pub_key),
     }])
     .unwrap();
     let account_code = target_account.code().clone();
@@ -173,10 +170,7 @@ fn prove_send_asset_via_wallet() {
     // clones account info
     let sender_account_storage = AccountStorage::new(vec![SlotItem {
         index: 0,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: sender_pub_key,
-        },
+        slot: StorageSlot::new_value(sender_pub_key),
     }])
     .unwrap();
     let sender_account_code = sender_account.code().clone();

--- a/mock/src/mock/account.rs
+++ b/mock/src/mock/account.rs
@@ -2,7 +2,7 @@ use miden_lib::transaction::memory::FAUCET_STORAGE_DATA_SLOT;
 use miden_objects::{
     accounts::{
         get_account_seed_single, Account, AccountCode, AccountId, AccountStorage, AccountType,
-        SlotItem, StorageSlot, StorageSlotType,
+        SlotItem, StorageSlot,
     },
     assembly::{Assembler, ModuleAst},
     assets::{Asset, AssetVault, FungibleAsset},
@@ -49,20 +49,14 @@ pub const STORAGE_VALUE_1: Word = [Felt::new(5), Felt::new(6), Felt::new(7), Fel
 pub fn storage_item_0() -> SlotItem {
     SlotItem {
         index: STORAGE_INDEX_0,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: STORAGE_VALUE_0,
-        },
+        slot: StorageSlot::new_value(STORAGE_VALUE_0),
     }
 }
 
 pub fn storage_item_1() -> SlotItem {
     SlotItem {
         index: STORAGE_INDEX_1,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: STORAGE_VALUE_1,
-        },
+        slot: StorageSlot::new_value(STORAGE_VALUE_1),
     }
 }
 
@@ -234,10 +228,7 @@ pub fn mock_fungible_faucet(
     };
     let account_storage = AccountStorage::new(vec![SlotItem {
         index: FAUCET_STORAGE_DATA_SLOT,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Value { value_arity: 0 },
-            value: [ZERO, ZERO, ZERO, initial_balance],
-        },
+        slot: StorageSlot::new_value([ZERO, ZERO, ZERO, initial_balance]),
     }])
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
@@ -266,10 +257,7 @@ pub fn mock_non_fungible_faucet(
 
     let account_storage = AccountStorage::new(vec![SlotItem {
         index: FAUCET_STORAGE_DATA_SLOT,
-        slot: StorageSlot {
-            slot_type: StorageSlotType::Map { value_arity: 0 },
-            value: *nft_tree.root(),
-        },
+        slot: StorageSlot::new_map(*nft_tree.root()),
     }])
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -44,6 +44,9 @@ pub struct StorageSlot {
 }
 
 impl StorageSlot {
+    /// Returns a new [StorageSlot] with the provided value.
+    ///
+    /// The value arity for the slot is set to 0.
     pub fn new_value(value: Word) -> Self {
         Self {
             slot_type: StorageSlotType::Value { value_arity: 0 },
@@ -51,6 +54,9 @@ impl StorageSlot {
         }
     }
 
+    /// Returns a new [StorageSlot] with a map defined by the provided root.
+    ///
+    /// The value arity for the slot is set to 0.
     pub fn new_map(root: Word) -> Self {
         Self {
             slot_type: StorageSlotType::Map { value_arity: 0 },
@@ -58,9 +64,13 @@ impl StorageSlot {
         }
     }
 
-    pub fn new_array(root: Word, depth: u8) -> Self {
+    /// Returns a new [StorageSlot] with an array defined by the provided root and the number of
+    /// elements.
+    ///
+    /// The max size of the array is set to 2^log_n and the value arity for the slot is set to 0.
+    pub fn new_array(root: Word, log_n: u8) -> Self {
         Self {
-            slot_type: StorageSlotType::Array { depth, value_arity: 0 },
+            slot_type: StorageSlotType::Array { depth: log_n, value_arity: 0 },
             value: root,
         }
     }
@@ -343,10 +353,7 @@ mod tests {
             },
             SlotItem {
                 index: 1,
-                slot: StorageSlot {
-                    slot_type: StorageSlotType::Value { value_arity: 0 },
-                    value: [ONE, ONE, ONE, ZERO],
-                },
+                slot: StorageSlot::new_value([ONE, ONE, ONE, ZERO]),
             },
             SlotItem {
                 index: 2,


### PR DESCRIPTION
This small PR is a follow-up to #513 to use storage slot constructors whenever possible with the primary intent of simplifying the code a bit.