### PR TITLE
CI: Swap-out deprecated rust toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,7 @@ jobs:
     name: check rust version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          profile: minimal
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: check rust versions
         run: ./scripts/check-rust-version.sh
 
@@ -26,13 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install minimal Rust with rustfmt & cargo-make
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: davidB/rust-cargo-make@v1
       - name: cargo make - format
         run: cargo make format
@@ -42,12 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install minimal Rust with clippy & cargo-make
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: clippy
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: davidB/rust-cargo-make@v1
       - name: cargo make - clippy
         run: cargo make clippy

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -19,11 +19,7 @@ jobs:
         toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: rustup target add wasm32-unknown-unknown
       - uses: davidB/rust-cargo-make@v1
       - name: cargo make - build-no-std

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: davidB/rust-cargo-make@v1
       - uses: taiki-e/install-action@nextest
       - name: cargo make - test


### PR DESCRIPTION
In this PR I remove the deprecated https://github.com/actions-rs and swap it with https://github.com/dtolnay/rust-toolchain