### PR TITLE
Implement output note builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BREAKING] Changed type of `version` and `timestamp` fields to `u32`, moved `version` to the beginning of block header (#639).
 * [BREAKING] Renamed `NoteEnvelope` into `NoteHeader` and introduced `NoteDetails` (#664).
 * [BREAKING] Updated `create_swap_note()` procedure to return `NoteDetails` and defined SWAP note tag format (#665).
+* Implemented `OutputNoteBuilder` (#669).
 
 ## 0.2.3 (2024-04-26) - `miden-tx` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,11 +769,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]

--- a/miden-lib/build.rs
+++ b/miden-lib/build.rs
@@ -26,7 +26,6 @@ const ASM_KERNELS_DIR: &str = "kernels/transaction";
 /// - Compiles contents of asm/miden directory into a Miden library file (.masl) under
 ///   miden namespace.
 /// - Compiles contents of asm/scripts directory into individual .masb files.
-#[cfg(not(feature = "docs-rs"))]
 fn main() -> io::Result<()> {
     // re-build when the MASM code changes
     println!("cargo:rerun-if-changed=asm");

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -2,9 +2,8 @@ use alloc::{string::String, vec::Vec};
 use core::fmt;
 
 use miden_objects::{
-    accounts::AccountStorage,
-    notes::{NoteAssets, NoteMetadata},
-    AccountError, AssetError, Digest, Felt, NoteError,
+    accounts::AccountStorage, notes::NoteMetadata, AccountError, AssetError, Digest, Felt,
+    NoteError,
 };
 
 // TRANSACTION KERNEL ERROR
@@ -12,17 +11,19 @@ use miden_objects::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionKernelError {
+    FailedToAddAssetToNote(NoteError),
     InvalidStorageSlotIndex(u64),
     MalformedAccountId(AccountError),
     MalformedAsset(AssetError),
     MalformedAssetOnAccountVaultUpdate(AssetError),
     MalformedNoteInputs(NoteError),
     MalformedNoteMetadata(NoteError),
+    MalformedNotePointer(String),
     MalformedNoteScript(Vec<Felt>),
     MalformedNoteType(NoteError),
     MalformedRecipientData(Vec<Felt>),
     MalformedTag(Felt),
-    MissingNoteDetails(NoteMetadata, NoteAssets, Digest),
+    MissingNoteDetails(NoteMetadata, Digest),
     MissingStorageSlotValue(u8, String),
     UnknownAccountProcedure(Digest),
 }
@@ -30,43 +31,48 @@ pub enum TransactionKernelError {
 impl fmt::Display for TransactionKernelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            TransactionKernelError::FailedToAddAssetToNote(err) => {
+                write!(f, "failed to add asset to note: {err}")
+            },
             TransactionKernelError::InvalidStorageSlotIndex(index) => {
                 let num_slots = AccountStorage::NUM_STORAGE_SLOTS;
                 write!(f, "storage slot index {index} is invalid, must be smaller than {num_slots}")
             },
             TransactionKernelError::MalformedAccountId(err) => {
-                write!( f, "Account id data extracted from the stack by the event handler is not well formed {}", err)
+                write!( f, "Account id data extracted from the stack by the event handler is not well formed {err}")
             },
             TransactionKernelError::MalformedAsset(err) => {
-                write!(f, "Asset data extracted from the stack by the event handler is not well formed {:?}", err)
+                write!(f, "Asset data extracted from the stack by the event handler is not well formed {err}")
             },
             TransactionKernelError::MalformedAssetOnAccountVaultUpdate(err) => {
                 write!(f, "malformed asset during account vault update: {err}")
             },
             TransactionKernelError::MalformedNoteInputs(err) => {
-                write!( f, "Note inputs data extracted from the advice map by the event handler is not well formed {}", err)
+                write!( f, "Note inputs data extracted from the advice map by the event handler is not well formed {err}")
             },
             TransactionKernelError::MalformedNoteMetadata(err) => {
-                write!(f, "Note metadata created by the event handler is not well formed {:?}", err)
+                write!(f, "Note metadata created by the event handler is not well formed {err}")
+            },
+            TransactionKernelError::MalformedNotePointer(err) => {
+                write!(f, "Note pointer is malformed {err}")
             },
             TransactionKernelError::MalformedNoteScript(data) => {
-                write!( f, "Note script data extracted from the advice map by the event handler is not well formed {:?}", data)
+                write!( f, "Note script data extracted from the advice map by the event handler is not well formed {data:?}")
             },
             TransactionKernelError::MalformedNoteType(err) => {
-                write!( f, "Note type data extracted from the stack by the event handler is not well formed {}", err)
+                write!( f, "Note type data extracted from the stack by the event handler is not well formed {err}")
             },
             TransactionKernelError::MalformedRecipientData(data) => {
-                write!(f, "Recipient data in the advice provider is not well formed {:?}", data)
+                write!(f, "Recipient data in the advice provider is not well formed {data:?}")
             },
             TransactionKernelError::MalformedTag(tag) => {
                 write!(
                     f,
-                    "Tag data extracted from the stack by the event handler is not well formed {}",
-                    tag
+                    "Tag data extracted from the stack by the event handler is not well formed {tag}"
                 )
             },
-            TransactionKernelError::MissingNoteDetails(metadata, vault, recipient) => {
-                write!( f, "Public note missing the details in the advice provider. metadata: {:?} vault: {:?} recipient: {:?}", metadata, vault, recipient)
+            TransactionKernelError::MissingNoteDetails(metadata, recipient) => {
+                write!( f, "Public note missing the details in the advice provider. metadata: {metadata:?}, recipient: {recipient:?}")
             },
             TransactionKernelError::MissingStorageSlotValue(index, err) => {
                 write!(f, "value for storage slot {index} could not be found: {err}")

--- a/miden-tx/src/host/note_builder.rs
+++ b/miden-tx/src/host/note_builder.rs
@@ -1,0 +1,81 @@
+use miden_objects::{
+    assets::Asset,
+    notes::{Note, NoteAssets, NoteHeader, NoteId, NoteType},
+};
+
+use super::{Digest, NoteMetadata, NoteRecipient, OutputNote, TransactionKernelError};
+
+// OUTPUT NOTE BUILDER
+// ================================================================================================
+
+/// Builder of an output note, provided primarily to enable adding assets to a note incrementally.
+pub struct OutputNoteBuilder {
+    metadata: NoteMetadata,
+    assets: NoteAssets,
+    recipient_digest: Digest,
+    recipient: Option<NoteRecipient>,
+}
+
+impl OutputNoteBuilder {
+    /// Returns a new [OutputNoteBuilder] instantiated from the provided metadata and recipient
+    /// digest.
+    ///
+    /// # Errors
+    /// Returns an error if the note type specified by the metadata is not [NoteType::OffChain] as
+    /// for public and encrypted note additional note details must be available.
+    pub fn new(
+        metadata: NoteMetadata,
+        recipient_digest: Digest,
+    ) -> Result<Self, TransactionKernelError> {
+        if metadata.note_type() != NoteType::OffChain {
+            return Err(TransactionKernelError::MissingNoteDetails(metadata, recipient_digest));
+        }
+
+        Ok(Self {
+            metadata,
+            recipient_digest,
+            assets: NoteAssets::default(),
+            recipient: None,
+        })
+    }
+
+    /// Returns a new [OutputNoteBuilder] instantiated from the provided metadata and recipient.
+    pub fn with_recipient(metadata: NoteMetadata, recipient: NoteRecipient) -> Self {
+        Self {
+            metadata,
+            recipient_digest: recipient.digest(),
+            recipient: Some(recipient),
+            assets: NoteAssets::default(),
+        }
+    }
+
+    /// Adds the specified asset to the note.
+    ///
+    /// # Errors
+    /// Returns an error if adding the asset to the note fails. This can happen for the following
+    /// reasons:
+    /// - The same non-fungible asset is already added to the note.
+    /// - A fungible asset issued by the same faucet is already added to the note and adding both
+    ///   assets together results in an invalid asset.
+    /// - Adding the asset to the the note will push the list beyond the [NoteAssets::MAX_NUM_ASSETS]
+    ///   limit.
+    pub fn add_asset(&mut self, asset: Asset) -> Result<(), TransactionKernelError> {
+        self.assets
+            .add_asset(asset)
+            .map_err(TransactionKernelError::FailedToAddAssetToNote)?;
+        Ok(())
+    }
+
+    /// Converts this builder to an [OutputNote].
+    pub fn build(self) -> OutputNote {
+        if self.metadata.note_type() == NoteType::Public {
+            let recipient = self.recipient.expect("missing expected note recipient");
+            let note = Note::new(self.assets, self.metadata, recipient);
+            OutputNote::Public(note)
+        } else {
+            let note_id = NoteId::new(self.recipient_digest, self.assets.commitment());
+            let header = NoteHeader::new(note_id, self.metadata);
+            OutputNote::Private(header)
+        }
+    }
+}

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -112,6 +112,22 @@ impl Asset {
             Self::NonFungible(asset) => asset.vault_key(),
         }
     }
+
+    /// Returns the inner fungible asset, or panics if the asset is not fungible.
+    pub fn unwrap_fungible(&self) -> FungibleAsset {
+        match self {
+            Asset::Fungible(asset) => *asset,
+            Asset::NonFungible(_) => panic!("the asset is non-fungible"),
+        }
+    }
+
+    /// Returns the inner non-fungible asset, or panics if the asset is fungible.
+    pub fn unwrap_non_fungible(&mut self) -> NonFungibleAsset {
+        match self {
+            Asset::Fungible(_) => panic!("the asset is fungible"),
+            Asset::NonFungible(asset) => *asset,
+        }
+    }
 }
 
 impl From<Asset> for Word {

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -196,10 +196,7 @@ impl std::error::Error for AssetVaultError {}
 pub enum NoteError {
     DuplicateFungibleAsset(AccountId),
     DuplicateNonFungibleAsset(NonFungibleAsset),
-    EmptyAssetList,
     InconsistentNoteTag(NoteType, u64),
-    InconsistentStubAssetHash(Digest, Digest),
-    InconsistentStubId(NoteId, NoteId),
     InvalidAssetData(AssetError),
     InvalidNoteSender(AccountError),
     InvalidNoteTagUseCase(u16),
@@ -223,10 +220,6 @@ impl NoteError {
 
     pub fn duplicate_non_fungible_asset(asset: NonFungibleAsset) -> Self {
         Self::DuplicateNonFungibleAsset(asset)
-    }
-
-    pub fn empty_asset_list() -> Self {
-        Self::EmptyAssetList
     }
 
     pub fn invalid_origin_index(msg: String) -> Self {

--- a/objects/src/notes/assets.rs
+++ b/objects/src/notes/assets.rs
@@ -131,7 +131,7 @@ impl NoteAssets {
         } else {
             // if the asset is not in the list, add it to the list
             self.assets.push(asset);
-            if self.num_assets() == MAX_ASSETS_PER_NOTE {
+            if self.assets.len() > Self::MAX_NUM_ASSETS {
                 return Err(NoteError::too_many_assets(self.assets.len()));
             }
         }

--- a/objects/src/notes/assets.rs
+++ b/objects/src/notes/assets.rs
@@ -210,7 +210,7 @@ impl Deserializable for NoteAssets {
 // ================================================================================================
 
 #[cfg(test)]
-mod tess {
+mod tests {
     use super::{compute_asset_commitment, NoteAssets};
     use crate::{
         accounts::account_id::{testing::ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN, AccountId},


### PR DESCRIPTION
This PR implements `OutputNoteBuilder` similar to the one mentioned in https://github.com/0xPolygonMiden/miden-base/pull/614#discussion_r1590553160.

As a part of this, a few other changes were made in the made in `miden-objects`:
- Added `NoteAssets::add_asset()` method.
- Relaxed the condition in `NoteAssets` that at least one asset must be present. When the note asset list is empty, asset hash is set to `Digest::default()`.