### PR TITLE
chore: add `next` as a branch for CI runs on merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,11 @@
 
 name: lint
 
- on:
-  push:
-    branches: [main, next]
-  pull_request:
-    types: [opened, reopened, synchronize] 
+on:
+ push:
+   branches: [main, next]
+ pull_request:
+   types: [opened, reopened, synchronize] 
 
 jobs:
   version:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,11 @@
 
 name: lint
 
-on:
+ on:
   push:
-    branches:
-      - [main, next]
+    branches: [main, next]
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize] 
 
 jobs:
   version:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ name: lint
 on:
   push:
     branches:
-      - main
+      - [main, next]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main, next]
   pull_request:
-    types: [opened, reopened, synchronize] 
+    types: [opened, reopened, synchronize]
 
 jobs:
   no-std:

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -2,7 +2,7 @@
 
 name: no-std
 
- on:
+on:
   push:
     branches: [main, next]
   pull_request:

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -2,12 +2,11 @@
 
 name: no-std
 
-on:
+ on:
   push:
-    branches:
-      - [main, next]
+    branches: [main, next]
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize] 
 
 jobs:
   no-std:

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -5,7 +5,7 @@ name: no-std
 on:
   push:
     branches:
-      - main
+      - [main, next]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
- on:
+on:
   push:
     branches: [main, next]
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - main
+      - [main, next]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,10 @@
 name: test
 
-on:
+ on:
   push:
-    branches:
-      - [main, next]
+    branches: [main, next]
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize] 
 
 jobs:
   test:


### PR DESCRIPTION
I saw that we were not running the CI on merge to `next`.

This PR should fix this issue and make sure that the CI runs on pushes to `main` and `next`.