### PR TITLE
chore: fix winterfell deprecations and no-std build setup

### DIFF
--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -16,7 +16,13 @@ rust-version = "1.75"
 [features]
 concurrent = ["miden-objects/concurrent", "std"]
 default = ["std"]
-std = ["assembly/std", "miden-objects/std", "miden-stdlib/std", "vm-processor/std"]
+std = [
+    "assembly/std",
+    "miden-objects/std",
+    "miden-stdlib/std",
+    "vm-processor/std",
+    "mock/std",
+]
 # the testing feature is required to enable the account creation pow patch
 testing = ["miden-objects/testing"]
 
@@ -25,7 +31,9 @@ miden-objects = { package = "miden-objects", path = "../objects", version = "0.2
 miden-stdlib = { workspace = true }
 
 [dev-dependencies]
-miden-objects = { package = "miden-objects", path = "../objects", version = "0.2", default-features = false, features = ["testing"]}
+miden-objects = { package = "miden-objects", path = "../objects", version = "0.2", default-features = false, features = [
+    "testing",
+] }
 mock = { package = "miden-mock", path = "../mock", default-features = false }
 vm-processor = { workspace = true, features = ["internals"] }
 

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use miden_objects::{
     accounts::{
         Account, AccountCode, AccountId, AccountStorage, AccountType, SlotItem, StorageSlot,
@@ -8,7 +10,6 @@ use miden_objects::{
 };
 
 use super::{AuthScheme, Library, MidenLib, TransactionKernel};
-use crate::utils::{string::*, vec};
 
 // FUNGIBLE FAUCET
 // ================================================================================================

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -1,13 +1,13 @@
+use alloc::string::{String, ToString};
+
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, AccountType, StorageSlot},
     assembly::ModuleAst,
     assets::AssetVault,
-    utils::format,
     AccountError, Word, ZERO,
 };
 
 use super::{AuthScheme, TransactionKernel};
-use crate::utils::{string::*, vec};
 
 // BASIC WALLET
 // ================================================================================================

--- a/miden-lib/src/lib.rs
+++ b/miden-lib/src/lib.rs
@@ -1,7 +1,10 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 use miden_objects::{
     assembly::{Library, LibraryNamespace, MaslLibrary, Version},
@@ -15,7 +18,7 @@ pub mod accounts;
 pub mod notes;
 pub mod transaction;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests;
 
 // RE-EXPORTS

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -1,6 +1,7 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
-    accounts::AccountId, assets::Asset, crypto::rand::FeltRng, notes::Note, utils::collections::*,
-    Felt, NoteError, Word,
+    accounts::AccountId, assets::Asset, crypto::rand::FeltRng, notes::Note, Felt, NoteError, Word,
 };
 
 use self::utils::build_note_script;

--- a/miden-lib/src/tests/test_note.rs
+++ b/miden-lib/src/tests/test_note.rs
@@ -1,7 +1,8 @@
+use alloc::{collections::BTreeMap, string::String};
+
 use miden_objects::{
     notes::Note,
     transaction::{PreparedTransaction, TransactionArgs},
-    utils::collections::*,
     WORD_SIZE,
 };
 use mock::{

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
     notes::Note,
     transaction::{OutputNote, OutputNotes},

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -1,6 +1,7 @@
+use alloc::string::String;
 use core::fmt;
 
-use miden_objects::{accounts::AccountStorage, utils::string::*, AssetError, Digest};
+use miden_objects::{accounts::AccountStorage, AssetError, Digest};
 
 // TRANSACTION KERNEL ERROR
 // ================================================================================================

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
     accounts::Account,
     transaction::{
@@ -9,7 +11,6 @@ use miden_objects::{
 };
 
 use super::TransactionKernel;
-use crate::utils::{collections::*, vec};
 
 // TRANSACTION KERNEL INPUTS
 // ================================================================================================

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
     accounts::AccountId,
     assembly::{Assembler, AssemblyContext, ProgramAst},
@@ -9,7 +11,6 @@ use miden_objects::{
 use miden_stdlib::StdLibrary;
 
 use super::MidenLib;
-use crate::utils::collections::*;
 
 pub mod memory;
 

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -1,3 +1,5 @@
+use alloc::{collections::BTreeMap, vec::Vec};
+
 use miden_objects::{
     assembly::{Assembler, AssemblyContext, ModuleAst, ProgramAst},
     transaction::{InputNotes, TransactionScript},
@@ -8,7 +10,6 @@ use super::{
     AccountCode, AccountId, CodeBlock, Digest, NoteScript, Program, TransactionCompilerError,
     TransactionKernel,
 };
-use crate::utils::{collections::*, vec};
 
 #[cfg(test)]
 mod tests;

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
     accounts::ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
     assets::{Asset, FungibleAsset},

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use core::fmt::{self, Display};
 
 use miden_objects::{
@@ -7,7 +8,6 @@ use miden_objects::{
 use miden_verifier::VerificationError;
 
 use super::{AccountError, AccountId, Digest, ExecutionError};
-use crate::utils::string::*;
 
 // TRANSACTION COMPILER ERROR
 // ================================================================================================

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     assembly::ProgramAst,
@@ -12,7 +14,6 @@ use super::{
     RecAdviceProvider, ScriptTarget, TransactionCompiler, TransactionExecutorError,
     TransactionHost,
 };
-use crate::utils::collections::*;
 
 mod data;
 pub use data::DataStore;

--- a/miden-tx/src/host/account_delta.rs
+++ b/miden-tx/src/host/account_delta.rs
@@ -1,3 +1,5 @@
+use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+
 use miden_lib::transaction::{memory::ACCT_STORAGE_ROOT_PTR, TransactionKernelError};
 use miden_objects::{
     accounts::{
@@ -10,10 +12,6 @@ use miden_objects::{
 use vm_processor::{ContextId, ProcessState};
 
 use super::{AdviceProvider, TransactionHost};
-use crate::utils::{
-    collections::{btree_map::*, *},
-    string::*,
-};
 
 // CONSTANTS
 // ================================================================================================
@@ -310,6 +308,8 @@ where
     V: Copy,
     K: Ord,
 {
+    use alloc::collections::btree_map::Entry;
+
     match delta_map.entry(key) {
         Entry::Occupied(mut entry) => {
             if entry.get() == &-amount {

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -1,3 +1,5 @@
+use alloc::{collections::BTreeMap, string::ToString};
+
 use miden_lib::transaction::{TransactionEvent, TransactionKernelError};
 use miden_objects::{
     accounts::{AccountDelta, AccountStub},
@@ -7,8 +9,6 @@ use vm_processor::{
     crypto::NodeIndex, AdviceExtractor, AdviceInjector, AdviceProvider, AdviceSource, ContextId,
     ExecutionError, Host, HostResponse, ProcessState,
 };
-
-use crate::utils::{collections::*, format, string::*};
 
 mod account_delta;
 use account_delta::AccountDeltaTracker;

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -1,7 +1,10 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 use miden_lib::transaction::TransactionKernel;
 pub use miden_objects::transaction::TransactionInputs;

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     accounts::{Account, AccountCode},

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -18,7 +18,7 @@ required-features = ["executable"]
 
 [features]
 default = ["std"]
-executable = ["dep:clap", "serde"]
+executable = ["std", "serde", "dep:clap"]
 serde = ["dep:serde", "miden-objects/serde"]
 std = ["miden-lib/std", "miden-objects/std"]
 
@@ -27,11 +27,17 @@ clap = { version = "4.4", features = ["derive"], optional = true }
 env_logger = { version = "0.11" }
 hex = { version = "0.4" }
 miden-lib = { path = "../miden-lib", version = "0.2" }
-miden-objects = { path = "../objects", version = "0.2", features = ["log", "serde", "testing"] }
+miden-objects = { path = "../objects", version = "0.2", features = [
+    "log",
+    "serde",
+    "testing",
+] }
 miden-prover = { workspace = true }
-postcard = { version = "1.0", features = [ "alloc" ] }
+postcard = { version = "1.0", features = ["alloc"] }
 rand = { version = "0.8" }
 rand-utils = { package = "winter-rand-utils", version = "0.8" }
 rand_pcg = { version = "0.3", features = ["serde1"] }
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = [
+    "derive",
+] }
 vm-processor = { workspace = true, features = ["internals"] }

--- a/mock/src/builders/account.rs
+++ b/mock/src/builders/account.rs
@@ -1,3 +1,8 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use miden_objects::{
     accounts::{Account, AccountStorage, AccountType, SlotItem},
     assets::{Asset, AssetVault},
@@ -8,7 +13,6 @@ use rand::Rng;
 use crate::{
     builders::{str_to_account_code, AccountBuilderError, AccountIdBuilder, AccountStorageBuilder},
     mock::account::DEFAULT_ACCOUNT_CODE,
-    utils::{collections::*, string::*},
 };
 
 /// Builder for an `Account`, the builder allows for a fluent API to construct an account. Each

--- a/mock/src/builders/account_id.rs
+++ b/mock/src/builders/account_id.rs
@@ -1,6 +1,7 @@
+use alloc::string::{String, ToString};
+
 use miden_objects::{
     accounts::{AccountId, AccountType},
-    utils::string::*,
     Digest, Word,
 };
 use rand::Rng;

--- a/mock/src/builders/account_storage.rs
+++ b/mock/src/builders/account_storage.rs
@@ -1,7 +1,6 @@
-use miden_objects::{
-    accounts::{AccountStorage, SlotItem},
-    utils::collections::*,
-};
+use alloc::vec::Vec;
+
+use miden_objects::accounts::{AccountStorage, SlotItem};
 
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/mock/src/builders/note.rs
+++ b/mock/src/builders/note.rs
@@ -1,3 +1,8 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use miden_objects::{
     accounts::AccountId,
     assembly::ProgramAst,
@@ -8,7 +13,6 @@ use miden_objects::{
 use rand::Rng;
 
 use super::TransactionKernel;
-use crate::utils::{collections::*, string::*};
 
 const DEFAULT_NOTE_CODE: &str = "\
 begin

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -1,22 +1,33 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
 
-use std::{fs::File, io::Read, path::PathBuf};
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+use std::{
+    fs::File,
+    io::Read,
+    path::PathBuf,
+    string::{String, ToString},
+};
 
 use miden_lib::transaction::{memory, ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     notes::NoteAssets,
-    transaction::{OutputNotes, PreparedTransaction, TransactionArgs, TransactionInputs},
-    utils::string::*,
+    transaction::{OutputNotes, PreparedTransaction},
+};
+#[cfg(feature = "std")]
+use miden_objects::{
+    transaction::{TransactionArgs, TransactionInputs},
     Felt,
 };
 use mock::host::MockHost;
-use vm_processor::{
-    AdviceInputs, AdviceProvider, DefaultHost, ExecutionError, ExecutionOptions, Host, Process,
-    StackInputs, Word,
-};
+use vm_processor::{AdviceInputs, ExecutionError, ExecutionOptions, Process, Word};
+#[cfg(feature = "std")]
+use vm_processor::{AdviceProvider, DefaultHost, Host, StackInputs};
 
 pub mod builders;
 pub mod constants;
@@ -28,6 +39,7 @@ pub mod utils;
 // ================================================================================================
 
 /// Loads the specified file and append `code` into its end.
+#[cfg(feature = "std")]
 fn load_file_with_code(imports: &str, code: &str, assembly_file: PathBuf) -> String {
     let mut module = String::new();
     File::open(assembly_file).unwrap().read_to_string(&mut module).unwrap();
@@ -57,6 +69,7 @@ pub fn run_tx_with_inputs(
 }
 
 /// Inject `code` along side the specified file and run it
+#[cfg(feature = "std")]
 pub fn run_within_tx_kernel<A>(
     imports: &str,
     code: &str,
@@ -87,6 +100,7 @@ where
 }
 
 /// Inject `code` along side the specified file and run it
+#[cfg(feature = "std")]
 pub fn run_within_host<H: Host>(
     imports: &str,
     code: &str,
@@ -113,6 +127,7 @@ pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
     memory::CONSUMED_NOTE_DATA_SECTION_OFFSET + note_idx * memory::NOTE_MEM_SIZE
 }
 
+#[cfg(feature = "std")]
 pub fn prepare_transaction(
     tx_inputs: TransactionInputs,
     tx_args: Option<TransactionArgs>,

--- a/mock/src/main.rs
+++ b/mock/src/main.rs
@@ -1,4 +1,4 @@
-use std::{boxed::Box, fs::File, io::Write, path::PathBuf, time::Instant};
+use std::{fs::File, io::Write, path::PathBuf, time::Instant};
 
 use clap::Parser;
 use miden_mock::mock::{

--- a/mock/src/main.rs
+++ b/mock/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Write, path::PathBuf, time::Instant};
+use std::{boxed::Box, fs::File, io::Write, path::PathBuf, time::Instant};
 
 use clap::Parser;
 use miden_mock::mock::{

--- a/mock/src/mock/chain.rs
+++ b/mock/src/mock/chain.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::fmt;
 
 use miden_objects::{
@@ -6,7 +7,6 @@ use miden_objects::{
     crypto::merkle::{LeafIndex, Mmr, PartialMmr, SimpleSmt, Smt},
     notes::{Note, NoteInclusionProof},
     transaction::{ChainMmr, InputNote},
-    utils::collections::*,
     BlockHeader, Digest, Felt, FieldElement, Word, ACCOUNT_TREE_DEPTH, NOTE_TREE_DEPTH,
 };
 use rand::{Rng, SeedableRng};

--- a/mock/src/mock/host/account_procs.rs
+++ b/mock/src/mock/host/account_procs.rs
@@ -1,7 +1,9 @@
+use alloc::collections::BTreeMap;
+
 use miden_lib::transaction::TransactionKernelError;
 use miden_objects::accounts::AccountCode;
 
-use super::{AdviceProvider, BTreeMap, Digest, NodeIndex, ProcessState};
+use super::{AdviceProvider, Digest, NodeIndex, ProcessState};
 
 // ACCOUNT PROCEDURE INDEX MAP
 // ================================================================================================

--- a/mock/src/mock/host/mod.rs
+++ b/mock/src/mock/host/mod.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use miden_lib::transaction::TransactionEvent;
 use miden_objects::{
     accounts::{delta::AccountVaultDelta, AccountStub},
@@ -7,8 +9,6 @@ use vm_processor::{
     crypto::NodeIndex, AdviceExtractor, AdviceInjector, AdviceInputs, AdviceProvider, AdviceSource,
     ContextId, ExecutionError, Host, HostResponse, MemAdviceProvider, ProcessState,
 };
-
-use crate::utils::{collections::*, string::*};
 
 mod account_procs;
 use account_procs::AccountProcedureIndexMap;

--- a/mock/src/mock/mmr_peaks.rs
+++ b/mock/src/mock/mmr_peaks.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_objects::crypto::merkle::MmrPeaks;
 
 pub fn empty_mmr_peaks() -> MmrPeaks {

--- a/mock/src/mock/notes.rs
+++ b/mock/src/mock/notes.rs
@@ -1,9 +1,10 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
     accounts::AccountId,
     assembly::{Assembler, ProgramAst},
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteScript},
-    utils::collections::*,
     Felt, Word, ZERO,
 };
 

--- a/mock/src/mock/transaction.rs
+++ b/mock/src/mock/transaction.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use miden_objects::{
     accounts::{Account, AccountDelta},
     notes::Note,
@@ -5,7 +7,6 @@ use miden_objects::{
         ChainMmr, ExecutedTransaction, InputNote, InputNotes, OutputNote, OutputNotes,
         TransactionArgs, TransactionInputs, TransactionOutputs,
     },
-    utils::collections::*,
     BlockHeader, Felt, FieldElement,
 };
 use vm_processor::{AdviceInputs, Operation, Program, Word};

--- a/mock/src/procedures.rs
+++ b/mock/src/procedures.rs
@@ -1,4 +1,7 @@
-use miden_objects::utils::string::*;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use super::{
     memory::{

--- a/mock/src/utils.rs
+++ b/mock/src/utils.rs
@@ -1,5 +1,10 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 pub use miden_objects::utils::*;
-use miden_objects::{notes::NoteAssets, utils::string::*, Word};
+use miden_objects::{notes::NoteAssets, Word};
 
 // TODO: These functions are duplicates from miden-lib/test/common/procedures.rs
 pub fn prepare_word(word: &Word) -> String {

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -1,14 +1,14 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::fmt;
 
 use super::{
     get_account_seed, Account, AccountError, ByteReader, Deserializable, DeserializationError,
     Digest, Felt, FieldElement, Hasher, Serializable, Word,
 };
-use crate::{
-    crypto::merkle::LeafIndex,
-    utils::{collections::*, format, hex_to_bytes, string::*},
-    ACCOUNT_TREE_DEPTH,
-};
+use crate::{crypto::merkle::LeafIndex, utils::hex_to_bytes, ACCOUNT_TREE_DEPTH};
 
 // ACCOUNT ID
 // ================================================================================================

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -1,10 +1,12 @@
+use alloc::vec::Vec;
+
 use assembly::ast::AstSerdeOptions;
 
 use super::{
     AccountError, Assembler, AssemblyContext, ByteReader, ByteWriter, Deserializable,
     DeserializationError, Digest, ModuleAst, Serializable,
 };
-use crate::{crypto::merkle::SimpleSmt, utils::collections::*};
+use crate::crypto::merkle::SimpleSmt;
 
 // CONSTANTS
 // ================================================================================================

--- a/objects/src/accounts/data.rs
+++ b/objects/src/accounts/data.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{self, File},
     io::{self, Read},
     path::Path,
+    vec::Vec,
 };
 
 use miden_crypto::utils::SliceReader;
@@ -13,7 +14,6 @@ use super::{
     },
     Account, Word,
 };
-use crate::utils::format;
 
 // ACCOUNT DATA
 // ================================================================================================
@@ -130,6 +130,7 @@ mod tests {
     use assembly::{ast::ModuleAst, Assembler};
     use miden_crypto::utils::{Deserializable, Serializable};
     use storage::AccountStorage;
+    #[cfg(feature = "std")]
     use tempfile::tempdir;
 
     use super::{AccountData, AuthData};
@@ -183,6 +184,7 @@ mod tests {
         assert_eq!(account_data, account_data_2);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn account_data_is_correctly_writen_and_read_to_and_from_file() {
         // setup temp directory

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -1,7 +1,9 @@
+use alloc::string::ToString;
+
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Serializable, Word, ZERO,
 };
-use crate::{assets::Asset, utils::string::*, AccountDeltaError};
+use crate::{assets::Asset, AccountDeltaError};
 
 mod storage;
 pub use storage::AccountStorageDelta;

--- a/objects/src/accounts/delta/storage.rs
+++ b/objects/src/accounts/delta/storage.rs
@@ -1,8 +1,9 @@
+use alloc::{string::ToString, vec::Vec};
+
 use super::{
     AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     Word,
 };
-use crate::utils::{collections::*, string::*};
 
 // CONSTANTS
 // ================================================================================================

--- a/objects/src/accounts/delta/vault.rs
+++ b/objects/src/accounts/delta/vault.rs
@@ -1,8 +1,9 @@
+use alloc::{string::ToString, vec::Vec};
+
 use super::{
     AccountDeltaError, Asset, ByteReader, ByteWriter, Deserializable, DeserializationError,
     Serializable,
 };
-use crate::utils::{collections::*, string::*};
 
 // ACCOUNT VAULT DELTA
 // ================================================================================================

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 #[cfg(feature = "concurrent")]
 use std::{
     sync::{
@@ -8,7 +9,6 @@ use std::{
 };
 
 use super::{compute_digest, AccountError, AccountId, AccountType, Digest, Felt, Word};
-use crate::utils::collections::*;
 
 // SEED GENERATORS
 // --------------------------------------------------------------------------------------------
@@ -172,13 +172,14 @@ pub fn get_account_seed_single(
 
 #[cfg(feature = "log")]
 mod log {
+    use alloc::string::String;
+
     use assembly::utils::to_hex;
 
     use super::{
         super::{digest_pow, Digest, FieldElement, Word},
         AccountId, AccountType,
     };
-    use crate::utils::string::*;
 
     /// Keeps track of the best digest found so far and count how many iterations have been done.
     pub struct Log {

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -1,11 +1,10 @@
+use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+
 use super::{
     AccountError, AccountStorageDelta, ByteReader, ByteWriter, Deserializable,
     DeserializationError, Digest, Felt, Hasher, Serializable, Word,
 };
-use crate::{
-    crypto::merkle::{LeafIndex, NodeIndex, SimpleSmt},
-    utils::{collections::*, string::*, vec},
-};
+use crate::crypto::merkle::{LeafIndex, NodeIndex, SimpleSmt};
 
 mod slot;
 pub use slot::StorageSlotType;
@@ -309,6 +308,8 @@ impl Deserializable for AccountStorage {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::{
         AccountStorage, Deserializable, Serializable, SlotItem, StorageSlot, StorageSlotType,
     };

--- a/objects/src/accounts/storage/slot.rs
+++ b/objects/src/accounts/storage/slot.rs
@@ -1,5 +1,6 @@
+use alloc::string::{String, ToString};
+
 use super::Felt;
-use crate::utils::string::*;
 
 // CONSTANTS
 // ================================================================================================

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -1,7 +1,7 @@
+use alloc::string::ToString;
 use core::fmt;
 
 use super::{parse_word, AccountId, AccountType, Asset, AssetError, Felt, Word, ZERO};
-use crate::utils::string::*;
 
 // FUNGIBLE ASSET
 // ================================================================================================

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -1,12 +1,10 @@
+use alloc::string::ToString;
+
 use super::{
     accounts::{AccountId, AccountType},
-    utils::{
-        serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-        string::*,
-    },
+    utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     AssetError, Felt, Hasher, Word, ZERO,
 };
-use crate::utils::format;
 
 mod fungible;
 pub use fungible::FungibleAsset;

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -1,7 +1,7 @@
+use alloc::{string::ToString, vec::Vec};
 use core::fmt;
 
 use super::{parse_word, AccountId, AccountType, Asset, AssetError, Felt, Hasher, Word};
-use crate::utils::{collections::*, string::*};
 
 /// Position of the faucet_id inside the [NonFungibleAsset] word.
 const FAUCET_ID_POS: usize = 1;

--- a/objects/src/assets/token_symbol.rs
+++ b/objects/src/assets/token_symbol.rs
@@ -1,5 +1,6 @@
+use alloc::string::{String, ToString};
+
 use super::{AssetError, Felt};
-use crate::utils::string::*;
 
 #[derive(Clone, Copy, Debug)]
 pub struct TokenSymbol(Felt);

--- a/objects/src/assets/vault.rs
+++ b/objects/src/assets/vault.rs
@@ -1,12 +1,10 @@
+use alloc::{string::ToString, vec::Vec};
+
 use super::{
     AccountId, AccountType, Asset, ByteReader, ByteWriter, Deserializable, DeserializationError,
     FungibleAsset, NonFungibleAsset, Serializable, ZERO,
 };
-use crate::{
-    crypto::merkle::Smt,
-    utils::{collections::*, string::*},
-    AssetVaultError, Digest,
-};
+use crate::{crypto::merkle::Smt, AssetVaultError, Digest};
 
 // ASSET VAULT
 // ================================================================================================

--- a/objects/src/block/header.rs
+++ b/objects/src/block/header.rs
@@ -1,7 +1,8 @@
+use alloc::vec::Vec;
+
 use super::{Digest, Felt, Hasher, ZERO};
-use crate::utils::{
-    collections::*,
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+use crate::utils::serde::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 
 /// The header of a block. It contains metadata about the block, commitments to the current
@@ -188,6 +189,8 @@ impl BlockHeader {
 
 #[cfg(feature = "testing")]
 mod mock {
+    use alloc::vec::Vec;
+
     use winter_rand_utils as rand;
 
     use crate::{

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use core::fmt;
 
 use assembly::AssemblyError;
@@ -8,7 +9,6 @@ use super::{
     assets::{Asset, FungibleAsset, NonFungibleAsset},
     crypto::merkle::MerkleError,
     notes::NoteId,
-    utils::string::*,
     Digest, Word,
 };
 use crate::utils::collections::*;

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -1,7 +1,10 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod accounts;
 pub mod assets;

--- a/objects/src/notes/assets.rs
+++ b/objects/src/notes/assets.rs
@@ -1,11 +1,10 @@
+use alloc::vec::Vec;
+
 use super::{
     Asset, ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher,
     NoteError, Serializable, Word, WORD_SIZE, ZERO,
 };
-use crate::{
-    utils::{collections::*, format},
-    MAX_ASSETS_PER_NOTE,
-};
+use crate::MAX_ASSETS_PER_NOTE;
 
 // NOTE ASSETS
 // ================================================================================================

--- a/objects/src/notes/envelope.rs
+++ b/objects/src/notes/envelope.rs
@@ -1,8 +1,9 @@
+use alloc::vec::Vec;
+
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Note, NoteId, NoteMetadata,
     Serializable, Word,
 };
-use crate::utils::collections::*;
 
 // NOTE ENVELOPE
 // ================================================================================================

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -1,11 +1,10 @@
+use alloc::vec::Vec;
+
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher, NoteError,
     Serializable, WORD_SIZE, ZERO,
 };
-use crate::{
-    utils::{collections::*, format},
-    MAX_INPUTS_PER_NOTE,
-};
+use crate::MAX_INPUTS_PER_NOTE;
 
 // NOTE INPUTS
 // ================================================================================================

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -1,9 +1,9 @@
+use alloc::string::String;
 use core::fmt::Display;
 
 use super::{Digest, Felt, Hasher, Note, Word};
 use crate::utils::{
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    string::*,
     HexParseError,
 };
 
@@ -133,6 +133,8 @@ impl Deserializable for NoteId {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::NoteId;
 
     #[test]

--- a/objects/src/notes/nullifier.rs
+++ b/objects/src/notes/nullifier.rs
@@ -1,10 +1,11 @@
+use alloc::string::String;
 use core::fmt::{Debug, Display, Formatter};
 
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher, Note,
     Serializable, Word, WORD_SIZE, ZERO,
 };
-use crate::utils::{hex_to_bytes, string::*, HexParseError};
+use crate::utils::{hex_to_bytes, HexParseError};
 
 // NULLIFIER
 // ================================================================================================

--- a/objects/src/notes/origin.rs
+++ b/objects/src/notes/origin.rs
@@ -1,11 +1,10 @@
+use alloc::string::ToString;
+
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, NoteError, Serializable,
     NOTE_TREE_DEPTH,
 };
-use crate::{
-    crypto::merkle::{MerklePath, NodeIndex},
-    utils::string::*,
-};
+use crate::crypto::merkle::{MerklePath, NodeIndex};
 
 /// Contains information about the origin of a note.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/objects/src/transaction/chain_mmr.rs
+++ b/objects/src/transaction/chain_mmr.rs
@@ -1,6 +1,7 @@
+use alloc::{collections::BTreeMap, vec::Vec};
+
 use crate::{
     crypto::merkle::{InnerNodeInfo, MmrPeaks, PartialMmr},
-    utils::collections::*,
     BlockHeader, ChainMmrError,
 };
 

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -1,14 +1,11 @@
+use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
 use core::fmt::Debug;
 
 use super::{BlockHeader, ChainMmr, Digest, Felt, Hasher, Word};
 use crate::{
     accounts::{validate_account_seed, Account},
     notes::{Note, NoteId, NoteInclusionProof, NoteOrigin, Nullifier},
-    utils::{
-        collections::*,
-        serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-        string::*,
-    },
+    utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     TransactionInputError, MAX_INPUT_NOTES_PER_TX,
 };
 
@@ -270,7 +267,7 @@ impl<T: ToNullifier> InputNotes<T> {
 
 impl<T: ToNullifier> IntoIterator for InputNotes<T> {
     type Item = T;
-    type IntoIter = vec::IntoIter<Self::Item>;
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.notes.into_iter()

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -1,13 +1,10 @@
+use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
 use core::fmt::Debug;
 
 use crate::{
     accounts::AccountStub,
     notes::{Note, NoteAssets, NoteEnvelope, NoteId, NoteMetadata},
-    utils::{
-        collections::*,
-        serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-        string::*,
-    },
+    utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     Digest, Felt, Hasher, TransactionOutputError, Word, MAX_OUTPUT_NOTES_PER_TX,
 };
 
@@ -148,7 +145,7 @@ impl<T: ToEnvelope> OutputNotes<T> {
 
 impl<T: ToEnvelope> IntoIterator for OutputNotes<T> {
     type Item = T;
-    type IntoIter = vec::IntoIter<Self::Item>;
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.notes.into_iter()

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -1,14 +1,15 @@
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
+
 use miden_verifier::ExecutionProof;
 
 use super::{AccountId, Digest, InputNotes, NoteEnvelope, Nullifier, OutputNotes, TransactionId};
 use crate::{
     accounts::{Account, AccountDelta},
     notes::{Note, NoteId},
-    utils::{
-        collections::*,
-        format,
-        serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    },
+    utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     ProvenTransactionError,
 };
 

--- a/objects/src/transaction/transaction_id.rs
+++ b/objects/src/transaction/transaction_id.rs
@@ -1,9 +1,9 @@
+use alloc::string::String;
 use core::fmt::{Debug, Display};
 
 use super::{Digest, ExecutedTransaction, Felt, Hasher, ProvenTransaction, Word, WORD_SIZE, ZERO};
-use crate::utils::{
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    string::*,
+use crate::utils::serde::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 
 // TRANSACTION ID

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -1,8 +1,9 @@
+use alloc::{collections::BTreeMap, vec::Vec};
+
 use super::{Digest, Felt, Word};
 use crate::{
     assembly::{Assembler, AssemblyContext, ProgramAst},
     notes::NoteId,
-    utils::collections::*,
     vm::CodeBlock,
     TransactionScriptError,
 };


### PR DESCRIPTION
This change addresses upstream deprecations/changes from facebook/winterfell#262 and 0xPolygonMiden/crypto#290.

As a necessary side effect of those deprecations, our no-std build setup needed to be adjusted. See the above-mentioned PRs for more info, but the gist of the change is to always build with `#![no_std]`, and enable `std` features conditionally, rather than the reverse. For the most part this has little effect on how code is actually written, aside from needing to be more explicit about imports in some cases (anything that would normally be provided by the libstd prelude).