### PR TITLE
fix: change `rng`type to `&mut R` in note creation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* [BREAKING] Change rng to mutable reference in note creation functions (#733).
 * Add new `NoteFile` object to represent serialized notes (#721).
 * Removed the `mock` crate in favor of having mock code behind the `testing` flag in remaining crates (#711).
 * [BREAKING] Create `auth` module for `TransactionAuthenticator` and other related objects (#714).

--- a/bench-tx/src/main.rs
+++ b/bench-tx/src/main.rs
@@ -122,7 +122,7 @@ pub fn benchmark_p2id() -> Result<TransactionProgress, String> {
         target_account_id,
         vec![fungible_asset],
         NoteType::Public,
-        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+        &mut RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -33,7 +33,7 @@ pub fn create_p2id_note<R: FeltRng>(
     target: AccountId,
     assets: Vec<Asset>,
     note_type: NoteType,
-    mut rng: R,
+    rng: &mut R,
 ) -> Result<Note, NoteError> {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2ID.masb"));
     let note_script = build_note_script(bytes)?;
@@ -67,7 +67,7 @@ pub fn create_p2idr_note<R: FeltRng>(
     assets: Vec<Asset>,
     note_type: NoteType,
     recall_height: u32,
-    mut rng: R,
+    rng: &mut R,
 ) -> Result<Note, NoteError> {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/P2IDR.masb"));
     let note_script = build_note_script(bytes)?;
@@ -97,7 +97,7 @@ pub fn create_swap_note<R: FeltRng>(
     offered_asset: Asset,
     requested_asset: Asset,
     note_type: NoteType,
-    mut rng: R,
+    rng: &mut R,
 ) -> Result<(Note, NoteDetails), NoteError> {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/SWAP.masb"));
     let note_script = build_note_script(bytes)?;

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -50,7 +50,7 @@ fn prove_p2id_script() {
         target_account_id,
         vec![fungible_asset],
         NoteType::Public,
-        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+        &mut RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 
@@ -153,7 +153,7 @@ fn p2id_script_multiple_assets() {
         target_account_id,
         vec![fungible_asset_1, fungible_asset_2],
         NoteType::Public,
-        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+        &mut RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -66,7 +66,7 @@ fn p2idr_script() {
         vec![fungible_asset],
         NoteType::Public,
         reclaim_block_height_in_time,
-        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+        &mut RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 
@@ -77,7 +77,7 @@ fn p2idr_script() {
         vec![fungible_asset],
         NoteType::Public,
         reclaim_block_height_reclaimable,
-        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+        &mut RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -53,7 +53,7 @@ fn prove_swap_script() {
         offered_asset,
         requested_asset,
         NoteType::Public,
-        RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+        &mut RpoRandomCoin::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
     )
     .unwrap();
 


### PR DESCRIPTION
Adresses [this comment](https://github.com/0xPolygonMiden/miden-node/pull/368#discussion_r1626329038).

Changes the note creation functions so that they receive a mutable reference to the rng.