### PR TITLE
Hash arbitrary number of elements in `masm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Created `get_serial_number` procedure to get the serial num of the currently processed note (#760).
 - [BREAKING] Added support for input notes with delayed verification of inclusion proofs (#724, #732, #759, #770, #772).
 - [BREAKING] Added support for conversion from `Nullifier` to `InputNoteCommitment`, commitment header return reference (#774).
+- Added `compute_inputs_hash` procedure for hash computation of the arbitrary number of note inouts (#750).
 
 ## 0.3.0 (2024-05-14)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blake3"
@@ -77,9 +77,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
 dependencies = [
  "jobserver",
  "libc",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "equivalent"
@@ -401,9 +401,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-air"
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "indexmap",
  "itoa",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6efccf6efa6fd0a80784f3894bc372ada67cc30d9c017fc907d4c0cdce86e7"
+checksum = "ef7d7195967f35140fc2542b44813572e0907cde8a818507177ba8db666e7f17"
 dependencies = [
  "rayon",
 ]

--- a/docs/architecture/transactions/procedures.md
+++ b/docs/architecture/transactions/procedures.md
@@ -42,6 +42,7 @@ To import the note procedures, set `use.miden::note` at the beginning of the fil
 | `get_assets`             | `[dest_ptr]`        | `[num_assets, dest_ptr]` | note | <ul> <li>Writes the assets of the currently executing note into memory starting at the specified address `dest_ptr `. </li><li> `num_assets` is the number of assets in the currently executing note.</li> </ul>  |
 | `get_inputs`             | `[dest_ptr]`        | `[dest_ptr]`            | note | <ul> <li>Writes the inputs of the currently executed note into memory starting at the specified address, `dest_ptr`. </li> </ul> |
 | `get_sender`             | `[]`                | `[sender]`             | note | <ul> <li>Returns the `sender` of the note currently being processed. Panics if a note is not being processed. </li> </ul>  |
+| `compute_inputs_hash`    | `[inputs_ptr, num_inputs]` | `[HASH]`        | note | <ul> <li>Computes hash of note inputs starting at the specified memory address.</li> </ul> |
 
 
 ### Tx

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -330,12 +330,7 @@ export.compute_inputs_hash_cdrop
         
         # if current value is the last value to drop (\"cycle\" number equals to the number of values 
         # to drop), push 1 instead of 0 to the stack
-        dup.12 eq.1
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.12 eq.1 swap
         # => [e_0, 0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
 
         # we need to drop first value anyway, since number of values is not divisible by 8
@@ -351,12 +346,7 @@ export.compute_inputs_hash_cdrop
         # prepare the second element of the E Word (e_1) for cdrop instruction
         # if current value is the last value to drop (\"cycle\" number equals to the number of values 
         # to drop), push 1 instead of 0 to the stack
-        dup.12 eq.2
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.12 eq.2 swap
         # => [e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
 
         # push latch variable onto the stack; this will be the control for the cdrop instruction
@@ -386,12 +376,7 @@ export.compute_inputs_hash_cdrop
         ### 2nd value ########################################################
 
         # repeat the above process but now compare drop_counter to 2
-        dup.13 eq.3
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.13 eq.3 swap
         movup.13 dup.14 eq.2 or
         dup movdn.14
         cdrop movdn.6
@@ -400,12 +385,7 @@ export.compute_inputs_hash_cdrop
         ### 3rd value ########################################################
 
         # repeat the above process but now compare drop_counter to 3
-        dup.13 eq.4
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.13 eq.4 swap
         movup.13 dup.14 eq.3 or
         dup movdn.14
         cdrop movdn.6
@@ -414,12 +394,7 @@ export.compute_inputs_hash_cdrop
         ### 4th value ########################################################
 
         # repeat the above process but now compare drop_counter to 4
-        dup.13 eq.5
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.13 eq.5 swap
         movup.13 dup.14 eq.4 or
         dup movdn.14
         cdrop movdn.6
@@ -428,12 +403,7 @@ export.compute_inputs_hash_cdrop
         ### 5th value ########################################################
 
         # repeat the above process but now compare drop_counter to 5
-        dup.13 eq.6
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.13 eq.6 swap
         movup.13 dup.14 eq.5 or
         dup movdn.14
         cdrop movdn.6
@@ -442,12 +412,7 @@ export.compute_inputs_hash_cdrop
         ### 6th value ########################################################
 
         # repeat the above process but now compare drop_counter to 6
-        dup.13 eq.7
-        if.true
-            push.1 swap
-        else
-            push.0 swap
-        end
+        dup.13 eq.7 swap
         movup.13 dup.14 eq.6 or
         cdrop movdn.6
         # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A', drop_counter]

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -1,5 +1,5 @@
 use.miden::kernels::tx::constants
-use.std::crypto::hashes::rpo
+use.std::crypto::hashes::native
 use.std::mem
 
 # ERRORS
@@ -26,7 +26,7 @@ proc.write_advice_data_to_memory
     # => [PERM, PERM, PERM, end_ptr, HASH]
 
     # extract the digest
-    exec.rpo::squeeze_digest
+    exec.native::state_to_digest
     # => [DIGEST, end_ptr, HASH]
 
     # drop pointer for reading from memory
@@ -147,16 +147,167 @@ end
 
 #! Computes hash of note inputs starting at the specified memory address.
 #!
-#! If the number if inputs is 0, procedure returns the empty word: [ZERO, ZERO, ZERO, ZERO].
+#! This procedure divides the hashing process into two parts: hashing pairs of words using 
+#! `absorb_double_words_from_memory` procedure and hashing the remaining values using the `hperm`
+#! instruction. 
 #!
-#! Inputs:  [inputs_ptr, num_inputs]
+#! Inputs:  [ptr, num_elements]
 #! Outputs: [HASH]
+#! Cycles: 
+#! - If number of elements divides by 8: 56 cycles + 3 * words
+#! - Else: 189 cycles + 3 * words
 #!
-#! Panics if num_inputs is greater than 128.
+#! Panics if num_elements is equals 0 or greater than 128.
 export.compute_inputs_hash
     # check that number of inputs is less than 128
-    dup.1 push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
+    dup.1 push.128 u32assert2 u32lte assert
 
-    exec.rpo::hash_memory
+    # move number of inputs to the top of the stack 
+    swap
+    # => [num_elements, ptr]
+
+    # check that number of inputs greater than 0
+    dup eq.0 assertz
+    # => [num_elements, ptr]
+
+    # get the number of double words
+    u32divmod.8 swap
+    # => [num_elements/8, num_elements%8, ptr]
+
+    # get the end_addr for hash_memory procedure (end address for pairs of words)
+    mul.2 dup.2 add movup.2
+    # => [ptr, end_addr, num_elements%8]
+
+    # get the padding flag to add it to the capacity part
+    dup.2 eq.0 not
+    # => [pad_flag, ptr, end_addr, num_elements%8]
+    
+    # prepare hasher state for RPO permutation 
+    push.0.0.0 padw padw 
+    # => [C, B, A, ptr, end_addr, num_elements%8]
+
+    # hash every pair of words
+    exec.native::hash_memory_even
+    # => [C', B', A', ptr', end_addr, num_elements%8] where ptr' = end_addr
+
+    # hash remaining input values if there are any left
+    # if num_elements%8 is ZERO and there are no elements to hash
+    dup.14 eq.0
+    if.true
+        # clean the stack
+        exec.native::state_to_digest
+        swapw dropw
+        # => [B']
+    else
+        # load the remaining double word
+        mem_stream
+        # => [E, D, A', ptr'+2, end_addr, num_elements%8]
+
+        # clean the stack
+        movup.12 drop movup.12 drop
+        # => [E, D, A', num_elements%8]
+
+        # get the number of elements we need to drop
+        # notice that drop_counter could be any number from 1 to 7
+        push.8 movup.13 sub movdn.12
+        # => [E, D, A', drop_counter]
+
+        ### 0th value ########################################################
+        
+        # if current value is the last value to drop ("cycle" number equals to the number of values
+        # to drop), push 1 instead of 0 to the stack
+        dup.12 eq.1 swap
+
+        # we need to drop first value anyway, since number of values is not divisible by 8
+        drop movdn.6
+        # => [e_2, e_1, e_0, d_3, d_2, d_1, 0/1, d_0, A', drop_counter]
+
+        ### 1st value ########################################################
+        
+        # prepare the second element of the E Word for cdrop instruction
+        # if current value is the last value to drop ("cycle" number equals to the number of values 
+        # to drop), push 1 instead of 0 to the stack
+        dup.12 eq.2 swap
+        # => [e_2, 0, e_1, e_0, d_3, d_2, d_1, 0/1, d_0, A', drop_counter]
+
+        # push latch variable onto the stack; this will be the control for the cdrop instruction
+        push.0
+        # => [latch = 0, e_2, 0, e_1, e_0, d_3, d_2, d_1, 0, d_0, A', drop_counter]
+
+        # get the flag whether the drop counter is equal 1
+        dup.14 eq.1
+        # => [drop_counter == 1, latch = 0, e_2, 0, e_1, e_0, d_3, d_2, d_1, 0, d_0, A', drop_counter]
+
+        # update the latch: if drop_counter == 1, latch will become 1
+        or
+        # => [latch', e_2, 0, e_1, e_0, d_3, d_2, d_1, 0, d_0, A', drop_counter]
+
+        # save the latch value 
+        dup movdn.14
+        # => [latch', e_2, 0, e_1, e_0, d_3, d_2, d_1, 0, d_0, A', latch', drop_counter]
+
+        # if latch == 1, drop 0; otherwise drop e_1
+        cdrop
+        # => [e_2_or_0, e_1, e_0, d_3, d_2, d_1, 0, d_0, A', latch', drop_counter]
+
+        # move the calculated value down the stack 
+        movdn.6
+        # => [e_1, e_0, d_3, d_2, d_1, 0, e_2_or_0, d_0, A', latch', drop_counter]
+
+        ### 2nd value ########################################################
+
+        # repeat the above process but now compare drop_counter to 2
+        dup.13 eq.3 swap
+        movup.13 dup.14 eq.2 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [e_0, d_3, d_2, d_1, 0, e_2_or_0, e_1_or_0, d_0, A', latch', drop_counter]
+
+        ### 3rd value ########################################################
+
+        # repeat the above process but now compare drop_counter to 3
+        dup.13 eq.4 swap
+        movup.13 dup.14 eq.3 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [d_3, d_2, d_1, 0, e_2_or_0, e_1_or_0, e_0_or_0, d_0, A', latch', drop_counter]
+
+        ### 4th value ########################################################
+
+        # repeat the above process but now compare drop_counter to 4
+        dup.13 eq.5 swap
+        movup.13 dup.14 eq.4 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [d_2, d_1, 0, e_2_or_0, e_1_or_0, e_0_or_0, d_3_or_0, d_0, A', latch', drop_counter]
+
+        ### 5th value ########################################################
+
+        # repeat the above process but now compare drop_counter to 5
+        dup.13 eq.6 swap
+        movup.13 dup.14 eq.5 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [d_1, 0, e_2_or_0, e_1_or_0, e_0_or_0, d_3_or_0, d_2_or_0, d_0, A', latch', drop_counter]
+
+        ### 6th value ########################################################
+
+        # repeat the above process but now compare drop_counter to 6
+        dup.13 eq.7 swap
+        movup.13 movup.14 eq.6 or
+        cdrop movdn.6
+        # => [0, e_2_or_0, e_1_or_0, e_0_or_0, d_3_or_0, d_2_or_0, d_1_or_0, d_0, A']
+        # or in other words
+        # => [C, B, A', ... ]
+        # notice that we don't need to check the d_0 value: entering the else branch means that 
+        # we have number of elements not divisible by 8, so we will have at least one element to 
+        # hash here (which turns out to be d_0)
+
+        hperm
+        # => [F, E, D]
+
+        exec.native::state_to_digest
+        # => [E]
+    end
 end
 

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -171,7 +171,7 @@ export.compute_inputs_hash
     u32divmod.8 swap
     # => [num_inputs/8, num_inputs%8, inputs_ptr]
 
-    # get the end_addr for hash_memory procedure (end address for pairs of words)
+    # get the end_addr for hash_memory_even procedure (end address for pairs of words)
     mul.2 dup.2 add movup.2
     # => [inputs_ptr, end_addr, num_inputs%8]
 

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -148,50 +148,47 @@ end
 #! Computes hash of note inputs starting at the specified memory address.
 #!
 #! This procedure divides the hashing process into two parts: hashing pairs of words using 
-#! `absorb_double_words_from_memory` procedure and hashing the remaining values using the `hperm`
-#! instruction. 
+#! `hash_memory_even` procedure and hashing the remaining values using the `hperm` instruction.
 #!
-#! Inputs:  [ptr, num_elements]
+#! If the number if inputs is 0, procedure returns the empty word: [0, 0, 0, 0].
+#!
+#! Inputs:  [inputs_ptr, num_inputs]
 #! Outputs: [HASH]
 #! Cycles: 
 #! - If number of elements divides by 8: 56 cycles + 3 * words
 #! - Else: 189 cycles + 3 * words
 #!
-#! Panics if num_elements is equals 0 or greater than 128.
+#! Panics if num_inputs is greater than 128.
 export.compute_inputs_hash
     # check that number of inputs is less than 128
     dup.1 push.128 u32assert2 u32lte assert
 
     # move number of inputs to the top of the stack 
     swap
-    # => [num_elements, ptr]
-
-    # check that number of inputs greater than 0
-    dup eq.0 assertz
-    # => [num_elements, ptr]
+    # => [num_inputs, inputs_ptr]
 
     # get the number of double words
     u32divmod.8 swap
-    # => [num_elements/8, num_elements%8, ptr]
+    # => [num_inputs/8, num_inputs%8, inputs_ptr]
 
     # get the end_addr for hash_memory procedure (end address for pairs of words)
     mul.2 dup.2 add movup.2
-    # => [ptr, end_addr, num_elements%8]
+    # => [inputs_ptr, end_addr, num_inputs%8]
 
     # get the padding flag to add it to the capacity part
     dup.2 eq.0 not
-    # => [pad_flag, ptr, end_addr, num_elements%8]
+    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
     
     # prepare hasher state for RPO permutation 
     push.0.0.0 padw padw 
-    # => [C, B, A, ptr, end_addr, num_elements%8]
+    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
 
     # hash every pair of words
     exec.native::hash_memory_even
-    # => [C', B', A', ptr', end_addr, num_elements%8] where ptr' = end_addr
+    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
 
     # hash remaining input values if there are any left
-    # if num_elements%8 is ZERO and there are no elements to hash
+    # if num_inputs%8 is ZERO and there are no elements to hash
     dup.14 eq.0
     if.true
         # clean the stack
@@ -201,11 +198,11 @@ export.compute_inputs_hash
     else
         # load the remaining double word
         mem_stream
-        # => [E, D, A', ptr'+2, end_addr, num_elements%8]
+        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
 
         # clean the stack
         movup.12 drop movup.12 drop
-        # => [E, D, A', num_elements%8]
+        # => [E, D, A', num_inputs%8]
 
         # get the number of elements we need to drop
         # notice that drop_counter could be any number from 1 to 7

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -156,14 +156,14 @@ export.compute_inputs_hash
     # => [num_inputs, inputs_ptr]
 
     # check that number of inputs is less than 128
-    dup push.128 u32lte assert
+    dup push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
     # => [num_inputs, inputs_ptr]
 
-    # get the number of word pairs to be hashed
+    # get the number of double words
     u32divmod.8 swap
     # => [num_inputs/8, num_inputs%8, inputs_ptr]
 
-    # get the end_addr for hash_memory_even proc
+    # get the end_addr for hash_memory_even proc (end address for pairs of words)
     u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
     # => [inputs_ptr, end_addr, num_inputs%8]
 
@@ -175,67 +175,93 @@ export.compute_inputs_hash
     push.0.0.0 padw padw 
     # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
 
-    exec.native::hash_memory_even
+    # hash every pair of words
+    dup.13 dup.13 neq
+    if.true
+        exec.native::hash_memory_even
+    end
     # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
 
+    # hash remaining input values if there any left
     # if num_inputs%8 is not ZERO
     dup.14 push.0 neq
     if.true
-        mem_stream
-        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
+        # if there are exactly 4 elements left to hash, just pad them with [0, 0, 0, 1] Word
+        dup.14 eq.4
+        if.true
+            # load the remaining word
+            dropw movup.8 mem_loadw
+            # => [B'', A', end_addr, num_inputs%8]
 
-        # clean the stack
-        movup.12 drop movup.12 drop
-        # => [E, D, A', num_inputs%8]
+            # clean the stack
+            movupw.2 dropw
+            # => [B'', A', end_addr, num_inputs%8]
 
-        # get the number of elements we need to drop
-        push.8 movup.13 u32wrapping_sub movdn.12
-        # => [E, D, A', drop_counter]
+            # push the capacity word
+            push.1.0.0.0
+            hperm
+            # => [F, E, D]
 
-        # get the number of zeros we will need to dap
-        dup.12 u32wrapping_sub.1 movdn.13
-        # => [E, D, A', drop_counter, zero_counter]
+            exec.native::state_to_digest
+            # => [E]
+        else
+            # load the remaining double word
+            mem_stream
+            # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
 
-        # check the drop_counter
-        dup.12 neq.0
-        while.true
-            # decrease the counter
-            movup.12 u32wrapping_sub.1 movdn.12
+            # clean the stack
+            movup.12 drop movup.12 drop
+            # => [E, D, A', num_inputs%8]
 
-            # drop the top element, push 0 to the stack and move it down to maintain the overall number
-            # of elements on stack to be able to access the drop_counter at position 12
-            drop push.0 movdn.11
+            # get the number of elements we need to drop
+            push.8 movup.13 u32wrapping_sub movdn.12
+            # => [E, D, A', drop_counter]
+
+            # get the number of zeros we will need to pad
+            dup.12 u32wrapping_sub.1 movdn.13
+            # => [E, D, A', drop_counter, zero_counter]
 
             # check the drop_counter
             dup.12 neq.0
-        end
-        # => [a, ..., x, A', 0, ..., 0, 0, zero_counter]
-        #                               ^-- 12th position
+            while.true
+                # decrease the counter
+                movup.12 u32wrapping_sub.1 movdn.12
 
-        # push the dividing 1 (move the previously added zero and incr it)
-        movup.12 add.1
-        # => [1, a, ..., x, A', 0, ..., 0, 0, zero_counter]
-        #                                  ^-- 12th position
+                # drop the top element, push 0 to the stack and move it down to maintain the overall
+                # number of elements on stack to be able to access the drop_counter at position 12
+                drop push.0 movdn.11
 
-        # check the zero_counter
-        dup.13 neq.0
-        while.true
-            # decrease the counter
-            movup.13 u32wrapping_sub.1 movdn.13
+                # check the drop_counter
+                dup.12 neq.0
+            end
+            # => [a, ..., x, A', 0, ..., 0, 0, zero_counter]
+            #                               ^-- 12th position
 
-            # move the previously added zero
-            movup.12
+            # push the dividing 1 (move the previously added zero and incr it)
+            movup.12 add.1
+            # => [1, a, ..., x, A', 0, ..., 0, 0, zero_counter]
+            #                                  ^-- 12th position
 
             # check the zero_counter
             dup.13 neq.0
-        end
-        # => [C, B, A', 0, 0, ... ]
-        
-        hperm
-        # => [F, E, D]
+            while.true
+                # decrease the counter
+                movup.13 u32wrapping_sub.1 movdn.13
 
-        exec.native::state_to_digest
-        # => [E]
+                # move the previously added zero
+                movup.12
+
+                # check the zero_counter
+                dup.13 neq.0
+            end
+            # => [C, B, A', 0, 0, ... ]
+            
+            hperm
+            # => [F, E, D]
+
+            exec.native::state_to_digest
+            # => [E]
+        end
     else
         dropw movdnw.2 dropw dropw
         # => [B']

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -146,12 +146,16 @@ export.get_serial_number
 end
 
 #! Computes hash of note inputs starting at the specified memory address.
+#! If the number if inputs is 0, procedure returns the empty word: [ZERO, ZERO, ZERO, ZERO].
 #!
 #! Inputs:  [inputs_ptr, num_inputs]
 #! Outputs: [HASH]
 #!
 #! Panics if num_inputs is greater than 128.
-export.compute_inputs_hash_while
+#!
+#! TODO: most of this fuction should be replaced by `hash_memory` function from the `native` module 
+#! of miden-vm.
+export.compute_inputs_hash
     # move number of inputs to the top of the stack 
     swap
     # => [num_inputs, inputs_ptr]
@@ -165,11 +169,11 @@ export.compute_inputs_hash_while
     # => [num_inputs/8, num_inputs%8, inputs_ptr]
 
     # get the end_addr for hash_memory_even proc (end address for pairs of words)
-    u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
+    mul.2 dup.2 add movup.2
     # => [inputs_ptr, end_addr, num_inputs%8]
 
     # get the padding flag to add it to the capacity part
-    dup.2 push.0 neq 
+    dup.2 eq.0 not
     # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
     
     # prepare hasher state for RPO permutation 
@@ -177,134 +181,7 @@ export.compute_inputs_hash_while
     # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
 
     # hash every pair of words
-    dup.13 dup.13 neq
-    if.true
-        exec.native::hash_memory_even
-    end
-    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
-
-    # hash remaining input values if there any left
-    # if num_inputs%8 is not ZERO
-    dup.14 push.0 neq
-    if.true
-        # if there are exactly 4 elements left to hash, just pad them with [0, 0, 0, 1] Word
-        dup.14 eq.4
-        if.true
-            # load the remaining word
-            dropw movup.8 mem_loadw
-            # => [B'', A', end_addr, num_inputs%8]
-
-            # clean the stack
-            movupw.2 dropw
-            # => [B'', A', end_addr, num_inputs%8]
-
-            # push the capacity word
-            push.1.0.0.0
-            hperm
-            # => [F, E, D]
-
-            exec.native::state_to_digest
-            # => [E]
-        else
-            # load the remaining double word
-            mem_stream
-            # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
-
-            # clean the stack
-            movup.12 drop movup.12 drop
-            # => [E, D, A', num_inputs%8]
-
-            # get the number of elements we need to drop
-            push.8 movup.13 u32wrapping_sub movdn.12
-            # => [E, D, A', drop_counter]
-
-            # get the number of zeros we will need to pad
-            dup.12 u32wrapping_sub.1 movdn.13
-            # => [E, D, A', drop_counter, zero_counter]
-
-            # check the drop_counter
-            dup.12 neq.0
-            while.true
-                # decrease the counter
-                movup.12 u32wrapping_sub.1 movdn.12
-
-                # drop the top element, push 0 to the stack and move it down to maintain the overall
-                # number of elements on stack to be able to access the drop_counter at position 12
-                drop push.0 movdn.11
-
-                # check the drop_counter
-                dup.12 neq.0
-            end
-            # => [a, ..., x, A', 0, ..., 0, 0, zero_counter]
-            #                               ^-- 12th position
-
-            # push the dividing 1 (move the previously added zero and incr it)
-            movup.12 add.1
-            # => [1, a, ..., x, A', 0, ..., 0, 0, zero_counter]
-            #                                  ^-- 12th position
-
-            # check the zero_counter
-            dup.13 neq.0
-            while.true
-                # decrease the counter
-                movup.13 u32wrapping_sub.1 movdn.13
-
-                # move the previously added zero
-                movup.12
-
-                # check the zero_counter
-                dup.13 neq.0
-            end
-            # => [C, B, A', 0, 0, ... ]
-            
-            hperm
-            # => [F, E, D]
-
-            exec.native::state_to_digest
-            # => [E]
-        end
-    else
-        dropw movdnw.2 dropw dropw
-        # => [B']
-    end
-end
-
-#! Computes hash of note inputs starting at the specified memory address.
-#!
-#! Inputs:  [inputs_ptr, num_inputs]
-#! Outputs: [HASH]
-#!
-#! Panics if num_inputs is greater than 128.
-export.compute_inputs_hash_cdrop
-    # move number of inputs to the top of the stack 
-    swap
-    # => [num_inputs, inputs_ptr]
-
-    # check that number of inputs is less than 128
-    dup push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
-    # => [num_inputs, inputs_ptr]
-
-    # get the number of double words
-    u32divmod.8 swap
-    # => [num_inputs/8, num_inputs%8, inputs_ptr]
-
-    # get the end_addr for hash_memory_even proc (end address for pairs of words)
-    u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
-    # => [inputs_ptr, end_addr, num_inputs%8]
-
-    # get the padding flag to add it to the capacity part
-    dup.2 push.0 neq 
-    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
-    
-    # prepare hasher state for RPO permutation 
-    push.0.0.0 padw padw 
-    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
-
-    # hash every pair of words
-    dup.13 dup.13 neq
-    if.true
-        exec.native::hash_memory_even
-    end
+    exec.native::hash_memory_even
     # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
 
     # hash remaining input values if there any left
@@ -326,7 +203,7 @@ export.compute_inputs_hash_cdrop
 
         ### 0th value ########################################################
         
-        # if current value is the last value to drop (\"cycle\" number equals to the number of values 
+        # if current value is the last value to drop ("cycle" number equals to the number of values 
         # to drop), push 1 instead of 0 to the stack
         dup.12 eq.1 swap
         # => [e_0, 0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
@@ -342,7 +219,7 @@ export.compute_inputs_hash_cdrop
         ### 1st value ########################################################
 
         # prepare the second element of the E Word (e_1) for cdrop instruction
-        # if current value is the last value to drop (\"cycle\" number equals to the number of values 
+        # if current value is the last value to drop ("cycle" number equals to the number of values 
         # to drop), push 1 instead of 0 to the stack
         dup.12 eq.2 swap
         # => [e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
@@ -411,15 +288,11 @@ export.compute_inputs_hash_cdrop
 
         # repeat the above process but now compare drop_counter to 6
         dup.13 eq.7 swap
-        movup.13 dup.14 eq.6 or
+        movup.13 movup.14 eq.6 or
         cdrop movdn.6
-        # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A', drop_counter]
+        # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A']
         # or in other words
-        # => [C, B, A', drop_counter, ... ]
-
-        # drop the drop_counter
-        movup.12 drop
-        # => [C, B, A']
+        # => [C, B, A', ... ]
 
         hperm
         # => [F, E, D]
@@ -432,146 +305,3 @@ export.compute_inputs_hash_cdrop
     end
 end
 
-#! Computes hash of note inputs starting at the specified memory address.
-#!
-#! Inputs:  [inputs_ptr, num_inputs]
-#! Outputs: [HASH]
-#!
-#! Panics if num_inputs is greater than 128.
-export.compute_inputs_hash_simple
-    # move number of inputs to the top of the stack 
-    swap
-    # => [num_inputs, inputs_ptr]
-
-    # check that number of inputs is less than 128
-    dup push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
-    # => [num_inputs, inputs_ptr]
-
-    # get the number of double words
-    u32divmod.8 swap
-    # => [num_inputs/8, num_inputs%8, inputs_ptr]
-
-    # get the end_addr for hash_memory_even proc (end address for pairs of words)
-    u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
-    # => [inputs_ptr, end_addr, num_inputs%8]
-
-    # get the padding flag to add it to the capacity part
-    dup.2 push.0 neq 
-    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
-    
-    # prepare hasher state for RPO permutation 
-    push.0.0.0 padw padw 
-    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
-
-    # hash every pair of words
-    dup.13 dup.13 neq
-    if.true
-        exec.native::hash_memory_even
-    end
-    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
-
-    # hash remaining input values if there any left
-    # if num_inputs%8 is not ZERO
-    dup.14 push.0 neq
-    if.true
-        # load the remaining double word
-        mem_stream
-        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
-
-        # clean the stack
-        movup.12 drop movup.12 drop
-        # => [E, D, A', num_inputs%8]
-
-        # get the number of elements we need to drop
-        # notice that drop_counter could be any number from 1 to 7
-        push.8 movup.13 u32wrapping_sub movdn.12
-        # => [E, D, A', drop_counter]
-
-        ### 0th value ########################################################
-        
-        # we need to drop first value anyway, since number of values is not divisible by 8
-        drop
-        # => [e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
-
-        # if current value is the last value to drop (\"cycle\" number equals to the number of values 
-        # to drop), push 1 instead of 0 to the stack
-        dup.11 eq.1
-        # => [0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
-
-        # move the calculated value down the stack 
-        movdn.6
-        # => [e_1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
-
-        ### 1st value ########################################################
-
-        # check whether we still need to drop top stack value and change it to the 0/1
-        dup.12 push.1 gt
-        if.true
-            # if we still need to do so, drop the value and push 0/1 on the stack, depending on 
-            # whether this prop was the last
-            drop dup.11 eq.2 
-        end 
-        # if we already dropped all necessary values, just move top stack value to its position
-        movdn.6
-        # => [e_2, e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, d_3, A', drop_counter]
-
-        ### 2nd value ########################################################
-
-        dup.12 push.2 gt
-        if.true
-            drop dup.11 eq.3 
-        end 
-        movdn.6
-        # => [e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, d_3, A', drop_counter]
-
-        ### 3rd value ########################################################
-
-        dup.12 push.3 gt
-        if.true
-            drop dup.11 eq.4
-        end 
-        movdn.6
-        # => [d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_3, A', drop_counter]
-
-        ### 4th value ########################################################
-
-        dup.12 push.4 gt
-        if.true
-            drop dup.11 eq.5
-        end 
-        movdn.6
-        # => [d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_3, A', drop_counter]
-
-        ### 5th value ########################################################
-
-        dup.12 push.5 gt
-        if.true
-            drop dup.11 eq.6
-        end 
-        movdn.6
-        # => [d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_3, A', drop_counter]
-
-        ### 6th value ########################################################
-
-        dup.12 push.6 gt
-        if.true
-            drop dup.11 eq.7
-        end 
-        movdn.6
-        # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A', drop_counter]
-
-
-        # drop the drop_counter
-        movup.12 drop
-        # => [C, B, A']
-
-        hperm
-        # => [F, E, D]
-
-        exec.native::state_to_digest
-        # => [E]
-    else
-        dropw movdnw.2 dropw dropw
-        # => [B']
-    end
-end

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -196,7 +196,7 @@ export.compute_inputs_hash
     if.true
         # clean the stack
         exec.native::state_to_digest
-        swapw dropw
+        swapw drop drop drop movdn.4
         # => [B']
     else
         # load the remaining double word

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -151,7 +151,8 @@ end
 #! Outputs: [HASH]
 #!
 #! Panics if num_inputs is greater than 128.
-export.compute_inputs_hash
+export.compute_inputs_hash_while
+    # move number of inputs to the top of the stack 
     swap
     # => [num_inputs, inputs_ptr]
 
@@ -262,6 +263,206 @@ export.compute_inputs_hash
             exec.native::state_to_digest
             # => [E]
         end
+    else
+        dropw movdnw.2 dropw dropw
+        # => [B']
+    end
+end
+
+#! Computes hash of note inputs starting at the specified memory address.
+#!
+#! Inputs:  [inputs_ptr, num_inputs]
+#! Outputs: [HASH]
+#!
+#! Panics if num_inputs is greater than 128.
+export.compute_inputs_hash_cdrop
+    # move number of inputs to the top of the stack 
+    swap
+    # => [num_inputs, inputs_ptr]
+
+    # check that number of inputs is less than 128
+    dup push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
+    # => [num_inputs, inputs_ptr]
+
+    # get the number of double words
+    u32divmod.8 swap
+    # => [num_inputs/8, num_inputs%8, inputs_ptr]
+
+    # get the end_addr for hash_memory_even proc (end address for pairs of words)
+    u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
+    # => [inputs_ptr, end_addr, num_inputs%8]
+
+    # get the padding flag to add it to the capacity part
+    dup.2 push.0 neq 
+    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
+    
+    # prepare hasher state for RPO permutation 
+    push.0.0.0 padw padw 
+    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
+
+    # hash every pair of words
+    dup.13 dup.13 neq
+    if.true
+        exec.native::hash_memory_even
+    end
+    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
+
+    # hash remaining input values if there any left
+    # if num_inputs%8 is not ZERO
+    dup.14 push.0 neq
+    if.true
+        # check whether we need to drop more than 4 elements
+
+        # load the remaining double word
+        mem_stream
+        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
+
+        # clean the stack
+        movup.12 drop movup.12 drop
+        # => [E, D, A', num_inputs%8]
+
+        # get the number of elements we need to drop
+        # notice that drop_counter could be any number from 1 to 7
+        push.8 movup.13 u32wrapping_sub movdn.12
+        # => [E, D, A', drop_counter]
+
+        ### 0th value ########################################################
+        
+        # if current value is the last value to drop (\"cycle\" number equals to the number of values 
+        # to drop), push 1 instead of 0 to the stack
+        dup.12 eq.1
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        # => [e_0, 0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
+
+        # we need to drop first value anyway, since number of values is not divisible by 8
+        drop
+        # => [0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
+
+        # move the calculated value down the stack 
+        movdn.6
+        # => [e_1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
+
+        ### 1st value ########################################################
+
+        # prepare the second element of the E Word (e_1) for cdrop instruction
+        # if current value is the last value to drop (\"cycle\" number equals to the number of values 
+        # to drop), push 1 instead of 0 to the stack
+        dup.12 eq.2
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        # => [e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
+
+        # push latch variable onto the stack; this will be the control for the cdrop instruction
+        push.0
+        # => [latch = 0, e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
+
+        # get the flag whether the drop counter is equal 1
+        dup.14 eq.1
+        # => [drop_counter == 1, latch = 0, e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
+
+        # update the latch: if drop_counter == 1, latch will become 1
+        or
+        # => [latch', e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
+
+        # save the latch value 
+        dup movdn.14
+        # => [latch', e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', latch', drop_counter]
+
+        # if latch == 1, drop 0/1; otherwise drop e_1
+        cdrop
+        # => [e_1_or_0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', latch', drop_counter]
+
+        # move the calculated value down the stack 
+        movdn.6
+        # => [e_2, e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, d_3, A', latch', drop_counter]
+
+        ### 2nd value ########################################################
+
+        # repeat the above process but now compare drop_counter to 2
+        dup.13 eq.3
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        movup.13 dup.14 eq.2 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, d_3, A', latch', drop_counter]
+
+        ### 3rd value ########################################################
+
+        # repeat the above process but now compare drop_counter to 3
+        dup.13 eq.4
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        movup.13 dup.14 eq.3 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_3, A', latch', drop_counter]
+
+        ### 4th value ########################################################
+
+        # repeat the above process but now compare drop_counter to 4
+        dup.13 eq.5
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        movup.13 dup.14 eq.4 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_3, A', latch', drop_counter]
+
+        ### 5th value ########################################################
+
+        # repeat the above process but now compare drop_counter to 5
+        dup.13 eq.6
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        movup.13 dup.14 eq.5 or
+        dup movdn.14
+        cdrop movdn.6
+        # => [d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_3, A', latch', drop_counter]
+
+        ### 6th value ########################################################
+
+        # repeat the above process but now compare drop_counter to 6
+        dup.13 eq.7
+        if.true
+            push.1 swap
+        else
+            push.0 swap
+        end
+        movup.13 dup.14 eq.6 or
+        cdrop movdn.6
+        # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A', drop_counter]
+        # or in other words
+        # => [C, B, A', drop_counter, ... ]
+
+        # drop the drop_counter
+        movup.12 drop
+        # => [C, B, A']
+
+        hperm
+        # => [F, E, D]
+
+        exec.native::state_to_digest
+        # => [E]
     else
         dropw movdnw.2 dropw dropw
         # => [B']

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -144,3 +144,100 @@ export.get_serial_number
     syscall.get_note_serial_number
     # => [SERIAL_NUMBER]
 end
+
+#! Computes hash of note inputs starting at the specified memory address.
+#!
+#! Inputs:  [inputs_ptr, num_inputs]
+#! Outputs: [HASH]
+#!
+#! Panics if num_inputs is greater than 128.
+export.compute_inputs_hash
+    swap
+    # => [num_inputs, inputs_ptr]
+
+    # check that number of inputs is less than 128
+    dup push.128 u32lte assert
+    # => [num_inputs, inputs_ptr]
+
+    # get the number of word pairs to be hashed
+    u32divmod.8 swap
+    # => [num_inputs/8, num_inputs%8, inputs_ptr]
+
+    # get the end_addr for hash_memory_even proc
+    u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
+    # => [inputs_ptr, end_addr, num_inputs%8]
+
+    # get the padding flag to add it to the capacity part
+    dup.2 push.0 neq 
+    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
+    
+    # prepare hasher state for RPO permutation 
+    push.0.0.0 padw padw 
+    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
+
+    exec.native::hash_memory_even
+    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
+
+    # if num_inputs%8 is not ZERO
+    dup.14 push.0 neq
+    if.true
+        mem_stream
+        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
+
+        # clean the stack
+        movup.12 drop movup.12 drop
+        # => [E, D, A', num_inputs%8]
+
+        # get the number of elements we need to drop
+        push.8 movup.13 u32wrapping_sub movdn.12
+        # => [E, D, A', drop_counter]
+
+        # get the number of zeros we will need to dap
+        dup.12 u32wrapping_sub.1 movdn.13
+        # => [E, D, A', drop_counter, zero_counter]
+
+        # check the drop_counter
+        dup.12 neq.0
+        while.true
+            # decrease the counter
+            movup.12 u32wrapping_sub.1 movdn.12
+
+            # drop the top element, push 0 to the stack and move it down to maintain the overall number
+            # of elements on stack to be able to access the drop_counter at position 12
+            drop push.0 movdn.11
+
+            # check the drop_counter
+            dup.12 neq.0
+        end
+        # => [a, ..., x, A', 0, ..., 0, 0, zero_counter]
+        #                               ^-- 12th position
+
+        # push the dividing 1 (move the previously added zero and incr it)
+        movup.12 add.1
+        # => [1, a, ..., x, A', 0, ..., 0, 0, zero_counter]
+        #                                  ^-- 12th position
+
+        # check the zero_counter
+        dup.13 neq.0
+        while.true
+            # decrease the counter
+            movup.13 u32wrapping_sub.1 movdn.13
+
+            # move the previously added zero
+            movup.12
+
+            # check the zero_counter
+            dup.13 neq.0
+        end
+        # => [C, B, A', 0, 0, ... ]
+        
+        hperm
+        # => [F, E, D]
+
+        exec.native::state_to_digest
+        # => [E]
+    else
+        dropw movdnw.2 dropw dropw
+        # => [B']
+    end
+end

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -311,8 +311,6 @@ export.compute_inputs_hash_cdrop
     # if num_inputs%8 is not ZERO
     dup.14 push.0 neq
     if.true
-        # check whether we need to drop more than 4 elements
-
         # load the remaining double word
         mem_stream
         # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
@@ -418,6 +416,150 @@ export.compute_inputs_hash_cdrop
         # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A', drop_counter]
         # or in other words
         # => [C, B, A', drop_counter, ... ]
+
+        # drop the drop_counter
+        movup.12 drop
+        # => [C, B, A']
+
+        hperm
+        # => [F, E, D]
+
+        exec.native::state_to_digest
+        # => [E]
+    else
+        dropw movdnw.2 dropw dropw
+        # => [B']
+    end
+end
+
+#! Computes hash of note inputs starting at the specified memory address.
+#!
+#! Inputs:  [inputs_ptr, num_inputs]
+#! Outputs: [HASH]
+#!
+#! Panics if num_inputs is greater than 128.
+export.compute_inputs_hash_simple
+    # move number of inputs to the top of the stack 
+    swap
+    # => [num_inputs, inputs_ptr]
+
+    # check that number of inputs is less than 128
+    dup push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
+    # => [num_inputs, inputs_ptr]
+
+    # get the number of double words
+    u32divmod.8 swap
+    # => [num_inputs/8, num_inputs%8, inputs_ptr]
+
+    # get the end_addr for hash_memory_even proc (end address for pairs of words)
+    u32wrapping_mul.2 dup.2 u32wrapping_add movup.2
+    # => [inputs_ptr, end_addr, num_inputs%8]
+
+    # get the padding flag to add it to the capacity part
+    dup.2 push.0 neq 
+    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
+    
+    # prepare hasher state for RPO permutation 
+    push.0.0.0 padw padw 
+    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
+
+    # hash every pair of words
+    dup.13 dup.13 neq
+    if.true
+        exec.native::hash_memory_even
+    end
+    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
+
+    # hash remaining input values if there any left
+    # if num_inputs%8 is not ZERO
+    dup.14 push.0 neq
+    if.true
+        # load the remaining double word
+        mem_stream
+        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
+
+        # clean the stack
+        movup.12 drop movup.12 drop
+        # => [E, D, A', num_inputs%8]
+
+        # get the number of elements we need to drop
+        # notice that drop_counter could be any number from 1 to 7
+        push.8 movup.13 u32wrapping_sub movdn.12
+        # => [E, D, A', drop_counter]
+
+        ### 0th value ########################################################
+        
+        # we need to drop first value anyway, since number of values is not divisible by 8
+        drop
+        # => [e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
+
+        # if current value is the last value to drop (\"cycle\" number equals to the number of values 
+        # to drop), push 1 instead of 0 to the stack
+        dup.11 eq.1
+        # => [0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
+
+        # move the calculated value down the stack 
+        movdn.6
+        # => [e_1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
+
+        ### 1st value ########################################################
+
+        # check whether we still need to drop top stack value and change it to the 0/1
+        dup.12 push.1 gt
+        if.true
+            # if we still need to do so, drop the value and push 0/1 on the stack, depending on 
+            # whether this prop was the last
+            drop dup.11 eq.2 
+        end 
+        # if we already dropped all necessary values, just move top stack value to its position
+        movdn.6
+        # => [e_2, e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, d_3, A', drop_counter]
+
+        ### 2nd value ########################################################
+
+        dup.12 push.2 gt
+        if.true
+            drop dup.11 eq.3 
+        end 
+        movdn.6
+        # => [e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, d_3, A', drop_counter]
+
+        ### 3rd value ########################################################
+
+        dup.12 push.3 gt
+        if.true
+            drop dup.11 eq.4
+        end 
+        movdn.6
+        # => [d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_3, A', drop_counter]
+
+        ### 4th value ########################################################
+
+        dup.12 push.4 gt
+        if.true
+            drop dup.11 eq.5
+        end 
+        movdn.6
+        # => [d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_3, A', drop_counter]
+
+        ### 5th value ########################################################
+
+        dup.12 push.5 gt
+        if.true
+            drop dup.11 eq.6
+        end 
+        movdn.6
+        # => [d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_3, A', drop_counter]
+
+        ### 6th value ########################################################
+
+        dup.12 push.6 gt
+        if.true
+            drop dup.11 eq.7
+        end 
+        movdn.6
+        # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A', drop_counter]
+
 
         # drop the drop_counter
         movup.12 drop

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -1,5 +1,5 @@
 use.miden::kernels::tx::constants
-use.std::crypto::hashes::native
+use.std::crypto::hashes::rpo
 use.std::mem
 
 # ERRORS
@@ -26,7 +26,7 @@ proc.write_advice_data_to_memory
     # => [PERM, PERM, PERM, end_ptr, HASH]
 
     # extract the digest
-    exec.native::state_to_digest
+    exec.rpo::squeeze_digest
     # => [DIGEST, end_ptr, HASH]
 
     # drop pointer for reading from memory
@@ -146,162 +146,17 @@ export.get_serial_number
 end
 
 #! Computes hash of note inputs starting at the specified memory address.
+#!
 #! If the number if inputs is 0, procedure returns the empty word: [ZERO, ZERO, ZERO, ZERO].
 #!
 #! Inputs:  [inputs_ptr, num_inputs]
 #! Outputs: [HASH]
 #!
 #! Panics if num_inputs is greater than 128.
-#!
-#! TODO: most of this fuction should be replaced by `hash_memory` function from the `native` module 
-#! of miden-vm.
 export.compute_inputs_hash
-    # move number of inputs to the top of the stack 
-    swap
-    # => [num_inputs, inputs_ptr]
-
     # check that number of inputs is less than 128
-    dup push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
-    # => [num_inputs, inputs_ptr]
+    dup.1 push.128 u32assert2 u32lte assert.err=ERR_NOTE_TOO_MANY_INPUTS
 
-    # get the number of double words
-    u32divmod.8 swap
-    # => [num_inputs/8, num_inputs%8, inputs_ptr]
-
-    # get the end_addr for hash_memory_even proc (end address for pairs of words)
-    mul.2 dup.2 add movup.2
-    # => [inputs_ptr, end_addr, num_inputs%8]
-
-    # get the padding flag to add it to the capacity part
-    dup.2 eq.0 not
-    # => [pad_flag, inputs_ptr, end_addr, num_inputs%8]
-    
-    # prepare hasher state for RPO permutation 
-    push.0.0.0 padw padw 
-    # => [C, B, A, inputs_ptr, end_addr, num_inputs%8]
-
-    # hash every pair of words
-    exec.native::hash_memory_even
-    # => [C', B', A', inputs_ptr', end_addr, num_inputs%8] where inputs_ptr' = end_addr
-
-    # hash remaining input values if there any left
-    # if num_inputs%8 is not ZERO
-    dup.14 push.0 neq
-    if.true
-        # load the remaining double word
-        mem_stream
-        # => [E, D, A', inputs_ptr'+2, end_addr, num_inputs%8]
-
-        # clean the stack
-        movup.12 drop movup.12 drop
-        # => [E, D, A', num_inputs%8]
-
-        # get the number of elements we need to drop
-        # notice that drop_counter could be any number from 1 to 7
-        push.8 movup.13 u32wrapping_sub movdn.12
-        # => [E, D, A', drop_counter]
-
-        ### 0th value ########################################################
-        
-        # if current value is the last value to drop ("cycle" number equals to the number of values 
-        # to drop), push 1 instead of 0 to the stack
-        dup.12 eq.1 swap
-        # => [e_0, 0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
-
-        # we need to drop first value anyway, since number of values is not divisible by 8
-        drop
-        # => [0/1, e_1, e_2, e_3, d_0, d_1, d_2, d_3, A', drop_counter]
-
-        # move the calculated value down the stack 
-        movdn.6
-        # => [e_1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
-
-        ### 1st value ########################################################
-
-        # prepare the second element of the E Word (e_1) for cdrop instruction
-        # if current value is the last value to drop ("cycle" number equals to the number of values 
-        # to drop), push 1 instead of 0 to the stack
-        dup.12 eq.2 swap
-        # => [e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
-
-        # push latch variable onto the stack; this will be the control for the cdrop instruction
-        push.0
-        # => [latch = 0, e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
-
-        # get the flag whether the drop counter is equal 1
-        dup.14 eq.1
-        # => [drop_counter == 1, latch = 0, e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
-
-        # update the latch: if drop_counter == 1, latch will become 1
-        or
-        # => [latch', e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', drop_counter]
-
-        # save the latch value 
-        dup movdn.14
-        # => [latch', e_1, 0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', latch', drop_counter]
-
-        # if latch == 1, drop 0/1; otherwise drop e_1
-        cdrop
-        # => [e_1_or_0/1, e_2, e_3, d_0, d_1, d_2, 0/1, d_3, A', latch', drop_counter]
-
-        # move the calculated value down the stack 
-        movdn.6
-        # => [e_2, e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, d_3, A', latch', drop_counter]
-
-        ### 2nd value ########################################################
-
-        # repeat the above process but now compare drop_counter to 2
-        dup.13 eq.3 swap
-        movup.13 dup.14 eq.2 or
-        dup movdn.14
-        cdrop movdn.6
-        # => [e_3, d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, d_3, A', latch', drop_counter]
-
-        ### 3rd value ########################################################
-
-        # repeat the above process but now compare drop_counter to 3
-        dup.13 eq.4 swap
-        movup.13 dup.14 eq.3 or
-        dup movdn.14
-        cdrop movdn.6
-        # => [d_0, d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_3, A', latch', drop_counter]
-
-        ### 4th value ########################################################
-
-        # repeat the above process but now compare drop_counter to 4
-        dup.13 eq.5 swap
-        movup.13 dup.14 eq.4 or
-        dup movdn.14
-        cdrop movdn.6
-        # => [d_1, d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_3, A', latch', drop_counter]
-
-        ### 5th value ########################################################
-
-        # repeat the above process but now compare drop_counter to 5
-        dup.13 eq.6 swap
-        movup.13 dup.14 eq.5 or
-        dup movdn.14
-        cdrop movdn.6
-        # => [d_2, 0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_3, A', latch', drop_counter]
-
-        ### 6th value ########################################################
-
-        # repeat the above process but now compare drop_counter to 6
-        dup.13 eq.7 swap
-        movup.13 movup.14 eq.6 or
-        cdrop movdn.6
-        # => [0/1, e_1_or_0/1, e_2_or_0/1, e_3_or_0/1, d_0_or_0/1, d_1_or_0/1, d_2_or_0/1, d_3, A']
-        # or in other words
-        # => [C, B, A', ... ]
-
-        hperm
-        # => [F, E, D]
-
-        exec.native::state_to_digest
-        # => [E]
-    else
-        dropw movdnw.2 dropw dropw
-        # => [B']
-    end
+    exec.rpo::hash_memory
 end
 

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     transaction::TransactionArgs,
     WORD_SIZE,
 };
-use vm_processor::{EMPTY_WORD, ONE};
+use vm_processor::{ProcessState, EMPTY_WORD, ONE};
 
 use super::{Felt, Process, ZERO};
 use crate::{
@@ -428,4 +428,58 @@ fn test_get_note_serial_number() {
 
     let serial_number = tx_context.input_notes().get_note(0).note().serial_num();
     assert_eq!(process.stack.get_word(0), serial_number);
+}
+
+#[test]
+fn test_get_inputs_hash() {
+    let tx_context = TransactionContextBuilder::with_standard_account(
+        ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
+        ONE,
+    )
+    .with_mock_notes(AssetPreservationStatus::Preserved)
+    .build();
+
+    let code = "
+        use.miden::note
+        
+        begin
+            push.1.2.3.4.1000 mem_storew dropw
+            push.5.6.7.8.1001 mem_storew dropw
+            push.9.10.11.12.1002 mem_storew dropw
+            push.13.14.15.16.1003 mem_storew dropw
+
+            push.5.1000
+            exec.note::compute_inputs_hash
+
+            push.8.1000
+            exec.note::compute_inputs_hash
+
+            push.15.1000
+            exec.note::compute_inputs_hash
+
+            push.0.1000
+            exec.note::compute_inputs_hash
+        end
+    ";
+
+    let process = tx_context.execute_code(code).unwrap();
+    let expected_stack = [
+        Felt::new(0),
+        Felt::new(0),
+        Felt::new(0),
+        Felt::new(0),
+        Felt::new(10300020282439016154),
+        Felt::new(3516596904277416676),
+        Felt::new(11018788508269249672),
+        Felt::new(7921509648524809116),
+        Felt::new(13608701685256682132),
+        Felt::new(16013969809933496273),
+        Felt::new(15720844923951376941),
+        Felt::new(15975159621759139720),
+        Felt::new(12095223039215569196),
+        Felt::new(16902760742589336416),
+        Felt::new(12194156716918087419),
+        Felt::new(2777745863384272413),
+    ];
+    assert_eq!(process.get_stack_state()[0..16], expected_stack);
 }


### PR DESCRIPTION
This PR implements `compute_inputs_hash` function in `note.masm` which allows to compute RPO hash of arbitrary number of Felt elements.

TODO:
- [x] Implement `compute_inputs_hash`
- [x] Update changelog 
- [x] Update docs