### PR TITLE
Fix issue 600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Replaced `cargo-make` with just `make` for running tasks (#696).
 * [BREAKING] Introduce `OutputNote::Partial` variant (#698).
 * [BREAKING] Split `Account` struct constructor into `new()` and `from_parts()` (#699).
+* [BREAKING] Changed the encoding of inputs notes in the advice map for consumed notes. Now the data
+  is prefixed by its length, and the input and output notes encoding match (#707).
 
 ## 0.3.0 (2024-05-14)
 

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -416,11 +416,12 @@ end
 #! Inputs: [0, 0, 0, 0, 0]
 #! Outputs: [NOTE_INPUTS_HASH, num_inputs]
 #!
+#! Where:
 #! - num_inputs is the number of inputs associated with the note.
 #! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
-export.get_note_inputs_info
+export.get_note_inputs_hash
     # get the number of inputs and the inputs hash
-    exec.note::get_inputs_info
+    exec.note::get_note_inputs_hash
     # => [NOTE_INPUTS_HASH, num_inputs, 0, 0, 0, 0, 0]
 
     # organize the stack for return
@@ -434,16 +435,11 @@ end
 #! Inputs: [0]
 #! Outputs: [sender]
 #!
+#! Where:
 #! - sender is the sender of the note currently being processed.
 export.get_note_sender
-    # get the note sender
-    exec.note::get_sender
-    # => [sender, 0]
-
-    # organize the stack for return
-    swap drop
+    exec.note::get_sender swap drop
     # => [sender]
-
 end
 
 #! Returns the block number of the last known block at the time of transaction execution.

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -410,23 +410,19 @@ export.get_note_vault_info
     # => [VAULT_HASH, num_assets]
 end
 
-#! Returns the number of inputs and inputs hash for the note currently being processed. Panics if
-#! a note is not being processed.
+#! Returns the current note's inputs hash.
 #!
-#! Inputs: [0, 0, 0, 0, 0]
-#! Outputs: [NOTE_INPUTS_HASH, num_inputs]
+#! Inputs: [ZERO]
+#! Outputs: [NOTE_INPUTS_HASH]
 #!
 #! Where:
-#! - num_inputs is the number of inputs associated with the note.
-#! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
+#! - NOTE_INPUTS_HASH, is the current note's inputs hash.
 export.get_note_inputs_hash
-    # get the number of inputs and the inputs hash
     exec.note::get_note_inputs_hash
-    # => [NOTE_INPUTS_HASH, num_inputs, 0, 0, 0, 0, 0]
+    # => [NOTE_INPUTS_HASH, ZERO]
 
-    # organize the stack for return
-    movup.5 drop movup.5 drop movup.5 drop movup.5 drop movup.5 drop
-    # => [NOTE_INPUTS_HASH, num_inputs]
+    swapw dropw
+    # => [NOTE_INPUTS_HASH]
 end
 
 #! Returns the sender of the note currently being processed. Panics if a note is not being

--- a/miden-lib/asm/kernels/transaction/main.masm
+++ b/miden-lib/asm/kernels/transaction/main.masm
@@ -36,152 +36,94 @@ const.EPILOGUE_END=131081
 # MAIN
 # =================================================================================================
 
-#! This is the entrypoint for the transaction kernel program. It is composed of the following
-#! program sections:
+#! Transaction kernel program.
 #!
-#! 1. Prologue: execute the transaction prologue which prepares the transaction for processing
-#!    by parsing the transaction data and setting up the root context.
-#! 2. Note Processing: execute the note processing loop which consumes each input note and
-#!    invokes the note script of each note via a `dyncall` instruction invocation.
-#! 3. Transaction Script Processing: execute the transaction script if it exists via the invocation
-#!    of a `dyncall` instruction.
-#! 4. Epilogue: execute the transaction epilogue which finalizes the transaction by computing the
-#!    created notes commitment, the final account hash, asserting asset invariant conditions and
-#!    asserting the nonce rules are upheld.
+#! This is the entry point of the transaction kernel, the program will perform the following
+#! operations:
 #!
-#! Stack:        [BH, acct_id, IAH, NC]
-#! Advice stack: [NR, PH, CR, SR, BR, PH, BN,
-#!                acct_id, ZERO, ZERO, nonce, AVR, ASR, ACR,
-#!                num_cn,
-#!                CN1_SN, CN1_SR, CN1_IR, CN1_VR, CN1_M, CN1_NA
-#!                CN1_A1, CN1_A2, ...
-#!                CN2_SN,CN2_SR, CN2_IR, CN2_VR, CN2_M, CN2_NA
-#!                CN2_A1, CN2_A2, ...,
-#!                ...,
-#!                TXSR]
-#! Output:       [CNC, FAH]
+#! 1. Run the prologue to prepare the transaction's root context.
+#! 2. Run all the notes' scripts.
+#! 3. Run the transaction script.
+#! 4. Run the epilogue to compute and validate the final state.
 #!
+#! See `prologue::prepare_transaction` for additional details on the VM's initial state, including the
+#! advice provider.
 #!
-#! - BH is the latest known block hash at the time of transaction execution.
-#! - acct_id is the account id of the account that the transaction is being executed against.
-#! - NR is the note root of the last known block.
-#! - PH is the previous hash of the last known block.
-#! - CR is the chain root of the last known block.
-#! - SR is the state root of the last known block.
-#! - BR is the batch root of the last known block.
-#! - PH is the proof hash of the last known block.
-#! - BN is the block number of the last known block ([block_number, 0, 0, 0]).
-#! - IAH is the initial account hash of the account that the transaction is being executed against.
-#! - NC is the nullifier commitment of the transaction. This is a sequential hash of all
-#!   (nullifier, script_root) pairs for the notes consumed in the transaction.
-#! - nonce is the account nonce.
-#! - AVR is the account vault root.
-#! - ASR is the account storage root.
-#! - ACR is the account code root.
-#! - num_cn is the number of consumed notes.
-#! - CN1_SN is the serial number of consumed note 1.
-#! - CN1_SR is the script root of consumed note 1.
-#! - CN1_IR is the inputs root of consumed note 1.
-#! - CN1_VR is the vault root of consumed note 1.
-#! - CN1_M is the metadata of consumed note 1.
-#! - CN1_NA are optional note args of consumed note 1.
-#! - CN1_A1 is the first asset of consumed note 1.
-#! - CN1_A2 is the second asset of consumed note 1.
-#! - CNC is the commitment to the notes created by the transaction.
-#! - FAH is the final account hash of the account that the transaction is being
-#!   executed against.
+#! Stack:   [BLOCK_HASH, account_id, INITIAL_ACCOUNT_HASH, NULLIFIER_COMMITMENT]
+#! Output:  [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+#!
+#! Where:
+#! - BLOCK_HASH, reference block for the transaction execution.
+#! - account_id, the account that the transaction is being executed against.
+#! - INITIAL_ACCOUNT_HASH, account state prior to the transaction, ZERO for new accounts.
+#! - NULLIFIER_COMMITMENT, sequential hash of all input notes' nullifiers.
+#! - CREATED_NOTES_COMMITMENT, commitment to the notes created by the transaction.
+#! - FINAL_ACCOUNT_HASH, account's hash after execution the transaction.
 proc.main.1
     # Prologue
     # ---------------------------------------------------------------------------------------------
-
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the execution of the prologue has started
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.PROLOGUE_START
 
-    # execute the transaction prologue
     exec.prologue::prepare_transaction
     # => []
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the execution of the prologue has ended
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.PROLOGUE_END
 
     # Note Processing
     # ---------------------------------------------------------------------------------------------
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the notes processing has started
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.NOTES_PROCESSING_START
 
-    # get the total number of consumed notes
     exec.memory::get_total_num_consumed_notes
     # => [num_consumed_notes]
 
-    # compute the pointer to the consumed note after the last consumed note (i.e. the pointer at
-    # which the looping should terminate)
+    # compute the memory location after all input notes, i.e. the exit condition
     dup exec.memory::get_consumed_note_ptr loc_store.0
     # => [num_consumed_notes]
 
-    # check if we have any notes to consume
     eq.0 not
     # => [should_loop]
 
-    # loop while we have notes to consume
     while.true
-        # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-        # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-        # emit trace to signal that the note execution has started
-        push.0 drop
+        push.0 drop                     # TODO: remove line, see miden-vm/#1122
         trace.NOTE_EXECUTION_START
+        # => []
 
-        # execute the note setup script
         exec.note::prepare_note
         # => [NOTE_SCRIPT_HASH, NOTE_ARGS]
 
-        # invoke the note script using the dyncall instruction
+        # run note's script
         dyncall
-        # => [OUTPUT_3, OUTPUT_2, OUTPUT_1, OUTPUT_0]
+        # => [X, X, X, X]
 
-        # clean up note script outputs
+        # Clear the stack, the note can leave up to 4 words on the stack due to the dyncall
         dropw dropw dropw dropw
         # => []
 
-        # check if we have more notes to consume and should loop again
         exec.note::increment_current_consumed_note_ptr
-        loc_load.0
-        neq
+        # => [current_consumed_note_ptr]
+
+        # loop condition, exit when the memory ptr is after all input notes
+        loc_load.0 neq
         # => [should_loop]
 
-        # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-        # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-        # emit trace to signal that the note execution has ended
-        push.0 drop
+        push.0 drop                     # TODO: remove line, see miden-vm/#1122
         trace.NOTE_EXECUTION_END
     end
 
-    # execute note processing teardown
     exec.note::note_processing_teardown
     # => []
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the notes processing has ended
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.NOTES_PROCESSING_END
 
     # Transaction Script Processing
     # ---------------------------------------------------------------------------------------------
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the processing of the transaction script has started
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.TX_SCRIPT_PROCESSING_START
 
     # execute the transaction script
@@ -205,30 +147,22 @@ proc.main.1
         # => []
     end
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the processing of the transaction script has ended
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.TX_SCRIPT_PROCESSING_END
 
     # Epilogue
     # ---------------------------------------------------------------------------------------------
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the execution of the epilogue has started
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.EPILOGUE_START
 
     # execute the transaction epilogue
     exec.epilogue::finalize_transaction
     # => [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
-    # TODO: we execute `push.0 drop` before `trace` as decorators are not supported without other
-    # instructions - see: https://github.com/0xPolygonMiden/miden-vm/issues/1122
-    # emit trace to signal that the execution of the epilogue has ended
-    push.0 drop
+    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.EPILOGUE_END
+    # => [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 end
 
 begin

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -774,14 +774,15 @@ export.get_consumed_note_ptr
     exec.constants::get_note_mem_size mul push.CONSUMED_NOTE_DATA_SECTION_OFFSET add
 end
 
-#! Set the hash of the consumed note at the specified memory address.
+#! Set the note id of the consumed note.
 #!
-#! Stack: [consumed_note_ptr, H]
-#! Output: [H]
+#! Stack: [consumed_note_ptr, NOTE_ID]
+#! Output: [NOTE_ID]
 #!
-#! - consumed_note_ptr is the memory address of the consumed note.
-#! - H is the hash of the consumed note.
-export.set_consumed_note_hash
+#! Where:
+#! - consumed_note_ptr, the consumed note's the memory address.
+#! - NOTE_ID, the note's id.
+export.set_consumed_note_id
     mem_storew
 end
 
@@ -871,17 +872,17 @@ export.set_consumed_note_metadata
     mem_storew dropw
 end
 
-#! Returns the note args of a consumed note located at the specified memory address.
+#! Returns the note's args.
 #!
 #! Stack: [consumed_note_ptr]
 #! Output: [NOTE_ARGS]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - NOTE_ARGS are optional note args of the consumed note.
+#! Where:
+#! - consumed_note_ptr, the start memory address of the note.
+#! - NOTE_ARGS, the note's args.
 export.get_consumed_note_args
     padw
-    movup.4 push.CONSUMED_NOTE_ARGS_OFFSET
- add
+    movup.4 push.CONSUMED_NOTE_ARGS_OFFSET add
     mem_loadw
 end
 
@@ -893,8 +894,7 @@ end
 #! - consumed_note_ptr is the memory address at which the consumed note data begins.
 #! - NOTE_ARGS are optional note args of the consumed note.
 export.set_consumed_note_args
-    push.CONSUMED_NOTE_ARGS_OFFSET
- add
+    push.CONSUMED_NOTE_ARGS_OFFSET add
     mem_storew dropw
 end
 

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -141,9 +141,8 @@ const.CONSUMED_NOTE_INPUTS_HASH_OFFSET=3
 const.CONSUMED_NOTE_ASSETS_HASH_OFFSET=4
 const.CONSUMED_NOTE_METADATA_OFFSET=5
 const.CONSUMED_NOTE_ARGS_OFFSET=6
-const.CONSUMED_NOTE_NUM_INPUTS_OFFSET=7
-const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=8
-const.CONSUMED_NOTE_ASSETS_OFFSET=9
+const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=7
+const.CONSUMED_NOTE_ASSETS_OFFSET=8
 
 # CREATED NOTES
 # -------------------------------------------------------------------------------------------------
@@ -896,30 +895,6 @@ end
 export.set_consumed_note_args
     push.CONSUMED_NOTE_ARGS_OFFSET add
     mem_storew dropw
-end
-
-#! Returns the number of inputs for the consumed note located at the specified memory address.
-#!
-#! Stack: [consumed_note_ptr]
-#! Output: [num_inputs]
-#!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - num_inputs is the number of inputs defined for the consumed note.
-export.get_consumed_note_num_inputs
-    push.CONSUMED_NOTE_NUM_INPUTS_OFFSET add
-    mem_load
-end
-
-#! Sets the number of inputs for a consumed note located at the specified memory address.
-#!
-#! Stack: [consumed_note_ptr, num_inputs]
-#! Output: []
-#!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - num_inputs is the number of inputs for the consumed note.
-export.set_consumed_note_num_inputs
-    push.CONSUMED_NOTE_NUM_INPUTS_OFFSET add
-    mem_store
 end
 
 #! Returns the number of assets in the consumed note located at the specified memory address.

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -77,31 +77,27 @@ export.get_vault_info
     # => [VAULT_HASH, num_assets]
 end
 
-#! Returns the number of inputs and inputs hash for the note currently being processed. Panics if
-#! a note is not being processed.
+#! Returns the commitment to the note's inputs.
+#!
+#! Panics if a note is not being processed.
 #!
 #! Inputs: []
-#! Outputs: [NOTE_INPUTS_HASH, num_inputs]
+#! Outputs: [NOTE_INPUTS_HASH]
 #!
-#! - num_inputs is the number of inputs associated with the note.
+#! Where:
 #! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
 export.get_note_inputs_hash
-    # get the current consumed note pointer
     exec.memory::get_current_consumed_note_ptr
     # => [ptr]
 
-    # assert the pointer is not zero - this would suggest the procedure has been called from an
-    # incorrect context
+    # The kernel memory is initialized by prologue::process_input_notes_data, and reset by
+    # note_processing_teardown before running the tx_script. If the value is `0` it is likely this
+    # procedure is being called outside of the kernel context.
     dup neq.0 assert.err=ERR_NOTE_INVALID_INPUTS
     # => [ptr]
 
-    # get the number of inputs for the note
-    dup exec.memory::get_consumed_note_num_inputs
-    # => [num_inputs, ptr]
-
-    # get the note inputs hash from the note pointer
-    swap exec.memory::get_consumed_note_inputs_hash
-    # => [NOTE_INPUTS_HASH, num_inputs]
+    exec.memory::get_consumed_note_inputs_hash
+    # => [NOTE_INPUTS_HASH]
 end
 
 #! Increment current consumed note pointer to the next note and returns the pointer value.

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -85,7 +85,7 @@ end
 #!
 #! - num_inputs is the number of inputs associated with the note.
 #! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
-export.get_inputs_info
+export.get_note_inputs_hash
     # get the current consumed note pointer
     exec.memory::get_current_consumed_note_ptr
     # => [ptr]
@@ -109,6 +109,7 @@ end
 #! Inputs: []
 #! Outputs: [current_consumed_note_ptr]
 #!
+#! Where:
 #! - current_consumed_note_ptr is the pointer to the next note to be processed.
 export.increment_current_consumed_note_ptr
     # get the current consumed note pointer
@@ -135,24 +136,23 @@ export.note_processing_teardown
     # => []
 end
 
-#! Prepares for the execution of a consumed note.  This involves:
-#! 1. Incrementing the current consumed note index and pointer.
-#! 2. Loading the note script root onto the stack.
+#! Prepares a note for execution.
+#!
+#! Loads the note's script root and args onto the stack.
 #!
 #! Stack: []
 #! Output: [NOTE_SCRIPT_ROOT, NOTE_ARGS]
 #!
-#! - NOTE_SCRIPT_ROOT is the note script root of the note currently being executed.
-#! - NOTE_ARGS are the note args of the note currently being executed.
+#! Where:
+#! - NOTE_SCRIPT_ROOT, the note's script root.
+#! - NOTE_ARGS, the note's arguments.
 export.prepare_note
-    # convert the index of the consumed note being executed to a pointer and store in memory
     exec.memory::get_current_consumed_note_ptr
     # => [note_ptr]
 
     dup exec.memory::get_consumed_note_args movup.4
     # => [note_ptr, NOTE_ARGS]
 
-    # read the note script root onto the stack
     exec.memory::get_consumed_note_script_root
     # => [NOTE_SCRIPT_ROOT, NOTE_ARGS]
 end

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -59,9 +59,6 @@ const.ERR_PROLOGUE_ACCT_ID_MISMATCH=0x00020019
 # Reference block MMR and note's authentication MMR must match
 const.ERR_PROLOGUE_NOTE_MMR_DIGEST_MISMATCH=0x0002001A
 
-# Number of note inputs exceeded the maximum limit of 128
-const.ERR_PROLOGUE_NOTE_TOO_MANY_INPUTS=0x0002001B
-
 # Number of note assets exceeded the maximum limit of 256
 const.ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS=0x0002001C
 
@@ -162,7 +159,7 @@ end
 #! This procedure loads the MMR peaks from the advice provider, verifies their hash matches the
 #! reference block, and insert the reference block in the MMR. The reference block is added to the
 #! MMR so that notes created at this block can be consumed, since the MMR can't contain it and is
-#! always one block behind. The number MMR peaks in is variable, from 16 up to 63, depending on
+#! always one block behind. The number MMR peaks is variable, from 16 up to 63, depending on
 #! `num_blocks`.
 #!
 #! Stack: []
@@ -564,7 +561,6 @@ end
 #!      ASSETS_HASH,
 #!      METADATA,
 #!      ARGS,
-#!      inputs_count,
 #!      assets_count,
 #!      ASSET_0, ..., ASSET_N,
 #!      block_num,
@@ -581,14 +577,13 @@ end
 #! - ASSETS_HASH, sequential hash of the padded note's assets.
 #! - METADATA, note's metadata.
 #! - ARGS, user arguments passed to the note.
-#! - inputs_count, note's inputs count.
 #! - assets_count, note's assets count.
 #! - ASSET_0, ..., ASSET_N, padded note's assets.
 #! - block_num, note's creation block number.
 #! - SUB_HASH, the block's sub_hash for which the note was created.
 #! - NOTE_ROOT, the merkle root of the note's tree.
 proc.process_input_note
-    # nullifier
+    # note details
     # ---------------------------------------------------------------------------------------------
 
     dup exec.memory::get_consumed_note_ptr
@@ -597,7 +592,7 @@ proc.process_input_note
     dup exec.memory::get_consumed_note_core_ptr
     # => [note_data_ptr, note_ptr, idx]
 
-    # read nullifier (SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH)
+    # read note details (SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH)
     padw padw padw
     adv_pipe hperm
     adv_pipe hperm
@@ -619,18 +614,6 @@ proc.process_input_note
     # => [note_ptr]
 
     padw adv_loadw dup.4 exec.memory::set_consumed_note_args
-    # => [note_ptr]
-
-    # number of inputs
-    # ---------------------------------------------------------------------------------------------
-
-    adv_push.1
-    # => [num_inputs, note_ptr]
-
-    dup exec.constants::get_max_inputs_per_note lte assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_INPUTS
-    # => [num_inputs, note_ptr]
-
-    dup.1 exec.memory::set_consumed_note_num_inputs
     # => [note_ptr]
 
     # assets
@@ -761,19 +744,13 @@ end
 #!
 #! Stack: []
 #! Advice stack: [num_notes],
-#! Advice map: { NULLIFIER_COMMITMENT => [(SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH, METADATA, NA, A0, ..., An){num_notes}] }
+#! Advice map: { NULLIFIER_COMMITMENT => NOTE_DATA }
 #! Output: []
 #!
 #! Where:
 #! - num_notes is the number of input notes.
 #! - NULLIFIER_COMMITMENT, sequential hash of all input notes' nullifiers.
-#! - SERIAL_NUMBER, note's serial.
-#! - SCRIPT_ROOT, note's script root.
-#! - INPUTS_HASH, sequential hash of the padded note's inputs.
-#! - ASSETS_HASH, sequential hash of the padded note's assets.
-#! - METADATA, note's metadata.
-#! - NA are optional note args for the nth input note.
-#! - A0..An are the assets of the nth input note.
+#! - NOTE_DATA, input notes' details, for format see prologue::process_input_note.
 proc.process_input_notes_data
     # get the number of input notes from the advice stack
     adv_push.1
@@ -952,7 +929,7 @@ end
 #! - number_of_input_notes, number of input notes.
 #! - TX_SCRIPT_ROOT, the transaction's script root.
 #! - MMR_PEAKS, is the MMR peak data, see process_chain_data
-#! - NOTE_DATA, is the data of all input notes, see process_input_notes_data
+#! - NOTE_DATA, input notes' details, for format see prologue::process_input_note.
 export.prepare_transaction
     exec.process_global_inputs
     # => []

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -490,11 +490,12 @@ end
 # INPUT NOTES DATA
 # =================================================================================================
 
-#! Authenticate the input note data provided via the advice provider is consistent with the
-#! the chain history.  This is achieved by:
-#! - authenticating the MMR leaf associated with the block the note was created in.
-#! - authenticating the note root associated with the block the note was created in.
-#! - authenticating the note and its metadata in the note Merkle tree from the block the note was
+#! Authenticates the input note data.
+#!
+#! This procedure will:
+#! - authenticate the MMR leaf associated with the block the note was created in.
+#! - authenticate the note root associated with the block the note was created in.
+#! - authenticate the note and its metadata in the note Merkle tree from the block the note was
 #!   created in.
 #!
 #! Operand stack: [AUTH_DIGEST]
@@ -505,8 +506,8 @@ end
 #! - AUTH_DIGEST is the digest of the input note data computed as hash(NOTE_HASH, NOTE_METADATA).
 #! - leaf_pos is the position of the leaf in the MMR associated with the block the note was created.
 #!   in. This is equivalent to the block number.
-#! - SUB_HASH is the sub hash of the block the note was created in.
-#! - NOTE_ROOT is the note root of the block the note was created in.
+#! - SUB_HASH, the block's sub_hash for which the note was created.
+#! - NOTE_ROOT, the merkle root of the note's tree.
 #! - note_index is the index of the note in the note Merkle tree.
 proc.authenticate_note.2
     # load data required for MMR get operation
@@ -556,101 +557,98 @@ end
 #! note hash.
 #!
 #! Stack: [idx]
-#! Advice stack: [SN, SR, IR, VR, NI, NA, A0, ..., An]
+#! Advice stack: [
+#!      SERIAL_NUMBER,
+#!      SCRIPT_ROOT,
+#!      INPUTS_HASH,
+#!      ASSETS_HASH,
+#!      METADATA,
+#!      ARGS,
+#!      inputs_count,
+#!      assets_count,
+#!      ASSET_0, ..., ASSET_N,
+#!      block_num,
+#!      SUB_HASH,
+#!      NOTE_ROOT,
+#! ]
 #! Output: []
 #!
 #! Where:
 #! - idx is the index of the input note.
-#! - SN is the serial number of input note `idx`.
-#! - SR is the script root of input note `idx`.
-#! - IR is the inputs root of input note `idx`.
-#! - VR is the vault root of input note `idx`.
-#! - NI is the number of inputs in input note `idx`.
-#! - NA is the number of assets in input note `idx`.
-#! - A0..An are the assets of input note `idx`.
+#! - SERIAL_NUMBER, note's serial.
+#! - SCRIPT_ROOT, note's script root.
+#! - INPUTS_HASH, sequential hash of the padded note's inputs.
+#! - ASSETS_HASH, sequential hash of the padded note's assets.
+#! - METADATA, note's metadata.
+#! - ARGS, user arguments passed to the note.
+#! - inputs_count, note's inputs count.
+#! - assets_count, note's assets count.
+#! - ASSET_0, ..., ASSET_N, padded note's assets.
+#! - block_num, note's creation block number.
+#! - SUB_HASH, the block's sub_hash for which the note was created.
+#! - NOTE_ROOT, the merkle root of the note's tree.
 proc.process_input_note
-    # read core note data
+    # nullifier
     # ---------------------------------------------------------------------------------------------
 
-    # dup the note index
-    dup
-    # => [idx, idx]
-
-    # compute address to store note hash
-    exec.memory::get_consumed_note_ptr
+    dup exec.memory::get_consumed_note_ptr
     # => [note_ptr, idx]
 
-    # compute address to store core note data
     dup exec.memory::get_consumed_note_core_ptr
     # => [note_data_ptr, note_ptr, idx]
 
-    # read nullifier data from the advice provider (serial_num, script_hash, input_hash, asset_hash)
-    padw padw padw adv_pipe hperm adv_pipe hperm
-    # => [PERM, PERM, PERM, note_data_ptr + 4, note_ptr, idx]
+    # read nullifier (SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH)
+    padw padw padw
+    adv_pipe hperm
+    adv_pipe hperm
+    exec.native::state_to_digest
+    # => [NULLIFIER, note_data_ptr + 4, note_ptr, idx]
 
-    # extract nullifier
-    exec.native::state_to_digest movup.4 drop
+    movup.4 drop
     # => [NULLIFIER, note_ptr, idx]
 
-    # compute address for nullifier
+    # save nullifier to memory
     movup.6 exec.memory::get_consumed_note_nullifier_ptr
-    # => [nullifier_ptr, NULLIFIER, note_ptr]
-
-    # store nullifier in memory and drop from stack
     mem_storew dropw
     # => [note_ptr]
 
-    # ingest note metadata
+    # metadata & args
     # ---------------------------------------------------------------------------------------------
 
-    # get the metadata from the advice provider and store in memory
-    padw adv_loadw dup.4
-    # => [note_ptr, NOTE_META, note_ptr]
-
-    exec.memory::set_consumed_note_metadata
+    padw adv_loadw dup.4 exec.memory::set_consumed_note_metadata
     # => [note_ptr]
 
-    # ingest note args
-    # ---------------------------------------------------------------------------------------------
-
-    # get the note args from the advice provider and store in memory
-    padw adv_loadw dup.4
-    # => [note_ptr, NOTE_ARGS, note_ptr]
-
-    exec.memory::set_consumed_note_args
+    padw adv_loadw dup.4 exec.memory::set_consumed_note_args
     # => [note_ptr]
 
-    # ingest number of note inputs
+    # number of inputs
     # ---------------------------------------------------------------------------------------------
 
-    # get the number of inputs from the advice provider and store it in memory
-    adv_push.1 dup dup.2
-    exec.memory::set_consumed_note_num_inputs
+    adv_push.1
     # => [num_inputs, note_ptr]
 
-    # make sure the number of inputs is in the valid range
-    exec.constants::get_max_inputs_per_note lte
-    assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_INPUTS
+    dup exec.constants::get_max_inputs_per_note lte assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_INPUTS
+    # => [num_inputs, note_ptr]
+
+    dup.1 exec.memory::set_consumed_note_num_inputs
     # => [note_ptr]
 
-    # ingest note assets
+    # assets
     # ---------------------------------------------------------------------------------------------
 
-    # get the number of assets from the advice provider and store it in memory
-    adv_push.1 dup dup.2
-    exec.memory::set_consumed_note_num_assets
+    adv_push.1
     # => [num_assets, note_ptr]
 
-    # assert the number of assets is within limits
-    dup exec.constants::get_max_assets_per_note lte
-    assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS
+    dup exec.constants::get_max_assets_per_note lte assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS
     # => [num_assets, note_ptr]
 
-    # round up the number of assets to the next multiple of 2 (simplifies reading of assets)
+    dup dup.2 exec.memory::set_consumed_note_num_assets
+    # => [num_assets, note_ptr]
+
+    # round up the number of assets, to the its padded length
     dup push.1 u32and add
     # => [rounded_num_assets, note_ptr]
 
-    # initiate counter for assets
     push.0
     # => [counter, rounded_num_assets, note_ptr]
 
@@ -674,25 +672,22 @@ proc.process_input_note
     end
     # => [PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
 
-    # extract digest
     exec.native::state_to_digest
-    # => [DIG, assets_ptr, counter, rounded_num_assets, note_ptr]
+    # => [ASSET_HASH_COMPUTED, assets_ptr, counter, rounded_num_assets, note_ptr]
 
     # clean and rearrange stack
     swapw drop drop drop dup movdn.5
-    # => [note_ptr, DIG, note_ptr]
+    # => [note_ptr, ASSET_HASH_COMPUTED, note_ptr]
 
     # get expected note vault from memory
     exec.memory::get_consumed_note_assets_hash
-    # => [V, DIG, note_ptr]
+    # => [ASSET_HASH, ASSET_HASH_COMPUTED, note_ptr]
 
     # assert that the computed hash matches the expected hash
     assert_eqw.err=ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH
     # => [note_ptr]
 
-    # TODO: make sure the last asset is not [ZERO; 4]?
-
-    # insert note assets into the input vault
+    # add the note assets into the input vault
     # ---------------------------------------------------------------------------------------------
     # prepare stack for iteration over note assets
     exec.memory::get_input_vault_root_ptr dup.1 exec.memory::get_consumed_note_assets_ptr
@@ -729,37 +724,31 @@ proc.process_input_note
     # clean stack
     drop drop drop
 
-    # compute note hash
+    # authentication hash
     # ---------------------------------------------------------------------------------------------
 
-    # TODO: This should be optimized using the `hperm` operation
-
-    # serial number hash - serial_hash = hmerge(serial_number, 0)
+    # compute the serial hash: hash(serial_num, ZERO)
     dup exec.memory::get_consumed_note_serial_num padw hmerge
     # => [SERIAL_HASH, note_ptr]
 
-    # hash serial_hash with script hash - merge_script = hmerge(serial_hash, script_hash)
+    # compute merge script hash: hash(hash(serial_num, ZERO), script_hash)
     dup.4 exec.memory::get_consumed_note_script_root hmerge
     # => [MERGE_SCRIPT, note_ptr]
 
-    # hash merge_script with inputs hash - recipient = hmerge(merge_script, inputs_hash)
+    # compute recipient: hash(hash(hash(serial_num, ZERO), script_hash), input_hash)
     dup.4 exec.memory::get_consumed_note_inputs_hash hmerge
     # => [RECIPIENT, note_ptr]
 
-    # hash recipient with vault hash - note_hash = hmerge(recipient, vault_hash)
+    # compute the note's id: hash(recipient, asset_hash)
     dup.4 exec.memory::get_consumed_note_assets_hash hmerge
-    # => [NOTE_HASH, note_ptr]
+    # => [NOTE_ID, note_ptr]
 
-    # store note hash in memory and clear stack
-    dup.4 exec.memory::set_consumed_note_hash
-    # => [NOTE_HASH]
+    # store note id in memory and clear stack
+    dup.4 exec.memory::set_consumed_note_id
+    # => [NOTE_ID]
 
-    # load the note metadata
-    movup.4 exec.memory::get_consumed_note_metadata
-    # => [NOTE_META, NOTE_HASH]
-
-    # merge the note hash with the note metadata to compute authentication digest
-    hmerge
+    # compute the authentication hash: hash(note_id, note_metadata)
+    movup.4 exec.memory::get_consumed_note_metadata hmerge
     # => [AUTH_DIGEST]
 
     exec.authenticate_note
@@ -772,16 +761,17 @@ end
 #!
 #! Stack: []
 #! Advice stack: [num_notes],
-#! Advice map: { NULLIFIER_COMMITMENT => [(SN, SR, IR, VR, M, NA, A0, ..., An){num_notes}] }
+#! Advice map: { NULLIFIER_COMMITMENT => [(SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH, METADATA, NA, A0, ..., An){num_notes}] }
 #! Output: []
 #!
+#! Where:
 #! - num_notes is the number of input notes.
 #! - NULLIFIER_COMMITMENT, sequential hash of all input notes' nullifiers.
-#! - SN is the serial number of the nth input note.
-#! - SR is the script root of the nth input note.
-#! - IR is the inputs root of the nth input note.
-#! - VR is the vault root of the nth input note.
-#! - M is the metadata of the nth input note.
+#! - SERIAL_NUMBER, note's serial.
+#! - SCRIPT_ROOT, note's script root.
+#! - INPUTS_HASH, sequential hash of the padded note's inputs.
+#! - ASSETS_HASH, sequential hash of the padded note's assets.
+#! - METADATA, note's metadata.
 #! - NA are optional note args for the nth input note.
 #! - A0..An are the assets of the nth input note.
 proc.process_input_notes_data
@@ -884,18 +874,18 @@ end
 # TRANSACTION SCRIPT
 # =================================================================================================
 
-#! Reads the transaction script root from the advice provider stack and stores the root at the
-#! appropriate memory address.
+#! Saves the transaction script root to memory.
 #!
-#! Advice Stack: [TXSR]
+#! Advice Stack: [TX_SCRIPT_ROOT]
 #! Stack: []
 #! Output: []
 #!
-#! - TXSR is the transaction script root.
+#! Where:
+#! - TX_SCRIPT_ROOT, the transaction's script root.
 proc.process_tx_script_root
     # read the transaction script root from the advice stack
     adv_loadw
-    # => [TXSR]
+    # => [TX_SCRIPT_ROOT]
 
     # store the transaction script root in memory
     exec.memory::set_tx_script_root
@@ -935,11 +925,12 @@ end
 #!     TX_SCRIPT_ROOT,
 #! ]
 #! Advice map: {
-#!      NULLIFIER_COMMITMENT: [NOTE_DATA_1, ..., NOTE_DATA_N],
-#!      CHAIN_MMR_HASH: [[num_blocks, 0, 0, 0], PEAK_1, ..., PEAK_N],
+#!      CHAIN_MMR_HASH: MMR_PEAKS,
+#!      NULLIFIER_COMMITMENT => NOTE_DATA,
 #! }
 #! Output: []
 #!
+#! Where:
 #! - BLOCK_HASH, reference block for the transaction execution.
 #! - account_id, the account that the transaction is being executed against.
 #! - INITIAL_ACCOUNT_HASH, account state prior to the transaction, ZERO for new accounts.
@@ -960,9 +951,8 @@ end
 #! - ACCOUNT_CODE_ROOT, account's code root.
 #! - number_of_input_notes, number of input notes.
 #! - TX_SCRIPT_ROOT, the transaction's script root.
-#! - NOTE_DATA_1 .. NOTE_DATA_N, the data of the input notes.
-#! - num_blocks, is the number of blocks in the MMR.
-#! - PEAK_1 .. PEAK_N, are the MMR peaks.
+#! - MMR_PEAKS, is the MMR peak data, see process_chain_data
+#! - NOTE_DATA, is the data of all input notes, see process_input_notes_data
 export.prepare_transaction
     exec.process_global_inputs
     # => []

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -66,18 +66,19 @@ export.get_assets
     # => [num_assets, dest_ptr]
 end
 
-#! Writes the inputs of the currently execute note into memory starting at the specified address.
+#! Loads the note's inputs to `dest_ptr`.
 #!
 #! Inputs: [dest_ptr]
 #! Outputs: [num_inputs, dest_ptr]
+#! Advice Map: { INPUTS_HASH: INPUTS }
 #!
+#! Where:
 #! - dest_ptr is the memory address to write the inputs.
+#! - INPUTS_HASH, sequential hash of the padded note's inputs.
+#! - INPUTS, the data corresponding to the note's inputs.
 export.get_inputs
-    padw push.0
-    # => [0, 0, 0, 0, 0, dest_ptr]
-
     # get the current consumed note inputs hash
-    syscall.get_note_inputs_info
+    padw push.0 syscall.get_note_inputs_hash
     # => [INPUTS_HASH, num_inputs, dest_ptr]
 
     # load the inputs from the advice map to the advice stack

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -1,3 +1,4 @@
+use.miden::kernels::tx::constants
 use.std::crypto::hashes::native
 use.std::mem
 
@@ -6,6 +7,9 @@ use.std::mem
 
 # Provided note data does not match the commitment
 const.ERR_NOTE_DATA_MISMATCH=0x00020040
+
+# Number of note inputs exceeded the maximum limit of 128
+const.ERR_NOTE_TOO_MANY_INPUTS=0x0002001B
 
 #! Writes the data currently on the advice stack into the memory at the specified location and
 #! verifies that the hash of the written data is equal to the provided hash.
@@ -68,25 +72,34 @@ end
 
 #! Loads the note's inputs to `dest_ptr`.
 #!
-#! Inputs: [dest_ptr]
-#! Outputs: [num_inputs, dest_ptr]
-#! Advice Map: { INPUTS_HASH: INPUTS }
+#! Inputs:
+#!   Stack: [dest_ptr]
+#!   Advice Map: { INPUTS_HASH: [inputs_len, INPUTS] }
+#! Outputs:
+#!   Stack: [num_inputs, dest_ptr]
 #!
 #! Where:
 #! - dest_ptr is the memory address to write the inputs.
 #! - INPUTS_HASH, sequential hash of the padded note's inputs.
+#! - inputs_len, the note's input count.
 #! - INPUTS, the data corresponding to the note's inputs.
 export.get_inputs
-    # get the current consumed note inputs hash
-    padw push.0 syscall.get_note_inputs_hash
-    # => [INPUTS_HASH, num_inputs, dest_ptr]
+    padw syscall.get_note_inputs_hash
+    # => [INPUTS_HASH, dest_ptr]
 
     # load the inputs from the advice map to the advice stack
     adv.push_mapval
-    # => [INPUTS_HASH, num_inputs, dest_ptr]
+    # => [INPUTS_HASH, dest_ptr]
+
+    adv_push.1
+    # => [num_inputs, INPUTS_HASH, dest_ptr]
+
+    # validate the input length
+    dup exec.constants::get_max_inputs_per_note lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
+    # => [num_inputs, INPUTS_HASH, dest_ptr]
 
     # calculate the number of words required to store the inputs
-    dup.4 u32divmod.4 neq.0 add
+    dup movdn.5 u32divmod.4 neq.0 add
     # => [num_words, INPUTS_HASH, num_inputs, dest_ptr]
 
     # round up the number of words the next multiple of 2
@@ -97,7 +110,7 @@ export.get_inputs
     dup.6 add dup.6
     # => [start_ptr, end_ptr, INPUTS_HASH, num_inputs, dest_ptr]
 
-    # write the data from the advice stack into memory
+    # check the input data matches the commitment, and write it to memory.
     exec.write_advice_data_to_memory
     # => [num_inputs, dest_ptr]
 end

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -26,11 +26,11 @@ use crate::transaction::{
         CHAIN_MMR_NUM_LEAVES_PTR, CHAIN_MMR_PEAKS_PTR, CHAIN_ROOT_PTR, CONSUMED_NOTE_ARGS_OFFSET,
         CONSUMED_NOTE_ASSETS_HASH_OFFSET, CONSUMED_NOTE_ASSETS_OFFSET, CONSUMED_NOTE_ID_OFFSET,
         CONSUMED_NOTE_INPUTS_HASH_OFFSET, CONSUMED_NOTE_METADATA_OFFSET,
-        CONSUMED_NOTE_NUM_ASSETS_OFFSET, CONSUMED_NOTE_NUM_INPUTS_OFFSET,
-        CONSUMED_NOTE_SCRIPT_ROOT_OFFSET, CONSUMED_NOTE_SECTION_OFFSET,
-        CONSUMED_NOTE_SERIAL_NUM_OFFSET, INIT_ACCT_HASH_PTR, INIT_NONCE_PTR, NOTE_ROOT_PTR,
-        NULLIFIER_COMMITMENT_PTR, NULLIFIER_DB_ROOT_PTR, PREV_BLOCK_HASH_PTR, PROOF_HASH_PTR,
-        PROTOCOL_VERSION_IDX, TIMESTAMP_IDX, TX_SCRIPT_ROOT_PTR,
+        CONSUMED_NOTE_NUM_ASSETS_OFFSET, CONSUMED_NOTE_SCRIPT_ROOT_OFFSET,
+        CONSUMED_NOTE_SECTION_OFFSET, CONSUMED_NOTE_SERIAL_NUM_OFFSET, INIT_ACCT_HASH_PTR,
+        INIT_NONCE_PTR, NOTE_ROOT_PTR, NULLIFIER_COMMITMENT_PTR, NULLIFIER_DB_ROOT_PTR,
+        PREV_BLOCK_HASH_PTR, PROOF_HASH_PTR, PROTOCOL_VERSION_IDX, TIMESTAMP_IDX,
+        TX_SCRIPT_ROOT_PTR,
     },
     TransactionKernel,
 };
@@ -318,12 +318,6 @@ fn consumed_notes_memory_assertions(
             read_note_element(process, note_idx, CONSUMED_NOTE_ARGS_OFFSET),
             Word::from(note_args[note_idx as usize]),
             "note args should be stored at the correct offset"
-        );
-
-        assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_NUM_INPUTS_OFFSET),
-            [Felt::from(note.inputs().num_values() as u32), ZERO, ZERO, ZERO],
-            "number of inputs should be stored at the correct offset"
         );
 
         assert_eq!(

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -12,6 +12,11 @@ use miden_objects::{
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionKernelError {
     FailedToAddAssetToNote(NoteError),
+    InvalidNoteInputs {
+        expected: Digest,
+        got: Digest,
+        data: Option<Vec<Felt>>,
+    },
     InvalidStorageSlotIndex(u64),
     MalformedAccountId(AccountError),
     MalformedAsset(AssetError),
@@ -23,10 +28,12 @@ pub enum TransactionKernelError {
     MalformedNoteType(NoteError),
     MalformedRecipientData(Vec<Felt>),
     MalformedTag(Felt),
-    MissingNoteDetails(NoteMetadata, Digest),
-    MissingStorageSlotValue(u8, String),
-    UnknownAccountProcedure(Digest),
     MissingNote(String),
+    MissingNoteDetails(NoteMetadata, Digest),
+    MissingNoteInputs,
+    MissingStorageSlotValue(u8, String),
+    TooFewElementsForNoteInputs,
+    UnknownAccountProcedure(Digest),
 }
 
 impl fmt::Display for TransactionKernelError {
@@ -34,6 +41,13 @@ impl fmt::Display for TransactionKernelError {
         match self {
             TransactionKernelError::FailedToAddAssetToNote(err) => {
                 write!(f, "failed to add asset to note: {err}")
+            },
+            TransactionKernelError::InvalidNoteInputs { expected, got, data } => {
+                write!(
+                    f,
+                    "The note input data does not match its hash, expected: {} got: {} data {:?}",
+                    expected, got, data
+                )
             },
             TransactionKernelError::InvalidStorageSlotIndex(index) => {
                 let num_slots = AccountStorage::NUM_STORAGE_SLOTS;
@@ -67,10 +81,7 @@ impl fmt::Display for TransactionKernelError {
                 write!(f, "Recipient data in the advice provider is not well formed {data:?}")
             },
             TransactionKernelError::MalformedTag(tag) => {
-                write!(
-                    f,
-                    "Tag data extracted from the stack by the event handler is not well formed {tag}"
-                )
+                write!( f, "Tag data extracted from the stack by the event handler is not well formed {tag}")
             },
             TransactionKernelError::MissingNote(note_ptr) => {
                 write!(f, "Cannot add asset to note with pointer {note_ptr}, note does not exist in the advice provider")
@@ -78,8 +89,17 @@ impl fmt::Display for TransactionKernelError {
             TransactionKernelError::MissingNoteDetails(metadata, recipient) => {
                 write!( f, "Public note missing the details in the advice provider. metadata: {metadata:?}, recipient: {recipient:?}")
             },
+            TransactionKernelError::MissingNoteInputs => {
+                write!(f, "Public note missing or incomplete inputs in the advice provider")
+            },
             TransactionKernelError::MissingStorageSlotValue(index, err) => {
                 write!(f, "value for storage slot {index} could not be found: {err}")
+            },
+            TransactionKernelError::TooFewElementsForNoteInputs => {
+                write!(
+                    f,
+                    "note input data in advice provider contains fewer elements than specified by its inputs length"
+                )
             },
             TransactionKernelError::UnknownAccountProcedure(proc_root) => {
                 write!(f, "account procedure with root {proc_root} is not in the advice provider")

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -324,7 +324,7 @@ fn add_input_notes_to_advice_inputs(
                 .unwrap(),
         );
 
-        // add the note elements to the combined vector of note data
+        // Note: keep in sync with the process_input_node kernel procedure
         note_data.extend(recipient.serial_num());
         note_data.extend(*recipient.script().hash());
         note_data.extend(*recipient.inputs().commitment());

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -193,14 +193,15 @@ pub const NOTE_MEM_SIZE: MemoryAddress = 512;
 // Each nullifier occupies a single word. A data section for each note consists of exactly 512
 // words and is laid out like so:
 //
-// ┌──────┬────────┬────────┬────────┬────────┬──────┬───────┬────────┬────────┬───────┬─────┬───────┬─────────┬
-// │ NOTE │ SERIAL │ SCRIPT │ INPUTS │ ASSETS │ META │ NOTE  │  NUM   │   NUM  │ ASSET │ ... │ ASSET │ PADDING │
-// │  ID  │  NUM   │  ROOT  │  HASH  │  HASH  │ DATA │ ARGS  │ INPUTS │ ASSETS │   0   │     │   n   │         │
-// ├──────┼────────┼────────┼────────┼────────┼──────┼───────┼────────┼────────┼───────┼─────┼───────┼─────────┤
-//    0        1       2        3        4       5       6       7        8      9 + n
+// ┌──────┬────────┬────────┬────────┬────────┬──────┬───────┬────────┬───────┬─────┬───────┬─────────┬
+// │ NOTE │ SERIAL │ SCRIPT │ INPUTS │ ASSETS │ META │ NOTE  │   NUM  │ ASSET │ ... │ ASSET │ PADDING │
+// │  ID  │  NUM   │  ROOT  │  HASH  │  HASH  │ DATA │ ARGS  │ ASSETS │   0   │     │   n   │         │
+// ├──────┼────────┼────────┼────────┼────────┼──────┼───────┼────────┼───────┼─────┼───────┼─────────┤
+//    0        1       2        3        4       5       6       7      8 + n
 //
-// Even though both NUM_NOTES and NUM_ASSETS take up a whole word, the actual values for these
-// variables are stored in the first element of the word.
+// - NUM_ASSETS is encoded [num_assets, 0, 0, 0].
+// - INPUTS_HASH is the key to look up note inputs in the advice map.
+// - ASSETS_HASH is the key to look up note assets in the advice map.
 
 /// The memory address at which the consumed note section begins.
 pub const CONSUMED_NOTE_SECTION_OFFSET: MemoryOffset = 1_048_576;
@@ -219,9 +220,8 @@ pub const CONSUMED_NOTE_INPUTS_HASH_OFFSET: MemoryOffset = 3;
 pub const CONSUMED_NOTE_ASSETS_HASH_OFFSET: MemoryOffset = 4;
 pub const CONSUMED_NOTE_METADATA_OFFSET: MemoryOffset = 5;
 pub const CONSUMED_NOTE_ARGS_OFFSET: MemoryOffset = 6;
-pub const CONSUMED_NOTE_NUM_INPUTS_OFFSET: MemoryOffset = 7;
-pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 8;
-pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 9;
+pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 7;
+pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 8;
 
 // OUTPUT NOTES DATA
 // ------------------------------------------------------------------------------------------------

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -196,7 +196,7 @@ const ERR_PROLOGUE_ACCT_HASH_MISMATCH: u32 = 131095;
 const ERR_PROLOGUE_OLD_ACCT_NONCE_ZERO: u32 = 131096;
 const ERR_PROLOGUE_ACCT_ID_MISMATCH: u32 = 131097;
 const ERR_PROLOGUE_NOTE_MMR_DIGEST_MISMATCH: u32 = 131098;
-const ERR_PROLOGUE_NOTE_TOO_MANY_INPUTS: u32 = 131099;
+const ERR_NOTE_TOO_MANY_INPUTS: u32 = 131099;
 const ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS: u32 = 131100;
 const ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH: u32 = 131101;
 const ERR_PROLOGUE_TOO_MANY_INPUT_NOTES: u32 = 131102;
@@ -269,7 +269,7 @@ pub const KERNEL_ERRORS: [(u32, &str); 71] = [
     (ERR_PROLOGUE_OLD_ACCT_NONCE_ZERO, "Existing account must have a non-zero nonce"),
     (ERR_PROLOGUE_ACCT_ID_MISMATCH, "Provided account ids via global inputs and advice provider do not match"),
     (ERR_PROLOGUE_NOTE_MMR_DIGEST_MISMATCH, "Reference block MMR and note's authentication MMR must match"),
-    (ERR_PROLOGUE_NOTE_TOO_MANY_INPUTS, "Number of note inputs exceeded the maximum limit of 128"),
+    (ERR_NOTE_TOO_MANY_INPUTS, "Number of note inputs exceeded the maximum limit of 128"),
     (ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS, "Number of note assets exceeded the maximum limit of 256"),
     (ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH, "Provided info about assets of an input do not match its commitment"),
     (ERR_PROLOGUE_TOO_MANY_INPUT_NOTES, "Number of input notes exceeded the kernel's maximum limit of 1023"),

--- a/objects/src/notes/note_id.rs
+++ b/objects/src/notes/note_id.rs
@@ -18,7 +18,7 @@ use crate::utils::{
 ///
 /// where `recipient` is defined as:
 ///
-/// > hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
+/// > hash(hash(hash(serial_num, ZERO), script_hash), input_hash)
 ///
 /// This achieves the following properties:
 /// - Every note can be reduced to a single unique ID.

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -6,7 +6,7 @@ use vm_processor::AdviceMap;
 use super::{Digest, Felt, Word};
 use crate::{
     assembly::{Assembler, AssemblyContext, ProgramAst},
-    notes::{NoteDetails, NoteId, NoteInputs},
+    notes::{NoteDetails, NoteId},
     vm::CodeBlock,
     TransactionScriptError,
 };
@@ -82,10 +82,8 @@ impl TransactionArgs {
         let script = note.script();
         let script_encoded: Vec<Felt> = script.into();
 
-        let inputs_key = NoteInputs::commitment_to_key(inputs.commitment());
-
         self.advice_map.insert(recipient.digest(), recipient.to_elements());
-        self.advice_map.insert(inputs_key, inputs.to_vec());
+        self.advice_map.insert(inputs.commitment(), inputs.format_for_advice());
         self.advice_map.insert(script.hash(), script_encoded);
     }
 


### PR DESCRIPTION
fixes #600 

- Removes the inputs length from the `NULLIFIER_COMMITMENT`, since now it is available in the `INPUTS_HASH`
- Removes the difference among consumed/created notes' inputs, now both encode the inputs prefixed by its length and padded to an even number of words
- Add the length as the first element to the `INPUTS_HASH`
- Update some of the documentation which was out of date