### PR TITLE
Fix note input padding or expected output notes

### DIFF
--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -100,9 +100,10 @@ impl<A: AdviceProvider> TransactionHost<A> {
                 return Err(TransactionKernelError::MalformedRecipientData(data.to_vec()));
             }
             let inputs_hash = Digest::new([data[0], data[1], data[2], data[3]]);
+            let inputs_key = NoteInputs::commitment_to_key(inputs_hash);
             let script_hash = Digest::new([data[4], data[5], data[6], data[7]]);
             let serial_num = [data[8], data[9], data[10], data[11]];
-            let input_els = self.adv_provider.get_mapped_values(&inputs_hash);
+            let input_els = self.adv_provider.get_mapped_values(&inputs_key);
             let script_data = self.adv_provider.get_mapped_values(&script_hash).unwrap_or(&[]);
 
             let inputs = NoteInputs::new(input_els.map(|e| e.to_vec()).unwrap_or_default())

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -2,9 +2,9 @@ use alloc::vec::Vec;
 
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher, NoteError,
-    Serializable, WORD_SIZE, ZERO,
+    Serializable, Word, WORD_SIZE, ZERO,
 };
-use crate::MAX_INPUTS_PER_NOTE;
+use crate::{MAX_INPUTS_PER_NOTE, ONE};
 
 // NOTE INPUTS
 // ================================================================================================
@@ -78,6 +78,20 @@ impl NoteInputs {
     /// Returns a vector of input values.
     pub fn to_vec(&self) -> Vec<Felt> {
         self.values.to_vec()
+    }
+
+    // UTILITIES
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the key under which the raw (un-padded inputs) are located in the advice map.
+    ///
+    /// TODO: eventually, this should go away. for now we need it because note inputs for input
+    /// notes are padded, while note inputs for expected output notes are note. switching to a
+    /// different padding scheme (e.g., RPX) would eliminate the need to have two different keys.
+    pub fn commitment_to_key(commitment: Digest) -> Digest {
+        let mut key: Word = commitment.into();
+        key[3] += ONE;
+        key.into()
     }
 }
 


### PR DESCRIPTION
This PR puts note inputs for the expected output notes under a different key so that we can put un-padded note inputs into the advice provider.

This is a temporary fix as note inputs should always be under the same key (the note input commitment). The proper approach would be to store note inputs in the advice map as follows:
```
note_inputs_commitment |-> [num_inputs, padded_inputs]
```