### PR TITLE
Dominik add debug assembler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2 (2024-04-23)
+
+* Added `with_debug_mode()` methods to `TransactionCompiler` and `TransactionExecutor` (#562).
+
 ## 0.2.1 (2024-04-12)
 
 * [BREAKING] Return a reference to `NoteMetadata` from output notes (#593).

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -51,6 +51,14 @@ impl TransactionCompiler {
         }
     }
 
+    // Debugger
+    // --------------------------------------------------------------------------------------------
+    /// Puts the [Assembler] instance into debug mode.
+    pub fn with_debug_mode(mut self, in_debug_mode: bool) -> Self {
+        self.assembler = self.assembler.with_debug_mode(in_debug_mode);
+        self
+    }
+
     // ACCOUNT CODE AND NOTE SCRIPT COMPILERS
     // --------------------------------------------------------------------------------------------
 

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -51,9 +51,11 @@ impl TransactionCompiler {
         }
     }
 
-    // Debugger
-    // --------------------------------------------------------------------------------------------
-    /// Puts the [Assembler] instance into debug mode.
+    /// Puts the [TransactionCompiler] into debug mode.
+    /// 
+    /// When transaction compiler is in debug mode, all transaction-related code (note scripts,
+    /// account code) will be compiled in debug mode which will preserve debug artifacts from the
+    /// original source code.
     pub fn with_debug_mode(mut self, in_debug_mode: bool) -> Self {
         self.assembler = self.assembler.with_debug_mode(in_debug_mode);
         self

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -52,6 +52,14 @@ impl<D: DataStore> TransactionExecutor<D> {
         }
     }
 
+    // Debugger
+    // --------------------------------------------------------------------------------------------
+    /// Puts the [TransactionCompiler] instance into debug mode.
+    pub fn with_debug_mode(mut self, in_debug_mode: bool) -> Self {
+        self.compiler = self.compiler.with_debug_mode(in_debug_mode);
+        self
+    }
+
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -52,9 +52,11 @@ impl<D: DataStore> TransactionExecutor<D> {
         }
     }
 
-    // Debugger
-    // --------------------------------------------------------------------------------------------
-    /// Puts the [TransactionCompiler] instance into debug mode.
+    /// Puts the [TransactionExecutor] into debug mode.
+    /// 
+    /// When transaction executor is in debug mode, all transaction-related code (note scripts,
+    /// account code) will be compiled and executed in debug mode. This will ensure that all debug
+    /// instructions present in the original source code are executed.
     pub fn with_debug_mode(mut self, in_debug_mode: bool) -> Self {
         self.compiler = self.compiler.with_debug_mode(in_debug_mode);
         self


### PR DESCRIPTION
As requested by the Pioneers and early users, we need to be able to start the assembler with debug mode. So I added a new function to the Assmber constructor.

```
    /// Returns a new Miden assembler instantiated with the transaction kernel and loaded with the
    /// Miden stdlib, the midenlib and in debug mode.
    pub fn assembler_with_debug() -> Assembler {
        Assembler::default()
            .with_library(&MidenLib::default())
            .expect("failed to load miden-lib")
            .with_library(&StdLibrary::default())
            .expect("failed to load std-lib")
            .with_kernel(Self::kernel())
            .expect("kernel must be well formed")
            .with_debug_mode(true)
    }
```

We could also use an enum `DebugMode` and the existing function `assembler()` but then we need to change every instance. So it might be good to accept code duplication here.