### PR TITLE
Apply account delta storage maps

### DIFF
--- a/bench-tx/src/utils.rs
+++ b/bench-tx/src/utils.rs
@@ -89,7 +89,7 @@ pub fn get_account_with_default_account_code(
 
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], BTreeMap::new()).unwrap();
 
     let account_vault = match assets {
         Some(asset) => AssetVault::new(&[asset]).unwrap(),

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString;
+use alloc::{collections::BTreeMap, string::ToString};
 
 use miden_objects::{
     accounts::{
@@ -72,7 +72,7 @@ pub fn create_basic_fungible_faucet(
     // - slot 1: token metadata as [max_supply, decimals, token_symbol, 0]
     let account_storage = AccountStorage::new(
         vec![SlotItem::new_value(0, 0, auth_data), SlotItem::new_value(1, 0, metadata)],
-        vec![],
+        BTreeMap::new(),
     )?;
 
     let account_seed = AccountId::get_account_seed(

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -1,4 +1,7 @@
-use alloc::string::{String, ToString};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+};
 
 use miden_objects::{
     accounts::{
@@ -58,7 +61,7 @@ pub fn create_basic_wallet(
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
 
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, storage_slot_0_data)], vec![])?;
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, storage_slot_0_data)], BTreeMap::new())?;
 
     let account_seed = AccountId::get_account_seed(
         init_seed,

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -223,7 +223,7 @@ fn add_account_to_advice_inputs(
 
     // If there are storage maps, we populate the merkle store and advice map
     if !account.storage().maps().is_empty() {
-        for map in account.storage().maps() {
+        for map in account.storage().maps().values() {
             // extend the merkle store and map with the storage maps
             inputs.extend_merkle_store(map.inner_nodes());
 

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -72,6 +72,8 @@ pub fn get_account_with_default_account_code(
     public_key: Word,
     assets: Option<Asset>,
 ) -> Account {
+    use std::collections::BTreeMap;
+
     use miden_objects::testing::account_code::DEFAULT_ACCOUNT_CODE;
     let account_code_src = DEFAULT_ACCOUNT_CODE;
     let account_code_ast = ModuleAst::parse(account_code_src).unwrap();
@@ -79,7 +81,7 @@ pub fn get_account_with_default_account_code(
 
     let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, public_key)], BTreeMap::new()).unwrap();
 
     let account_vault = match assets {
         Some(asset) => AssetVault::new(&[asset]).unwrap(),

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -1,5 +1,7 @@
 extern crate alloc;
 
+use std::collections::BTreeMap;
+
 use miden_lib::{
     accounts::faucets::create_basic_fungible_faucet,
     transaction::{memory::FAUCET_STORAGE_DATA_SLOT, TransactionKernel},
@@ -297,7 +299,7 @@ fn get_faucet_account_with_max_supply_and_total_issuance(
             SlotItem::new_value(0, 0, public_key),
             SlotItem::new_value(1, 0, faucet_storage_slot_1),
         ],
-        vec![],
+        BTreeMap::new(),
     )
     .unwrap();
 

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
 use miden_objects::{
     accounts::{
@@ -86,7 +88,8 @@ fn prove_receive_asset_via_wallet() {
 
     // clone account info
     let account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, target_pub_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, target_pub_key)], BTreeMap::new())
+            .unwrap();
     let account_code = target_account.code().clone();
     // vault delta
     let target_account_after: Account = Account::from_parts(
@@ -162,7 +165,8 @@ fn prove_send_asset_via_wallet() {
 
     // clones account info
     let sender_account_storage =
-        AccountStorage::new(vec![SlotItem::new_value(0, 0, sender_pub_key)], vec![]).unwrap();
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, sender_pub_key)], BTreeMap::new())
+            .unwrap();
     let sender_account_code = sender_account.code().clone();
 
     // vault delta

--- a/objects/src/accounts/data.rs
+++ b/objects/src/accounts/data.rs
@@ -94,6 +94,8 @@ impl Deserializable for AccountData {
 
 #[cfg(test)]
 mod tests {
+    use alloc::collections::BTreeMap;
+
     use miden_crypto::{
         dsa::rpo_falcon512::SecretKey,
         utils::{Deserializable, Serializable},
@@ -118,7 +120,7 @@ mod tests {
 
         // create account and auth
         let vault = AssetVault::new(&[]).unwrap();
-        let storage = AccountStorage::new(vec![], vec![]).unwrap();
+        let storage = AccountStorage::new(vec![], BTreeMap::new()).unwrap();
         let nonce = Felt::new(0);
         let account = Account::from_parts(id, vault, storage, code, nonce);
         let account_seed = Some(Word::default());

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -370,17 +370,25 @@ mod tests {
             ),
         ];
         let mut storage_map = StorageMap::with_entries(storage_map_leaves_2).unwrap();
-        let mut account = build_account(vec![asset_0], init_nonce, vec![word], Some(storage_map.clone()));
+        let mut account =
+            build_account(vec![asset_0], init_nonce, vec![word], Some(storage_map.clone()));
 
-        let new_map_entry = (Digest::new([Felt::new(101), Felt::new(102), Felt::new(103), Felt::new(104)]), [Felt::new(9_u64), Felt::new(10_u64), Felt::new(11_u64), Felt::new(12_u64)]);
-        let updated_map = StorageMapDelta::from(vec![], vec![(new_map_entry.0.into(), new_map_entry.1)]);
+        let new_map_entry = (
+            Digest::new([Felt::new(101), Felt::new(102), Felt::new(103), Felt::new(104)]),
+            [Felt::new(9_u64), Felt::new(10_u64), Felt::new(11_u64), Felt::new(12_u64)],
+        );
+        let updated_map =
+            StorageMapDelta::from(vec![], vec![(new_map_entry.0.into(), new_map_entry.1)]);
         storage_map.insert(new_map_entry.0, new_map_entry.1);
 
         // build account delta
         let final_nonce = Felt::new(2);
         let storage_delta = AccountStorageDeltaBuilder::new()
             .add_cleared_items([0])
-            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]), (254_u8, storage_map.root().into())])
+            .add_updated_items([
+                (1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
+                (254_u8, storage_map.root().into()),
+            ])
             .add_updated_maps([(254_u8, updated_map)])
             .build()
             .unwrap();
@@ -390,7 +398,12 @@ mod tests {
         // apply delta and create final_account
         account.apply_delta(&account_delta).unwrap();
 
-        let final_account = build_account(vec![asset_1], final_nonce, vec![Word::default(), word], Some(storage_map));
+        let final_account = build_account(
+            vec![asset_1],
+            final_nonce,
+            vec![Word::default(), word],
+            Some(storage_map),
+        );
 
         // assert account is what it should be
         assert_eq!(account, final_account);

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -315,10 +315,11 @@ mod tests {
         utils::{Deserializable, Serializable},
         Felt, Word,
     };
+    use vm_processor::Digest;
 
     use super::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
     use crate::{
-        accounts::{delta::AccountStorageDeltaBuilder, Account},
+        accounts::{delta::AccountStorageDeltaBuilder, Account, StorageMap, StorageMapDelta},
         testing::storage::{build_account, build_account_delta, build_assets},
     };
 
@@ -327,7 +328,7 @@ mod tests {
         let init_nonce = Felt::new(1);
         let (asset_0, _) = build_assets();
         let word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-        let account = build_account(vec![asset_0], init_nonce, vec![word]);
+        let account = build_account(vec![asset_0], init_nonce, vec![word], None);
 
         let serialized = account.to_bytes();
         let deserialized = Account::read_from_bytes(&serialized).unwrap();
@@ -357,13 +358,30 @@ mod tests {
         let init_nonce = Felt::new(1);
         let (asset_0, asset_1) = build_assets();
         let word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-        let mut account = build_account(vec![asset_0], init_nonce, vec![word]);
+        // StorageMap with values
+        let storage_map_leaves_2: [(Digest, Word); 2] = [
+            (
+                Digest::new([Felt::new(101), Felt::new(102), Felt::new(103), Felt::new(104)]),
+                [Felt::new(1_u64), Felt::new(2_u64), Felt::new(3_u64), Felt::new(4_u64)],
+            ),
+            (
+                Digest::new([Felt::new(105), Felt::new(106), Felt::new(107), Felt::new(108)]),
+                [Felt::new(5_u64), Felt::new(6_u64), Felt::new(7_u64), Felt::new(8_u64)],
+            ),
+        ];
+        let mut storage_map = StorageMap::with_entries(storage_map_leaves_2).unwrap();
+        let mut account = build_account(vec![asset_0], init_nonce, vec![word], Some(storage_map.clone()));
+
+        let new_map_entry = (Digest::new([Felt::new(101), Felt::new(102), Felt::new(103), Felt::new(104)]), [Felt::new(9_u64), Felt::new(10_u64), Felt::new(11_u64), Felt::new(12_u64)]);
+        let updated_map = StorageMapDelta::from(vec![], vec![(new_map_entry.0.into(), new_map_entry.1)]);
+        storage_map.insert(new_map_entry.0, new_map_entry.1);
 
         // build account delta
         let final_nonce = Felt::new(2);
         let storage_delta = AccountStorageDeltaBuilder::new()
             .add_cleared_items([0])
-            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)])])
+            .add_updated_items([(1_u8, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]), (254_u8, storage_map.root().into())])
+            .add_updated_maps([(254_u8, updated_map)])
             .build()
             .unwrap();
         let account_delta =
@@ -371,7 +389,8 @@ mod tests {
 
         // apply delta and create final_account
         account.apply_delta(&account_delta).unwrap();
-        let final_account = build_account(vec![asset_1], final_nonce, vec![Word::default(), word]);
+
+        let final_account = build_account(vec![asset_1], final_nonce, vec![Word::default(), word], Some(storage_map));
 
         // assert account is what it should be
         assert_eq!(account, final_account);
@@ -383,7 +402,7 @@ mod tests {
         // build account
         let init_nonce = Felt::new(1);
         let (asset, _) = build_assets();
-        let mut account = build_account(vec![asset], init_nonce, vec![Word::default()]);
+        let mut account = build_account(vec![asset], init_nonce, vec![Word::default()], None);
 
         // build account delta
         let storage_delta = AccountStorageDeltaBuilder::new()
@@ -403,7 +422,7 @@ mod tests {
         // build account
         let init_nonce = Felt::new(2);
         let (asset, _) = build_assets();
-        let mut account = build_account(vec![asset], init_nonce, vec![Word::default()]);
+        let mut account = build_account(vec![asset], init_nonce, vec![Word::default()], None);
 
         // build account delta
         let final_nonce = Felt::new(1);
@@ -424,7 +443,7 @@ mod tests {
         // build account
         let init_nonce = Felt::new(1);
         let word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-        let mut account = build_account(vec![], init_nonce, vec![word]);
+        let mut account = build_account(vec![], init_nonce, vec![word], None);
 
         // build account delta
         let final_nonce = Felt::new(2);

--- a/objects/src/accounts/storage/map.rs
+++ b/objects/src/accounts/storage/map.rs
@@ -1,11 +1,15 @@
-use vm_core::Felt;
+use vm_core::EMPTY_WORD;
 
 use super::{
-    AccountError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, Word,
+    AccountError, ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Serializable,
+    Word,
 };
-use crate::crypto::{
-    hash::rpo::RpoDigest,
-    merkle::{InnerNodeInfo, LeafIndex, Smt, SmtLeaf, SmtProof, SMT_DEPTH},
+use crate::{
+    accounts::StorageMapDelta,
+    crypto::{
+        hash::rpo::RpoDigest,
+        merkle::{InnerNodeInfo, LeafIndex, Smt, SmtLeaf, SmtProof, SMT_DEPTH},
+    },
 };
 
 // ACCOUNT STORAGE MAP
@@ -94,10 +98,28 @@ impl StorageMap {
         self.map.inner_nodes() // Delegate to Smt's inner_nodes method
     }
 
-    // STATE MUTATORS
+    // DATA MUTATORS
     // --------------------------------------------------------------------------------------------
     pub fn insert(&mut self, key: RpoDigest, value: Word) -> Word {
         self.map.insert(key, value) // Delegate to Smt's insert method
+    }
+
+    /// Applies the provided delta to this account storage.
+    ///
+    /// This method assumes that the delta has been validated by the calling method and so, no
+    /// additional validation of delta is performed.
+    pub(super) fn apply_delta(&mut self, map_delta: StorageMapDelta) -> Result<(), AccountError> {
+        // apply the updated leaves to the storage map
+        for (key, value) in map_delta.updated_leaves.iter() {
+            self.insert(key.into(), *value);
+        }
+
+        // apply the cleared leaves to the storage map
+        for key in map_delta.cleared_leaves.iter() {
+            self.insert(key.into(), EMPTY_WORD);
+        }
+
+        Ok(())
     }
 }
 

--- a/objects/src/accounts/storage/map.rs
+++ b/objects/src/accounts/storage/map.rs
@@ -96,7 +96,6 @@ impl StorageMap {
 
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
-
     pub fn insert(&mut self, key: RpoDigest, value: Word) -> Word {
         self.map.insert(key, value) // Delegate to Smt's insert method
     }

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -1,8 +1,7 @@
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 
 use super::{
-    AccountError, AccountStorageDelta, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Digest, Felt, Hasher, Serializable, Word,
+    AccountError, AccountStorageDelta, ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher, Serializable, StorageMapDelta, Word, ZERO
 };
 use crate::crypto::merkle::{LeafIndex, NodeIndex, SimpleSmt};
 
@@ -245,6 +244,16 @@ impl AccountStorage {
         &self.maps
     }
 
+    // Returns the storage map with a given root.
+    pub fn find_storage_map_by_root(&mut self, target_root: Digest) -> Option<&mut StorageMap> {
+        for map in &mut self.maps {
+            if map.root() == target_root {
+                return Some(map);
+            }
+        }
+        None
+    }
+
     // DATA MUTATORS
     // --------------------------------------------------------------------------------------------
 
@@ -258,6 +267,12 @@ impl AccountStorage {
     /// - The delta implies an update to a reserved account slot.
     /// - The updates violate storage layout constraints.
     pub(super) fn apply_delta(&mut self, delta: &AccountStorageDelta) -> Result<(), AccountError> {
+        // Map updates are applied first as we need to find the storage map by its old root
+        // and every map updates always involves updating the root in the Storage slots as well.
+        for &(slot_idx, ref map_delta) in delta.updated_maps.iter() {
+            self.set_map_item(slot_idx, map_delta.clone())?;
+        }
+
         for &slot_idx in delta.cleared_items.iter() {
             self.set_item(slot_idx, Word::default())?;
         }
@@ -281,10 +296,68 @@ impl AccountStorage {
             return Err(AccountError::StorageSlotIsReserved(index));
         }
 
+        // only value slots of basic arity can currently be updated
+        match self.layout[index as usize] {
+            StorageSlotType::Value { value_arity } => {
+                if value_arity > 0 {
+                    return Err(AccountError::StorageSlotInvalidValueArity {
+                        slot: index,
+                        expected: 0,
+                        actual: value_arity,
+                    });
+                }
+            },
+            StorageSlotType::Map { value_arity } => {
+                if value_arity > 0 {
+                    return Err(AccountError::StorageSlotInvalidValueArity {
+                        slot: index,
+                        expected: 0,
+                        actual: value_arity,
+                    });
+                }
+            }
+            slot_type => Err(AccountError::StorageSlotNotValueSlot(index, slot_type))?,
+        }
+
         // update the slot and return
         let index = LeafIndex::new(index.into()).expect("index is u8 - index within range");
         let slot_value = self.slots.insert(index, value);
         Ok(slot_value)
+    }
+
+    /// Updates a storage map at the specified index.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The index specifies a reserved storage slot.
+    /// - The index is not u8.
+    /// - The map does not exist at the specified index.
+    pub fn set_map_item(&mut self, index: u8, map_delta: StorageMapDelta) -> Result<(), AccountError> {
+        // layout commitment slot cannot be updated
+        if index == Self::SLOT_LAYOUT_COMMITMENT_INDEX {
+            return Err(AccountError::StorageSlotIsReserved(index));
+        }
+
+        // load the storage map
+        let index = LeafIndex::new(index as u64).expect("index is u8 - index within range");
+        let old_map_root: Digest = self
+            .slots
+            .get_leaf(&index).into();
+
+        let storage_map = self.find_storage_map_by_root(old_map_root)
+            .ok_or(AccountError::StorageMapNotFound(index.value()))?;
+
+        // apply the updated leaves to the storage map
+        for (key, value) in map_delta.updated_leaves.iter() {
+            storage_map.insert(key.into(), *value);
+        }
+
+        // apply the cleared leaves to the storage map
+        for key in map_delta.cleared_leaves.iter() {
+            storage_map.insert(key.into(), [ZERO; 4]);
+        }
+
+        Ok(())
     }
 }
 

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -1,7 +1,8 @@
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 
 use super::{
-    AccountError, AccountStorageDelta, ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Felt, Hasher, Serializable, StorageMapDelta, Word, ZERO
+    AccountError, AccountStorageDelta, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Digest, Felt, Hasher, Serializable, StorageMapDelta, Word, ZERO,
 };
 use crate::crypto::merkle::{LeafIndex, NodeIndex, SimpleSmt};
 
@@ -315,7 +316,7 @@ impl AccountStorage {
                         actual: value_arity,
                     });
                 }
-            }
+            },
             slot_type => Err(AccountError::StorageSlotNotValueSlot(index, slot_type))?,
         }
 
@@ -332,7 +333,11 @@ impl AccountStorage {
     /// - The index specifies a reserved storage slot.
     /// - The index is not u8.
     /// - The map does not exist at the specified index.
-    pub fn set_map_item(&mut self, index: u8, map_delta: StorageMapDelta) -> Result<(), AccountError> {
+    pub fn set_map_item(
+        &mut self,
+        index: u8,
+        map_delta: StorageMapDelta,
+    ) -> Result<(), AccountError> {
         // layout commitment slot cannot be updated
         if index == Self::SLOT_LAYOUT_COMMITMENT_INDEX {
             return Err(AccountError::StorageSlotIsReserved(index));
@@ -340,11 +345,10 @@ impl AccountStorage {
 
         // load the storage map
         let index = LeafIndex::new(index as u64).expect("index is u8 - index within range");
-        let old_map_root: Digest = self
-            .slots
-            .get_leaf(&index).into();
+        let old_map_root: Digest = self.slots.get_leaf(&index).into();
 
-        let storage_map = self.find_storage_map_by_root(old_map_root)
+        let storage_map = self
+            .find_storage_map_by_root(old_map_root)
             .ok_or(AccountError::StorageMapNotFound(index.value()))?;
 
         // apply the updated leaves to the storage map

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -433,7 +433,7 @@ impl Deserializable for AccountStorage {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::{collections::BTreeMap, vec::Vec};
 
     use miden_crypto::hash::rpo::RpoDigest;
 
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     fn account_storage_serialization() {
         // empty storage
-        let storage = AccountStorage::new(Vec::new(), Vec::new()).unwrap();
+        let storage = AccountStorage::new(Vec::new(), BTreeMap::new()).unwrap();
         let bytes = storage.to_bytes();
         assert_eq!(storage, AccountStorage::read_from_bytes(&bytes).unwrap());
 
@@ -453,7 +453,7 @@ mod tests {
                 SlotItem::new_value(0, 0, [ONE, ONE, ONE, ONE]),
                 SlotItem::new_value(2, 0, [ONE, ONE, ONE, ZERO]),
             ],
-            vec![],
+            BTreeMap::new(),
         )
         .unwrap();
         let bytes = storage.to_bytes();
@@ -471,6 +471,8 @@ mod tests {
             ),
         ];
         let storage_map = StorageMap::with_entries(storage_map_leaves_2).unwrap();
+        let mut maps = BTreeMap::new();
+        maps.insert(2, storage_map.clone());
         let storage = AccountStorage::new(
             vec![
                 SlotItem::new_value(0, 1, [ONE, ONE, ONE, ONE]),
@@ -478,7 +480,7 @@ mod tests {
                 SlotItem::new_map(2, 0, storage_map.root().into()),
                 SlotItem::new_array(3, 3, 4, [ONE, ZERO, ZERO, ZERO]),
             ],
-            vec![storage_map],
+            maps,
         )
         .unwrap();
         let bytes = storage.to_bytes();

--- a/objects/src/accounts/storage/testing.rs
+++ b/objects/src/accounts/storage/testing.rs
@@ -32,12 +32,6 @@ impl AccountStorageBuilder {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn add_maps<I: IntoIterator<Item = StorageMap>>(&mut self, maps: I) -> &mut Self {
-        self.maps.extend(maps);
-        self
-    }
-
     pub fn build(&self) -> AccountStorage {
         AccountStorage::new(self.items.clone(), self.maps.clone()).unwrap()
     }

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -34,7 +34,7 @@ pub enum AccountError {
     StorageSlotInvalidValueArity { slot: u8, expected: u8, actual: u8 },
     StorageSlotIsReserved(u8),
     StorageSlotNotValueSlot(u8, StorageSlotType),
-    StorageMapNotFound(u64),
+    StorageMapNotFound(u8),
     StorageMapTooManyMaps { expected: usize, actual: usize },
     StubDataIncorrectLength(usize, usize),
 }

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -33,7 +33,7 @@ pub enum AccountError {
     SeedDigestTooFewTrailingZeros { expected: u32, actual: u32 },
     StorageSlotInvalidValueArity { slot: u8, expected: u8, actual: u8 },
     StorageSlotIsReserved(u8),
-    StorageSlotNotValueSlot(u8, StorageSlotType),
+    StorageSlotArrayNotAllowed(u8, StorageSlotType),
     StorageMapNotFound(u8),
     StorageMapTooManyMaps { expected: usize, actual: usize },
     StubDataIncorrectLength(usize, usize),

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -34,6 +34,7 @@ pub enum AccountError {
     StorageSlotInvalidValueArity { slot: u8, expected: u8, actual: u8 },
     StorageSlotIsReserved(u8),
     StorageSlotNotValueSlot(u8, StorageSlotType),
+    StorageMapNotFound(u64),
     StorageMapTooManyMaps { expected: usize, actual: usize },
     StubDataIncorrectLength(usize, usize),
 }

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    collections::BTreeMap,
     string::{String, ToString},
     vec::Vec,
 };
@@ -234,13 +235,15 @@ pub fn mock_account_vault() -> AssetVault {
 
 pub fn mock_account_storage() -> AccountStorage {
     // create account storage
+    let mut maps = BTreeMap::new();
+    maps.insert(STORAGE_INDEX_2, storage_map_2());
     AccountStorage::new(
         vec![
             SlotItem::new_value(STORAGE_INDEX_0, 0, STORAGE_VALUE_0),
             SlotItem::new_value(STORAGE_INDEX_1, 0, STORAGE_VALUE_1),
             SlotItem::new_map(STORAGE_INDEX_2, 0, storage_map_2().root().into()),
         ],
-        vec![storage_map_2()],
+        maps,
     )
     .unwrap()
 }

--- a/objects/src/testing/storage.rs
+++ b/objects/src/testing/storage.rs
@@ -1,4 +1,5 @@
 use alloc::{string::String, vec::Vec};
+
 use assembly::Assembler;
 use miden_crypto::merkle::Smt;
 use vm_core::{Felt, FieldElement, Word, ZERO};
@@ -242,12 +243,17 @@ pub fn generate_account_seed(
 // UTILITIES
 // --------------------------------------------------------------------------------------------
 
-pub fn build_account(assets: Vec<Asset>, nonce: Felt, storage_items: Vec<Word>, map: Option<StorageMap>) -> Account {
+pub fn build_account(
+    assets: Vec<Asset>,
+    nonce: Felt,
+    storage_items: Vec<Word>,
+    map: Option<StorageMap>,
+) -> Account {
     let id = AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap();
     let code = make_account_code();
 
     let vault = AssetVault::new(&assets).unwrap();
-    let slot_items: Vec<SlotItem> = storage_items
+    let mut slot_items: Vec<SlotItem> = storage_items
         .into_iter()
         .enumerate()
         .map(|(index, item)| SlotItem::new_value(index as u8, 0, item))
@@ -255,12 +261,8 @@ pub fn build_account(assets: Vec<Asset>, nonce: Felt, storage_items: Vec<Word>, 
 
     let mut maps = Vec::new();
     if let Some(map) = map {
-        let slot_map = StorageSlotType::Map { value_arity: 0 };
-        let slot_item_map_root: SlotItem = SlotItem {
-            index: 254,
-            slot: StorageSlot { slot_type: slot_map, value: *map.root() },
-        };
-        slot_items.push(slot_item_map_root);
+        let slot_item_map = SlotItem::new_map(254, 0, *map.root());
+        slot_items.push(slot_item_map);
         maps.push(map);
     }
 

--- a/objects/src/testing/storage.rs
+++ b/objects/src/testing/storage.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
 use assembly::Assembler;
 use miden_crypto::merkle::Smt;
@@ -31,13 +31,13 @@ use crate::{
 #[derive(Default, Debug, Clone)]
 pub struct AccountStorageBuilder {
     items: Vec<SlotItem>,
-    maps: Vec<StorageMap>,
+    maps: BTreeMap<u8, StorageMap>,
 }
 
 /// Builder for an `AccountStorage`, the builder can be configured and used multiple times.
 impl AccountStorageBuilder {
     pub fn new() -> Self {
-        Self { items: vec![], maps: vec![] }
+        Self { items: vec![], maps: BTreeMap::new() }
     }
 
     pub fn add_item(&mut self, item: SlotItem) -> &mut Self {
@@ -53,14 +53,8 @@ impl AccountStorageBuilder {
     }
 
     #[allow(dead_code)]
-    pub fn add_map(&mut self, map: StorageMap) -> &mut Self {
-        self.maps.push(map);
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn add_maps<I: IntoIterator<Item = StorageMap>>(&mut self, maps: I) -> &mut Self {
-        self.maps.extend(maps);
+    pub fn add_map(&mut self, index: u8, map: StorageMap) -> &mut Self {
+        self.maps.insert(index, map);
         self
     }
 
@@ -115,7 +109,7 @@ pub fn mock_fungible_faucet(
             0,
             [ZERO, ZERO, ZERO, initial_balance],
         )],
-        vec![],
+        BTreeMap::new(),
     )
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
@@ -144,7 +138,7 @@ pub fn mock_non_fungible_faucet(
 
     let account_storage = AccountStorage::new(
         vec![SlotItem::new_map(FAUCET_STORAGE_DATA_SLOT, 0, *nft_tree.root())],
-        vec![],
+        BTreeMap::new(),
     )
     .unwrap();
     let account_id = AccountId::try_from(account_id).unwrap();
@@ -259,11 +253,11 @@ pub fn build_account(
         .map(|(index, item)| SlotItem::new_value(index as u8, 0, item))
         .collect();
 
-    let mut maps = Vec::new();
+    let mut maps = BTreeMap::new();
     if let Some(map) = map {
         let slot_item_map = SlotItem::new_map(254, 0, *map.root());
         slot_items.push(slot_item_map);
-        maps.push(map);
+        maps.insert(254_u8, map);
     }
 
     let storage = AccountStorage::new(slot_items, maps).unwrap();


### PR DESCRIPTION
This PR fixes the bug that the account storage delta was not applied for `set_map_item`. The application is also tested in `valid_account_delta_is_correctly_applied()`.

I changed `maps` in `AccountStorage` to `BTreeMap<u8, StorageMap>`

```Rust
pub struct AccountStorage {
    slots: SimpleSmt<STORAGE_TREE_DEPTH>,
    layout: Vec<StorageSlotType>,
    maps: BTreeMap<u8, StorageMap>,
}
```

We need that in order to identify the StorageMaps when we want to apply the delta. 