### PR TITLE
fix: create SWAP note inputs with a single element

### DIFF
--- a/miden-lib/src/notes/utils.rs
+++ b/miden-lib/src/notes/utils.rs
@@ -2,7 +2,7 @@ use miden_objects::{
     accounts::AccountId,
     assembly::ProgramAst,
     notes::{NoteInputs, NoteRecipient, NoteScript},
-    NoteError, Word, ZERO,
+    NoteError, Word,
 };
 
 use crate::transaction::TransactionKernel;
@@ -29,7 +29,7 @@ pub fn build_p2id_recipient(
     // the script hash every time we call the SWAP script
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
     let note_script = build_note_script(bytes)?;
-    let note_inputs = NoteInputs::new(vec![target.into(), ZERO, ZERO, ZERO])?;
+    let note_inputs = NoteInputs::new(vec![target.into()])?;
 
     Ok(NoteRecipient::new(serial_num, note_script, note_inputs))
 }


### PR DESCRIPTION
We found an issue when testing the flow for swap notes on `miden-client`. We were almost able to do a swap between 2 clients `A` and `B`. `A` ran the swap transaction, which created a note for `B` and the expected payback note. `B` consumed the note, and sent the remaining details to `A`. When we tried to consume the note with `A` we got this error:

```rust
transaction executor error: ExecuteTransactionProgramFailed(FailedAssertion { clk: 2261, err_code: 131074, err_msg: Some("P2ID scripts expect exactly 1 note input") })
```

The issue was with the way we create the payback note. VM already adds the padding to the inputs, so creating a note with `vec![X, ZERO, ZERO, ZERO]` will actually create it as if there were 4 different inputs instead of a single one. This causes an error when trying to consume the note as it asserts that there is a single input.

I tested manually removing the 0's from the database and was able to successfully consume the note.

related to https://github.com/0xPolygonMiden/miden-client/issues/311 