### PR TITLE
Made the `DataStore` conditionally `async`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +68,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -63,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -79,6 +94,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +118,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -128,6 +169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,9 +182,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
@@ -305,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -337,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "embedded-io"
@@ -383,7 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -412,6 +459,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -500,7 +553,7 @@ checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -544,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -556,9 +609,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -575,6 +628,17 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
@@ -608,6 +672,8 @@ dependencies = [
 name = "miden-bench-tx"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "maybe-async",
  "miden-lib",
  "miden-mock",
  "miden-objects",
@@ -616,6 +682,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -720,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60994609096a8cb1e32f1fcf1c8ed63bed9b24b32730658609bad841e8caeaf9"
+checksum = "71db091ccda04c854d2da3ee4978c14066bf93442c246de8585ffa22f8b0e5ef"
 dependencies = [
  "miden-assembly",
 ]
@@ -731,6 +798,8 @@ dependencies = [
 name = "miden-tx"
 version = "0.4.0"
 dependencies = [
+ "async-trait",
+ "maybe-async",
  "miden-lib",
  "miden-mock",
  "miden-objects",
@@ -751,6 +820,26 @@ dependencies = [
  "miden-core",
  "tracing",
  "winter-verifier",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -828,6 +917,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +967,29 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -895,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -972,6 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,7 +1165,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1051,18 +1197,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1092,6 +1238,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,9 +1285,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1132,7 +1303,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1146,10 +1317,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.5"
+name = "tokio"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -1236,7 +1437,16 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1245,7 +1455,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1254,15 +1479,21 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1272,9 +1503,21 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1290,9 +1533,21 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1302,9 +1557,21 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ doc-serve: ## Serves documentation site
 
 .PHONY: test-default
 test-default: ## Run default tests excluding `prove`
-	$(DEBUG_ASSERTIONS) cargo nextest run --profile default --cargo-profile test-release --features concurrent,testing --filter-expr "not test(prove)"
+	$(DEBUG_ASSERTIONS) cargo nextest run --profile default --cargo-profile test-release --features concurrent,testing,sync --filter-expr "not test(prove)"
 
 
 .PHONY: test-prove
 test-prove: ## Run `prove` tests (tests which use the Miden prover)
-	$(DEBUG_ASSERTIONS) cargo nextest run --profile prove --cargo-profile test-release --features concurrent,testing --filter-expr "test(prove)"
+	$(DEBUG_ASSERTIONS) cargo nextest run --profile prove --cargo-profile test-release --features concurrent,testing,sync --filter-expr "test(prove)"
 
 
 .PHONY: test

--- a/bench-tx/Cargo.toml
+++ b/bench-tx/Cargo.toml
@@ -13,12 +13,20 @@ exclude.workspace = true
 name = "bench-tx"
 path = "src/main.rs"
 
+[features]
+sync = ["maybe-async/is_sync", "miden-tx/sync"]
+
 [dependencies]
+async-trait = "0.1.80"
+maybe-async = "0.2.10"
 miden-lib = { path = "../miden-lib", version = "0.4" }
 miden-objects = { path = "../objects", version = "0.4" }
 miden-tx = { path = "../miden-tx", version = "0.4" }
-mock = { package = "miden-mock", path = "../mock"  }
+mock = { package = "miden-mock", path = "../mock" }
 rand = { workspace = true }
 serde = { package = "serde", version = "1.0" }
-serde_json = { package = "serde_json", version = "1.0", features = ["preserve_order"] }
+serde_json = { package = "serde_json", version = "1.0", features = [
+    "preserve_order",
+] }
+tokio = { version = "1", features = ["full"] }
 vm-processor = { workspace = true }

--- a/bench-tx/src/main.rs
+++ b/bench-tx/src/main.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use maybe_async::{async_impl, maybe_async, sync_impl};
 use std::{
     fs::{read_to_string, write, File},
     io::Write,
@@ -7,6 +6,7 @@ use std::{
     rc::Rc,
 };
 
+use maybe_async::{async_impl, maybe_async, sync_impl};
 use miden_lib::{
     notes::create_p2id_note, transaction::ToTransactionKernelInputs, utils::Serializable,
 };

--- a/bench-tx/src/utils.rs
+++ b/bench-tx/src/utils.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 pub use alloc::collections::BTreeMap;
 
+use maybe_async::maybe_async;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, SlotItem, StorageSlot},
@@ -114,8 +115,9 @@ impl Default for MockDataStore {
     }
 }
 
+#[maybe_async]
 impl DataStore for MockDataStore {
-    fn get_transaction_inputs(
+    async fn get_transaction_inputs(
         &self,
         account_id: AccountId,
         block_num: u32,
@@ -142,7 +144,7 @@ impl DataStore for MockDataStore {
         .unwrap())
     }
 
-    fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
+    async fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
         assert_eq!(account_id, self.account.id());
         Ok(self.account.code().module().clone())
     }

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -17,11 +17,25 @@ name = "miden-tx"
 path = "tests/integration/main.rs"
 
 [features]
-concurrent = ["miden-lib/concurrent", "miden-objects/concurrent", "miden-prover/concurrent", "std"]
+concurrent = [
+    "miden-lib/concurrent",
+    "miden-objects/concurrent",
+    "miden-prover/concurrent",
+    "std",
+]
 default = ["std"]
-std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]
+std = [
+    "miden-lib/std",
+    "miden-objects/std",
+    "miden-prover/std",
+    "miden-verifier/std",
+    "vm-processor/std",
+]
+sync = ["maybe-async/is_sync"]
 
 [dependencies]
+async-trait = "0.1.80"
+maybe-async = "0.2.10"
 miden-lib = { path = "../miden-lib", version = "0.4", default-features = false }
 miden-objects = { path = "../objects", version = "0.4", default-features = false }
 miden-prover = { workspace = true }

--- a/miden-tx/src/executor/data_store.rs
+++ b/miden-tx/src/executor/data_store.rs
@@ -1,3 +1,7 @@
+#[cfg(not(feature = "sync"))]
+use alloc::boxed::Box;
+
+use maybe_async::maybe_async;
 use miden_objects::{
     accounts::AccountId, assembly::ModuleAst, notes::NoteId, transaction::TransactionInputs,
 };
@@ -9,6 +13,7 @@ use crate::DataStoreError;
 
 /// The [DataStore] trait defines the interface that transaction objects use to fetch data
 /// required for transaction execution.
+#[maybe_async]
 pub trait DataStore {
     /// Returns account, chain, and input note data required to execute a transaction against
     /// the account with the specified ID and consuming the set of specified input notes.
@@ -25,7 +30,7 @@ pub trait DataStore {
     /// - Any of the notes with the specified IDs were already consumed.
     /// - The combination of specified inputs resulted in a transaction input error.
     /// - The data store encountered some internal error
-    fn get_transaction_inputs(
+    async fn get_transaction_inputs(
         &self,
         account_id: AccountId,
         block_ref: u32,
@@ -33,5 +38,5 @@ pub trait DataStore {
     ) -> Result<TransactionInputs, DataStoreError>;
 
     /// Returns the account code [ModuleAst] associated with the specified [AccountId].
-    fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError>;
+    async fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError>;
 }

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "sync"))]
 use alloc::boxed::Box;
-
 use alloc::vec::Vec;
 
 use maybe_async::maybe_async;

--- a/miden-tx/src/tests.rs
+++ b/miden-tx/src/tests.rs
@@ -1,5 +1,9 @@
+#[cfg(not(feature = "sync"))]
+use alloc::boxed::Box;
+
 use alloc::vec::Vec;
 
+use maybe_async::maybe_async;
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     accounts::{
@@ -50,7 +54,7 @@ use super::{
 // TESTS
 // ================================================================================================
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn transaction_executor_witness() {
     let data_store = MockDataStore::default();
     let mut executor: TransactionExecutor<_, ()> =
@@ -90,7 +94,7 @@ fn transaction_executor_witness() {
     assert_eq!(executed_transaction.output_notes(), &tx_outputs.output_notes);
 }
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn executed_transaction_account_delta() {
     let data_store = MockDataStore::new(AssetPreservationStatus::PreservedWithAccountVaultDelta);
     let mut executor: TransactionExecutor<_, ()> =
@@ -347,7 +351,7 @@ fn executed_transaction_account_delta() {
     );
 }
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn executed_transaction_output_notes() {
     let data_store = MockDataStore::new(AssetPreservationStatus::PreservedWithAccountVaultDelta);
     let mut executor: TransactionExecutor<_, ()> =
@@ -536,7 +540,7 @@ fn executed_transaction_output_notes() {
     assert_eq!(NoteHeader::from(created_note), NoteHeader::new(note_id, *note_metadata));
 }
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn prove_witness_and_verify() {
     let data_store = MockDataStore::default();
     let mut executor: TransactionExecutor<_, ()> =
@@ -569,7 +573,7 @@ fn prove_witness_and_verify() {
 // TEST TRANSACTION SCRIPT
 // ================================================================================================
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn test_tx_script() {
     let data_store = MockDataStore::default();
     let mut executor: TransactionExecutor<_, ()> =
@@ -658,8 +662,9 @@ impl Default for MockDataStore {
     }
 }
 
+#[maybe_async]
 impl DataStore for MockDataStore {
-    fn get_transaction_inputs(
+    async fn get_transaction_inputs(
         &self,
         account_id: AccountId,
         block_num: u32,
@@ -686,7 +691,7 @@ impl DataStore for MockDataStore {
         .unwrap())
     }
 
-    fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
+    async fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
         assert_eq!(account_id, self.account.id());
         Ok(self.account.code().module().clone())
     }

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -1,6 +1,7 @@
 mod scripts;
 mod wallet;
 
+use maybe_async::maybe_async;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
     accounts::{
@@ -98,8 +99,9 @@ impl Default for MockDataStore {
     }
 }
 
+#[maybe_async]
 impl DataStore for MockDataStore {
-    fn get_transaction_inputs(
+    async fn get_transaction_inputs(
         &self,
         account_id: AccountId,
         block_num: u32,
@@ -126,7 +128,7 @@ impl DataStore for MockDataStore {
         .unwrap())
     }
 
-    fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
+    async fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
         assert_eq!(account_id, self.account.id());
         Ok(self.account.code().module().clone())
     }

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -29,7 +29,7 @@ use crate::{
 // TESTS MINT FUNGIBLE ASSET
 // ================================================================================================
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     let (faucet_pub_key, falcon_auth) = get_new_pk_and_authenticator();
     let faucet_account =
@@ -103,7 +103,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     );
 }
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
     let (faucet_pub_key, falcon_auth) = get_new_pk_and_authenticator();
     let faucet_account =
@@ -162,7 +162,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
 // TESTS BURN FUNGIBLE ASSET
 // ================================================================================================
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     let (faucet_pub_key, falcon_auth) = get_new_pk_and_authenticator();
     let faucet_account =

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -28,7 +28,7 @@ use crate::{
 // ===============================================================================================
 // We test the Pay to ID script. So we create a note that can only be consumed by the target
 // account.
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn prove_p2id_script() {
     // Create assets
     let faucet_id = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
@@ -129,7 +129,7 @@ fn prove_p2id_script() {
 
 /// We test the Pay to script with 2 assets to test the loop inside the script.
 /// So we create a note containing two assets that can only be consumed by the target account.
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn p2id_script_multiple_assets() {
     // Create assets
     let faucet_id = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -26,7 +26,7 @@ use crate::{get_account_with_default_account_code, get_new_pk_and_authenticator,
 // to provide a block height to the P2ID script. Before the block height is reached,
 // the note can only be consumed by the target account. After the block height is reached,
 // the note can also be consumed (reclaimed) by the sender account.
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn p2idr_script() {
     // Create assets
     let faucet_id = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -22,7 +22,7 @@ use crate::{
     prove_and_verify_transaction, MockDataStore,
 };
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 fn prove_swap_script() {
     // Create assets
     let faucet_id = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     get_note_with_fungible_asset_and_script, prove_and_verify_transaction, MockDataStore,
 };
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 // Testing the basic Miden wallet - receiving an asset
 fn prove_receive_asset_via_wallet() {
     // Create assets
@@ -105,7 +105,7 @@ fn prove_receive_asset_via_wallet() {
     assert_eq!(executed_transaction.final_account().hash(), target_account_after.hash());
 }
 
-#[test]
+#[maybe_async::test(feature = "sync")]
 /// Testing the basic Miden wallet - sending an asset
 fn prove_send_asset_via_wallet() {
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();


### PR DESCRIPTION
In this PR I propose the addition of conditional `async` for the `DataStore` trait:

This will enable the use of this trait in a web context ( WASM, WebGPU ) and is needed by the wallet team.

I have used the classic [maybe-async-rs]() crate for multiple reasons: 
- Our implementation of it in Winterfell: [winter-maybe-async] is mainly a copy paste of our needed functionality. But considering that we need to export it now to other crates outside of Winterfell like Miden base and Miden VM we will need more functionalities which would finally bring us to literally *copy-paste* the whole `maybe-async-rs` repo.
- We could pin the `maybe-async-rs` repo to a certain version to make sure that we do not have any dependency risk
- `maybe-async-rs` provides useful macros for testing and for conditional compilation of code in sync and async context
- `maybe-async-rs` is `async` first when our implementation is `sync` first which prevents the use of `tokio` which requires main functions to be async in downstream crates.

Still a WIP, making some tests.

closes: #668 