### PR TITLE
Optional initial hash for new accounts

### DIFF
--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -101,13 +101,13 @@ impl TransactionKernel {
     ///   tuples for the notes consumed by the transaction.
     pub fn build_input_stack(
         acct_id: AccountId,
-        init_acct_hash: Digest,
+        init_acct_hash: Option<Digest>,
         input_notes_hash: Digest,
         block_hash: Digest,
     ) -> StackInputs {
         let mut inputs: Vec<Felt> = Vec::with_capacity(13);
         inputs.extend(input_notes_hash);
-        inputs.extend_from_slice(init_acct_hash.as_elements());
+        inputs.extend_from_slice(init_acct_hash.unwrap_or_default().as_elements());
         inputs.push(acct_id.into());
         inputs.extend_from_slice(block_hash.as_elements());
         StackInputs::new(inputs)

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::Not;
+
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     notes::{NoteEnvelope, Nullifier},
@@ -7,7 +9,7 @@ use miden_objects::{
 };
 use miden_prover::prove;
 pub use miden_prover::ProvingOptions;
-use vm_processor::{Digest, MemAdviceProvider};
+use vm_processor::MemAdviceProvider;
 
 use super::{TransactionHost, TransactionProverError};
 
@@ -48,7 +50,7 @@ impl TransactionProver {
         let input_notes: InputNotes<Nullifier> = (tx_witness.tx_inputs().input_notes()).into();
 
         let account_id = tx_witness.account().id();
-        let initial_account_hash = tx_witness.account().hash();
+        let initial_hash = tx_witness.account().is_new().not().then(|| tx_witness.account().hash());
         let block_hash = tx_witness.block_header().hash();
         let tx_script_root = tx_witness.tx_args().tx_script().map(|script| *script.hash());
 
@@ -63,12 +65,6 @@ impl TransactionProver {
         let (_, map, _) = advice_provider.into_parts();
         let tx_outputs = TransactionKernel::parse_transaction_outputs(&stack_outputs, &map.into())
             .map_err(TransactionProverError::InvalidTransactionOutput)?;
-
-        let initial_hash = if tx_witness.account().is_new() {
-            Digest::default()
-        } else {
-            initial_account_hash
-        };
 
         let builder = ProvenTransactionBuilder::new(
             account_id,

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::Not;
+
 use crate::{
     assembly::{Assembler, AssemblyContext, ModuleAst},
     assets::AssetVault,
@@ -110,16 +112,12 @@ impl Account {
     /// proofs.
     ///
     /// For existing accounts, this is exactly the same as [Account::hash()], however, for new
-    /// accounts this value is set to [ZERO; 4]. This is because when a transaction is executed
-    /// agains a new account, public input for the initial account state is set to [ZERO; 4] to
+    /// accounts this value is set to `None`. This is because when a transaction is executed
+    /// against a new account, public input for the initial account state is set to `None` to
     /// distinguish new accounts from existing accounts. The actual hash of the initial account
     /// state (and the initial state itself), are provided to the VM via the advice provider.
-    pub fn proof_init_hash(&self) -> Digest {
-        if self.is_new() {
-            Digest::default()
-        } else {
-            self.hash()
-        }
+    pub fn proof_init_hash(&self) -> Option<Digest> {
+        self.is_new().not().then(|| self.hash())
     }
 
     /// Returns unique identifier of this account.

--- a/objects/src/transaction/transaction_id.rs
+++ b/objects/src/transaction/transaction_id.rs
@@ -24,13 +24,15 @@ pub struct TransactionId(Digest);
 impl TransactionId {
     /// Returns a new [TransactionId] instantiated from the provided transaction components.
     pub fn new(
-        init_account_hash: Digest,
+        init_account_hash: Option<Digest>,
         final_account_hash: Digest,
         input_notes_hash: Digest,
         output_notes_hash: Digest,
     ) -> Self {
+        debug_assert_ne!(init_account_hash, Some(Digest::default()));
+
         let mut elements = [ZERO; 4 * WORD_SIZE];
-        elements[..4].copy_from_slice(init_account_hash.as_elements());
+        elements[..4].copy_from_slice(init_account_hash.unwrap_or_default().as_elements());
         elements[4..8].copy_from_slice(final_account_hash.as_elements());
         elements[8..12].copy_from_slice(input_notes_hash.as_elements());
         elements[12..].copy_from_slice(output_notes_hash.as_elements());
@@ -89,7 +91,7 @@ impl From<&ExecutedTransaction> for TransactionId {
         let input_notes_hash = tx.input_notes().commitment();
         let output_notes_hash = tx.output_notes().commitment();
         Self::new(
-            tx.initial_account().hash(),
+            tx.initial_account().proof_init_hash(),
             tx.final_account().hash(),
             input_notes_hash,
             output_notes_hash,


### PR DESCRIPTION
Made `initial_account_hash` in `ProvenTransaction`, `ProvenTransactionBuilder` and `TransactionId` constructor optional.

I also considered to make `hash` in `Account` optional, but finally decided to leave it without changes.

Resolves https://github.com/0xPolygonMiden/miden-base/issues/522