### PR TITLE
refactor: split Account constructor into `new()` and `from_parts()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.0 (TBD)
 
+### Enhancements
+
+* [BREAKING] Split `Account` struct constructor into `new()` and `from_parts()` (#699).
+
 ## 0.3.0 (2024-05-14)
 
 * Introduce the `miden-bench-tx` crate used for transactions benchmarking (#577).

--- a/bench-tx/src/utils.rs
+++ b/bench-tx/src/utils.rs
@@ -211,7 +211,7 @@ pub fn get_account_with_default_account_code(
         None => AssetVault::new(&[]).unwrap(),
     };
 
-    Account::new(account_id, account_vault, account_storage, account_code, Felt::new(1))
+    Account::from_parts(account_id, account_vault, account_storage, account_code, Felt::new(1))
 }
 
 pub fn write_bench_results_to_json(

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -6,7 +6,7 @@ use miden_objects::{
         StorageSlot,
     },
     assembly::LibraryPath,
-    assets::{AssetVault, TokenSymbol},
+    assets::TokenSymbol,
     AccountError, Felt, Word, ZERO,
 };
 
@@ -84,7 +84,6 @@ pub fn create_basic_fungible_faucet(
         ],
         vec![],
     )?;
-    let account_vault = AssetVault::new(&[]).expect("error on empty vault");
 
     let account_seed = AccountId::get_account_seed(
         init_seed,
@@ -93,9 +92,6 @@ pub fn create_basic_fungible_faucet(
         account_code.root(),
         account_storage.root(),
     )?;
-    let account_id = AccountId::new(account_seed, account_code.root(), account_storage.root())?;
-    Ok((
-        Account::new(account_id, account_vault, account_storage, account_code, ZERO),
-        account_seed,
-    ))
+
+    Ok((Account::new(account_seed, account_code, account_storage)?, account_seed))
 }

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -6,8 +6,7 @@ use miden_objects::{
         StorageSlot,
     },
     assembly::ModuleAst,
-    assets::AssetVault,
-    AccountError, Word, ZERO,
+    AccountError, Word,
 };
 
 use super::{AuthScheme, TransactionKernel};
@@ -67,7 +66,6 @@ pub fn create_basic_wallet(
         }],
         vec![],
     )?;
-    let account_vault = AssetVault::new(&[]).expect("error on empty vault");
 
     let account_seed = AccountId::get_account_seed(
         init_seed,
@@ -76,9 +74,6 @@ pub fn create_basic_wallet(
         account_code.root(),
         account_storage.root(),
     )?;
-    let account_id = AccountId::new(account_seed, account_code.root(), account_storage.root())?;
-    Ok((
-        Account::new(account_id, account_vault, account_storage, account_code, ZERO),
-        account_seed,
-    ))
+
+    Ok((Account::new(account_seed, account_code, account_storage)?, account_seed))
 }

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -203,7 +203,7 @@ pub fn get_account_with_default_account_code(
         None => AssetVault::new(&[]).unwrap(),
     };
 
-    Account::new(account_id, account_vault, account_storage, account_code, Felt::new(1))
+    Account::from_parts(account_id, account_vault, account_storage, account_code, Felt::new(1))
 }
 
 #[cfg(test)]

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -315,7 +315,7 @@ fn get_faucet_account_with_max_supply_and_total_issuance(
             .unwrap();
     };
 
-    Account::new(
+    Account::from_parts(
         faucet_account_id,
         AssetVault::new(&[]).unwrap(),
         faucet_account_storage.clone(),

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -80,7 +80,7 @@ fn prove_p2id_script() {
     assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());
 
     // vault delta
-    let target_account_after: Account = Account::new(
+    let target_account_after: Account = Account::from_parts(
         target_account.id(),
         AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
@@ -180,7 +180,7 @@ fn p2id_script_multiple_assets() {
         .unwrap();
 
     // vault delta
-    let target_account_after: Account = Account::new(
+    let target_account_after: Account = Account::from_parts(
         target_account.id(),
         AssetVault::new(&[fungible_asset_1, fungible_asset_2]).unwrap(),
         target_account.storage().clone(),

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -112,7 +112,7 @@ fn p2idr_script() {
         .unwrap();
 
     // Assert that the target_account received the funds and the nonce increased by 1
-    let target_account_after: Account = Account::new(
+    let target_account_after: Account = Account::from_parts(
         target_account_id,
         AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
@@ -199,7 +199,7 @@ fn p2idr_script() {
     assert_eq!(executed_transaction_4.account_delta().nonce(), Some(Felt::new(2)));
 
     // Vault delta
-    let target_account_after: Account = Account::new(
+    let target_account_after: Account = Account::from_parts(
         target_account_id,
         AssetVault::new(&[fungible_asset]).unwrap(),
         target_account.storage().clone(),
@@ -231,7 +231,7 @@ fn p2idr_script() {
     assert_eq!(executed_transaction_5.account_delta().nonce(), Some(Felt::new(2)));
 
     // Vault delta (Note: vault was empty before)
-    let sender_account_after: Account = Account::new(
+    let sender_account_after: Account = Account::from_parts(
         sender_account_id,
         AssetVault::new(&[fungible_asset]).unwrap(),
         sender_account.storage().clone(),

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -79,7 +79,7 @@ fn prove_swap_script() {
         .expect("Transaction consuming swap note failed");
 
     // target account vault delta
-    let target_account_after: Account = Account::new(
+    let target_account_after: Account = Account::from_parts(
         target_account.id(),
         AssetVault::new(&[offered_asset]).unwrap(),
         target_account.storage().clone(),

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -95,7 +95,7 @@ fn prove_receive_asset_via_wallet() {
     .unwrap();
     let account_code = target_account.code().clone();
     // vault delta
-    let target_account_after: Account = Account::new(
+    let target_account_after: Account = Account::from_parts(
         target_account.id(),
         AssetVault::new(&[fungible_asset_1.into()]).unwrap(),
         account_storage,
@@ -181,7 +181,7 @@ fn prove_send_asset_via_wallet() {
     let sender_account_code = sender_account.code().clone();
 
     // vault delta
-    let sender_account_after: Account = Account::new(
+    let sender_account_after: Account = Account::from_parts(
         data_store.account.id(),
         AssetVault::new(&[]).unwrap(),
         sender_account_storage,

--- a/mock/src/builders/account.rs
+++ b/mock/src/builders/account.rs
@@ -88,7 +88,7 @@ impl<T: Rng> AccountBuilder<T> {
         let account_id = self.account_id_builder.build()?;
         let account_code =
             str_to_account_code(&self.code).map_err(AccountBuilderError::AccountError)?;
-        Ok(Account::new(account_id, vault, storage, account_code, self.nonce))
+        Ok(Account::from_parts(account_id, vault, storage, account_code, self.nonce))
     }
 
     /// Build an account using the provided `seed`.
@@ -100,7 +100,7 @@ impl<T: Rng> AccountBuilder<T> {
         let account_id = self.account_id_builder.with_seed(seed)?;
         let account_code =
             str_to_account_code(&self.code).map_err(AccountBuilderError::AccountError)?;
-        Ok(Account::new(account_id, vault, storage, account_code, self.nonce))
+        Ok(Account::from_parts(account_id, vault, storage, account_code, self.nonce))
     }
 
     /// Build an account using the provided `seed` and `storage`.
@@ -126,6 +126,6 @@ impl<T: Rng> AccountBuilder<T> {
         let account_id = self.account_id_builder.with_seed(seed)?;
         let account_code =
             str_to_account_code(&self.code).map_err(AccountBuilderError::AccountError)?;
-        Ok(Account::new(account_id, vault, storage, account_code, self.nonce))
+        Ok(Account::from_parts(account_id, vault, storage, account_code, self.nonce))
     }
 }

--- a/mock/src/mock/account.rs
+++ b/mock/src/mock/account.rs
@@ -285,14 +285,14 @@ pub fn mock_new_account(assembler: &Assembler) -> Account {
         generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOffChain);
     let account_storage = mock_account_storage();
     let account_code = mock_account_code(assembler);
-    Account::new(acct_id, AssetVault::default(), account_storage, account_code, ZERO)
+    Account::from_parts(acct_id, AssetVault::default(), account_storage, account_code, ZERO)
 }
 
 pub fn mock_account(account_id: u64, nonce: Felt, account_code: AccountCode) -> Account {
     let account_storage = mock_account_storage();
     let account_vault = mock_account_vault();
     let account_id = AccountId::try_from(account_id).unwrap();
-    Account::new(account_id, account_vault, account_storage, account_code, nonce)
+    Account::from_parts(account_id, account_vault, account_storage, account_code, nonce)
 }
 
 // MOCK FAUCET
@@ -319,7 +319,7 @@ pub fn mock_fungible_faucet(
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
     let account_code = mock_account_code(assembler);
-    Account::new(account_id, AssetVault::default(), account_storage, account_code, nonce)
+    Account::from_parts(account_id, AssetVault::default(), account_storage, account_code, nonce)
 }
 
 pub fn mock_non_fungible_faucet(
@@ -351,7 +351,7 @@ pub fn mock_non_fungible_faucet(
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
     let account_code = mock_account_code(assembler);
-    Account::new(account_id, AssetVault::default(), account_storage, account_code, nonce)
+    Account::from_parts(account_id, AssetVault::default(), account_storage, account_code, nonce)
 }
 
 // ACCOUNT SEED GENERATION

--- a/objects/src/accounts/data.rs
+++ b/objects/src/accounts/data.rs
@@ -120,7 +120,7 @@ mod tests {
         let vault = AssetVault::new(&[]).unwrap();
         let storage = AccountStorage::new(vec![], vec![]).unwrap();
         let nonce = Felt::new(0);
-        let account = Account::new(id, vault, storage, code, nonce);
+        let account = Account::from_parts(id, vault, storage, code, nonce);
         let account_seed = Some(Word::default());
         let auth_secret_key = AuthSecretKey::RpoFalcon512(SecretKey::new());
 


### PR DESCRIPTION
Addresses #676.