### PR TITLE
fix: Account details propagation

### DIFF
--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use std::println;
 
 use miden_objects::{
     accounts::Account,

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use std::println;
 
 use miden_objects::{
     accounts::Account,
@@ -58,6 +59,7 @@ impl ToTransactionKernelInputs for ExecutedTransaction {
 impl ToTransactionKernelInputs for TransactionWitness {
     fn get_kernel_inputs(&self) -> (StackInputs, AdviceInputs) {
         let account = self.account();
+
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.proof_init_hash(),

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -72,6 +72,7 @@ impl std::error::Error for TransactionExecutorError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransactionProverError {
     ProveTransactionProgramFailed(ExecutionError),
+    InvalidAccountDelta(AccountError),
     InvalidTransactionOutput(TransactionOutputError),
     ProvenTransactionError(ProvenTransactionError),
 }
@@ -81,6 +82,9 @@ impl Display for TransactionProverError {
         match self {
             TransactionProverError::ProveTransactionProgramFailed(inner) => {
                 write!(f, "Proving transaction failed: {}", inner)
+            },
+            TransactionProverError::InvalidAccountDelta(account_error) => {
+                write!(f, "Applying account delta failed: {}", account_error)
             },
             TransactionProverError::InvalidTransactionOutput(inner) => {
                 write!(f, "Transaction ouptut invalid: {}", inner)

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -363,13 +363,13 @@ pub enum ProvenTransactionError {
 impl fmt::Display for ProvenTransactionError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            ProvenTransactionError::AccountFinalHashMismatch(tx_digest, details_hash) => {
-                write!(f, "Proven transaction account_final_hash {} and account_details.hash must match {}.", tx_digest, details_hash)
+            ProvenTransactionError::AccountFinalHashMismatch(account_final_hash, details_hash) => {
+                write!(f, "Proven transaction account_final_hash {} and account_details.hash must match {}.", account_final_hash, details_hash)
             },
             ProvenTransactionError::AccountIdMismatch(tx_id, details_id) => {
                 write!(
                     f,
-                    "Provent transaction account_id {} and account_details.id must match {}.",
+                    "Proven transaction account_id {} and account_details.id must match {}.",
                     tx_id, details_id,
                 )
             },

--- a/objects/src/transaction/transaction_id.rs
+++ b/objects/src/transaction/transaction_id.rs
@@ -89,7 +89,7 @@ impl From<&ExecutedTransaction> for TransactionId {
         let input_notes_hash = tx.input_notes().commitment();
         let output_notes_hash = tx.output_notes().commitment();
         Self::new(
-            tx.initial_account().hash(),
+            tx.initial_account().proof_init_hash(),
             tx.final_account().hash(),
             input_notes_hash,
             output_notes_hash,


### PR DESCRIPTION
We were originally setting the initial `Account` (`tx_witness.account()`) where we want to propagate the latest account state. This fixes the account hash mismatch issue we were seeing from the client when executing transactions with onchain accounts.
Additionally, this also applies the fix discussed on #529.