### PR TITLE
storage delta as an argument (closes #444)

### DIFF
--- a/objects/src/accounts/delta/builder.rs
+++ b/objects/src/accounts/delta/builder.rs
@@ -1,0 +1,57 @@
+use alloc::vec::Vec;
+
+use super::{AccountStorageDelta, StorageMapDelta, Word};
+use crate::AccountDeltaError;
+
+#[derive(Clone, Debug, Default)]
+pub struct AccountStorageDeltaBuilder {
+    pub cleared_items: Vec<u8>,
+    pub updated_items: Vec<(u8, Word)>,
+    pub updated_maps: Vec<(u8, StorageMapDelta)>,
+}
+
+impl AccountStorageDeltaBuilder {
+    // CONSTRUCTORS
+    // -------------------------------------------------------------------------------------------
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // MODIFIERS
+    // -------------------------------------------------------------------------------------------
+    pub fn add_cleared_items<I>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = u8>,
+    {
+        self.cleared_items.extend(items);
+        self
+    }
+
+    pub fn add_updated_items<I>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = (u8, Word)>,
+    {
+        self.updated_items.extend(items);
+        self
+    }
+
+    pub fn add_updated_maps<I>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = (u8, StorageMapDelta)>,
+    {
+        self.updated_maps.extend(items);
+        self
+    }
+
+    // BUILDERS
+    // -------------------------------------------------------------------------------------------
+    pub fn build(self) -> Result<AccountStorageDelta, AccountDeltaError> {
+        let delta = AccountStorageDelta {
+            cleared_items: self.cleared_items,
+            updated_items: self.updated_items,
+            updated_maps: self.updated_maps,
+        };
+        delta.validate()?;
+        Ok(delta)
+    }
+}

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -6,6 +6,9 @@ use super::{
 };
 use crate::{assets::Asset, AccountDeltaError};
 
+mod builder;
+pub use builder::AccountStorageDeltaBuilder;
+
 mod storage;
 pub use storage::{AccountStorageDelta, StorageMapDelta};
 

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -331,16 +331,9 @@ pub mod testing {
         added_assets: Vec<Asset>,
         removed_assets: Vec<Asset>,
         nonce: Felt,
+        storage_delta: AccountStorageDelta,
     ) -> AccountDelta {
-        let word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-        let storage_delta = AccountStorageDelta {
-            cleared_items: vec![0],
-            updated_items: vec![(1, word)],
-            updated_maps: vec![],
-        };
-
         let vault_delta = AccountVaultDelta { added_assets, removed_assets };
-
         AccountDelta::new(storage_delta, vault_delta, Some(nonce)).unwrap()
     }
 
@@ -366,7 +359,7 @@ mod tests {
     };
 
     use super::{testing::*, AccountDelta, AccountStorageDelta, AccountVaultDelta};
-    use crate::accounts::Account;
+    use crate::accounts::{delta::AccountStorageDeltaBuilder, Account};
 
     #[test]
     fn test_serde_account() {
@@ -384,7 +377,13 @@ mod tests {
     fn test_serde_account_delta() {
         let final_nonce = Felt::new(2);
         let (asset_0, asset_1) = build_assets();
-        let account_delta = build_account_delta(vec![asset_1], vec![asset_0], final_nonce);
+        let storage_delta = AccountStorageDeltaBuilder::new()
+            .add_cleared_items([0])
+            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)])])
+            .build()
+            .unwrap();
+        let account_delta =
+            build_account_delta(vec![asset_1], vec![asset_0], final_nonce, storage_delta);
 
         let serialized = account_delta.to_bytes();
         let deserialized = AccountDelta::read_from_bytes(&serialized).unwrap();
@@ -401,7 +400,13 @@ mod tests {
 
         // build account delta
         let final_nonce = Felt::new(2);
-        let account_delta = build_account_delta(vec![asset_1], vec![asset_0], final_nonce);
+        let storage_delta = AccountStorageDeltaBuilder::new()
+            .add_cleared_items([0])
+            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)])])
+            .build()
+            .unwrap();
+        let account_delta =
+            build_account_delta(vec![asset_1], vec![asset_0], final_nonce, storage_delta);
 
         // apply delta and create final_account
         account.apply_delta(&account_delta).unwrap();
@@ -420,7 +425,12 @@ mod tests {
         let mut account = build_account(vec![asset], init_nonce, vec![Word::default()]);
 
         // build account delta
-        let account_delta = build_account_delta(vec![], vec![asset], init_nonce);
+        let storage_delta = AccountStorageDeltaBuilder::new()
+            .add_cleared_items([0])
+            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)])])
+            .build()
+            .unwrap();
+        let account_delta = build_account_delta(vec![], vec![asset], init_nonce, storage_delta);
 
         // apply delta
         account.apply_delta(&account_delta).unwrap()
@@ -436,7 +446,12 @@ mod tests {
 
         // build account delta
         let final_nonce = Felt::new(1);
-        let account_delta = build_account_delta(vec![], vec![asset], final_nonce);
+        let storage_delta = AccountStorageDeltaBuilder::new()
+            .add_cleared_items([0])
+            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)])])
+            .build()
+            .unwrap();
+        let account_delta = build_account_delta(vec![], vec![asset], final_nonce, storage_delta);
 
         // apply delta
         account.apply_delta(&account_delta).unwrap()


### PR DESCRIPTION
Implements [this request](https://github.com/0xPolygonMiden/miden-base/issues/444#issuecomment-2068741278), the storage delta is now an argument.

Note: IMO it would be best to have builders for these, but so far we have put most builders for testing purposes on the mock crate, and it is unresolved how to use these factories. So I kept this simple.