### PR TITLE
Use seeded RNG for falcon secret key generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "miden-processor",
  "miden-prover",
  "miden-verifier",
+ "rand_chacha",
 ]
 
 [[package]]

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -1,4 +1,5 @@
 use alloc::{collections::BTreeMap, vec::Vec};
+
 use miden_objects::{
     assembly::ProgramAst,
     transaction::{PreparedTransaction, TransactionArgs, TransactionScript},

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+
 use miden_objects::{
     accounts::{AccountId, AccountStub},
     assets::Asset,

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -30,3 +30,4 @@ vm-processor = { workspace = true }
 
 [dev-dependencies]
 mock = { package = "miden-mock", path = "../mock", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -25,6 +25,7 @@ use mock::{
         transaction::{mock_inputs, mock_inputs_with_existing},
     },
 };
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use vm_processor::utils::Deserializable;
 
 // MOCK DATA STORE
@@ -132,7 +133,10 @@ pub fn prove_and_verify_transaction(
 
 #[cfg(test)]
 pub fn get_new_key_pair_with_advice_map() -> (Word, Vec<Felt>) {
-    let sec_key = SecretKey::new();
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let sec_key = SecretKey::with_rng(&mut rng);
     let pub_key: Word = sec_key.public_key().into();
     let mut pk_sk_bytes = sec_key.to_bytes();
     pk_sk_bytes.append(&mut pub_key.to_bytes());

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -14,6 +14,7 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use mock::{mock::account::ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN, utils::prepare_word};
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
 use crate::{
     get_new_key_pair_with_advice_map, get_note_with_fungible_asset_and_script,
@@ -221,7 +222,10 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
 #[test]
 fn faucet_contract_creation() {
     // we need a Falcon Public Key to create the wallet account
-    let sec_key = SecretKey::new();
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let sec_key = SecretKey::with_rng(&mut rng);
     let pub_key = sec_key.public_key();
     let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 { pub_key };
 

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -17,6 +17,7 @@ use mock::{
     },
     utils::prepare_word,
 };
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map,
@@ -192,10 +193,13 @@ fn prove_send_asset_via_wallet() {
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn wallet_creation() {
-    // we need a Falcon Public Key to create the wallet account
-
     use miden_objects::accounts::AccountType;
-    let sec_key = SecretKey::new();
+
+    // we need a Falcon Public Key to create the wallet account
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let sec_key = SecretKey::with_rng(&mut rng);
     let pub_key = sec_key.public_key();
     let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 { pub_key };
 

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -308,6 +308,8 @@ pub fn hash_account(
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::{
         Account, AccountCode, AccountDelta, AccountId, AccountStorage, AccountStorageDelta,
         AccountVaultDelta, Assembler, Felt, ModuleAst, SlotItem, StorageSlot, StorageSlotType,
@@ -315,7 +317,6 @@ mod tests {
         ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
     };
     use crate::assets::{Asset, AssetVault, FungibleAsset};
-    use alloc::vec::Vec;
 
     fn build_account(assets: Vec<Asset>, nonce: Felt, storage_items: Vec<Word>) -> Account {
         // build account code

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::{
     accounts::AccountId,
     assembly::{Assembler, AssemblyContext, ProgramAst},
@@ -6,7 +8,6 @@ use crate::{
     vm::CodeBlock,
     Digest, Felt, Hasher, NoteError, Word, NOTE_TREE_DEPTH, WORD_SIZE, ZERO,
 };
-use alloc::vec::Vec;
 
 mod assets;
 pub use assets::NoteAssets;


### PR DESCRIPTION
This PR should hopefully fix test flakiness described in #566. The main chain is to use seeded PRNG for generating Falcon keys instead of using OS-provided randomness.