### PR TITLE
Add `fmt --check` to CI and makefile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./scripts/check-rust-version.sh
 
   rustfmt:
-    name: rustfmt nightly on ubuntu-latest
+    name: rustfmt check nightly on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
           override: true
       - uses: davidB/rust-cargo-make@v1
       - name: cargo make - format
-        run: cargo make format
+        run: cargo make format-check
 
   clippy:
     name: clippy stable on ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           components: rustfmt
           override: true
       - uses: davidB/rust-cargo-make@v1
-      - name: cargo make - format
+      - name: cargo make - format-check
         run: cargo make format-check
 
   clippy:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,10 +18,14 @@ toolchain = "nightly"
 args = ["fix", "--allow-staged", "--allow-dirty", "--all-targets", "--all-features"]
 
 [tasks.format]
-description = "Runs Rustfmt"
-command = "cargo"
 toolchain = "nightly"
-args = ["fmt"]
+command = "cargo"
+args = ["fmt", "--all"]
+
+[tasks.format-check]
+toolchain = "nightly"
+command = "cargo"
+args = ["fmt", "--all", "--check"]
 
 [tasks.lint]
 description = "Runs all linting tasks (Clippy, fixing, formatting)"


### PR DESCRIPTION
In this PR I propose the addition of `fmt --check` enabling error logging in the CI.

Closes: #622 