### PR TITLE
tests: using nextest by default and enabling test timeouts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,16 @@
+[profile.default]
+slow-timeout = { period = "5s", terminate-after = 2 }
+
+[profile.prove]
+# A test which also generates a proof takes around 1min to complete on a M2
+slow-timeout = { period = "120s", terminate-after = 2 }
+
+[profile.ci-default]
+failure-output = "immediate-final"
+fail-fast = false
+
+[profile.ci-prove]
+# A test which also generates a proof takes around 120sec to complete in the CI
+slow-timeout = { period = "200s", terminate-after = 2 }
+failure-output = "immediate-final"
+fail-fast = false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,3 @@
-# Runs testing related jobs.
-
 name: test
 
 on:
@@ -28,5 +26,6 @@ jobs:
           toolchain: ${{matrix.toolchain}}
           override: true
       - uses: davidB/rust-cargo-make@v1
+      - uses: taiki-e/install-action@nextest
       - name: cargo make - test
-        run: cargo make test-${{matrix.args}}
+        run: cargo make ci-test-${{matrix.args}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [workspace]
-members = ["miden-lib", "miden-tx", "mock", "objects"]
-
 resolver = "2"
+members = [
+    "miden-lib",
+    "miden-tx",
+    "mock",
+    "objects",
+]
 
 [workspace.package]
 edition = "2021"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -48,20 +48,40 @@ disabled = true
 [tasks.test-default]
 description = "Run default tests excluding `prove`"
 workspace = false
+env = { "RUSTFLAGS" = "-C debug-assertions" }
 command = "cargo"
-args = ["test", "--profile", "test-release", "--features", "concurrent,testing", "--", "--skip", "prove"]
+args = ["nextest", "run", "--profile", "default", "--cargo-profile", "test-release", "--features", "concurrent,testing", "--filter-expr", "not test(prove)"]
 
 [tasks.test-prove]
 description = "Run `prove` tests (tests which use the Miden prover)"
 workspace = false
+env = { "RUSTFLAGS" = "-C debug-assertions" }
 command = "cargo"
-args = ["test", "--release", "--features", "concurrent,testing", "prove"]
+args = ["nextest", "run", "--profile", "prove", "--cargo-profile", "test-release", "--features", "concurrent,testing", "--filter-expr", "test(prove)"]
 
 [tasks.test-all]
 description = "Run all tests"
 workspace = false
 env = { "RUSTFLAGS" = "-C debug-assertions" }
 run_task = { name = ["test-default", "test-prove"], parallel = true }
+
+[tasks.ci-test-default]
+description = "Run default tests excluding `prove`"
+workspace = false
+command = "cargo"
+args = ["nextest", "run", "--profile", "ci-default", "--cargo-profile", "test-release", "--features", "concurrent,testing", "--filter-expr", "not test(prove)"]
+
+[tasks.ci-test-prove]
+description = "Run `prove` tests (tests which use the Miden prover)"
+workspace = false
+command = "cargo"
+args = ["nextest", "run", "--profile", "ci-prove", "--cargo-profile", "test-release", "--features", "concurrent,testing", "--filter-expr", "test(prove)"]
+
+[tasks.ci-test-all]
+description = "Run all tests"
+workspace = false
+env = { "RUSTFLAGS" = "-C debug-assertions" }
+run_task = { name = ["nextest-default", "nextest-prove"], parallel = true }
 
 # --- building ------------------------------------------------------------------------------------
 [tasks.build]


### PR DESCRIPTION
Using `nextest` by default and setting up the timeout. The goal is to figure out what is causing issues on the CI.