### PR TITLE
ToNullifier to ToInputNoteCommitment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [BREAKING] Added support for delegated authenticated notes (#724).
 * [BREAKING] Changed rng to mutable reference in note creation functions (#733).
 * Added transaction IDs to the `Block` struct (#734).
+* [BREAKING] Replaced `ToNullifier` trait with `ToInputNoteCommitments`, which includes the `note_id` for delayed note authentication (#732).
 
 ## 0.3.0 (2024-05-14)
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -27,7 +27,7 @@ impl ToTransactionKernelInputs for PreparedTransaction {
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.init_hash(),
-            self.input_notes().nullifier_commitment(),
+            self.input_notes().commitment(),
             self.block_header().hash(),
         );
 
@@ -44,7 +44,7 @@ impl ToTransactionKernelInputs for ExecutedTransaction {
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.init_hash(),
-            self.input_notes().nullifier_commitment(),
+            self.input_notes().commitment(),
             self.block_header().hash(),
         );
 
@@ -62,7 +62,7 @@ impl ToTransactionKernelInputs for TransactionWitness {
         let stack_inputs = TransactionKernel::build_input_stack(
             account.id(),
             account.init_hash(),
-            self.input_notes().nullifier_commitment(),
+            self.input_notes().commitment(),
             self.block_header().hash(),
         );
 
@@ -271,7 +271,7 @@ fn add_account_to_advice_inputs(
 /// - And all notes details together under the nullifier commitment.
 ///
 fn add_input_notes_to_advice_inputs(
-    notes: &InputNotes,
+    notes: &InputNotes<InputNote>,
     tx_args: &TransactionArgs,
     inputs: &mut AdviceInputs,
 ) {
@@ -337,5 +337,5 @@ fn add_input_notes_to_advice_inputs(
     }
 
     // NOTE: keep map in sync with the `process_input_notes_data` kernel procedure
-    inputs.extend_map([(notes.nullifier_commitment(), note_data)]);
+    inputs.extend_map([(notes.commitment(), note_data)]);
 }

--- a/miden-tx/src/compiler/mod.rs
+++ b/miden-tx/src/compiler/mod.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 
 use miden_objects::{
     assembly::{Assembler, AssemblyContext, ModuleAst, ProgramAst},
-    transaction::{InputNotes, TransactionScript},
+    transaction::{InputNote, InputNotes, TransactionScript},
     Felt, NoteError, TransactionScriptError, Word,
 };
 
@@ -150,7 +150,7 @@ impl TransactionCompiler {
     pub fn compile_transaction(
         &self,
         account_id: AccountId,
-        notes: &InputNotes,
+        notes: &InputNotes<InputNote>,
         tx_script: Option<&ProgramAst>,
     ) -> Result<Program, TransactionCompilerError> {
         // Fetch the account interface from the `account_procedures` map. Return an error if the
@@ -219,7 +219,7 @@ impl TransactionCompiler {
     fn compile_notes(
         &self,
         target_account_interface: &[Digest],
-        notes: &InputNotes,
+        notes: &InputNotes<InputNote>,
         assembly_context: &mut AssemblyContext,
     ) -> Result<Vec<CodeBlock>, TransactionCompilerError> {
         let mut note_programs = Vec::new();

--- a/miden-tx/src/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/kernel_tests/test_prologue.rs
@@ -113,7 +113,7 @@ fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &Prepared
 
     assert_eq!(
         read_root_mem_value(process, INPUT_NOTES_COMMITMENT_PTR),
-        inputs.input_notes().nullifier_commitment().as_elements(),
+        inputs.input_notes().commitment().as_elements(),
         "The nullifier commitment should be stored at the INPUT_NOTES_COMMITMENT_PTR"
     );
 

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -3,10 +3,7 @@ use alloc::vec::Vec;
 use miden_lib::transaction::{ToTransactionKernelInputs, TransactionKernel};
 use miden_objects::{
     accounts::delta::AccountUpdateDetails,
-    notes::Nullifier,
-    transaction::{
-        InputNotes, OutputNote, ProvenTransaction, ProvenTransactionBuilder, TransactionWitness,
-    },
+    transaction::{OutputNote, ProvenTransaction, ProvenTransactionBuilder, TransactionWitness},
 };
 use miden_prover::prove;
 pub use miden_prover::ProvingOptions;
@@ -45,7 +42,7 @@ impl TransactionProver {
     ) -> Result<ProvenTransaction, TransactionProverError> {
         let tx_witness: TransactionWitness = transaction.into();
 
-        let input_notes: InputNotes<Nullifier> = tx_witness.tx_inputs().input_notes().into();
+        let input_notes = tx_witness.tx_inputs().input_notes();
         let account_id = tx_witness.account().id();
         let block_hash = tx_witness.block_header().hash();
 

--- a/miden-tx/src/verifier/mod.rs
+++ b/miden-tx/src/verifier/mod.rs
@@ -35,7 +35,7 @@ impl TransactionVerifier {
         let stack_inputs = TransactionKernel::build_input_stack(
             transaction.account_id(),
             transaction.account_update().init_state_hash(),
-            transaction.input_notes().nullifier_commitment(),
+            transaction.input_notes().commitment(),
             transaction.block_ref(),
         );
         let stack_outputs = TransactionKernel::build_output_stack(

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -1,9 +1,9 @@
 use core::cell::OnceCell;
 
 use super::{
-    Account, AccountDelta, AccountId, AccountStub, AdviceInputs, BlockHeader, InputNotes,
-    OutputNotes, Program, TransactionArgs, TransactionId, TransactionInputs, TransactionOutputs,
-    TransactionWitness,
+    Account, AccountDelta, AccountId, AccountStub, AdviceInputs, BlockHeader, InputNote,
+    InputNotes, OutputNotes, Program, TransactionArgs, TransactionId, TransactionInputs,
+    TransactionOutputs, TransactionWitness,
 };
 
 // EXECUTED TRANSACTION
@@ -89,7 +89,7 @@ impl ExecutedTransaction {
     }
 
     /// Returns the notes consumed in this transaction.
-    pub fn input_notes(&self) -> &InputNotes {
+    pub fn input_notes(&self) -> &InputNotes<InputNote> {
         self.tx_inputs.input_notes()
     }
 

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -17,10 +17,12 @@ mod tx_witness;
 
 pub use chain_mmr::ChainMmr;
 pub use executed_tx::ExecutedTransaction;
-pub use inputs::{InputNote, InputNotes, ToNullifier, TransactionInputs};
+pub use inputs::{InputNote, InputNotes, ToInputNoteCommitments, TransactionInputs};
 pub use outputs::{OutputNote, OutputNotes, TransactionOutputs};
 pub use prepared_tx::PreparedTransaction;
-pub use proven_tx::{ProvenTransaction, ProvenTransactionBuilder, TxAccountUpdate};
+pub use proven_tx::{
+    InputNoteCommitment, ProvenTransaction, ProvenTransactionBuilder, TxAccountUpdate,
+};
 pub use transaction_id::TransactionId;
 pub use tx_args::{TransactionArgs, TransactionScript};
 pub use tx_witness::TransactionWitness;

--- a/objects/src/transaction/prepared_tx.rs
+++ b/objects/src/transaction/prepared_tx.rs
@@ -1,4 +1,6 @@
-use super::{Account, BlockHeader, InputNotes, Program, TransactionArgs, TransactionInputs};
+use super::{
+    Account, BlockHeader, InputNote, InputNotes, Program, TransactionArgs, TransactionInputs,
+};
 
 // PREPARED TRANSACTION
 // ================================================================================================
@@ -44,7 +46,7 @@ impl PreparedTransaction {
     }
 
     /// Returns the notes to be consumed in this transaction.
-    pub fn input_notes(&self) -> &InputNotes {
+    pub fn input_notes(&self) -> &InputNotes<InputNote> {
         self.tx_inputs.input_notes()
     }
 

--- a/objects/src/transaction/transaction_id.rs
+++ b/objects/src/transaction/transaction_id.rs
@@ -78,7 +78,7 @@ impl From<&ProvenTransaction> for TransactionId {
         Self::new(
             tx.account_update().init_state_hash(),
             tx.account_update().final_state_hash(),
-            tx.input_notes().nullifier_commitment(),
+            tx.input_notes().commitment(),
             tx.output_notes().commitment(),
         )
     }
@@ -86,7 +86,7 @@ impl From<&ProvenTransaction> for TransactionId {
 
 impl From<&ExecutedTransaction> for TransactionId {
     fn from(tx: &ExecutedTransaction) -> Self {
-        let input_notes_hash = tx.input_notes().nullifier_commitment();
+        let input_notes_hash = tx.input_notes().commitment();
         let output_notes_hash = tx.output_notes().commitment();
         Self::new(
             tx.initial_account().init_hash(),

--- a/objects/src/transaction/tx_witness.rs
+++ b/objects/src/transaction/tx_witness.rs
@@ -1,5 +1,6 @@
 use super::{
-    Account, AdviceInputs, BlockHeader, InputNotes, Program, TransactionArgs, TransactionInputs,
+    Account, AdviceInputs, BlockHeader, InputNote, InputNotes, Program, TransactionArgs,
+    TransactionInputs,
 };
 
 // TRANSACTION WITNESS
@@ -61,7 +62,7 @@ impl TransactionWitness {
     }
 
     /// Returns the notes consumed in this transaction.
-    pub fn input_notes(&self) -> &InputNotes {
+    pub fn input_notes(&self) -> &InputNotes<InputNote> {
         self.tx_inputs.input_notes()
     }
 


### PR DESCRIPTION
follow up to https://github.com/0xPolygonMiden/miden-base/pull/726

Instead of removing the `ToNullifier` trait, this replaces said trait with `ToInputNoteCommitment`. The change is mainly the additional of the `Option<NoteId>`, which will be used by https://github.com/0xPolygonMiden/miden-base/issues/353 .

The decision to keep the trait is due to code reuse. Mainly of the `NoteInputs` which does the validation for the number of inputs and computes the input notes commitment. The alternative of using a wrapper type ended duplicating validation code, when I tried to remove the duplicated the error handling become worse and introduced `unwraps`. Keeping the trait eliminates these concerns.