### PR TITLE
fix: Correct padding amount in code array when serializing note scripts 

### DIFF
--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -74,7 +74,11 @@ impl From<&NoteScript> for Vec<Felt> {
         let len = bytes.len();
 
         // Pad the data so that it can be encoded with u32
-        let missing = len % 4;
+        let missing = if len % 4 > 0 {
+            4 - (len % 4)
+        } else {
+            0
+        };
         bytes.resize(bytes.len() + missing, 0);
 
         let final_size = 5 + bytes.len();

--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -74,11 +74,7 @@ impl From<&NoteScript> for Vec<Felt> {
         let len = bytes.len();
 
         // Pad the data so that it can be encoded with u32
-        let missing = if len % 4 > 0 {
-            4 - (len % 4)
-        } else {
-            0
-        };
+        let missing = if len % 4 > 0 { 4 - (len % 4) } else { 0 };
         bytes.resize(bytes.len() + missing, 0);
 
         let final_size = 5 + bytes.len();


### PR DESCRIPTION
This was causing `UnexpectedEOF` when deserializing note scripts on the `miden-client` integration test that creates a custom note with custom note scripts. Seems like other scripts (like the usual P2ID) happened to have the correct value here and so we did not find this earlier.

I think this was also the cause for this error reported on Discord: https://discord.com/channels/893151281848406016/1114419272165376030/1235204660168495195

For a repro, here's what I used to debug:

<details>


```rust
const NOTE_SCRIPT: &str = "# Custom P2ID note script
            #
            # This note script asserts that the note args are exactly the same as passed 
            # (currently defined as {expected_note_arg}).
            # This note script is based off of the P2ID note script because notes currently need to have 
            # assets, otherwise it could have been boiled down to the assert. 

            use.miden::account
            use.miden::note
            use.miden::contracts::wallets::basic->wallet
            proc.add_note_assets_to_account
                push.0 exec.note::get_assets
                # => [num_of_assets, 0 = ptr, ...]

                # compute the pointer at which we should stop iterating
                dup.1 add
                # => [end_ptr, ptr, ...]

                # pad the stack and move the pointer to the top
                padw movup.5
                # => [ptr, 0, 0, 0, 0, end_ptr, ...]

                # compute the loop latch
                dup dup.6 neq
                # => [latch, ptr, 0, 0, 0, 0, end_ptr, ...]

                while.true
                    # => [ptr, 0, 0, 0, 0, end_ptr, ...]

                    # save the pointer so that we can use it later
                    dup movdn.5
                    # => [ptr, 0, 0, 0, 0, ptr, end_ptr, ...]

                    # load the asset and add it to the account
                    mem_loadw call.wallet::receive_asset
                    # => [ASSET, ptr, end_ptr, ...]

                    # increment the pointer and compare it to the end_ptr
                    movup.4 add.1 dup dup.6 neq
                    # => [latch, ptr+1, ASSET, end_ptr, ...]
                end

                # clear the stack
                drop dropw drop
            end

            begin
                # => [NOTE_ARG] 
                push.{expected_note_arg} assert_eqw
                # drop the note script root
                dropw

                # store the note inputs to memory starting at address 0
                push.0 exec.note::get_inputs
                # => [num_inputs, inputs_ptr]

                # make sure the number of inputs is 1
                eq.1 assert
                # => [inputs_ptr]

                # read the target account id from the note inputs
                mem_load
                # => [target_account_id]

                exec.account::get_id
                # => [account_id, target_account_id, ...]

                # ensure account_id = target_account_id, fails otherwise
                assert_eq
                # => [...]

                exec.add_note_assets_to_account
                # => [...]
            end
        ";



#[test]
fn test() {
    use miden_objects::notes::NoteScript;
    let expected_note_arg = [Felt::new(9), Felt::new(12), Felt::new(18), Felt::new(3)]
        .iter()
        .map(|x| x.to_string())
        .collect::<Vec<_>>()
        .join(".");
    let tx_compiler = TransactionCompiler::new();

    let note_script = ProgramAst::parse(&NOTE_SCRIPT.replace("{expected_note_arg}", &expected_note_arg)).unwrap();
    let note_script = tx_compiler.compile_note_script(note_script, vec![]).unwrap();
    
    let note_script_encoded: Vec<Felt> = note_script.clone().into();
    let note_script_decoded: NoteScript = (note_script_encoded.clone()).try_into().unwrap();
}

```
</details>
