### PR TITLE
docs: update docs for asset parsing change on cli

### DIFF
--- a/docs/introduction/get-started/create-account-use-faucet.md
+++ b/docs/introduction/get-started/create-account-use-faucet.md
@@ -28,16 +28,16 @@ The Miden client facilitates interaction with the Miden rollup and provides a wa
 3. Initialize the client. This creates the `miden-client.toml` file.
 
 ```shell
-miden init --rpc xxx.xxx.xxx.xxx
+miden init --rpc 18.203.155.106
 ```
 For the --rpc flag, enter the IP that the Miden team supplied.
 
 ## Create a new Miden account
 
-1. Create a new account of type `basic-mutable` using the following command:
+1. Create a new account of type `mutable` using the following command:
 
       ```shell
-      miden account new basic-mutable
+      miden new-wallet --mutable
       ```
 
 2. List all created accounts by running the following command:
@@ -59,7 +59,7 @@ Save the account ID for a future step.
 
 3. Paste this ID into the **Request test tokens** input field on the faucet website and click **Send Private Note**.
 
-!!! tip 
+!!! tip
       You can also click **Send Public Note**. If you do this, the note's details will be public and you will not need to download and import it, so you can skip to [Sync the client](#sync-the-client).  
 
 4. After a few seconds your browser should download - or prompt you to download - a file called `note.mno` (mno = Miden note). It contains the funds the faucet sent to your address.
@@ -71,7 +71,7 @@ Save the account ID for a future step.
 1. Import the private note that you have received using the following commands: 
 
       ```shell
-      miden import note <path-to-note>/note.mno
+      miden import <path-to-note>/note.mno
       ```
 
 2. You should see something like this:
@@ -83,7 +83,7 @@ Save the account ID for a future step.
 3. Now that the note has been successfully imported, you can view the note's information using the following command: 
 
       ```shell
-      miden notes -l
+      miden notes
       ```
 
 4. You should see something like this:
@@ -115,7 +115,7 @@ State synced to block 179672
 1. Now that we have synced the client, the input-note imported from the faucet should have a `Commit Height` confirming it exists at the rollup level:
 
       ```shell
-      miden notes -l
+      miden notes
       ```
 
 2. You should see something like this:
@@ -125,14 +125,14 @@ State synced to block 179672
 3. Find your account and note id by listing both `accounts` and `notes`:
 
       ```shell
-      miden account -l
-      miden notes -l
+      miden account
+      miden notes
       ```
 
 4. Consume the note and add the funds from its vault to our account using the following command: 
 
       ```shell
-      miden tx new consume-notes --account <Account-Id> <Note-Id>
+      miden consume-notes --account <Account-Id> <Note-Id>
       ```
 
   Amazing! You just have created a client-side zero-knowledge proof locally on your machine. 
@@ -145,7 +145,7 @@ State synced to block 179672
 5. View your updated account's vault containing the tokens sent by the faucet by running the following command: 
 
       ```shell
-      miden account show <Account-Id> 
+      miden account --show <Account-Id>
       ```
 
 6. You should now see your accounts vault containing the funds sent by the faucet. 

--- a/docs/introduction/get-started/p2p-private.md
+++ b/docs/introduction/get-started/p2p-private.md
@@ -36,7 +36,7 @@ In this section, we show you how to make private transactions and send funds to 
     To do this, run:
 
     ```shell
-    miden send --sender <regular-account-id-A> --target <regular-account-id-B> --faucet <faucet-account-id> 50 --note-type private
+    miden send --sender <regular-account-id-A> --target <regular-account-id-B> --asset 50::<faucet-account-id> --note-type private
     ```
 
     !!! note

--- a/docs/introduction/get-started/p2p-private.md
+++ b/docs/introduction/get-started/p2p-private.md
@@ -13,10 +13,10 @@ In this section, we show you how to make private transactions and send funds to 
 !!! tip
       Remember to use the [Miden client documentation](https://docs.polygon.technology/miden/miden-client/cli-reference/) for clarifications.
 
-1. Create a second account to send funds with. Previously, we created a type `basic-mutable` account (account A). Now, create another `basic-mutable` (account B) using the following command:
+1. Create a second account to send funds with. Previously, we created a type `mutable` account (account A). Now, create another `mutable` (account B) using the following command:
 
       ```shell
-      miden account new basic-mutable
+      miden new-wallet --mutable
       ```
 
 2. List and view the newly created accounts with the following command:
@@ -36,7 +36,7 @@ In this section, we show you how to make private transactions and send funds to 
     To do this, run:
 
     ```shell
-    miden tx new p2id --sender <regular-account-id-A> --target <regular-account-id-B> --faucet <faucet-account-id> 50 --note-type private
+    miden send --sender <regular-account-id-A> --target <regular-account-id-B> --faucet <faucet-account-id> 50 --note-type private
     ```
 
     !!! note
@@ -53,13 +53,13 @@ In this section, we show you how to make private transactions and send funds to 
 3. Get the second note id.
 
     ```sh
-    miden notes list 
+    miden notes
     ```
 
 4. Have the second account consume the note.
 
     ```sh
-    miden tx new consume-notes --account <regular-account-ID-B> <input-note-id>
+    miden consume-notes --account <regular-account-ID-B> <input-note-id>
     ```
 
     !!! tip
@@ -70,7 +70,7 @@ In this section, we show you how to make private transactions and send funds to 
 5. Check the second account:
 
     ```shell
-    miden account show <regular-account-ID-B>
+    miden account --show <regular-account-ID-B>
     ```
 
     ![Result of listing miden accounts](../../img/get-started/account-b.png)
@@ -78,14 +78,14 @@ In this section, we show you how to make private transactions and send funds to 
 6. Check the original account:
 
     ```sh
-    miden account show <regular-account-ID-A>
+    miden account --show <regular-account-ID-A>
     ```
 
     ![Result of listing miden accounts](../../img/get-started/account-a.png)
 
 Wanna do more? [Sending public notes](p2p-public.md)
 
-## Congratulations! 
+## Congratulations!
 
 You have successfully configured and used the Miden client to interact with a Miden rollup and faucet. 
 

--- a/docs/introduction/get-started/p2p-public.md
+++ b/docs/introduction/get-started/p2p-public.md
@@ -6,16 +6,16 @@ In this section, we show you how to execute transactions and send funds to anoth
 
 !!! important "Prerequisite steps"
     - You should have already followed the [prerequisite steps](prerequisites.md) and [get started](create-account-use-faucet.md) documents.
-    - You should have *not* reset the state of your local client. 
+    - You should have *not* reset the state of your local client.
 
 ## Create a second client
 
 !!! tip
       Remember to use the [Miden client documentation](https://docs.polygon.technology/miden/miden-client/cli-reference/) for clarifications.
 
-This is an alternative to the [private P2P transactions](p2p-private.md) process. 
+This is an alternative to the [private P2P transactions](p2p-private.md) process.
 
-In this tutorial, we use two different clients to simulate two different remote users who don't share local state. 
+In this tutorial, we use two different clients to simulate two different remote users who don't share local state.
 
 To do this, we use two terminals with their own state (using their own `miden-client.toml`).
 
@@ -29,14 +29,14 @@ To do this, we use two terminals with their own state (using their own `miden-cl
 2. Initialize the client. This creates the `miden-client.toml` file line-by-line.
 
     ```sh
-    miden init --rpc xxx.xxx.xxx.xxx
+    miden init --rpc 18.203.155.106
     ```
     For the `--rpc` flag, enter the IP that the Miden team supplied.
 
 3. On the new client, create a new [basic account](https://docs.polygon.technology/miden/miden-base/architecture/accounts/#account-types):
 
     ```shell
-    miden account new basic-mutable -s on-chain
+    miden new-wallet --mutable -s on-chain
     ```
 
     We refer to this account as _Account C_. Note that we set the account's storage mode to `on-chain`, which means that the account details are public and its latest state can be retrieved from the node.
@@ -49,12 +49,12 @@ To do this, we use two terminals with their own state (using their own `miden-cl
 
 ## Transfer assets between accounts
 
-1. Now we can transfer some of the tokens we received from the faucet to our new account C. Remember to switch back to `miden-client` directory, since you'll be making txn from Account ID A.
+1. Now we can transfer some of the tokens we received from the faucet to our new account C. Remember to switch back to `miden-client` directory, since you'll be making the txn from Account ID A.
 
     To do this, from the first client run:
 
     ```shell
-    miden tx new p2id --sender <basic-account-id-A> --target <basic-account-id-B> --faucet <faucet-account-id> 50 --note-type public
+    miden send --sender <basic-account-id-A> --target <basic-account-id-B> --faucet <faucet-account-id> 50 --note-type public
     ```
 
     !!! note
@@ -71,7 +71,7 @@ To do this, we use two terminals with their own state (using their own `miden-cl
 3. At this point, we should have received the public note details. 
 
     ```sh
-    miden notes list 
+    miden notes --list
     ```
 
     Because the note was retrieved from the node, the commit height will be included and displayed.
@@ -79,18 +79,18 @@ To do this, we use two terminals with their own state (using their own `miden-cl
 4. Have the second account consume the note.
 
     ```sh
-    miden tx new consume-notes --account <regular-account-ID-B> <input-note-id> 
+    miden consume-notes --account <regular-account-ID-B> <input-note-id>
     ```
 
     !!! tip
         It's possible to use a short version of the note id: 7 characters after the `0x` is sufficient, e.g. `0x6ae613a`.
 
-That's it! 
+That's it!
 
 Account C has now consumed the note and there should be new assets in the account:
 
 ```sh
-miden account show <account-ID> 
+miden account --show <account-ID> 
 ```
 
 ## Clear state

--- a/docs/introduction/get-started/p2p-public.md
+++ b/docs/introduction/get-started/p2p-public.md
@@ -54,7 +54,7 @@ To do this, we use two terminals with their own state (using their own `miden-cl
     To do this, from the first client run:
 
     ```shell
-    miden send --sender <basic-account-id-A> --target <basic-account-id-B> --faucet <faucet-account-id> 50 --note-type public
+    miden send --sender <basic-account-id-A> --target <basic-account-id-B> --asset 50::<faucet-account-id> --note-type public
     ```
 
     !!! note


### PR DESCRIPTION
This PR does 2 things:

1. Cherry picks the merge commit from #692 from main
2. Updates the getting-started documentation to reflect the change in asset parsing. Now instead of `--faucet <faucet_id> <amount>` it is `--asset <amount>::<faucet_id>`