### PR TITLE
Added missing instruction to change directory from client 2 to client 1

### DIFF
--- a/docs/introduction/get-started/p2p-public.md
+++ b/docs/introduction/get-started/p2p-public.md
@@ -56,7 +56,7 @@ To do this, we use two terminals with their own state (using their own `miden-cl
 
 ## Transfer assets between accounts
 
-1. Now we can transfer some of the tokens we received from the faucet to our new account C. 
+1. Now we can transfer some of the tokens we received from the faucet to our new account C. Remember to switch back to `miden-client` directory, since you'll be making txn from Account ID A.
 
     To do this, from the first client run:
 


### PR DESCRIPTION
The documentation missed the instruction for use to switch from miden-client-2 to miden-client. Since the txn is to be made from Account A, the directory has to be switched.