### PR TITLE
Refactored `compute_tx_hash`

### DIFF
--- a/objects/src/block/mod.rs
+++ b/objects/src/block/mod.rs
@@ -123,7 +123,7 @@ impl Block {
     }
 
     /// Returns an iterator over all transactions which affected accounts in the block with corresponding account IDs.
-    pub fn transaction(&self) -> impl Iterator<Item = (TransactionId, AccountId)> + '_ {
+    pub fn transactions(&self) -> impl Iterator<Item = (TransactionId, AccountId)> + '_ {
         self.updated_accounts.iter().flat_map(|update| {
             update
                 .transactions


### PR DESCRIPTION
As follow-up of this conversation: https://github.com/0xPolygonMiden/miden-node/pull/377#discussion_r1631269898
Refactored `compute_tx_hash` in order to get rid of duplicate logics.