### PR TITLE
Add a tracking tag for `NoteFile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* Add `Option<NoteTag>`to `NoteFile` (#741).
 * Replaced `cargo-make` with just `make` for running tasks (#696).
 * [BREAKING] Introduce `OutputNote::Partial` variant (#698).
 * [BREAKING] Split `Account` struct constructor into `new()` and `from_parts()` (#699).


### PR DESCRIPTION
Adresses [this comment](https://github.com/0xPolygonMiden/miden-client/issues/371#issuecomment-2147197187):
> To differentiate between the two cases, we may need to modify the NoteFile in miden-base to change the details variant to something like NoteDetails(NoteDetails, Option<NoteTag>).

The idea is to have a way to import a note that is not intended to be tracked (when the tag is `None`). These notes will be specifically retrieved by ID from the node. 