### PR TITLE
Swap note updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BREAKING] Refactored account update details, moved `Block` to `miden-objects` (#618, #621).
 * [BREAKING] Changed type of `version` and `timestamp` fields to `u32`, moved `version` to the beginning of block header (#639).
 * [BREAKING] Renamed `NoteEnvelope` into `NoteHeader` and introduced `NoteDetails` (#664).
+* [BREAKING] Updated `create_swap_note()` procedure to return `NoteDetails` and defined SWAP note tag format (#665).
 
 ## 0.2.3 (2024-04-26) - `miden-tx` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,47 +19,48 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -88,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
@@ -134,9 +135,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
@@ -224,9 +225,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "constant_time_eq"
@@ -403,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -501,6 +502,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -791,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -814,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -143,12 +143,12 @@ pub fn create_swap_note<R: FeltRng>(
 // ================================================================================================
 
 /// Returns a note tag for a swap note with the specified parameters.
-/// 
+///
 /// Use case ID for the returned tag is set to 0.
-/// 
+///
 /// Tag payload is constructed by taking asset tags (8 bits of faucet ID) and concatenating them
 /// together as offered_asset_tag + requested_asset tag.
-/// 
+///
 /// Network execution hint for the returned tag is set to `Local`.
 fn build_swap_tag(
     note_type: NoteType,

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -161,10 +161,10 @@ fn build_swap_tag(
     // reason we skip the 4 most significant bits is that these encode metadata of underlying
     // faucets and are likely to be the same for many different faucets.
 
-    let offered_asset_id: u64 = offered_asset.faucet_id().is_faucet().into();
+    let offered_asset_id: u64 = offered_asset.faucet_id().into();
     let offered_asset_tag = (offered_asset_id >> 52) as u8;
 
-    let requested_asset_id: u64 = requested_asset.faucet_id().is_faucet().into();
+    let requested_asset_id: u64 = requested_asset.faucet_id().into();
     let requested_asset_tag = (requested_asset_id >> 52) as u8;
 
     let payload = ((offered_asset_tag as u16) << 8) | (requested_asset_tag as u16);

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -121,19 +121,57 @@ pub fn create_swap_note<R: FeltRng>(
         payback_tag.inner().into(),
     ])?;
 
-    // TODO: build the tag for the SWAP use case
-    let tag = 0.into();
+    // build the tag for the SWAP use case
+    let tag = build_swap_tag(note_type, &offered_asset, &requested_asset)?;
     let serial_num = rng.draw_word();
     let aux = ZERO;
 
+    // build the outgoing note
     let metadata = NoteMetadata::new(sender, note_type, tag, aux)?;
     let assets = NoteAssets::new(vec![offered_asset])?;
     let recipient = NoteRecipient::new(serial_num, note_script, inputs);
     let note = Note::new(assets, metadata, recipient);
 
-    // construct the payback note details
+    // build the payback note details
     let payback_assets = NoteAssets::new(vec![requested_asset])?;
     let payback_note = NoteDetails::new(payback_assets, payback_recipient);
 
     Ok((note, payback_note))
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns a note tag for a swap note with the specified parameters.
+/// 
+/// Use case ID for the returned tag is set to 0.
+/// 
+/// Tag payload is constructed by taking asset tags (8 bits of faucet ID) and concatenating them
+/// together as offered_asset_tag + requested_asset tag.
+/// 
+/// Network execution hint for the returned tag is set to `Local`.
+fn build_swap_tag(
+    note_type: NoteType,
+    offered_asset: &Asset,
+    requested_asset: &Asset,
+) -> Result<NoteTag, NoteError> {
+    const SWAP_USE_CASE_ID: u16 = 0;
+
+    // get bits 4..12 from faucet IDs of both assets, these bits will form the tag payload; the
+    // reason we skip the 4 most significant bits is that these encode metadata of underlying
+    // faucets and are likely to be the same for many different faucets.
+
+    let offered_asset_id: u64 = offered_asset.faucet_id().is_faucet().into();
+    let offered_asset_tag = (offered_asset_id >> 52) as u8;
+
+    let requested_asset_id: u64 = requested_asset.faucet_id().is_faucet().into();
+    let requested_asset_tag = (requested_asset_id >> 52) as u8;
+
+    let payload = ((offered_asset_tag as u16) << 8) | (requested_asset_tag as u16);
+
+    let execution = NoteExecutionHint::Local;
+    match note_type {
+        NoteType::Public => NoteTag::for_public_use_case(SWAP_USE_CASE_ID, payload, execution),
+        _ => NoteTag::for_local_use_case(SWAP_USE_CASE_ID, payload),
+    }
 }

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -5,8 +5,8 @@ use miden_objects::{
     assets::Asset,
     crypto::rand::FeltRng,
     notes::{
-        Note, NoteAssets, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient, NoteTag,
-        NoteType,
+        Note, NoteAssets, NoteDetails, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient,
+        NoteTag, NoteType,
     },
     NoteError, Word, ZERO,
 };
@@ -83,7 +83,8 @@ pub fn create_p2idr_note<R: FeltRng>(
     Ok(Note::new(vault, metadata, recipient))
 }
 
-/// Generates a SWAP note - swap of assets between two accounts.
+/// Generates a SWAP note - swap of assets between two accounts - and returns the note as well as
+/// [NoteDetails] for the payback note.
 ///
 /// This script enables a swap of 2 assets between the `sender` account and any other account that
 /// is willing to consume the note. The consumer will receive the `offered_asset` and will create a
@@ -97,24 +98,26 @@ pub fn create_swap_note<R: FeltRng>(
     requested_asset: Asset,
     note_type: NoteType,
     mut rng: R,
-) -> Result<(Note, Word), NoteError> {
+) -> Result<(Note, NoteDetails), NoteError> {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/SWAP.masb"));
     let note_script = build_note_script(bytes)?;
 
     let payback_serial_num = rng.draw_word();
     let payback_recipient = utils::build_p2id_recipient(sender, payback_serial_num)?;
-    let asset_word: Word = requested_asset.into();
+
+    let payback_recipient_word: Word = payback_recipient.digest().into();
+    let requested_asset_word: Word = requested_asset.into();
     let payback_tag = NoteTag::from_account_id(sender, NoteExecutionHint::Local)?;
 
     let inputs = NoteInputs::new(vec![
-        payback_recipient[0],
-        payback_recipient[1],
-        payback_recipient[2],
-        payback_recipient[3],
-        asset_word[0],
-        asset_word[1],
-        asset_word[2],
-        asset_word[3],
+        payback_recipient_word[0],
+        payback_recipient_word[1],
+        payback_recipient_word[2],
+        payback_recipient_word[3],
+        requested_asset_word[0],
+        requested_asset_word[1],
+        requested_asset_word[2],
+        requested_asset_word[3],
         payback_tag.inner().into(),
     ])?;
 
@@ -124,9 +127,13 @@ pub fn create_swap_note<R: FeltRng>(
     let aux = ZERO;
 
     let metadata = NoteMetadata::new(sender, note_type, tag, aux)?;
-    let vault = NoteAssets::new(vec![offered_asset])?;
+    let assets = NoteAssets::new(vec![offered_asset])?;
     let recipient = NoteRecipient::new(serial_num, note_script, inputs);
-    let note = Note::new(vault, metadata, recipient);
+    let note = Note::new(assets, metadata, recipient);
 
-    Ok((note, payback_serial_num))
+    // construct the payback note details
+    let payback_assets = NoteAssets::new(vec![requested_asset])?;
+    let payback_note = NoteDetails::new(payback_assets, payback_recipient);
+
+    Ok((note, payback_note))
 }

--- a/miden-lib/src/notes/utils.rs
+++ b/miden-lib/src/notes/utils.rs
@@ -1,6 +1,8 @@
 use miden_objects::{
-    accounts::AccountId, assembly::ProgramAst, notes::NoteScript, Digest, Hasher, NoteError, Word,
-    ZERO,
+    accounts::AccountId,
+    assembly::ProgramAst,
+    notes::{NoteInputs, NoteRecipient, NoteScript},
+    NoteError, Word, ZERO,
 };
 
 use crate::transaction::TransactionKernel;
@@ -15,21 +17,16 @@ pub fn build_note_script(bytes: &[u8]) -> Result<NoteScript, NoteError> {
     Ok(note_script)
 }
 
-/// Creates the RECIPIENT for the P2ID note script created by the SWAP script
-pub fn build_p2id_recipient(target: AccountId, serial_num: Word) -> Result<Digest, NoteError> {
+/// Creates a [NoteRecipient] for the P2ID note script created by the SWAP script.
+pub fn build_p2id_recipient(
+    target: AccountId,
+    serial_num: Word,
+) -> Result<NoteRecipient, NoteError> {
     // TODO: add lazy_static initialization or compile-time optimization instead of re-generating
     // the script hash every time we call the SWAP script
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
     let note_script = build_note_script(bytes)?;
+    let note_inputs = NoteInputs::new(vec![target.into(), ZERO, ZERO, ZERO])?;
 
-    let script_hash = note_script.hash();
-
-    let serial_num_hash = Hasher::merge(&[serial_num.into(), Digest::default()]);
-
-    let merge_script = Hasher::merge(&[serial_num_hash, script_hash]);
-
-    Ok(Hasher::merge(&[
-        merge_script,
-        Hasher::hash_elements(&[target.into(), ZERO, ZERO, ZERO]),
-    ]))
+    Ok(NoteRecipient::new(serial_num, note_script, note_inputs))
 }

--- a/miden-lib/src/notes/utils.rs
+++ b/miden-lib/src/notes/utils.rs
@@ -18,7 +18,7 @@ pub fn build_note_script(bytes: &[u8]) -> Result<NoteScript, NoteError> {
 }
 
 /// Creates a [NoteRecipient] for the P2ID note.
-/// 
+///
 /// Notes created with this recipient will be P2ID notes consumable by the specified target
 /// account.
 pub fn build_p2id_recipient(

--- a/miden-lib/src/notes/utils.rs
+++ b/miden-lib/src/notes/utils.rs
@@ -17,7 +17,10 @@ pub fn build_note_script(bytes: &[u8]) -> Result<NoteScript, NoteError> {
     Ok(note_script)
 }
 
-/// Creates a [NoteRecipient] for the P2ID note script created by the SWAP script.
+/// Creates a [NoteRecipient] for the P2ID note.
+/// 
+/// Notes created with this recipient will be P2ID notes consumable by the specified target
+/// account.
 pub fn build_p2id_recipient(
     target: AccountId,
     serial_num: Word,

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -26,10 +26,10 @@ use crate::{
 fn prove_swap_script() {
     // Create assets
     let faucet_id = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
-    let fungible_asset: Asset = FungibleAsset::new(faucet_id, 100).unwrap().into();
+    let offered_asset: Asset = FungibleAsset::new(faucet_id, 100).unwrap().into();
 
     let faucet_id_2 = AccountId::try_from(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
-    let non_fungible_asset: Asset = NonFungibleAsset::new(
+    let requested_asset: Asset = NonFungibleAsset::new(
         &NonFungibleAssetDetails::new(faucet_id_2, vec![1, 2, 3, 4]).unwrap(),
     )
     .unwrap()
@@ -44,14 +44,14 @@ fn prove_swap_script() {
     let target_account = get_account_with_default_account_code(
         target_account_id,
         target_pub_key,
-        Some(non_fungible_asset),
+        Some(requested_asset),
     );
 
     // Create the note containing the SWAP script
     let (note, payback_note) = create_swap_note(
         sender_account_id,
-        fungible_asset,
-        non_fungible_asset,
+        offered_asset,
+        requested_asset,
         NoteType::Public,
         RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
@@ -78,13 +78,10 @@ fn prove_swap_script() {
         .execute_transaction(target_account_id, block_ref, &note_ids, tx_args_target)
         .expect("Transaction consuming swap note failed");
 
-    // Prove, serialize/deserialize and verify the transaction
-    assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());
-
     // target account vault delta
     let target_account_after: Account = Account::new(
         target_account.id(),
-        AssetVault::new(&[fungible_asset]).unwrap(),
+        AssetVault::new(&[offered_asset]).unwrap(),
         target_account.storage().clone(),
         target_account.code().clone(),
         Felt::new(2),
@@ -101,9 +98,12 @@ fn prove_swap_script() {
     let tag = NoteTag::from_account_id(sender_account_id, NoteExecutionHint::Local).unwrap();
     let note_metadata =
         NoteMetadata::new(target_account_id, NoteType::OffChain, tag, ZERO).unwrap();
-    let assets = NoteAssets::new(vec![non_fungible_asset]).unwrap();
+    let assets = NoteAssets::new(vec![requested_asset]).unwrap();
     let note_id = NoteId::new(recipient.digest(), assets.commitment());
 
     let created_note = executed_transaction.output_notes().get_note(0);
     assert_eq!(NoteHeader::from(created_note), NoteHeader::new(note_id, note_metadata));
+
+    // Prove, serialize/deserialize and verify the transaction
+    assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());
 }

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -1,4 +1,4 @@
-use miden_lib::notes::{create_swap_note, utils::build_p2id_recipient};
+use miden_lib::notes::create_swap_note;
 use miden_objects::{
     accounts::{
         account_id::testing::{
@@ -48,7 +48,7 @@ fn prove_swap_script() {
     );
 
     // Create the note containing the SWAP script
-    let (note, repay_serial_num) = create_swap_note(
+    let (note, payback_note) = create_swap_note(
         sender_account_id,
         fungible_asset,
         non_fungible_asset,
@@ -97,12 +97,12 @@ fn prove_swap_script() {
     assert_eq!(executed_transaction.output_notes().num_notes(), 1);
 
     // Check if the created `Note` is what we expect
-    let recipient = build_p2id_recipient(sender_account_id, repay_serial_num).unwrap();
+    let recipient = payback_note.recipient().clone();
     let tag = NoteTag::from_account_id(sender_account_id, NoteExecutionHint::Local).unwrap();
     let note_metadata =
         NoteMetadata::new(target_account_id, NoteType::OffChain, tag, ZERO).unwrap();
     let assets = NoteAssets::new(vec![non_fungible_asset]).unwrap();
-    let note_id = NoteId::new(recipient, assets.commitment());
+    let note_id = NoteId::new(recipient.digest(), assets.commitment());
 
     let created_note = executed_transaction.output_notes().get_note(0);
     assert_eq!(NoteHeader::from(created_note), NoteHeader::new(note_id, note_metadata));

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -97,6 +97,14 @@ impl Asset {
         matches!(self, Self::Fungible(_))
     }
 
+    /// Returns ID of the faucet which issued this asset.
+    pub fn faucet_id(&self) -> AccountId {
+        match self {
+            Self::Fungible(asset) => asset.faucet_id(),
+            Self::NonFungible(asset) => asset.faucet_id(),
+        }
+    }
+
     /// Returns the key which is used to store this asset in the account vault.
     pub fn vault_key(&self) -> Word {
         match self {


### PR DESCRIPTION
This PR addresses #412 and #640, specifically:

- Updates `create_swap_note()` function to return `NoteDetails` for the payback note.
- Defines tag format for the SWAP note and sets it correctly.

There doesn't seem to be a test which tests creation of SWAP notes - we should probably add it at some point (maybe as a part of #446.

Also, we should think of a place where we document all used note tag formats (right now, the only one we have is SWAP).