### PR TITLE
Add stack validation for `TransactionKernel::parse_output_stack` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [BREAKING] Split `Account` struct constructor into `new()` and `from_parts()` (#699).
 * [BREAKING] Changed the encoding of inputs notes in the advice map for consumed notes. Now the data
   is prefixed by its length, and the input and output notes encoding match (#707).
+* Added validation for the output stack to make sure it was properly cleaned (#717).
 
 ## 0.3.0 (2024-05-14)
 

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -30,6 +30,11 @@ pub use errors::{
     TransactionEventParsingError, TransactionKernelError, TransactionTraceParsingError,
 };
 
+// CONSTANTS
+// ================================================================================================
+
+const ZERO_WORD: [Felt; 4] = [ZERO, ZERO, ZERO, ZERO];
+
 // TRANSACTION KERNEL
 // ================================================================================================
 
@@ -138,7 +143,7 @@ impl TransactionKernel {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - Two last words on the stack are not equal to zero words.
+    /// - Words 3 and 4 on the stack are not ZERO.
     /// - Overflow addresses are not empty.
     pub fn parse_output_stack(
         stack: &StackOutputs,
@@ -153,13 +158,12 @@ impl TransactionKernel {
             .into();
 
         // make sure that the stack has been properly cleaned
-        let zero_word = [ZERO, ZERO, ZERO, ZERO];
-        if stack.get_stack_word(8).expect("third word missing") != zero_word {
+        if stack.get_stack_word(8).expect("third word missing") != ZERO_WORD {
             return Err(TransactionOutputError::OutputStackInvalid(
                 "Third word on output stack should consist only of ZEROs".into(),
             ));
         }
-        if stack.get_stack_word(12).expect("fourth word missing") != zero_word {
+        if stack.get_stack_word(12).expect("fourth word missing") != ZERO_WORD {
             return Err(TransactionOutputError::OutputStackInvalid(
                 "Fourth word on output stack should consist only of ZEROs".into(),
             ));

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -331,6 +331,7 @@ pub enum TransactionOutputError {
     OutputNoteDataNotFound,
     OutputNoteDataInvalid(NoteError),
     OutputNotesCommitmentInconsistent(Digest, Digest),
+    OutputStackInvalid(String),
     TooManyOutputNotes { max: usize, actual: usize },
 }
 


### PR DESCRIPTION
This small PR adds a validation for `TransactionKernel::parse_output_stack` function to make sure that stack was properly cleaned (two last words are zero words) and overflowing addresses are empty. 