### PR TITLE
Fix `README` badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Miden Rollup protocol
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/base/blob/main/LICENSE)
-[![test](https://github.com/0xPolygonMiden/base/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/base/actions/workflows/test.yml)
-[![no-std](https://github.com/0xPolygonMiden/base/actions/workflows/no-std.yml/badge.svg)](https://github.com/0xPolygonMiden/base/actions/workflows/no-std.yml)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/miden-base/blob/main/LICENSE)
+[![test](https://github.com/0xPolygonMiden/miden-base/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-base/actions/workflows/test.yml)
+[![no-std](https://github.com/0xPolygonMiden/miden-base/actions/workflows/no-std.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-base/actions/workflows/no-std.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.75+-lightgray.svg)]()
-[![CRATE](https://img.shields.io/crates/v/miden-base)](https://crates.io/crates/miden-base)
 
 Description and core structures for the Miden Rollup protocol.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![test](https://github.com/0xPolygonMiden/miden-base/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-base/actions/workflows/test.yml)
 [![no-std](https://github.com/0xPolygonMiden/miden-base/actions/workflows/no-std.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-base/actions/workflows/no-std.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.75+-lightgray.svg)]()
+[![GitHub Release](https://img.shields.io/github/release/0xPolygonMiden/miden-base)]()  
 
 Description and core structures for the Miden Rollup protocol.
 


### PR DESCRIPTION
In this PR I propose to fix the README.md badges.

Fixed links to ci jobs + removed the crates.io badge because not relevant in the case of the base.

Addresses this comment: https://github.com/0xPolygonMiden/miden-base/pull/534#discussion_r1537811876