### PR TITLE
feat: add get_recipient_hash procedure 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* Implemented `build_recipient_hash` to build recipient hash for custom notes (#710)
 * Replaced `cargo-make` with just `make` for running tasks (#696).
 * [BREAKING] Introduce `OutputNote::Partial` variant (#698).
 * [BREAKING] Split `Account` struct constructor into `new()` and `from_parts()` (#699).

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -88,3 +88,25 @@ export.add_asset_to_note
     movdn.4 dropw
     # => [note_ptr]
 end
+
+#! Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_HASH, and input
+#!
+#! Inputs: [SERIAL_NUM, SCRIPT_HASH, input]
+#! Outputs: [RECIPIENT]
+#!
+#! Only allows a single input currently   
+export.build_recipient_hash
+  padw hmerge
+  # => [SERIAL_NUM_HASH, SCRIPT_HASH, input] 
+
+# merge SERIAL_NUM_HASH and SCRIPT_HASH
+  swapw hmerge
+  # => [SERIAL_SCRIPT_HASH, input] 
+
+  # compute the INPUT_HASH. Note: only one input is allowed
+  swapw swap.3 padw hmerge
+  # => [INPUT_HASH, SERIAL_SCRIPT_HASH]
+
+  hmerge
+  # [RECIPIENT]
+end

--- a/miden-lib/src/tests/test_tx.rs
+++ b/miden-lib/src/tests/test_tx.rs
@@ -458,6 +458,64 @@ fn test_create_note_and_add_same_nft_twice() {
     );
 }
 
+#[test]
+fn test_build_recipient_hash() {
+    let (tx_inputs, tx_args) =
+        mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
+
+    let input_note_1 = tx_inputs.input_notes().get_note(0).note();
+
+    // create output note
+    let output_serial_no = [ZERO, ONE, Felt::new(2), Felt::new(3)];
+    let tag = 8888;
+    let single_input = 2;
+    let inputs = NoteInputs::new(vec![Felt::new(single_input)]).unwrap();
+    let recipient = NoteRecipient::new(output_serial_no, input_note_1.script().clone(), inputs);
+
+    let code = format!(
+        "
+    use.miden::kernels::tx::prologue
+    use.miden::tx
+    begin
+        exec.prologue::prepare_transaction
+        # input
+        push.{inputs}
+        # SCRIPT_HASH
+        push.{script_hash}
+        # SERIAL_NUM
+        push.{output_serial_no}
+        exec.tx::build_recipient_hash
+        
+        push.{PUBLIC_NOTE}
+        push.{tag}
+        exec.tx::create_note
+    end
+    ",
+        inputs = single_input,
+        script_hash = input_note_1.script().clone().hash(),
+        output_serial_no = prepare_word(&output_serial_no),
+        PUBLIC_NOTE = NoteType::Public as u8,
+        tag = tag,
+    );
+
+    let transaction = prepare_transaction(tx_inputs, tx_args, &code, None);
+    let process = run_tx(&transaction).unwrap();
+
+    assert_eq!(
+        process.get_mem_value(ContextId::root(), NUM_CREATED_NOTES_PTR).unwrap(),
+        [ONE, ZERO, ZERO, ZERO],
+        "number of created notes must increment by 1",
+    );
+
+    let recipient_digest: Vec<Felt> = recipient.clone().digest().to_vec();
+
+    assert_eq!(
+        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_RECIPIENT_OFFSET),
+        recipient_digest.as_slice(),
+        "recipient hash not correct",
+    );
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 


### PR DESCRIPTION
Adding a procedure that returns the note recipient hash for a custom note script and dynamic note input. This PR resolves #706 

This added procedure can only calculate the recipient hash for a note with a single input. 