### PR TITLE
Removed to nullifier trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [BREAKING] Changed the encoding of inputs notes in the advice map for consumed notes. Now the data
   is prefixed by its length, and the input and output notes encoding match (#707).
 * Added validation for the output stack to make sure it was properly cleaned (#717).
+* [BREAKING] Added support for delegated authenticated notes (#724).
 
 ## 0.3.0 (2024-05-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   is prefixed by its length, and the input and output notes encoding match (#707).
 * Added validation for the output stack to make sure it was properly cleaned (#717).
 * [BREAKING] Added support for delegated authenticated notes (#724).
+* [BREAKING] Removed the `ToNullifier` trait (#726).
 
 ## 0.3.0 (2024-05-14)
 

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -564,6 +564,7 @@ end
 #!      ARGS,
 #!      assets_count,
 #!      ASSET_0, ..., ASSET_N,
+#!      is_authenticated,
 #!      block_num,
 #!      SUB_HASH,
 #!      NOTE_ROOT,
@@ -580,6 +581,7 @@ end
 #! - ARGS, user arguments passed to the note.
 #! - assets_count, note's assets count.
 #! - ASSET_0, ..., ASSET_N, padded note's assets.
+#! - is_authenticated, boolean indicating if the note contains an authentication proof.
 #! - block_num, note's creation block number.
 #! - SUB_HASH, the block's sub_hash for which the note was created.
 #! - NOTE_ROOT, the merkle root of the note's tree.
@@ -735,7 +737,12 @@ proc.process_input_note
     movup.4 exec.memory::get_consumed_note_metadata hmerge
     # => [AUTH_DIGEST]
 
-    exec.authenticate_note
+    adv_push.1
+    if.true
+        exec.authenticate_note
+    else
+        dropw
+    end
 end
 
 #! Process the input notes data provided via the advice provider. This involves reading the data

--- a/miden-lib/src/tests/test_prologue.rs
+++ b/miden-lib/src/tests/test_prologue.rs
@@ -113,7 +113,7 @@ fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &Prepared
 
     assert_eq!(
         read_root_mem_value(process, INPUT_NOTES_COMMITMENT_PTR),
-        inputs.input_notes().nullifier_commitment().as_elements(),
+        inputs.input_notes().commitment().as_elements(),
         "The nullifier commitment should be stored at the INPUT_NOTES_COMMITMENT_PTR"
     );
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -27,7 +27,7 @@ impl ToTransactionKernelInputs for PreparedTransaction {
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.init_hash(),
-            self.input_notes().nullifier_commitment(),
+            self.input_notes().commitment(),
             self.block_header().hash(),
         );
 
@@ -44,7 +44,7 @@ impl ToTransactionKernelInputs for ExecutedTransaction {
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.init_hash(),
-            self.input_notes().nullifier_commitment(),
+            self.input_notes().commitment(),
             self.block_header().hash(),
         );
 
@@ -62,7 +62,7 @@ impl ToTransactionKernelInputs for TransactionWitness {
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.init_hash(),
-            self.input_notes().nullifier_commitment(),
+            self.input_notes().commitment(),
             self.block_header().hash(),
         );
 
@@ -337,5 +337,5 @@ fn add_input_notes_to_advice_inputs(
     }
 
     // NOTE: keep map in sync with the `process_input_notes_data` kernel procedure
-    inputs.extend_map([(notes.nullifier_commitment(), note_data)]);
+    inputs.extend_map([(notes.commitment(), note_data)]);
 }

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -195,7 +195,7 @@ fn test_transaction_compilation_succeeds() {
     .unwrap();
     let notes = notes
         .into_iter()
-        .map(|note| InputNote::new(note, mock_inclusion_proof.clone()))
+        .map(|note| InputNote::authenticated(note, mock_inclusion_proof.clone()))
         .collect::<Vec<_>>();
 
     let notes = InputNotes::new(notes).unwrap();

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -3,10 +3,7 @@ use alloc::vec::Vec;
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     accounts::delta::AccountUpdateDetails,
-    notes::Nullifier,
-    transaction::{
-        InputNotes, OutputNote, ProvenTransaction, ProvenTransactionBuilder, TransactionWitness,
-    },
+    transaction::{OutputNote, ProvenTransaction, ProvenTransactionBuilder, TransactionWitness},
 };
 use miden_prover::prove;
 pub use miden_prover::ProvingOptions;
@@ -45,7 +42,7 @@ impl TransactionProver {
     ) -> Result<ProvenTransaction, TransactionProverError> {
         let tx_witness: TransactionWitness = transaction.into();
 
-        let input_notes: InputNotes<Nullifier> = tx_witness.tx_inputs().input_notes().into();
+        let input_notes = tx_witness.tx_inputs().input_notes();
         let account_id = tx_witness.account().id();
         let block_hash = tx_witness.block_header().hash();
 
@@ -75,7 +72,7 @@ impl TransactionProver {
             block_hash,
             proof,
         )
-        .add_input_notes(input_notes)
+        .add_input_notes(input_notes.iter().cloned())
         .add_output_notes(output_notes);
 
         let builder = match account_id.is_on_chain() {

--- a/miden-tx/src/verifier/mod.rs
+++ b/miden-tx/src/verifier/mod.rs
@@ -35,7 +35,7 @@ impl TransactionVerifier {
         let stack_inputs = TransactionKernel::build_input_stack(
             transaction.account_id(),
             transaction.account_update().init_state_hash(),
-            transaction.input_notes().nullifier_commitment(),
+            transaction.input_notes().commitment(),
             transaction.block_ref(),
         );
         let stack_outputs = TransactionKernel::build_output_stack(

--- a/mock/src/mock/chain.rs
+++ b/mock/src/mock/chain.rs
@@ -104,7 +104,7 @@ impl<R: Rng> Objects<R> {
             .enumerate()
             .map(|(index, note)| {
                 let auth_index = LeafIndex::new(index as u64).expect("index bigger than 2**20");
-                InputNote::new(
+                InputNote::authenticated(
                     note.clone(),
                     NoteInclusionProof::new(
                         header.block_num(),
@@ -621,7 +621,7 @@ pub fn mock_chain_data(consumed_notes: Vec<Note>) -> (ChainMmr, Vec<InputNote>) 
             let block_header = &block_chain[index];
             let auth_index = LeafIndex::new(index as u64).unwrap();
 
-            InputNote::new(
+            InputNote::authenticated(
                 note,
                 NoteInclusionProof::new(
                     block_header.block_num(),

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,6 +1,5 @@
 use super::{
     accounts::{Account, AccountDelta, AccountId, AccountStub},
-    notes::Nullifier,
     vm::{AdviceInputs, Program},
     BlockHeader, Digest, Felt, Hasher, Word, WORD_SIZE, ZERO,
 };
@@ -17,7 +16,7 @@ mod tx_witness;
 
 pub use chain_mmr::ChainMmr;
 pub use executed_tx::ExecutedTransaction;
-pub use inputs::{InputNote, InputNotes, ToNullifier, TransactionInputs};
+pub use inputs::{InputNote, InputNotes, TransactionInputs};
 pub use outputs::{OutputNote, OutputNotes, TransactionOutputs};
 pub use prepared_tx::PreparedTransaction;
 pub use proven_tx::{ProvenTransaction, ProvenTransactionBuilder, TxAccountUpdate};

--- a/objects/src/transaction/transaction_id.rs
+++ b/objects/src/transaction/transaction_id.rs
@@ -78,7 +78,7 @@ impl From<&ProvenTransaction> for TransactionId {
         Self::new(
             tx.account_update().init_state_hash(),
             tx.account_update().final_state_hash(),
-            tx.input_notes().nullifier_commitment(),
+            tx.input_notes().commitment(),
             tx.output_notes().commitment(),
         )
     }
@@ -86,7 +86,7 @@ impl From<&ProvenTransaction> for TransactionId {
 
 impl From<&ExecutedTransaction> for TransactionId {
     fn from(tx: &ExecutedTransaction) -> Self {
-        let input_notes_hash = tx.input_notes().nullifier_commitment();
+        let input_notes_hash = tx.input_notes().commitment();
         let output_notes_hash = tx.output_notes().commitment();
         Self::new(
             tx.initial_account().init_hash(),


### PR DESCRIPTION
Follow up to https://github.com/0xPolygonMiden/miden-base/pull/724 in preparation for https://github.com/0xPolygonMiden/miden-base/issues/353 . The `ToNullifier` trait was used only to commit to the input notes, but the input notes commitment now also needs the `NoteId`. This PR doesn't do any behaviour change, it is just in preparation for the change to the commitment.