### PR TITLE
feat: Serialize auth secret keys

### DIFF
--- a/miden-tx/src/host/tx_authenticator.rs
+++ b/miden-tx/src/host/tx_authenticator.rs
@@ -63,11 +63,10 @@ impl AuthSecretKey {
 
 impl Serializable for AuthSecretKey {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let mut bytes = vec![self.key_id()];
+        target.write_u8(self.key_id());
         match self {
-            AuthSecretKey::RpoFalcon512(key_pair) => {
-                bytes.append(&mut key_pair.to_bytes());
-                target.write_bytes(&bytes);
+            AuthSecretKey::RpoFalcon512(secret_key) => {
+                target.write_bytes(&secret_key.to_bytes());
             },
         }
     }

--- a/miden-tx/src/host/tx_authenticator.rs
+++ b/miden-tx/src/host/tx_authenticator.rs
@@ -213,8 +213,6 @@ impl TransactionAuthenticator for () {
 
 #[cfg(test)]
 mod test {
-    
-
     use miden_objects::crypto::dsa::rpo_falcon512::SecretKey;
     use mock::utils::{Deserializable, Serializable};
 

--- a/miden-tx/src/host/tx_authenticator.rs
+++ b/miden-tx/src/host/tx_authenticator.rs
@@ -66,7 +66,7 @@ impl Serializable for AuthSecretKey {
         target.write_u8(self.key_id());
         match self {
             AuthSecretKey::RpoFalcon512(secret_key) => {
-                target.write_bytes(&secret_key.to_bytes());
+                secret_key.write_into(target);
             },
         }
     }

--- a/miden-tx/src/host/tx_authenticator.rs
+++ b/miden-tx/src/host/tx_authenticator.rs
@@ -78,8 +78,8 @@ impl Deserializable for AuthSecretKey {
         match auth_key_id {
             // RpoFalcon512
             0u8 => {
-                let key_pair = SecretKey::read_from(source)?;
-                Ok(AuthSecretKey::RpoFalcon512(key_pair))
+                let secret_key = SecretKey::read_from(source)?;
+                Ok(AuthSecretKey::RpoFalcon512(secret_key))
             },
             val => Err(DeserializationError::InvalidValue(val.to_string())),
         }


### PR DESCRIPTION
We have a [very similar enum](https://github.com/0xPolygonMiden/miden-client/blob/4bf6ad3943d60a4c7735cb4caa35a702ea81f8a7/src/store/mod.rs#L238) to `AuthSecretKey` in the client. If we implement `Serialize` for it we can make it the canonical enum and get rid of the client one. 