### PR TITLE
Derive `Ord` and `PartialOrd` for `NoteTag`

### DIFF
--- a/objects/src/notes/note_tag.rs
+++ b/objects/src/notes/note_tag.rs
@@ -10,7 +10,7 @@ use super::{
 // NOTE TAG
 // ================================================================================================
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NoteTag(u32);
 


### PR DESCRIPTION
Remake of PR #644 as it was reverted.

Add Ord and PartialOrd derives to NoteTag so that we can use BTreeSetto check for duplicates efficiently.
