### PR TITLE
fix: Update `NoteTree`

### DIFF
--- a/objects/src/block/note_tree.rs
+++ b/objects/src/block/note_tree.rs
@@ -55,7 +55,7 @@ impl BlockNoteTree {
         note_idx_in_batch: usize,
     ) -> Result<MerklePath, MerkleError> {
         let leaf_index =
-            LeafIndex::<NOTE_LEAF_DEPTH>::new(Self::note_index(batch_idx, note_idx_in_batch))?;
+            LeafIndex::<NOTE_LEAF_DEPTH>::new(Self::leaf_index(batch_idx, note_idx_in_batch))?;
 
         Ok(self.0.open(&leaf_index).path)
     }
@@ -63,12 +63,9 @@ impl BlockNoteTree {
     // HELPERS
     // --------------------------------------------------------------------------------------------
 
-    fn note_index(batch_idx: usize, note_idx_in_batch: usize) -> u64 {
-        (batch_idx * MAX_NOTES_PER_BATCH + note_idx_in_batch) as u64
-    }
-
-    fn leaf_index(batch_idx: usize, note_idx_in_batch: usize) -> u64 {
-        Self::note_index(batch_idx, note_idx_in_batch) * 2
+    /// Returns the leaf index for a Note. The metadata is located on the adjacent index.
+    pub fn leaf_index(batch_idx: usize, note_idx_in_batch: usize) -> u64 {
+        (batch_idx * MAX_NOTES_PER_BATCH * 2 + (note_idx_in_batch * 2)) as u64
     }
 }
 


### PR DESCRIPTION
We are seeing some issues when enabling concurrency on integration tests in the client, where notes do not verify their existence in the block correctly:

```rust
called `Result::unwrap()` on an `Err` value: TransactionExecutionError(FetchTransactionInputsFailed(InvalidTransactionInput(InputNoteNotInBlock(NoteId(RpoDigest([3100900936425824196, 3907943233439131404, 4644488447496776785, 10368496932609474686])), 3))))
```
This is the code that fails:
https://github.com/0xPolygonMiden/miden-base/blob/69ec4dc4e1a6f78d3d370c6b3b2bd25b5887ebc8/objects/src/transaction/inputs.rs#L84-L88

Upon some investigation we found that the merkle path was not being correctly sent out from the node. This still doesn't fix the issue however. The reason that this doesn't happen without concurrent tests is that all notes fall on the 0 subtree and calculations are correct in that case.
