### PR TITLE
Allow updates to all item slots

### DIFF
--- a/bench-tx/src/utils.rs
+++ b/bench-tx/src/utils.rs
@@ -89,7 +89,7 @@ pub fn get_account_with_default_account_code(
 
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], BTreeMap::new()).unwrap();
 
     let account_vault = match assets {
         Some(asset) => AssetVault::new(&[asset]).unwrap(),

--- a/bench-tx/src/utils.rs
+++ b/bench-tx/src/utils.rs
@@ -3,7 +3,7 @@ pub use alloc::collections::BTreeMap;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    accounts::{Account, AccountCode, AccountId, AccountStorage, SlotItem, StorageSlot},
+    accounts::{Account, AccountCode, AccountId, AccountStorage, SlotItem},
     assembly::ModuleAst,
     assets::{Asset, AssetVault},
     Felt, Word,
@@ -88,14 +88,8 @@ pub fn get_account_with_default_account_code(
     let account_assembler = TransactionKernel::assembler();
 
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
-    let account_storage = AccountStorage::new(
-        vec![SlotItem {
-            index: 0,
-            slot: StorageSlot::new_value(public_key),
-        }],
-        vec![],
-    )
-    .unwrap();
+    let account_storage =
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], vec![]).unwrap();
 
     let account_vault = match assets {
         Some(asset) => AssetVault::new(&[asset]).unwrap(),

--- a/miden-lib/asm/miden/kernels/tx/account.masm
+++ b/miden-lib/asm/miden/kernels/tx/account.masm
@@ -403,7 +403,7 @@ export.set_map_item.2
     # note smt::set expects the stack to be [NEW_VALUE, KEY, OLD_ROOT, ...]
     swapw exec.smt::set
     # => [OLD_VALUE, NEW_ROOT, KEY, NEW_VALUE, index, ...]
-    
+
     # store OLD_VALUE and NEW_ROOT until the end of the procedure 
     loc_storew.0 dropw loc_storew.1 dropw
     # => [KEY, NEW_VALUE, index, ...]

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -3,7 +3,6 @@ use alloc::string::ToString;
 use miden_objects::{
     accounts::{
         Account, AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType, SlotItem,
-        StorageSlot,
     },
     assembly::LibraryPath,
     assets::TokenSymbol,
@@ -72,16 +71,7 @@ pub fn create_basic_fungible_faucet(
     // - slot 0: authentication data
     // - slot 1: token metadata as [max_supply, decimals, token_symbol, 0]
     let account_storage = AccountStorage::new(
-        vec![
-            SlotItem {
-                index: 0,
-                slot: StorageSlot::new_value(auth_data),
-            },
-            SlotItem {
-                index: 1,
-                slot: StorageSlot::new_value(metadata),
-            },
-        ],
+        vec![SlotItem::new_value(0, 0, auth_data), SlotItem::new_value(1, 0, metadata)],
         vec![],
     )?;
 

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString;
+use alloc::{collections::BTreeMap, string::ToString};
 
 use miden_objects::{
     accounts::{
@@ -72,7 +72,7 @@ pub fn create_basic_fungible_faucet(
     // - slot 1: token metadata as [max_supply, decimals, token_symbol, 0]
     let account_storage = AccountStorage::new(
         vec![SlotItem::new_value(0, 0, auth_data), SlotItem::new_value(1, 0, metadata)],
-        vec![],
+        BTreeMap::new(),
     )?;
 
     let account_seed = AccountId::get_account_seed(

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -1,4 +1,7 @@
-use alloc::string::{String, ToString};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+};
 
 use miden_objects::{
     accounts::{
@@ -58,7 +61,7 @@ pub fn create_basic_wallet(
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
 
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, storage_slot_0_data)], vec![])?;
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, storage_slot_0_data)], BTreeMap::new())?;
 
     let account_seed = AccountId::get_account_seed(
         init_seed,

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -2,8 +2,7 @@ use alloc::string::{String, ToString};
 
 use miden_objects::{
     accounts::{
-        Account, AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType,
-        StorageSlot,
+        Account, AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType, SlotItem,
     },
     assembly::ModuleAst,
     AccountError, Word,
@@ -58,13 +57,8 @@ pub fn create_basic_wallet(
     let account_assembler = TransactionKernel::assembler();
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
 
-    let account_storage = AccountStorage::new(
-        vec![miden_objects::accounts::SlotItem {
-            index: 0,
-            slot: StorageSlot::new_value(storage_slot_0_data),
-        }],
-        vec![],
-    )?;
+    let account_storage =
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, storage_slot_0_data)], vec![])?;
 
     let account_seed = AccountId::get_account_seed(
         init_seed,

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -223,7 +223,7 @@ fn add_account_to_advice_inputs(
 
     // If there are storage maps, we populate the merkle store and advice map
     if !account.storage().maps().is_empty() {
-        for map in account.storage().maps() {
+        for map in account.storage().maps().values() {
             // extend the merkle store and map with the storage maps
             inputs.extend_merkle_store(map.inner_nodes());
 

--- a/miden-tx/src/kernel_tests/test_account.rs
+++ b/miden-tx/src/kernel_tests/test_account.rs
@@ -10,7 +10,7 @@ use miden_objects::{
             ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
             ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
         },
-        AccountId, AccountType, StorageSlotType,
+        AccountId, AccountType, SlotItem, StorageSlotType,
     },
     crypto::{hash::rpo::RpoDigest, merkle::LeafIndex},
     testing::{
@@ -18,7 +18,8 @@ use miden_objects::{
         notes::AssetPreservationStatus,
         prepare_word,
         storage::{
-            storage_item_0, storage_item_1, storage_item_2, storage_map_2, STORAGE_LEAVES_2,
+            storage_map_2, STORAGE_INDEX_0, STORAGE_INDEX_1, STORAGE_INDEX_2, STORAGE_LEAVES_2,
+            STORAGE_VALUE_0, STORAGE_VALUE_1,
         },
     },
 };
@@ -246,7 +247,10 @@ fn test_is_faucet_procedure() {
 
 #[test]
 fn test_get_item() {
-    for storage_item in [storage_item_0(), storage_item_1()] {
+    for storage_item in [
+        SlotItem::new_value(STORAGE_INDEX_0, 0, STORAGE_VALUE_0),
+        SlotItem::new_value(STORAGE_INDEX_1, 0, STORAGE_VALUE_1),
+    ] {
         let (tx_inputs, tx_args) =
             mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
@@ -335,7 +339,11 @@ fn test_set_item() {
 // Test different account storage types
 #[test]
 fn test_get_storage_data_type() {
-    for storage_item in [storage_item_0(), storage_item_1(), storage_item_2()] {
+    for storage_item in [
+        SlotItem::new_value(STORAGE_INDEX_0, 0, STORAGE_VALUE_0),
+        SlotItem::new_value(STORAGE_INDEX_1, 0, STORAGE_VALUE_1),
+        SlotItem::new_map(STORAGE_INDEX_2, 0, storage_map_2().root().into()),
+    ] {
         let (tx_inputs, tx_args) =
             mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
@@ -385,7 +393,7 @@ fn test_get_map_item() {
     let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
-    let storage_item = storage_item_2();
+    let storage_item = SlotItem::new_map(STORAGE_INDEX_2, 0, storage_map_2().root().into());
     for (key, value) in STORAGE_LEAVES_2 {
         let code = format!(
             "
@@ -433,7 +441,7 @@ fn test_set_map_item() {
     let (tx_inputs, tx_args) =
         mock_inputs(MockAccountType::StandardExisting, AssetPreservationStatus::Preserved);
 
-    let storage_item = storage_item_2();
+    let storage_item = SlotItem::new_map(STORAGE_INDEX_2, 0, storage_map_2().root().into());
 
     let code = format!(
         "

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -5,7 +5,7 @@ use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
     accounts::{
         account_id::testing::ACCOUNT_ID_SENDER, Account, AccountCode, AccountId, AccountStorage,
-        SlotItem, StorageSlot,
+        SlotItem,
     },
     assembly::{ModuleAst, ProgramAst},
     assets::{Asset, AssetVault, FungibleAsset},
@@ -78,14 +78,8 @@ pub fn get_account_with_default_account_code(
     let account_assembler = TransactionKernel::assembler();
 
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
-    let account_storage = AccountStorage::new(
-        vec![SlotItem {
-            index: 0,
-            slot: StorageSlot::new_value(public_key),
-        }],
-        vec![],
-    )
-    .unwrap();
+    let account_storage =
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], vec![]).unwrap();
 
     let account_vault = match assets {
         Some(asset) => AssetVault::new(&[asset]).unwrap(),

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -72,6 +72,8 @@ pub fn get_account_with_default_account_code(
     public_key: Word,
     assets: Option<Asset>,
 ) -> Account {
+    use std::collections::BTreeMap;
+
     use miden_objects::testing::account_code::DEFAULT_ACCOUNT_CODE;
     let account_code_src = DEFAULT_ACCOUNT_CODE;
     let account_code_ast = ModuleAst::parse(account_code_src).unwrap();
@@ -79,7 +81,7 @@ pub fn get_account_with_default_account_code(
 
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], BTreeMap::new()).unwrap();
 
     let account_vault = match assets {
         Some(asset) => AssetVault::new(&[asset]).unwrap(),

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -8,7 +8,7 @@ use miden_lib::{
 use miden_objects::{
     accounts::{
         account_id::testing::ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN, Account, AccountCode, AccountId,
-        AccountStorage, AccountStorageType, SlotItem, StorageSlot,
+        AccountStorage, AccountStorageType, SlotItem,
     },
     assembly::{ModuleAst, ProgramAst},
     assets::{Asset, AssetVault, FungibleAsset, TokenSymbol},
@@ -294,14 +294,8 @@ fn get_faucet_account_with_max_supply_and_total_issuance(
     let faucet_storage_slot_1 = [Felt::new(max_supply), Felt::new(0), Felt::new(0), Felt::new(0)];
     let mut faucet_account_storage = AccountStorage::new(
         vec![
-            SlotItem {
-                index: 0,
-                slot: StorageSlot::new_value(public_key),
-            },
-            SlotItem {
-                index: 1,
-                slot: StorageSlot::new_value(faucet_storage_slot_1),
-            },
+            SlotItem::new_value(0, 0, public_key),
+            SlotItem::new_value(1, 0, faucet_storage_slot_1),
         ],
         vec![],
     )

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -1,5 +1,7 @@
 extern crate alloc;
 
+use std::collections::BTreeMap;
+
 use miden_lib::{
     accounts::faucets::create_basic_fungible_faucet,
     transaction::{memory::FAUCET_STORAGE_DATA_SLOT, TransactionKernel},
@@ -297,7 +299,7 @@ fn get_faucet_account_with_max_supply_and_total_issuance(
             SlotItem::new_value(0, 0, public_key),
             SlotItem::new_value(1, 0, faucet_storage_slot_1),
         ],
-        vec![],
+        BTreeMap::new(),
     )
     .unwrap();
 

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
 use miden_objects::{
     accounts::{
@@ -86,7 +88,8 @@ fn prove_receive_asset_via_wallet() {
 
     // clone account info
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, target_pub_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, target_pub_key)], BTreeMap::new())
+            .unwrap();
     let account_code = target_account.code().clone();
     // vault delta
     let target_account_after: Account = Account::from_parts(
@@ -162,7 +165,8 @@ fn prove_send_asset_via_wallet() {
 
     // clones account info
     let sender_account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, sender_pub_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, sender_pub_key)], BTreeMap::new())
+            .unwrap();
     let sender_account_code = sender_account.code().clone();
 
     // vault delta

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -5,7 +5,7 @@ use miden_objects::{
             ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_OFF_CHAIN_SENDER,
             ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
         },
-        Account, AccountId, AccountStorage, SlotItem, StorageSlot,
+        Account, AccountId, AccountStorage, SlotItem,
     },
     assembly::ProgramAst,
     assets::{Asset, AssetVault, FungibleAsset},
@@ -85,14 +85,8 @@ fn prove_receive_asset_via_wallet() {
     assert_eq!(executed_transaction.account_delta().nonce(), Some(Felt::new(2)));
 
     // clone account info
-    let account_storage = AccountStorage::new(
-        vec![SlotItem {
-            index: 0,
-            slot: StorageSlot::new_value(target_pub_key),
-        }],
-        vec![],
-    )
-    .unwrap();
+    let account_storage =
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, target_pub_key)], vec![]).unwrap();
     let account_code = target_account.code().clone();
     // vault delta
     let target_account_after: Account = Account::from_parts(
@@ -167,14 +161,8 @@ fn prove_send_asset_via_wallet() {
     assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());
 
     // clones account info
-    let sender_account_storage = AccountStorage::new(
-        vec![SlotItem {
-            index: 0,
-            slot: StorageSlot::new_value(sender_pub_key),
-        }],
-        vec![],
-    )
-    .unwrap();
+    let sender_account_storage =
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, sender_pub_key)], vec![]).unwrap();
     let sender_account_code = sender_account.code().clone();
 
     // vault delta

--- a/objects/src/accounts/data.rs
+++ b/objects/src/accounts/data.rs
@@ -94,6 +94,8 @@ impl Deserializable for AccountData {
 
 #[cfg(test)]
 mod tests {
+    use alloc::collections::BTreeMap;
+
     use miden_crypto::{
         dsa::rpo_falcon512::SecretKey,
         utils::{Deserializable, Serializable},
@@ -118,7 +120,7 @@ mod tests {
 
         // create account and auth
         let vault = AssetVault::new(&[]).unwrap();
-        let storage = AccountStorage::new(vec![], vec![]).unwrap();
+        let storage = AccountStorage::new(vec![], BTreeMap::new()).unwrap();
         let nonce = Felt::new(0);
         let account = Account::from_parts(id, vault, storage, code, nonce);
         let account_seed = Some(Word::default());

--- a/objects/src/accounts/storage/map.rs
+++ b/objects/src/accounts/storage/map.rs
@@ -1,5 +1,3 @@
-use vm_core::EMPTY_WORD;
-
 use super::{
     AccountError, ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Serializable,
     Word,
@@ -14,8 +12,8 @@ use crate::{
 
 // ACCOUNT STORAGE MAP
 // ================================================================================================
-
-pub const EMPTY_STORAGE_MAP: Word = [
+/// Empty storage map root.
+pub const EMPTY_STORAGE_MAP_ROOT: Word = [
     Felt::new(15321474589252129342),
     Felt::new(17373224439259377994),
     Felt::new(15071539326562317628),
@@ -108,15 +106,15 @@ impl StorageMap {
     ///
     /// This method assumes that the delta has been validated by the calling method and so, no
     /// additional validation of delta is performed.
-    pub(super) fn apply_delta(&mut self, map_delta: StorageMapDelta) -> Result<(), AccountError> {
+    pub fn apply_delta(&mut self, delta: &StorageMapDelta) -> Result<(), AccountError> {
         // apply the updated leaves to the storage map
-        for (key, value) in map_delta.updated_leaves.iter() {
+        for (key, value) in delta.updated_leaves.iter() {
             self.insert(key.into(), *value);
         }
 
         // apply the cleared leaves to the storage map
-        for key in map_delta.cleared_leaves.iter() {
-            self.insert(key.into(), EMPTY_WORD);
+        for key in delta.cleared_leaves.iter() {
+            self.insert(key.into(), Smt::EMPTY_VALUE);
         }
 
         Ok(())
@@ -149,7 +147,7 @@ impl Deserializable for StorageMap {
 mod tests {
     use miden_crypto::{hash::rpo::RpoDigest, Felt};
 
-    use super::{Deserializable, Serializable, StorageMap, Word, EMPTY_STORAGE_MAP};
+    use super::{Deserializable, Serializable, StorageMap, Word, EMPTY_STORAGE_MAP_ROOT};
 
     #[test]
     fn account_storage_serialization() {
@@ -178,6 +176,6 @@ mod tests {
     #[test]
     fn test_empty_storage_map_constants() {
         // If these values don't match, update the constants.
-        assert_eq!(*StorageMap::default().root(), EMPTY_STORAGE_MAP);
+        assert_eq!(*StorageMap::default().root(), EMPTY_STORAGE_MAP_ROOT);
     }
 }

--- a/objects/src/accounts/storage/map.rs
+++ b/objects/src/accounts/storage/map.rs
@@ -1,3 +1,5 @@
+use vm_core::Felt;
+
 use super::{
     AccountError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, Word,
 };
@@ -8,6 +10,13 @@ use crate::crypto::{
 
 // ACCOUNT STORAGE MAP
 // ================================================================================================
+
+pub const EMPTY_STORAGE_MAP: Word = [
+    Felt::new(15321474589252129342),
+    Felt::new(17373224439259377994),
+    Felt::new(15071539326562317628),
+    Felt::new(3312677166725950353),
+];
 
 /// Account storage map is a Sparse Merkle Tree of depth 64. It can be used to store more data as
 /// there is in plain usage of the storage slots. The root of the SMT consumes one account storage
@@ -119,7 +128,7 @@ impl Deserializable for StorageMap {
 mod tests {
     use miden_crypto::{hash::rpo::RpoDigest, Felt};
 
-    use super::{Deserializable, Serializable, StorageMap, Word};
+    use super::{Deserializable, Serializable, StorageMap, Word, EMPTY_STORAGE_MAP};
 
     #[test]
     fn account_storage_serialization() {
@@ -143,5 +152,11 @@ mod tests {
 
         let bytes = storage_map.to_bytes();
         assert_eq!(storage_map, StorageMap::read_from_bytes(&bytes).unwrap());
+    }
+
+    #[test]
+    fn test_empty_storage_map_constants() {
+        // If these values don't match, update the constants.
+        assert_eq!(*StorageMap::default().root(), EMPTY_STORAGE_MAP);
     }
 }

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -32,6 +32,41 @@ pub struct SlotItem {
     pub slot: StorageSlot,
 }
 
+impl SlotItem {
+    /// Returns a new [SlotItem] with the [StorageSlotType::Value] type.
+    pub fn new_value(index: u8, arity: u8, value: Word) -> Self {
+        Self {
+            index,
+            slot: StorageSlot {
+                slot_type: StorageSlotType::Value { value_arity: arity },
+                value,
+            },
+        }
+    }
+
+    /// Returns a new [SlotItem] with the [StorageSlotType::Map] type.
+    pub fn new_map(index: u8, arity: u8, value: Word) -> Self {
+        Self {
+            index,
+            slot: StorageSlot {
+                slot_type: StorageSlotType::Map { value_arity: arity },
+                value,
+            },
+        }
+    }
+
+    /// Returns a new [SlotItem] with the [StorageSlotType::Array] type.
+    pub fn new_array(index: u8, arity: u8, depth: u8, value: Word) -> Self {
+        Self {
+            index,
+            slot: StorageSlot {
+                slot_type: StorageSlotType::Array { depth, value_arity: arity },
+                value,
+            },
+        }
+    }
+}
+
 /// Represents a single storage slot entry.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -360,10 +395,7 @@ mod tests {
 
     use miden_crypto::hash::rpo::RpoDigest;
 
-    use super::{
-        AccountStorage, Deserializable, Felt, Serializable, SlotItem, StorageMap, StorageSlot,
-        StorageSlotType, Word,
-    };
+    use super::{AccountStorage, Deserializable, Felt, Serializable, SlotItem, StorageMap, Word};
     use crate::{ONE, ZERO};
 
     #[test]
@@ -376,20 +408,8 @@ mod tests {
         // storage with values for default types
         let storage = AccountStorage::new(
             vec![
-                SlotItem {
-                    index: 0,
-                    slot: StorageSlot {
-                        slot_type: StorageSlotType::default(),
-                        value: [ONE, ONE, ONE, ONE],
-                    },
-                },
-                SlotItem {
-                    index: 2,
-                    slot: StorageSlot {
-                        slot_type: StorageSlotType::default(),
-                        value: [ONE, ONE, ONE, ZERO],
-                    },
-                },
+                SlotItem::new_value(0, 0, [ONE, ONE, ONE, ONE]),
+                SlotItem::new_value(2, 0, [ONE, ONE, ONE, ZERO]),
             ],
             vec![],
         )
@@ -411,28 +431,10 @@ mod tests {
         let storage_map = StorageMap::with_entries(storage_map_leaves_2).unwrap();
         let storage = AccountStorage::new(
             vec![
-                SlotItem {
-                    index: 0,
-                    slot: StorageSlot {
-                        slot_type: StorageSlotType::Value { value_arity: 1 },
-                        value: [ONE, ONE, ONE, ONE],
-                    },
-                },
-                SlotItem {
-                    index: 1,
-                    slot: StorageSlot::new_value([ONE, ONE, ONE, ZERO]),
-                },
-                SlotItem {
-                    index: 2,
-                    slot: StorageSlot::new_map(Word::from(storage_map.root())),
-                },
-                SlotItem {
-                    index: 3,
-                    slot: StorageSlot {
-                        slot_type: StorageSlotType::Array { depth: 4, value_arity: 3 },
-                        value: [ONE, ZERO, ZERO, ZERO],
-                    },
-                },
+                SlotItem::new_value(0, 1, [ONE, ONE, ONE, ONE]),
+                SlotItem::new_value(1, 0, [ONE, ONE, ONE, ZERO]),
+                SlotItem::new_map(2, 0, storage_map.root().into()),
+                SlotItem::new_array(3, 3, 4, [ONE, ZERO, ZERO, ZERO]),
             ],
             vec![storage_map],
         )

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -264,7 +264,6 @@ impl AccountStorage {
     /// - The updates violate storage layout constraints.
     /// - The updated value has an arity different from 0.
     pub(super) fn apply_delta(&mut self, delta: &AccountStorageDelta) -> Result<(), AccountError> {
-
         // --- update storage maps --------------------------------------------
 
         for &(slot_idx, ref map_delta) in delta.updated_maps.iter() {

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -160,9 +160,9 @@ impl AccountStorage {
             .count();
 
         if maps.len() > count {
-            return Err(AccountError::StorageMapToManyMaps {
-                expected: (count),
-                actual: (maps.len()),
+            return Err(AccountError::StorageMapTooManyMaps {
+                expected: count,
+                actual: maps.len(),
             });
         }
 

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -281,20 +281,6 @@ impl AccountStorage {
             return Err(AccountError::StorageSlotIsReserved(index));
         }
 
-        // only value slots of basic arity can currently be updated
-        match self.layout[usize::from(index)] {
-            StorageSlotType::Value { value_arity } => {
-                if value_arity > 0 {
-                    return Err(AccountError::StorageSlotInvalidValueArity {
-                        slot: index,
-                        expected: 0,
-                        actual: value_arity,
-                    });
-                }
-            },
-            slot_type => Err(AccountError::StorageSlotNotValueSlot(index, slot_type))?,
-        }
-
         // update the slot and return
         let index = LeafIndex::new(index.into()).expect("index is u8 - index within range");
         let slot_value = self.slots.insert(index, value);

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -162,7 +162,7 @@ impl AccountStorage {
         let mut layout = vec![StorageSlotType::default(); Self::NUM_STORAGE_SLOTS];
 
         // set the slot type for the layout commitment
-        layout[Self::SLOT_LAYOUT_COMMITMENT_INDEX as usize] =
+        layout[usize::from(Self::SLOT_LAYOUT_COMMITMENT_INDEX)] =
             StorageSlotType::Value { value_arity: 64 };
 
         // process entries to extract type data
@@ -173,14 +173,14 @@ impl AccountStorage {
                     return Err(AccountError::StorageSlotIsReserved(item.index));
                 }
 
-                layout[item.index as usize] = item.slot.slot_type;
-                Ok((item.index as u64, item.slot.value))
+                layout[usize::from(item.index)] = item.slot.slot_type;
+                Ok((item.index.into(), item.slot.value))
             })
             .collect::<Result<Vec<_>, AccountError>>()?;
 
         // add layout commitment entry
         entries.push((
-            Self::SLOT_LAYOUT_COMMITMENT_INDEX as u64,
+            Self::SLOT_LAYOUT_COMMITMENT_INDEX.into(),
             *Hasher::hash_elements(&layout.iter().map(Felt::from).collect::<Vec<_>>()),
         ));
 
@@ -216,7 +216,7 @@ impl AccountStorage {
     ///
     /// If the item is not present in the storage, [ZERO; 4] is returned.
     pub fn get_item(&self, index: u8) -> Digest {
-        let item_index = NodeIndex::new(Self::STORAGE_TREE_DEPTH, index as u64)
+        let item_index = NodeIndex::new(Self::STORAGE_TREE_DEPTH, index.into())
             .expect("index is u8 - index within range");
         self.slots.get_node(item_index).expect("index is u8 - index within range")
     }
@@ -278,7 +278,7 @@ impl AccountStorage {
         }
 
         // only value slots of basic arity can currently be updated
-        match self.layout[index as usize] {
+        match self.layout[usize::from(index)] {
             StorageSlotType::Value { value_arity } => {
                 if value_arity > 0 {
                     return Err(AccountError::StorageSlotInvalidValueArity {
@@ -292,7 +292,7 @@ impl AccountStorage {
         }
 
         // update the slot and return
-        let index = LeafIndex::new(index as u64).expect("index is u8 - index within range");
+        let index = LeafIndex::new(index.into()).expect("index is u8 - index within range");
         let slot_value = self.slots.insert(index, value);
         Ok(slot_value)
     }

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -403,7 +403,7 @@ impl Deserializable for AccountStorage {
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::BTreeMap;
+    use alloc::{collections::BTreeMap, vec::Vec};
 
     use miden_crypto::hash::rpo::RpoDigest;
 
@@ -412,22 +412,22 @@ mod tests {
 
     #[test]
     fn account_storage_serialization() {
-        // // empty storage
-        // let storage = AccountStorage::new(Vec::new(), BTreeMap::new()).unwrap();
-        // let bytes = storage.to_bytes();
-        // assert_eq!(storage, AccountStorage::read_from_bytes(&bytes).unwrap());
+        // empty storage
+        let storage = AccountStorage::new(Vec::new(), BTreeMap::new()).unwrap();
+        let bytes = storage.to_bytes();
+        assert_eq!(storage, AccountStorage::read_from_bytes(&bytes).unwrap());
 
-        // // storage with values for default types
-        // let storage = AccountStorage::new(
-        //     vec![
-        //         SlotItem::new_value(0, 0, [ONE, ONE, ONE, ONE]),
-        //         SlotItem::new_value(2, 0, [ONE, ONE, ONE, ZERO]),
-        //     ],
-        //     BTreeMap::new(),
-        // )
-        // .unwrap();
-        // let bytes = storage.to_bytes();
-        // assert_eq!(storage, AccountStorage::read_from_bytes(&bytes).unwrap());
+        // storage with values for default types
+        let storage = AccountStorage::new(
+            vec![
+                SlotItem::new_value(0, 0, [ONE, ONE, ONE, ONE]),
+                SlotItem::new_value(2, 0, [ONE, ONE, ONE, ZERO]),
+            ],
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let bytes = storage.to_bytes();
+        assert_eq!(storage, AccountStorage::read_from_bytes(&bytes).unwrap());
 
         // storage with values for complex types
         let storage_map_leaves_2: [(RpoDigest, Word); 2] = [

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -191,7 +191,7 @@ impl AccountStorage {
         // add layout commitment entry
         entries.push((
             AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX.into(),
-            *Hasher::hash_elements(&layout.iter().map(Felt::from).collect::<Vec<_>>()),
+            *layout_commitment(&layout),
         ));
 
         // construct storage slots smt and populate the types vector.
@@ -237,7 +237,7 @@ impl AccountStorage {
 
     /// Returns a commitment to the storage layout.
     pub fn layout_commitment(&self) -> Digest {
-        Hasher::hash_elements(&self.layout.iter().map(Felt::from).collect::<Vec<_>>())
+        layout_commitment(&self.layout)
     }
 
     /// Returns the storage maps for this storage.
@@ -300,6 +300,14 @@ impl AccountStorage {
         let slot_value = self.slots.insert(index, value);
         Ok(slot_value)
     }
+}
+
+// UTILITIES
+// ------------------------------------------------------------------------------------------------
+
+/// Computes the commitment to the given layout
+fn layout_commitment(layout: &[StorageSlotType]) -> Digest {
+    Hasher::hash_elements(&layout.iter().map(Felt::from).collect::<Vec<_>>())
 }
 
 // SERIALIZATION

--- a/objects/src/accounts/storage/slot.rs
+++ b/objects/src/accounts/storage/slot.rs
@@ -1,5 +1,8 @@
 use alloc::string::{String, ToString};
 
+use vm_core::utils::{Deserializable, Serializable};
+use vm_processor::DeserializationError;
+
 use super::Felt;
 
 // CONSTANTS
@@ -137,5 +140,23 @@ impl From<StorageSlotType> for Felt {
 impl From<&StorageSlotType> for Felt {
     fn from(value: &StorageSlotType) -> Self {
         Self::from(*value)
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for StorageSlotType {
+    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+        target.write_u16(self.into());
+    }
+}
+
+impl Deserializable for StorageSlotType {
+    fn read_from<R: vm_core::utils::ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, vm_processor::DeserializationError> {
+        let encoded = source.read_u16()?;
+        StorageSlotType::try_from(encoded).map_err(DeserializationError::InvalidValue)
     }
 }

--- a/objects/src/accounts/storage/slot.rs
+++ b/objects/src/accounts/storage/slot.rs
@@ -57,7 +57,6 @@ impl StorageSlotType {
     pub fn is_default(&self) -> bool {
         match self {
             StorageSlotType::Value { value_arity } => *value_arity == 0,
-            StorageSlotType::Map { value_arity } => *value_arity == 0,
             _ => false,
         }
     }

--- a/objects/src/accounts/storage/slot.rs
+++ b/objects/src/accounts/storage/slot.rs
@@ -7,7 +7,7 @@ use vm_core::{
 };
 use vm_processor::DeserializationError;
 
-use super::{Felt, EMPTY_STORAGE_MAP, STORAGE_TREE_DEPTH};
+use super::{map::EMPTY_STORAGE_MAP_ROOT, Felt, STORAGE_TREE_DEPTH};
 
 // CONSTANTS
 // ================================================================================================
@@ -57,15 +57,16 @@ impl StorageSlotType {
     pub fn is_default(&self) -> bool {
         match self {
             StorageSlotType::Value { value_arity } => *value_arity == 0,
+            StorageSlotType::Map { value_arity } => *value_arity == 0,
             _ => false,
         }
     }
 
     /// Returns the empty [Word] for a value of this type.
-    pub fn empty_word(&self) -> Word {
+    pub fn default_word(&self) -> Word {
         match self {
             StorageSlotType::Value { .. } => SimpleSmt::<STORAGE_TREE_DEPTH>::EMPTY_VALUE,
-            StorageSlotType::Map { .. } => EMPTY_STORAGE_MAP,
+            StorageSlotType::Map { .. } => EMPTY_STORAGE_MAP_ROOT,
             StorageSlotType::Array { .. } => EMPTY_WORD,
         }
     }

--- a/objects/src/accounts/storage/slot.rs
+++ b/objects/src/accounts/storage/slot.rs
@@ -1,9 +1,13 @@
 use alloc::string::{String, ToString};
 
-use vm_core::utils::{Deserializable, Serializable};
+use miden_crypto::merkle::SimpleSmt;
+use vm_core::{
+    utils::{Deserializable, Serializable},
+    Word, EMPTY_WORD,
+};
 use vm_processor::DeserializationError;
 
-use super::Felt;
+use super::{Felt, EMPTY_STORAGE_MAP, STORAGE_TREE_DEPTH};
 
 // CONSTANTS
 // ================================================================================================
@@ -54,6 +58,15 @@ impl StorageSlotType {
         match self {
             StorageSlotType::Value { value_arity } => *value_arity == 0,
             _ => false,
+        }
+    }
+
+    /// Returns the empty [Word] for a value of this type.
+    pub fn empty_word(&self) -> Word {
+        match self {
+            StorageSlotType::Value { .. } => SimpleSmt::<STORAGE_TREE_DEPTH>::EMPTY_VALUE,
+            StorageSlotType::Map { .. } => EMPTY_STORAGE_MAP,
+            StorageSlotType::Array { .. } => EMPTY_WORD,
         }
     }
 }

--- a/objects/src/accounts/storage/testing.rs
+++ b/objects/src/accounts/storage/testing.rs
@@ -32,12 +32,6 @@ impl AccountStorageBuilder {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn add_maps<I: IntoIterator<Item = StorageMap>>(&mut self, maps: I) -> &mut Self {
-        self.maps.extend(maps);
-        self
-    }
-
     pub fn build(&self) -> AccountStorage {
         AccountStorage::new(self.items.clone(), self.maps.clone()).unwrap()
     }

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -34,7 +34,7 @@ pub enum AccountError {
     StorageSlotInvalidValueArity { slot: u8, expected: u8, actual: u8 },
     StorageSlotIsReserved(u8),
     StorageSlotNotValueSlot(u8, StorageSlotType),
-    StorageMapToManyMaps { expected: usize, actual: usize },
+    StorageMapTooManyMaps { expected: usize, actual: usize },
     StubDataIncorrectLength(usize, usize),
 }
 

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -33,7 +33,8 @@ pub enum AccountError {
     SeedDigestTooFewTrailingZeros { expected: u32, actual: u32 },
     StorageSlotInvalidValueArity { slot: u8, expected: u8, actual: u8 },
     StorageSlotIsReserved(u8),
-    StorageSlotNotValueSlot(u8, StorageSlotType),
+    StorageSlotArrayNotAllowed(u8, StorageSlotType),
+    StorageMapNotFound(u8),
     StorageMapTooManyMaps { expected: usize, actual: usize },
     StubDataIncorrectLength(usize, usize),
 }

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -14,8 +14,8 @@ use super::{
     assets::non_fungible_asset,
     constants::FUNGIBLE_ASSET_AMOUNT,
     storage::{
-        generate_account_seed, storage_item_0, storage_item_1, storage_item_2, storage_map_2,
-        AccountSeedType, AccountStorageBuilder,
+        generate_account_seed, storage_map_2, AccountSeedType, AccountStorageBuilder,
+        STORAGE_INDEX_0, STORAGE_INDEX_1, STORAGE_INDEX_2, STORAGE_VALUE_0, STORAGE_VALUE_1,
     },
 };
 use crate::{
@@ -235,7 +235,11 @@ pub fn mock_account_vault() -> AssetVault {
 pub fn mock_account_storage() -> AccountStorage {
     // create account storage
     AccountStorage::new(
-        vec![storage_item_0(), storage_item_1(), storage_item_2()],
+        vec![
+            SlotItem::new_value(STORAGE_INDEX_0, 0, STORAGE_VALUE_0),
+            SlotItem::new_value(STORAGE_INDEX_1, 0, STORAGE_VALUE_1),
+            SlotItem::new_map(STORAGE_INDEX_2, 0, storage_map_2().root().into()),
+        ],
         vec![storage_map_2()],
     )
     .unwrap()

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    collections::BTreeMap,
     string::{String, ToString},
     vec::Vec,
 };
@@ -234,13 +235,15 @@ pub fn mock_account_vault() -> AssetVault {
 
 pub fn mock_account_storage() -> AccountStorage {
     // create account storage
+    let mut maps = BTreeMap::new();
+    maps.insert(STORAGE_INDEX_2, storage_map_2());
     AccountStorage::new(
         vec![
             SlotItem::new_value(STORAGE_INDEX_0, 0, STORAGE_VALUE_0),
             SlotItem::new_value(STORAGE_INDEX_1, 0, STORAGE_VALUE_1),
             SlotItem::new_map(STORAGE_INDEX_2, 0, storage_map_2().root().into()),
         ],
-        vec![storage_map_2()],
+        maps,
     )
     .unwrap()
 }

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -134,7 +134,7 @@ impl<T: Rng> AccountBuilder<T> {
         let inner_storage = self.storage_builder.build();
 
         for (key, value) in inner_storage.slots().leaves() {
-            if key != 255 {
+            if key != AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX.into() {
                 // don't copy the reserved key
                 storage.set_item(key as u8, *value).map_err(AccountBuilderError::AccountError)?;
             }

--- a/objects/src/testing/storage.rs
+++ b/objects/src/testing/storage.rs
@@ -21,7 +21,7 @@ use crate::{
         code::testing::make_account_code,
         get_account_seed_single, Account, AccountDelta, AccountId, AccountStorage,
         AccountStorageDelta, AccountStorageType, AccountType, AccountVaultDelta, SlotItem,
-        StorageMap, StorageSlot, StorageSlotType,
+        StorageMap,
     },
     assets::{Asset, AssetVault, FungibleAsset},
     notes::NoteAssets,
@@ -91,29 +91,8 @@ pub const STORAGE_LEAVES_2: [(Digest, Word); 2] = [
     ),
 ];
 
-pub fn storage_item_0() -> SlotItem {
-    SlotItem {
-        index: STORAGE_INDEX_0,
-        slot: StorageSlot::new_value(STORAGE_VALUE_0),
-    }
-}
-
-pub fn storage_item_1() -> SlotItem {
-    SlotItem {
-        index: STORAGE_INDEX_1,
-        slot: StorageSlot::new_value(STORAGE_VALUE_1),
-    }
-}
-
 pub fn storage_map_2() -> StorageMap {
     StorageMap::with_entries(STORAGE_LEAVES_2).unwrap()
-}
-
-pub fn storage_item_2() -> SlotItem {
-    SlotItem {
-        index: STORAGE_INDEX_2,
-        slot: StorageSlot::new_map(Word::from(storage_map_2().root())),
-    }
 }
 
 // MOCK FAUCET
@@ -131,10 +110,11 @@ pub fn mock_fungible_faucet(
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE)
     };
     let account_storage = AccountStorage::new(
-        vec![SlotItem {
-            index: FAUCET_STORAGE_DATA_SLOT,
-            slot: StorageSlot::new_value([ZERO, ZERO, ZERO, initial_balance]),
-        }],
+        vec![SlotItem::new_value(
+            FAUCET_STORAGE_DATA_SLOT,
+            0,
+            [ZERO, ZERO, ZERO, initial_balance],
+        )],
         vec![],
     )
     .unwrap();
@@ -163,10 +143,7 @@ pub fn mock_non_fungible_faucet(
     // TODO: add nft tree data to account storage?
 
     let account_storage = AccountStorage::new(
-        vec![SlotItem {
-            index: FAUCET_STORAGE_DATA_SLOT,
-            slot: StorageSlot::new_map(*nft_tree.root()),
-        }],
+        vec![SlotItem::new_map(FAUCET_STORAGE_DATA_SLOT, 0, *nft_tree.root())],
         vec![],
     )
     .unwrap();
@@ -270,17 +247,11 @@ pub fn build_account(assets: Vec<Asset>, nonce: Felt, storage_items: Vec<Word>) 
     let id = AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
     let code = make_account_code();
 
-    // build account data
     let vault = AssetVault::new(&assets).unwrap();
-
-    let slot_type = StorageSlotType::Value { value_arity: 0 };
     let slot_items: Vec<SlotItem> = storage_items
         .into_iter()
         .enumerate()
-        .map(|(index, item)| SlotItem {
-            index: index as u8,
-            slot: StorageSlot { slot_type, value: item },
-        })
+        .map(|(index, item)| SlotItem::new_value(index as u8, 0, item))
         .collect();
     let storage = AccountStorage::new(slot_items, vec![]).unwrap();
 


### PR DESCRIPTION
Bugfix for set_item with a mapping.

This PR also:

- Add utils to create slot items, to make the tests a little bit shorter and more explicit
- Add a empty value for all slot types, so the serialization can skip empty maps and arrays in addition to empty values
- Removes some code duplication, adds some docs, and tries to stream line the account storage serde