### PR TITLE
bugfix: fix note script serialization and re-enable tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
 dependencies = [
  "jobserver",
  "libc",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -419,9 +419,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]

--- a/miden-lib/src/tests/test_account.rs
+++ b/miden-lib/src/tests/test_account.rs
@@ -33,7 +33,7 @@ use crate::transaction::memory::{ACCT_CODE_ROOT_PTR, ACCT_NEW_CODE_ROOT_PTR};
 
 #[test]
 pub fn test_set_code_is_not_immediate() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = "
@@ -46,7 +46,7 @@ pub fn test_set_code_is_not_immediate() {
         end
         ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction).unwrap();
 
     // assert the code root is not changed
@@ -241,7 +241,7 @@ fn test_is_faucet_procedure() {
 #[test]
 fn test_get_item() {
     for storage_item in [storage_item_0(), storage_item_1()] {
-        let tx_inputs =
+        let (tx_inputs, tx_args) =
             mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
         let code = format!(
@@ -268,14 +268,14 @@ fn test_get_item() {
             item_value = prepare_word(&storage_item.slot.value)
         );
 
-        let transaction = prepare_transaction(tx_inputs, None, &code, None);
+        let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
         let _process = run_tx(&transaction).unwrap();
     }
 }
 
 #[test]
 fn test_set_item() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // copy the initial account slots (SMT)
@@ -322,7 +322,7 @@ fn test_set_item() {
         new_root = prepare_word(&account_smt.root()),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
@@ -330,7 +330,7 @@ fn test_set_item() {
 #[ignore]
 #[test]
 fn test_get_map_item() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
@@ -361,7 +361,7 @@ fn test_get_map_item() {
         child_value = prepare_word(&CHILD_STORAGE_VALUE_0)
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, code.as_str(), None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code.as_str(), None);
     let _process = run_tx(&transaction).unwrap();
 }
 
@@ -370,7 +370,7 @@ fn test_get_map_item() {
 
 #[test]
 fn test_get_vault_commitment() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let account = tx_inputs.account();
@@ -392,7 +392,7 @@ fn test_get_vault_commitment() {
         expected_vault_commitment = prepare_word(&account.vault().commitment()),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
@@ -401,7 +401,7 @@ fn test_get_vault_commitment() {
 
 #[test]
 fn test_authenticate_procedure() {
-    let tx_inputs =
+    let (tx_inputs, _tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let account = tx_inputs.account();
 
@@ -415,7 +415,7 @@ fn test_authenticate_procedure() {
     ];
 
     for (root, valid) in test_cases.into_iter() {
-        let tx_inputs =
+        let (tx_inputs, tx_args) =
             mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
         let code = format!(
@@ -437,7 +437,7 @@ fn test_authenticate_procedure() {
             root = prepare_word(&root)
         );
 
-        let transaction = prepare_transaction(tx_inputs, None, &code, None);
+        let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
         let process = run_tx(&transaction);
 
         match valid {

--- a/miden-lib/src/tests/test_asset.rs
+++ b/miden-lib/src/tests/test_asset.rs
@@ -14,7 +14,7 @@ use super::{Hasher, Word, ONE};
 
 #[test]
 fn test_create_fungible_asset_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -41,7 +41,7 @@ fn test_create_fungible_asset_succeeds() {
         "
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -57,7 +57,7 @@ fn test_create_fungible_asset_succeeds() {
 
 #[test]
 fn test_create_non_fungible_asset_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -84,14 +84,14 @@ fn test_create_non_fungible_asset_succeeds() {
         non_fungible_asset_data_hash = prepare_word(&Hasher::hash(&NON_FUNGIBLE_ASSET_DATA)),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
     assert_eq!(process.get_stack_word(0), Word::from(non_fungible_asset));
 }
 
 #[test]
 fn test_validate_non_fungible_asset() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -113,7 +113,7 @@ fn test_validate_non_fungible_asset() {
         asset = prepare_word(&encoded)
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
     assert_eq!(process.get_stack_word(0), encoded);
 }

--- a/miden-lib/src/tests/test_asset_vault.rs
+++ b/miden-lib/src/tests/test_asset_vault.rs
@@ -19,7 +19,7 @@ use crate::transaction::memory;
 
 #[test]
 fn test_get_balance() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
@@ -36,7 +36,7 @@ fn test_get_balance() {
     "
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -47,7 +47,7 @@ fn test_get_balance() {
 
 #[test]
 fn test_get_balance_non_fungible_fails() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
@@ -63,7 +63,7 @@ fn test_get_balance_non_fungible_fails() {
     "#
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -71,7 +71,7 @@ fn test_get_balance_non_fungible_fails() {
 
 #[test]
 fn test_has_non_fungible_asset() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let non_fungible_asset = tx_inputs.account().vault().assets().next().unwrap();
 
@@ -89,7 +89,7 @@ fn test_has_non_fungible_asset() {
         non_fungible_asset_key = prepare_word(&non_fungible_asset.vault_key())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(process.stack.get(0), ONE);
@@ -97,7 +97,7 @@ fn test_has_non_fungible_asset() {
 
 #[test]
 fn test_add_fungible_asset_success() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let mut account_vault = tx_inputs.account().vault().clone();
 
@@ -120,7 +120,7 @@ fn test_add_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&add_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -136,7 +136,7 @@ fn test_add_fungible_asset_success() {
 
 #[test]
 fn test_add_non_fungible_asset_fail_overflow() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let mut account_vault = tx_inputs.account().vault().clone();
 
@@ -159,7 +159,7 @@ fn test_add_non_fungible_asset_fail_overflow() {
         FUNGIBLE_ASSET = prepare_word(&add_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -168,7 +168,7 @@ fn test_add_non_fungible_asset_fail_overflow() {
 
 #[test]
 fn test_add_non_fungible_asset_success() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let faucet_id: AccountId = ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
@@ -194,7 +194,7 @@ fn test_add_non_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&add_non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -210,7 +210,7 @@ fn test_add_non_fungible_asset_success() {
 
 #[test]
 fn test_add_non_fungible_asset_fail_duplicate() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let faucet_id: AccountId = ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
@@ -234,7 +234,7 @@ fn test_add_non_fungible_asset_fail_duplicate() {
         NON_FUNGIBLE_ASSET = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -243,7 +243,7 @@ fn test_add_non_fungible_asset_fail_duplicate() {
 
 #[test]
 fn test_remove_fungible_asset_success_no_balance_remaining() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let mut account_vault = tx_inputs.account().vault().clone();
 
@@ -266,7 +266,7 @@ fn test_remove_fungible_asset_success_no_balance_remaining() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -282,7 +282,7 @@ fn test_remove_fungible_asset_success_no_balance_remaining() {
 
 #[test]
 fn test_remove_fungible_asset_fail_remove_too_much() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let faucet_id: AccountId = ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
@@ -304,7 +304,7 @@ fn test_remove_fungible_asset_fail_remove_too_much() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -312,7 +312,7 @@ fn test_remove_fungible_asset_fail_remove_too_much() {
 
 #[test]
 fn test_remove_fungible_asset_success_balance_remaining() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let mut account_vault = tx_inputs.account().vault().clone();
 
@@ -335,7 +335,7 @@ fn test_remove_fungible_asset_success_balance_remaining() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -351,7 +351,7 @@ fn test_remove_fungible_asset_success_balance_remaining() {
 
 #[test]
 fn test_remove_inexisting_non_fungible_asset_fails() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let faucet_id: AccountId = ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1.try_into().unwrap();
@@ -382,7 +382,7 @@ fn test_remove_inexisting_non_fungible_asset_fails() {
         FUNGIBLE_ASSET = prepare_word(&non_existent_non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -395,7 +395,7 @@ fn test_remove_inexisting_non_fungible_asset_fails() {
 
 #[test]
 fn test_remove_non_fungible_asset_success() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let faucet_id: AccountId = ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN.try_into().unwrap();
@@ -419,7 +419,7 @@ fn test_remove_non_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(

--- a/miden-lib/src/tests/test_faucet.rs
+++ b/miden-lib/src/tests/test_faucet.rs
@@ -24,7 +24,7 @@ use crate::transaction::memory::FAUCET_STORAGE_DATA_SLOT;
 
 #[test]
 fn test_mint_fungible_asset_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -67,13 +67,13 @@ fn test_mint_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_mint_fungible_asset_fails_not_faucet_account() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
@@ -90,14 +90,14 @@ fn test_mint_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
     assert!(process.is_err());
 }
 
 #[test]
 fn test_mint_fungible_asset_inconsistent_faucet_id() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -120,7 +120,7 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -128,7 +128,7 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() {
 
 #[test]
 fn test_mint_fungible_asset_fails_saturate_max_amount() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -152,7 +152,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() {
         saturating_amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_FAUCET_INITIAL_BALANCE + 1
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -165,7 +165,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() {
 #[ignore]
 #[test]
 fn test_mint_non_fungible_asset_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -213,13 +213,13 @@ fn test_mint_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_mint_non_fungible_asset_fails_not_faucet_account() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN);
 
@@ -238,7 +238,7 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -246,7 +246,7 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() {
 
 #[test]
 fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let non_fungible_asset = non_fungible_asset(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1);
 
@@ -265,7 +265,7 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -273,7 +273,7 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
 
 #[test]
 fn test_mint_non_fungible_asset_fails_asset_already_exists() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -298,7 +298,7 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -309,7 +309,7 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
 
 #[test]
 fn test_burn_fungible_asset_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
             nonce: ONE,
@@ -353,13 +353,13 @@ fn test_burn_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_burn_fungible_asset_fails_not_faucet_account() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = format!(
@@ -376,7 +376,7 @@ fn test_burn_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -384,7 +384,7 @@ fn test_burn_fungible_asset_fails_not_faucet_account() {
 
 #[test]
 fn test_burn_fungible_asset_inconsistent_faucet_id() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -407,14 +407,14 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
     assert!(process.is_err());
 }
 
 #[test]
 fn test_burn_fungible_asset_insufficient_input_amount() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
             nonce: ONE,
@@ -438,7 +438,7 @@ fn test_burn_fungible_asset_insufficient_input_amount() {
         saturating_amount = CONSUMED_ASSET_1_AMOUNT + 1
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -451,7 +451,7 @@ fn test_burn_fungible_asset_insufficient_input_amount() {
 #[ignore]
 #[test]
 fn test_burn_non_fungible_asset_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -499,13 +499,13 @@ fn test_burn_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_burn_non_fungible_asset_fails_does_not_exist() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -535,7 +535,7 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -543,7 +543,7 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() {
 
 #[test]
 fn test_burn_non_fungible_asset_fails_not_faucet_account() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::TooManyNonFungibleInput,
     );
@@ -569,7 +569,7 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -577,7 +577,7 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() {
 
 #[test]
 fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::NonFungibleFaucet {
             acct_id: ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -607,7 +607,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -618,7 +618,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
 
 #[test]
 fn test_get_total_issuance_succeeds() {
-    let tx_inputs = mock_inputs(
+    let (tx_inputs, tx_args) = mock_inputs(
         MockAccountType::FungibleFaucet {
             acct_id: ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
             nonce: ONE,
@@ -647,6 +647,6 @@ fn test_get_total_issuance_succeeds() {
     ",
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }

--- a/miden-lib/src/tests/test_note.rs
+++ b/miden-lib/src/tests/test_note.rs
@@ -15,7 +15,6 @@ use mock::{
     procedures::prepare_word,
     run_tx,
 };
-use vm_processor::AdviceMap;
 
 use super::{ContextId, Felt, Process, ProcessState, ZERO};
 use crate::transaction::memory::CURRENT_CONSUMED_NOTE_PTR;
@@ -351,8 +350,8 @@ fn test_note_script_and_note_args() {
         (tx_inputs.input_notes().get_note(1).note().id(), note_args[0]),
     ]);
 
-    let mut tx_args = TransactionArgs::new(None, Some(note_args_map), AdviceMap::default());
-    tx_args.get_advice_map_mut().extend(tx_args_notes.get_advice_map().clone());
+    let tx_args =
+        TransactionArgs::new(None, Some(note_args_map), tx_args_notes.advice_map().clone());
 
     let transaction = prepare_transaction(tx_inputs.clone(), tx_args, code, None);
     let process = run_tx(&transaction).unwrap();

--- a/miden-lib/src/tests/test_note.rs
+++ b/miden-lib/src/tests/test_note.rs
@@ -15,13 +15,14 @@ use mock::{
     procedures::prepare_word,
     run_tx,
 };
+use vm_processor::AdviceMap;
 
 use super::{ContextId, Felt, Process, ProcessState, ZERO};
 use crate::transaction::memory::CURRENT_CONSUMED_NOTE_PTR;
 
 #[test]
 fn test_get_sender_no_sender() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // calling get_sender should return sender
@@ -41,7 +42,7 @@ fn test_get_sender_no_sender() {
         end
         ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -49,7 +50,7 @@ fn test_get_sender_no_sender() {
 
 #[test]
 fn test_get_sender() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // calling get_sender should return sender
@@ -66,7 +67,7 @@ fn test_get_sender() {
         end
         ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction).unwrap();
 
     let sender = transaction.input_notes().get_note(0).note().metadata().sender().into();
@@ -75,7 +76,7 @@ fn test_get_sender() {
 
 #[test]
 fn test_get_vault_data() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let notes = tx_inputs.input_notes();
@@ -119,13 +120,13 @@ fn test_get_vault_data() {
         note_1_num_assets = notes.get_note(1).note().assets().num_assets(),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_get_assets() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let notes = tx_inputs.input_notes();
 
@@ -225,17 +226,15 @@ fn test_get_assets() {
         NOTE_1_ASSET_ASSERTIONS = construct_asset_assertions(notes.get_note(1).note()),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_get_inputs() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let notes = tx_inputs.input_notes();
-
-    const DEST_POINTER_NOTE_0: u32 = 100000000;
 
     fn construct_input_assertions(note: &Note) -> String {
         let mut code = String::new();
@@ -254,58 +253,56 @@ fn test_get_inputs() {
         code
     }
 
-    let note1 = notes.get_note(0).note();
+    let note0 = notes.get_note(0).note();
 
-    // calling get_assets should return assets at the specified address
     let code = format!(
         "
         use.miden::kernels::tx::prologue
         use.miden::kernels::tx::note->note_internal
         use.miden::note
 
-        proc.process_note_0
+        begin
+            # => [BH, acct_id, IAH, NC]
+            exec.prologue::prepare_transaction
+            # => []
+
+            exec.note_internal::prepare_note
+            # => [NOTE_SCRIPT_ROOT, NOTE_ARGS]
+
             # drop the note inputs
-            dropw
+            dropw dropw
+            # => []
 
-            # set the destination pointer for note 0 assets
-            push.{DEST_POINTER_NOTE_0}
+            push.{NOTE_0_PTR} exec.note::get_inputs
+            # => [num_inputs, dest_ptr]
 
-            # get the assets
-            exec.note::get_inputs
+            eq.{num_inputs} assert
+            # => [dest_ptr]
 
-            # assert the correct num_inputs and pointer is returned
-            eq.{note1_num_inputs} assert
-            dup eq.{DEST_POINTER_NOTE_0} assert
+            dup eq.{NOTE_0_PTR} assert
+            # => [dest_ptr]
 
             # apply note 1 input assertions
-            {note1_input_assertions}
+            {input_assertions}
+            # => [dest_ptr]
 
             # clean the pointer
             drop
-        end
-
-        begin
-            # prepare tx
-            exec.prologue::prepare_transaction
-
-            # prepare note 0
-            exec.note_internal::prepare_note
-
-            # process note 0
-            call.process_note_0
+            # => []
         end
         ",
-        note1_num_inputs = note1.inputs().num_values(),
-        note1_input_assertions = construct_input_assertions(note1),
+        num_inputs = note0.inputs().num_values(),
+        input_assertions = construct_input_assertions(note0),
+        NOTE_0_PTR = 100000000,
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
 #[test]
 fn test_note_setup() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = "
@@ -318,7 +315,7 @@ fn test_note_setup() {
         end
         ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction).unwrap();
 
     note_setup_stack_assertions(&process, &transaction);
@@ -332,7 +329,7 @@ fn test_note_script_and_note_args() {
         [Felt::new(92), Felt::new(92), Felt::new(92), Felt::new(92)],
     ];
 
-    let tx_inputs =
+    let (tx_inputs, tx_args_notes) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = "
@@ -354,9 +351,10 @@ fn test_note_script_and_note_args() {
         (tx_inputs.input_notes().get_note(1).note().id(), note_args[0]),
     ]);
 
-    let tx_args = TransactionArgs::new(None, Some(note_args_map));
+    let mut tx_args = TransactionArgs::new(None, Some(note_args_map), AdviceMap::default());
+    tx_args.get_advice_map_mut().extend(tx_args_notes.get_advice_map().clone());
 
-    let transaction = prepare_transaction(tx_inputs.clone(), Some(tx_args), code, None);
+    let transaction = prepare_transaction(tx_inputs.clone(), tx_args, code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(process.stack.get_word(0), note_args[0]);

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -15,7 +15,7 @@ use mock::{
     },
     prepare_transaction, run_tx, run_tx_with_inputs,
 };
-use vm_processor::AdviceInputs;
+use vm_processor::{AdviceInputs, AdviceMap};
 
 use super::{build_module_path, ContextId, Felt, Process, ProcessState, Word, TX_KERNEL_DIR, ZERO};
 use crate::transaction::{
@@ -42,7 +42,7 @@ const PROLOGUE_FILE: &str = "prologue.masm";
 
 #[test]
 fn test_transaction_prologue() {
-    let tx_inputs =
+    let (tx_inputs, tx_args_notes) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let code = "
@@ -75,10 +75,11 @@ fn test_transaction_prologue() {
         (tx_inputs.input_notes().get_note(1).note().id(), note_args[1]),
     ]);
 
-    let tx_args = TransactionArgs::new(Some(tx_script), Some(note_args_map));
+    let mut tx_args =
+        TransactionArgs::new(Some(tx_script), Some(note_args_map), AdviceMap::default());
+    tx_args.get_advice_map_mut().extend(tx_args_notes.get_advice_map().clone());
 
-    let transaction =
-        prepare_transaction(tx_inputs.clone(), Some(tx_args), code, Some(assembly_file));
+    let transaction = prepare_transaction(tx_inputs.clone(), tx_args, code, Some(assembly_file));
 
     let process = run_tx(&transaction).unwrap();
 
@@ -340,7 +341,7 @@ fn consumed_notes_memory_assertions(
 pub fn test_prologue_create_account() {
     let (_acct_id, account_seed) =
         generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
-    let tx_inputs = mock_inputs_with_account_seed(
+    let (tx_inputs, tx_args) = mock_inputs_with_account_seed(
         MockAccountType::StandardNew,
         AssetPreservationStatus::Preserved,
         Some(account_seed),
@@ -353,7 +354,7 @@ pub fn test_prologue_create_account() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let _process = run_tx(&transaction).unwrap();
 }
 
@@ -362,7 +363,7 @@ pub fn test_prologue_create_account() {
 pub fn test_prologue_create_account_valid_fungible_faucet_reserved_slot() {
     let (acct_id, account_seed) =
         generate_account_seed(AccountSeedType::FungibleFaucetValidInitialBalance);
-    let tx_inputs = mock_inputs_with_account_seed(
+    let (tx_inputs, tx_args) = mock_inputs_with_account_seed(
         MockAccountType::FungibleFaucet {
             acct_id: acct_id.into(),
             nonce: ZERO,
@@ -379,7 +380,7 @@ pub fn test_prologue_create_account_valid_fungible_faucet_reserved_slot() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_ok());
@@ -390,7 +391,7 @@ pub fn test_prologue_create_account_valid_fungible_faucet_reserved_slot() {
 pub fn test_prologue_create_account_invalid_fungible_faucet_reserved_slot() {
     let (acct_id, account_seed) =
         generate_account_seed(AccountSeedType::FungibleFaucetInvalidInitialBalance);
-    let tx_inputs = mock_inputs_with_account_seed(
+    let (tx_inputs, tx_args) = mock_inputs_with_account_seed(
         MockAccountType::FungibleFaucet {
             acct_id: acct_id.into(),
             nonce: ZERO,
@@ -407,7 +408,7 @@ pub fn test_prologue_create_account_invalid_fungible_faucet_reserved_slot() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err());
@@ -418,7 +419,7 @@ pub fn test_prologue_create_account_invalid_fungible_faucet_reserved_slot() {
 pub fn test_prologue_create_account_valid_non_fungible_faucet_reserved_slot() {
     let (acct_id, account_seed) =
         generate_account_seed(AccountSeedType::NonFungibleFaucetValidReservedSlot);
-    let tx_inputs = mock_inputs_with_account_seed(
+    let (tx_inputs, tx_args) = mock_inputs_with_account_seed(
         MockAccountType::NonFungibleFaucet {
             acct_id: acct_id.into(),
             nonce: ZERO,
@@ -435,7 +436,7 @@ pub fn test_prologue_create_account_valid_non_fungible_faucet_reserved_slot() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_ok())
@@ -446,7 +447,7 @@ pub fn test_prologue_create_account_valid_non_fungible_faucet_reserved_slot() {
 pub fn test_prologue_create_account_invalid_non_fungible_faucet_reserved_slot() {
     let (acct_id, account_seed) =
         generate_account_seed(AccountSeedType::NonFungibleFaucetInvalidReservedSlot);
-    let tx_inputs = mock_inputs_with_account_seed(
+    let (tx_inputs, tx_args) = mock_inputs_with_account_seed(
         MockAccountType::NonFungibleFaucet {
             acct_id: acct_id.into(),
             nonce: ZERO,
@@ -463,7 +464,7 @@ pub fn test_prologue_create_account_invalid_non_fungible_faucet_reserved_slot() 
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     let process = run_tx(&transaction);
     assert!(process.is_err());
 }
@@ -473,7 +474,7 @@ pub fn test_prologue_create_account_invalid_non_fungible_faucet_reserved_slot() 
 pub fn test_prologue_create_account_invalid_seed() {
     let (_acct_id, account_seed) =
         generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
-    let tx_inputs = mock_inputs_with_account_seed(
+    let (tx_inputs, tx_args) = mock_inputs_with_account_seed(
         MockAccountType::StandardNew,
         AssetPreservationStatus::Preserved,
         Some(account_seed),
@@ -488,7 +489,7 @@ pub fn test_prologue_create_account_invalid_seed() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs, None, code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, code, None);
     //let (program, stack_inputs, mut advice_provider) = build_tx_inputs(&transaction);
 
     // lets override the seed with an invalid seed to ensure the kernel fails
@@ -501,7 +502,7 @@ pub fn test_prologue_create_account_invalid_seed() {
 
 #[test]
 fn test_get_blk_version() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let code = "
     use.miden::kernels::tx::memory
@@ -513,7 +514,7 @@ fn test_get_blk_version() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs.clone(), None, code, None);
+    let transaction = prepare_transaction(tx_inputs.clone(), tx_args, code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(process.stack.get(0), tx_inputs.block_header().version());
@@ -521,7 +522,7 @@ fn test_get_blk_version() {
 
 #[test]
 fn test_get_blk_timestamp() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let code = "
     use.miden::kernels::tx::memory
@@ -533,7 +534,7 @@ fn test_get_blk_timestamp() {
     end
     ";
 
-    let transaction = prepare_transaction(tx_inputs.clone(), None, code, None);
+    let transaction = prepare_transaction(tx_inputs.clone(), tx_args, code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(process.stack.get(0), tx_inputs.block_header().timestamp());

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -15,7 +15,7 @@ use mock::{
     },
     prepare_transaction, run_tx, run_tx_with_inputs,
 };
-use vm_processor::{AdviceInputs, AdviceMap};
+use vm_processor::AdviceInputs;
 
 use super::{build_module_path, ContextId, Felt, Process, ProcessState, Word, TX_KERNEL_DIR, ZERO};
 use crate::transaction::{
@@ -75,9 +75,11 @@ fn test_transaction_prologue() {
         (tx_inputs.input_notes().get_note(1).note().id(), note_args[1]),
     ]);
 
-    let mut tx_args =
-        TransactionArgs::new(Some(tx_script), Some(note_args_map), AdviceMap::default());
-    tx_args.get_advice_map_mut().extend(tx_args_notes.get_advice_map().clone());
+    let tx_args = TransactionArgs::new(
+        Some(tx_script),
+        Some(note_args_map),
+        tx_args_notes.advice_map().clone(),
+    );
 
     let transaction = prepare_transaction(tx_inputs.clone(), tx_args, code, Some(assembly_file));
 

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -25,7 +25,7 @@ use crate::transaction::memory::{
 
 #[test]
 fn test_create_note() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
     let account_id = tx_inputs.account().id();
 
@@ -55,7 +55,7 @@ fn test_create_note() {
         asset = prepare_word(&asset),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(
@@ -98,7 +98,7 @@ fn test_create_note() {
 
 #[test]
 fn test_create_note_with_invalid_tag() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     let recipient = [ZERO, ONE, Felt::new(2), Felt::new(3)];
@@ -127,7 +127,7 @@ fn test_create_note_with_invalid_tag() {
         asset = prepare_word(&asset),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction);
 
     assert!(process.is_err(), "Transaction should have failed because the tag is invalid");
@@ -172,7 +172,7 @@ fn test_create_note_too_many_notes() {
 
 #[test]
 fn test_get_output_notes_hash() {
-    let tx_inputs =
+    let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
     // extract input note data
@@ -259,7 +259,7 @@ fn test_get_output_notes_hash() {
         )),
     );
 
-    let transaction = prepare_transaction(tx_inputs, None, &code, None);
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
     let process = run_tx(&transaction).unwrap();
 
     assert_eq!(

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -94,7 +94,7 @@ fn extend_advice_inputs(
     add_chain_mmr_to_advice_inputs(tx_inputs.block_chain(), advice_inputs);
     add_account_to_advice_inputs(tx_inputs.account(), tx_inputs.account_seed(), advice_inputs);
     add_input_notes_to_advice_inputs(tx_inputs.input_notes(), tx_args, advice_inputs);
-    advice_inputs.extend_map(tx_args.get_advice_map().clone());
+    advice_inputs.extend_map(tx_args.advice_map().clone());
     add_tx_script_inputs_to_advice_map(tx_args.tx_script(), advice_inputs);
 }
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -94,6 +94,7 @@ fn extend_advice_inputs(
     add_chain_mmr_to_advice_inputs(tx_inputs.block_chain(), advice_inputs);
     add_account_to_advice_inputs(tx_inputs.account(), tx_inputs.account_seed(), advice_inputs);
     add_input_notes_to_advice_inputs(tx_inputs.input_notes(), tx_args, advice_inputs);
+    advice_inputs.extend_map(tx_args.get_advice_map().clone());
     add_tx_script_inputs_to_advice_map(tx_args.tx_script(), advice_inputs);
 }
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -95,7 +95,6 @@ fn extend_advice_inputs(
     add_account_to_advice_inputs(tx_inputs.account(), tx_inputs.account_seed(), advice_inputs);
     add_input_notes_to_advice_inputs(tx_inputs.input_notes(), tx_args, advice_inputs);
     advice_inputs.extend_map(tx_args.advice_map().clone());
-    add_tx_script_inputs_to_advice_map(tx_args.tx_script(), advice_inputs);
 }
 
 // ADVICE STACK BUILDER
@@ -336,18 +335,4 @@ fn add_input_notes_to_advice_inputs(
 
     // insert the combined note data into the advice map
     inputs.extend_map([(notes.commitment(), note_data)]);
-}
-
-// TRANSACTION SCRIPT INJECTOR
-// ------------------------------------------------------------------------------------------------
-
-/// Inserts the following entries into the advice map:
-/// - input_hash |-> input, for each tx_script input
-fn add_tx_script_inputs_to_advice_map(
-    tx_script: Option<&TransactionScript>,
-    inputs: &mut AdviceInputs,
-) {
-    if let Some(tx_script) = tx_script {
-        inputs.extend_map(tx_script.inputs().iter().map(|(hash, input)| (*hash, input.clone())));
-    }
 }

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -141,10 +141,9 @@ impl<D: DataStore> TransactionExecutor<D> {
         account_id: AccountId,
         block_ref: u32,
         notes: &[NoteId],
-        tx_args: Option<TransactionArgs>,
+        tx_args: TransactionArgs,
     ) -> Result<ExecutedTransaction, TransactionExecutorError> {
-        let transaction =
-            self.prepare_transaction(account_id, block_ref, notes, tx_args.unwrap_or_default())?;
+        let transaction = self.prepare_transaction(account_id, block_ref, notes, tx_args)?;
 
         let (stack_inputs, advice_inputs) = transaction.get_kernel_inputs();
         let advice_recorder: RecAdviceProvider = advice_inputs.into();

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -100,10 +100,10 @@ impl<A: AdviceProvider> TransactionHost<A> {
                 return Err(TransactionKernelError::MalformedRecipientData(data.to_vec()));
             }
             let inputs_hash = Digest::new([data[0], data[1], data[2], data[3]]);
-            let script_root = Digest::new([data[4], data[5], data[6], data[7]]);
+            let script_hash = Digest::new([data[4], data[5], data[6], data[7]]);
             let serial_num = [data[8], data[9], data[10], data[11]];
             let input_els = self.adv_provider.get_mapped_values(&inputs_hash);
-            let script_data = self.adv_provider.get_mapped_values(&script_root).unwrap_or(&[]);
+            let script_data = self.adv_provider.get_mapped_values(&script_hash).unwrap_or(&[]);
 
             let inputs = NoteInputs::new(input_els.map(|e| e.to_vec()).unwrap_or_default())
                 .map_err(TransactionKernelError::MalformedNoteInputs)?;

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -210,8 +210,8 @@ fn executed_transaction_account_delta() {
     );
     let tx_script_code = ProgramAst::parse(&tx_script).unwrap();
     let tx_script = executor.compile_tx_script(tx_script_code, vec![], vec![]).unwrap();
-    let mut tx_args = TransactionArgs::with_tx_script(tx_script);
-    tx_args.get_advice_map_mut().extend(data_store.tx_args.get_advice_map().clone());
+    let tx_args =
+        TransactionArgs::new(Some(tx_script), None, data_store.tx_args.advice_map().clone());
 
     let block_ref = data_store.block_header.block_num();
     let note_ids = data_store.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -340,8 +340,8 @@ fn test_tx_script() {
             vec![],
         )
         .unwrap();
-    let mut tx_args = TransactionArgs::with_tx_script(tx_script);
-    tx_args.get_advice_map_mut().extend(data_store.tx_args.get_advice_map().clone());
+    let tx_args =
+        TransactionArgs::new(Some(tx_script), None, data_store.tx_args.advice_map().clone());
 
     let executed_transaction =
         executor.execute_transaction(account_id, block_ref, &note_ids, tx_args);

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -79,7 +79,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     let tx_args = TransactionArgs::with_tx_script(tx_script);
 
     let executed_transaction = executor
-        .execute_transaction(faucet_account.id(), block_ref, &note_ids, Some(tx_args))
+        .execute_transaction(faucet_account.id(), block_ref, &note_ids, tx_args)
         .unwrap();
 
     assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());
@@ -152,7 +152,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
 
     // Execute the transaction and get the witness
     let executed_transaction =
-        executor.execute_transaction(faucet_account.id(), block_ref, &note_ids, Some(tx_args));
+        executor.execute_transaction(faucet_account.id(), block_ref, &note_ids, tx_args);
 
     assert!(executed_transaction.is_err());
 }
@@ -210,7 +210,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
-        .execute_transaction(faucet_account.id(), block_ref, &note_ids, None)
+        .execute_transaction(faucet_account.id(), block_ref, &note_ids, data_store.tx_args.clone())
         .unwrap();
 
     // Prove, serialize/deserialize and verify the transaction

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -15,7 +15,6 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use mock::mock::account::DEFAULT_AUTH_SCRIPT;
-use vm_processor::AdviceMap;
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map,
@@ -71,7 +70,7 @@ fn prove_p2id_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
+    let tx_args_target = TransactionArgs::with_tx_script(tx_script_target);
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
@@ -113,8 +112,7 @@ fn prove_p2id_script() {
         )
         .unwrap();
 
-    let tx_args_malicious =
-        TransactionArgs::new(Some(tx_script_malicious), None, AdviceMap::default());
+    let tx_args_malicious = TransactionArgs::with_tx_script(tx_script_malicious);
 
     let block_ref = data_store_malicious_account.block_header.block_num();
     let note_ids = data_store_malicious_account
@@ -185,7 +183,7 @@ fn p2id_script_multiple_assets() {
         )
         .unwrap();
 
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
+    let tx_args_target = TransactionArgs::with_tx_script(tx_script_target);
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
@@ -223,8 +221,7 @@ fn p2id_script_multiple_assets() {
             vec![],
         )
         .unwrap();
-    let tx_args_malicious =
-        TransactionArgs::new(Some(tx_script_malicious), None, AdviceMap::default());
+    let tx_args_malicious = TransactionArgs::with_tx_script(tx_script_malicious);
 
     let block_ref = data_store_malicious_account.block_header.block_num();
     let note_origins = data_store_malicious_account

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -1,4 +1,4 @@
-use miden_lib::notes::create_p2id_note;
+use miden_lib::{notes::create_p2id_note, transaction::TransactionKernel};
 use miden_objects::{
     accounts::{
         Account, AccountId, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
@@ -9,12 +9,13 @@ use miden_objects::{
     assembly::ProgramAst,
     assets::{Asset, AssetVault, FungibleAsset},
     crypto::rand::RpoRandomCoin,
-    notes::NoteType,
+    notes::{NoteScript, NoteType},
     transaction::TransactionArgs,
     Felt,
 };
 use miden_tx::TransactionExecutor;
 use mock::mock::account::DEFAULT_AUTH_SCRIPT;
+use vm_processor::AdviceMap;
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map,
@@ -70,11 +71,11 @@ fn prove_p2id_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None);
+    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
-        .execute_transaction(target_account_id, block_ref, &note_ids, Some(tx_args_target))
+        .execute_transaction(target_account_id, block_ref, &note_ids, tx_args_target)
         .unwrap();
 
     // Prove, serialize/deserialize and verify the transaction
@@ -112,7 +113,8 @@ fn prove_p2id_script() {
         )
         .unwrap();
 
-    let tx_args_malicious = TransactionArgs::new(Some(tx_script_malicious), None);
+    let tx_args_malicious =
+        TransactionArgs::new(Some(tx_script_malicious), None, AdviceMap::default());
 
     let block_ref = data_store_malicious_account.block_header.block_num();
     let note_ids = data_store_malicious_account
@@ -126,7 +128,7 @@ fn prove_p2id_script() {
         malicious_account_id,
         block_ref,
         &note_ids,
-        Some(tx_args_malicious),
+        tx_args_malicious,
     );
 
     // Check that we got the expected result - TransactionExecutorError
@@ -183,11 +185,11 @@ fn p2id_script_multiple_assets() {
         )
         .unwrap();
 
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None);
+    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
-        .execute_transaction(target_account_id, block_ref, &note_ids, Some(tx_args_target))
+        .execute_transaction(target_account_id, block_ref, &note_ids, tx_args_target)
         .unwrap();
 
     // vault delta
@@ -221,7 +223,8 @@ fn p2id_script_multiple_assets() {
             vec![],
         )
         .unwrap();
-    let tx_args_malicious = TransactionArgs::new(Some(tx_script_malicious), None);
+    let tx_args_malicious =
+        TransactionArgs::new(Some(tx_script_malicious), None, AdviceMap::default());
 
     let block_ref = data_store_malicious_account.block_header.block_num();
     let note_origins = data_store_malicious_account
@@ -235,9 +238,22 @@ fn p2id_script_multiple_assets() {
         malicious_account_id,
         block_ref,
         &note_origins,
-        Some(tx_args_malicious),
+        tx_args_malicious,
     );
 
     // Check that we got the expected result - TransactionExecutorError
     assert!(executed_transaction_2.is_err());
+}
+
+#[test]
+fn test_note_script_to_from_felt() {
+    let assembler = TransactionKernel::assembler();
+
+    let note_program_ast = ProgramAst::parse("begin push.1 drop end").unwrap();
+    let (note_script, _) = NoteScript::new(note_program_ast, &assembler).unwrap();
+
+    let encoded: Vec<Felt> = (&note_script).into();
+    let decoded: NoteScript = encoded.try_into().unwrap();
+
+    assert_eq!(note_script, decoded);
 }

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -14,7 +14,6 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use mock::mock::account::DEFAULT_AUTH_SCRIPT;
-use vm_processor::AdviceMap;
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map, MockDataStore,
@@ -108,7 +107,7 @@ fn p2idr_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
+    let tx_args_target = TransactionArgs::with_tx_script(tx_script_target);
 
     // Execute the transaction and get the witness
     let executed_transaction_1 = executor_1
@@ -140,7 +139,7 @@ fn p2idr_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_sender = TransactionArgs::new(Some(tx_script_sender), None, AdviceMap::default());
+    let tx_args_sender = TransactionArgs::with_tx_script(tx_script_sender);
 
     let block_ref_2 = data_store_2.block_header.block_num();
     let note_ids_2 = data_store_2.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -172,8 +171,7 @@ fn p2idr_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_malicious =
-        TransactionArgs::new(Some(tx_script_malicious), None, AdviceMap::default());
+    let tx_args_malicious = TransactionArgs::with_tx_script(tx_script_malicious);
 
     let block_ref_3 = data_store_3.block_header.block_num();
     let note_ids_3 = data_store_3.notes.iter().map(|note| note.id()).collect::<Vec<_>>();

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -14,6 +14,7 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use mock::mock::account::DEFAULT_AUTH_SCRIPT;
+use vm_processor::AdviceMap;
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map, MockDataStore,
@@ -107,16 +108,11 @@ fn p2idr_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None);
+    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
 
     // Execute the transaction and get the witness
     let executed_transaction_1 = executor_1
-        .execute_transaction(
-            target_account_id,
-            block_ref_1,
-            &note_ids,
-            Some(tx_args_target.clone()),
-        )
+        .execute_transaction(target_account_id, block_ref_1, &note_ids, tx_args_target.clone())
         .unwrap();
 
     // Assert that the target_account received the funds and the nonce increased by 1
@@ -144,7 +140,7 @@ fn p2idr_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_sender = TransactionArgs::new(Some(tx_script_sender), None);
+    let tx_args_sender = TransactionArgs::new(Some(tx_script_sender), None, AdviceMap::default());
 
     let block_ref_2 = data_store_2.block_header.block_num();
     let note_ids_2 = data_store_2.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -154,7 +150,7 @@ fn p2idr_script() {
         sender_account_id,
         block_ref_2,
         &note_ids_2,
-        Some(tx_args_sender.clone()),
+        tx_args_sender.clone(),
     );
 
     // Check that we got the expected result - TransactionExecutorError and not ExecutedTransaction
@@ -176,7 +172,8 @@ fn p2idr_script() {
             vec![],
         )
         .unwrap();
-    let tx_args_malicious = TransactionArgs::new(Some(tx_script_malicious), None);
+    let tx_args_malicious =
+        TransactionArgs::new(Some(tx_script_malicious), None, AdviceMap::default());
 
     let block_ref_3 = data_store_3.block_header.block_num();
     let note_ids_3 = data_store_3.notes.iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -186,7 +183,7 @@ fn p2idr_script() {
         malicious_account_id,
         block_ref_3,
         &note_ids_3,
-        Some(tx_args_malicious.clone()),
+        tx_args_malicious.clone(),
     );
 
     // Check that we got the expected result - TransactionExecutorError and not ExecutedTransaction
@@ -207,7 +204,7 @@ fn p2idr_script() {
 
     // Execute the transaction and get the witness
     let executed_transaction_4 = executor_4
-        .execute_transaction(target_account_id, block_ref_4, &note_ids_4, Some(tx_args_target))
+        .execute_transaction(target_account_id, block_ref_4, &note_ids_4, tx_args_target)
         .unwrap();
 
     // Check that we got the expected result - ExecutedTransaction
@@ -240,7 +237,7 @@ fn p2idr_script() {
 
     // Execute the transaction and get the witness
     let executed_transaction_5 = executor_5
-        .execute_transaction(sender_account_id, block_ref_5, &note_ids_5, Some(tx_args_sender))
+        .execute_transaction(sender_account_id, block_ref_5, &note_ids_5, tx_args_sender)
         .unwrap();
 
     // Assert that the sender_account received the funds and the nonce increased by 1
@@ -275,7 +272,7 @@ fn p2idr_script() {
         malicious_account_id,
         block_ref_6,
         &note_ids_6,
-        Some(tx_args_malicious),
+        tx_args_malicious,
     );
 
     // Check that we got the expected result - TransactionExecutorError and not ExecutedTransaction

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -14,7 +14,6 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use mock::mock::account::DEFAULT_AUTH_SCRIPT;
-use vm_processor::AdviceMap;
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map,
@@ -71,7 +70,7 @@ fn prove_swap_script() {
     let tx_script_target = executor
         .compile_tx_script(tx_script_code.clone(), vec![(target_pub_key, target_sk_felt)], vec![])
         .unwrap();
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
+    let tx_args_target = TransactionArgs::with_tx_script(tx_script_target);
 
     let executed_transaction = executor
         .execute_transaction(target_account_id, block_ref, &note_ids, tx_args_target)

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -14,6 +14,7 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use mock::mock::account::DEFAULT_AUTH_SCRIPT;
+use vm_processor::AdviceMap;
 
 use crate::{
     get_account_with_default_account_code, get_new_key_pair_with_advice_map,
@@ -70,10 +71,10 @@ fn prove_swap_script() {
     let tx_script_target = executor
         .compile_tx_script(tx_script_code.clone(), vec![(target_pub_key, target_sk_felt)], vec![])
         .unwrap();
-    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None);
+    let tx_args_target = TransactionArgs::new(Some(tx_script_target), None, AdviceMap::default());
 
     let executed_transaction = executor
-        .execute_transaction(target_account_id, block_ref, &note_ids, Some(tx_args_target))
+        .execute_transaction(target_account_id, block_ref, &note_ids, tx_args_target)
         .expect("Transaction consuming swap note failed");
 
     // Prove, serialize/deserialize and verify the transaction

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -74,7 +74,7 @@ fn prove_receive_asset_via_wallet() {
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
-        .execute_transaction(target_account.id(), block_ref, &note_ids, Some(tx_args))
+        .execute_transaction(target_account.id(), block_ref, &note_ids, tx_args)
         .unwrap();
 
     // Prove, serialize/deserialize and verify the transaction
@@ -102,12 +102,8 @@ fn prove_receive_asset_via_wallet() {
 }
 
 #[test]
-#[ignore]
 /// Testing the basic Miden wallet - sending an asset
 fn prove_send_asset_via_wallet() {
-    // Mock data
-    // We need an asset and an account that owns that asset
-    // Create assets
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
     let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
 
@@ -149,7 +145,7 @@ fn prove_send_asset_via_wallet() {
         end
         ",
             recipient = prepare_word(&recipient),
-            note_type = NoteType::Public as u8,
+            note_type = NoteType::OffChain as u8,
             tag = tag,
             asset = prepare_word(&fungible_asset_1.into())
         )
@@ -161,12 +157,10 @@ fn prove_send_asset_via_wallet() {
         .unwrap();
     let tx_args: TransactionArgs = TransactionArgs::with_tx_script(tx_script);
 
-    // Execute the transaction and get the witness
     let executed_transaction = executor
-        .execute_transaction(sender_account.id(), block_ref, &note_ids, Some(tx_args))
+        .execute_transaction(sender_account.id(), block_ref, &note_ids, tx_args)
         .unwrap();
 
-    // Prove, serialize/deserialize and verify the transaction
     assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());
 
     // clones account info

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -129,7 +129,7 @@ pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
 #[cfg(feature = "std")]
 pub fn prepare_transaction(
     tx_inputs: TransactionInputs,
-    tx_args: Option<TransactionArgs>,
+    tx_args: TransactionArgs,
     code: &str,
     file_path: Option<PathBuf>,
 ) -> PreparedTransaction {
@@ -142,6 +142,5 @@ pub fn prepare_transaction(
 
     let program = assembler.compile(code).unwrap();
 
-    let tx_args = tx_args.unwrap_or_default();
     PreparedTransaction::new(program, tx_inputs, tx_args)
 }

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -117,7 +117,7 @@ impl TransactionArgs {
     }
 
     /// Returns a reference to the args [AdviceMap].
-    pub fn get_advice_map(&self) -> &AdviceMap {
+    pub fn advice_map(&self) -> &AdviceMap {
         &self.advice_map
     }
 

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -120,11 +120,6 @@ impl TransactionArgs {
     pub fn advice_map(&self) -> &AdviceMap {
         &self.advice_map
     }
-
-    /// Returns a mutable reference to the args [AdviceMap].
-    pub fn get_advice_map_mut(&mut self) -> &mut AdviceMap {
-        &mut self.advice_map
-    }
 }
 
 // TRANSACTION SCRIPT

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -1,9 +1,11 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
+use vm_processor::AdviceMap;
+
 use super::{Digest, Felt, Word};
 use crate::{
     assembly::{Assembler, AssemblyContext, ProgramAst},
-    notes::NoteId,
+    notes::{Note, NoteId},
     vm::CodeBlock,
     TransactionScriptError,
 };
@@ -13,16 +15,17 @@ use crate::{
 
 /// A struct that represents optional transaction arguments.
 ///
-/// Transaction arguments consist of:
 /// - Transaction script: a program that is executed in a transaction after all input notes
 ///   scripts have been executed.
 /// - Note arguments: data put onto the the stack right before a note script is executed. These
 ///   are different from note inputs, as the user executing the transaction can specify arbitrary
 ///   note args.
+/// - Advice map: Provides data needed by the runtime, like the details of a public note.
 #[derive(Clone, Debug, Default)]
 pub struct TransactionArgs {
     tx_script: Option<TransactionScript>,
     note_args: BTreeMap<NoteId, Word>,
+    advice_map: AdviceMap,
 }
 
 impl TransactionArgs {
@@ -34,10 +37,12 @@ impl TransactionArgs {
     pub fn new(
         tx_script: Option<TransactionScript>,
         note_args: Option<BTreeMap<NoteId, Word>>,
+        advice_map: AdviceMap,
     ) -> Self {
         Self {
             tx_script,
             note_args: note_args.unwrap_or_default(),
+            advice_map,
         }
     }
 
@@ -46,12 +51,56 @@ impl TransactionArgs {
         Self {
             tx_script: Some(tx_script),
             note_args: BTreeMap::default(),
+            advice_map: AdviceMap::default(),
         }
     }
 
     /// Returns new [TransactionArgs] instantiated with the provided note arguments.
     pub fn with_note_args(not_args: BTreeMap<NoteId, Word>) -> Self {
-        Self { tx_script: None, note_args: not_args }
+        Self {
+            tx_script: None,
+            note_args: not_args,
+            advice_map: AdviceMap::default(),
+        }
+    }
+
+    // MODIFIERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Populates the advice inputs with the details of [Note]s.
+    ///
+    /// The map is extended with the following keys:
+    ///
+    /// - recipient |-> recipient details (inputs_hash, script_hash, serial_num)
+    /// - intputs_hash |-> inputs
+    /// - script_hash |-> script
+    ///
+    pub fn add_expected_output_note(&mut self, note: &Note) {
+        let recipient = note.recipient();
+        let inputs = note.inputs();
+        let script = note.script();
+        let script_encoded: Vec<Felt> = script.into();
+
+        self.advice_map.insert(recipient.digest(), recipient.to_elements());
+        self.advice_map.insert(inputs.commitment(), inputs.to_padded_values());
+        self.advice_map.insert(script.hash(), script_encoded);
+    }
+
+    /// Populates the advice inputs with the details of [Note]s.
+    ///
+    /// The map is extended with the following keys:
+    ///
+    /// - recipient |-> recipient details (inputs_hash, script_hash, serial_num)
+    /// - intputs_hash |-> inputs
+    /// - script_hash |-> script
+    ///
+    pub fn extend_expected_output_notes<T>(&mut self, notes: T)
+    where
+        T: IntoIterator<Item = Note>,
+    {
+        for note in notes {
+            self.add_expected_output_note(&note);
+        }
     }
 
     // PUBLIC ACCESSORS
@@ -65,6 +114,16 @@ impl TransactionArgs {
     /// Returns a reference to a specific note argument.
     pub fn get_note_args(&self, note_id: NoteId) -> Option<&Word> {
         self.note_args.get(&note_id)
+    }
+
+    /// Returns a reference to the args [AdviceMap].
+    pub fn get_advice_map(&self) -> &AdviceMap {
+        &self.advice_map
+    }
+
+    /// Returns a mutable reference to the args [AdviceMap].
+    pub fn get_advice_map_mut(&mut self) -> &mut AdviceMap {
+        &mut self.advice_map
     }
 }
 

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -34,11 +34,19 @@ impl TransactionArgs {
 
     /// Returns new [TransactionArgs] instantiated with the provided transaction script and note
     /// arguments.
+    ///
+    /// If tx_script is provided, this also adds all mappings from the transaction script inputs
+    /// to the advice map.
     pub fn new(
         tx_script: Option<TransactionScript>,
         note_args: Option<BTreeMap<NoteId, Word>>,
-        advice_map: AdviceMap,
+        mut advice_map: AdviceMap,
     ) -> Self {
+        // add transaction script inputs to the advice map
+        if let Some(ref tx_script) = tx_script {
+            advice_map.extend(tx_script.inputs().iter().map(|(hash, input)| (*hash, input.clone())))
+        }
+
         Self {
             tx_script,
             note_args: note_args.unwrap_or_default(),
@@ -48,20 +56,12 @@ impl TransactionArgs {
 
     /// Returns new [TransactionArgs] instantiated with the provided transaction script.
     pub fn with_tx_script(tx_script: TransactionScript) -> Self {
-        Self {
-            tx_script: Some(tx_script),
-            note_args: BTreeMap::default(),
-            advice_map: AdviceMap::default(),
-        }
+        Self::new(Some(tx_script), Some(BTreeMap::default()), AdviceMap::default())
     }
 
     /// Returns new [TransactionArgs] instantiated with the provided note arguments.
-    pub fn with_note_args(not_args: BTreeMap<NoteId, Word>) -> Self {
-        Self {
-            tx_script: None,
-            note_args: not_args,
-            advice_map: AdviceMap::default(),
-        }
+    pub fn with_note_args(note_args: BTreeMap<NoteId, Word>) -> Self {
+        Self::new(None, Some(note_args), AdviceMap::default())
     }
 
     // MODIFIERS


### PR DESCRIPTION
There were two bugs in the `NoteScript` encoding to `Vec<Felt>`. One off-by-one in the encoder, and a broken offset in the decoder.  This PR fixes both issues and adds a test.

This also re-enables the tests disabled by https://github.com/0xPolygonMiden/miden-base/pull/572 