### PR TITLE
Fixed account seed generation math overflow

### DIFF
--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -32,7 +32,7 @@ pub fn get_account_seed(
         let send = send.clone();
         let stop = Arc::clone(&stop);
         let mut init_seed = init_seed;
-        init_seed[0] += count as u8;
+        init_seed[0] = init_seed[0].wrapping_add(count as u8);
         spawn(move || {
             get_account_seed_inner(
                 send,


### PR DESCRIPTION
I stumbled upon math overflow on seed generation during tests when initial seed is generated randomly.

```
thread 'db::tests::test_sql_select_accounts' panicked at /Users/polydez/.cargo/git/checkouts/miden-base-c72873dca0cede8b/d6af2ae/objects/src/accounts/seed.rs:35:9:
attempt to add with overflow
```