### PR TITLE
Avoid copying of note's metadata in getter

### DIFF
--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -95,7 +95,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     assert_eq!(created_note.id(), id);
     assert_eq!(
         created_note.metadata(),
-        NoteMetadata::new(faucet_account.id(), NoteType::OffChain, tag, ZERO).unwrap()
+        &NoteMetadata::new(faucet_account.id(), NoteType::OffChain, tag, ZERO).unwrap()
     );
 }
 

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -181,10 +181,10 @@ impl OutputNote {
     }
 
     /// Note's metadata.
-    pub fn metadata(&self) -> NoteMetadata {
+    pub fn metadata(&self) -> &NoteMetadata {
         match self {
-            OutputNote::Public(note) => *note.metadata(),
-            OutputNote::Private(note) => *note.metadata(),
+            OutputNote::Public(note) => note.metadata(),
+            OutputNote::Private(note) => note.metadata(),
         }
     }
 }


### PR DESCRIPTION
Let user of the getter decide, if they need to copy it.