### PR TITLE
fix: comment out serialization/deserialization of source locations

### DIFF
--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -157,7 +157,7 @@ impl Eq for AccountCode {}
 
 impl Serializable for AccountCode {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // module imports and source locations are not serialized on account code
+        // debug info (this includes module imports and source locations) is not serialized with account code
         self.module.write_into(target, MODULE_SERDE_OPTIONS);
         // since the number of procedures is guaranteed to be between 1 and 256, we can store the
         // number as a single byte - but we do have to subtract 1 to store 256 as 255.
@@ -168,7 +168,7 @@ impl Serializable for AccountCode {
 
 impl Deserializable for AccountCode {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        // module imports and source locations are not serialized on account code
+        // debug info (this includes module imports and source locations) is not serialized with account code
         let module = ModuleAst::read_from(source, MODULE_SERDE_OPTIONS)?;
         let num_procedures = (source.read_u8()? as usize) + 1;
         let procedures = source.read_many::<Digest>(num_procedures)?;

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -220,13 +220,15 @@ mod tests {
         ";
 
         // build account code from source
-        let module = ModuleAst::parse(source).unwrap();
+        let mut module = ModuleAst::parse(source).unwrap();
+        module.clear_locations();
         let assembler = Assembler::default();
         let code1 = AccountCode::new(module, &assembler).unwrap();
 
         // serialize and deserialize the code; make sure deserialized version matches the original
         let bytes = code1.to_bytes();
         let code2 = AccountCode::read_from_bytes(&bytes).unwrap();
+
         assert_eq!(code1, code2)
     }
 }

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -158,7 +158,8 @@ impl Eq for AccountCode {}
 impl Serializable for AccountCode {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.module.write_into(target, MODULE_SERDE_OPTIONS);
-        self.module.write_source_locations(target);
+        // FIXME: this is failing even when serializing and de-serializing a proven mint tx
+        // self.module.write_source_locations(target);
         // since the number of procedures is guaranteed to be between 1 and 256, we can store the
         // number as a single byte - but we do have to subtract 1 to store 256 as 255.
         target.write_u8((self.procedures.len() - 1) as u8);
@@ -168,8 +169,9 @@ impl Serializable for AccountCode {
 
 impl Deserializable for AccountCode {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mut module = ModuleAst::read_from(source, MODULE_SERDE_OPTIONS)?;
-        module.load_source_locations(source)?;
+        let module = ModuleAst::read_from(source, MODULE_SERDE_OPTIONS)?;
+        // FIXME: this is failing even when serializing and de-serializing a proven mint tx
+        // module.load_source_locations(source)?;
         let num_procedures = (source.read_u8()? as usize) + 1;
         let procedures = source.read_many::<Digest>(num_procedures)?;
 

--- a/objects/src/accounts/data.rs
+++ b/objects/src/accounts/data.rs
@@ -156,7 +156,10 @@ mod tests {
                 push.1 push.2 add
             end
         ";
-        let module = ModuleAst::parse(source).unwrap();
+        let mut module = ModuleAst::parse(source).unwrap();
+        // clears are needed since imports and source locations are not serialized for account code
+        module.clear_locations();
+        module.clear_imports();
         let assembler = Assembler::default();
         let code = AccountCode::new(module, &assembler).unwrap();
 


### PR DESCRIPTION
We were getting a deserialization error on the node when submitting a proven mint transaction:

```bash
cargo run --release --features testing,concurrent tx new mint 0x031cb9e685e6f6fa 0x29df14411f9b1667 20
    Finished release [optimized] target(s) in 0.11s
     Running `target/release/miden-client tx new mint 0x031cb9e685e6f6fa 0x29df14411f9b1667 20`
rpc api error: rpc request failed for submit_proven_transaction: status: InvalidArgument, message: "Invalid transaction", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Wed, 10 Apr 2024 03:56:04 GMT", "content-length": "0"} }
```

Particularly, the point of failure was when deserializing the `AccountDetails` of the `ProvenTransaction`. And more specifically when serializing the account's code during source locations' deserialization. We checked that by removing that serialization the error doesn't happen anymore and we were able to submit the mint transaction to the node. Perhaps a fix on miden-assembly is needed, but this at least unblocks us on the client side.

## Steps to reproduce

- clone the client and checkout to `mFragaBA-add-account-details-endpoint`
- add these lines on `submit_proven_transaction` of `src/client/transactions.rs`:

```rust
+        let serialized_details = proven_transaction.account_details().to_bytes();
+
+        let _deserialized_details = <Option<AccountDetails>>::read_from_bytes(&serialized_details).expect("should be able to deserialize");
```

- run the client, create a fungible faucet with `cargo run --release --features testing,concurrent account new fungible-faucet --token-symbol BTC --decimals 10 --max-supply 10000 -s on-chain`
- create a regular onchain account with `cargo run --release --features testing,concurrent account new basic-immutable -s on-chain`
- do a sync with `cargo run --release --features testing,concurrent sync`
- list the created accounts with `cargo run --release --features testing,concurrent account list`
- run a mint tx with `cargo run --release --features testing,concurrent tx new mint <TARGET_ACCOUNT_ID_HEX> <FAUCET_ACCOUNT_ID_HEX> 33`