### PR TITLE
Properly handle debug mode in transaction executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,9 +577,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "miden-air"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695ee3a51649711a6c202e4c7280222b66e987c8abefce9090fdc49412bbcbe"
+checksum = "b7693eea191d7a8005486ee98d85f48769309cbd991b830548f1884994243df3"
 dependencies = [
  "miden-core",
  "winter-air",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2354079aba5325d514bcacc9f0396fe0679949400efcda363c8702a157aa3f77"
+checksum = "40dbd2701d7a0dd2ee9bb429388c21145a83e3228144ed086dfc04d676b8bc3a"
 dependencies = [
  "blake3",
  "cc",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682f881050c637bbf01bee5970d5f13d818b544b7f0ea3ecb1b624aa54ec04e3"
+checksum = "e9c71213c51622c497511c4ac2406c625a3e98a75fc951b477f52fa0b5a83f87"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1211,9 +1211,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys",
 ]

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -52,7 +52,7 @@ impl TransactionCompiler {
     }
 
     /// Puts the [TransactionCompiler] into debug mode.
-    /// 
+    ///
     /// When transaction compiler is in debug mode, all transaction-related code (note scripts,
     /// account code) will be compiled in debug mode which will preserve debug artifacts from the
     /// original source code.

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -53,12 +53,26 @@ impl<D: DataStore> TransactionExecutor<D> {
     }
 
     /// Puts the [TransactionExecutor] into debug mode.
-    /// 
+    ///
     /// When transaction executor is in debug mode, all transaction-related code (note scripts,
     /// account code) will be compiled and executed in debug mode. This will ensure that all debug
     /// instructions present in the original source code are executed.
     pub fn with_debug_mode(mut self, in_debug_mode: bool) -> Self {
         self.compiler = self.compiler.with_debug_mode(in_debug_mode);
+        if in_debug_mode && !self.exec_options.enable_debugging() {
+            self.exec_options = self.exec_options.with_debugging();
+        } else if !in_debug_mode && self.exec_options.enable_debugging() {
+            // since we can't set the debug mode directly, we re-create execution options using
+            // the same values as current execution options (except for debug mode which defaults
+            // to false)
+            self.exec_options = ExecutionOptions::new(
+                Some(self.exec_options.max_cycles()),
+                self.exec_options.expected_cycles(),
+                self.exec_options.enable_tracing(),
+            )
+            .expect("failed to clone execution options");
+        }
+
         self
     }
 


### PR DESCRIPTION
This PR makes sure when `TransactionExecutor` is instantiated in debug mode, transaction code will be executed in debug mode on the VM.