### PR TITLE
fix: compilation for testing feature and wasm

### DIFF
--- a/miden-tx/src/testing/utils.rs
+++ b/miden-tx/src/testing/utils.rs
@@ -6,14 +6,18 @@ use std::{
     string::{String, ToString},
 };
 
-use miden_lib::transaction::{memory, ToTransactionKernelInputs, TransactionKernel};
+#[cfg(not(target_family = "wasm"))]
+use miden_lib::transaction::TransactionKernel;
+use miden_lib::transaction::{memory, ToTransactionKernelInputs};
 use miden_objects::transaction::PreparedTransaction;
 #[cfg(feature = "std")]
 use miden_objects::{
     transaction::{TransactionArgs, TransactionInputs},
     Felt,
 };
-use vm_processor::{AdviceInputs, ExecutionError, Process, Word};
+#[cfg(not(target_family = "wasm"))]
+use vm_processor::Word;
+use vm_processor::{AdviceInputs, ExecutionError, Process};
 #[cfg(feature = "std")]
 use vm_processor::{AdviceProvider, DefaultHost, ExecutionOptions, Host, StackInputs};
 


### PR DESCRIPTION
after https://github.com/0xPolygonMiden/miden-client/pull/378 got merged, I tried the changes against miden base's `next` branch and got some errors:

```rust
mFragaBA> cargo check --target wasm32-unknown-unknown --features testing,async,wasm --no-default-features
error[E0425]: cannot find function `rand_array` in crate `rand`
   --> /Users/lambda/.cargo/git/checkouts/miden-base-c72873dca0cede8b/97ae4cb/objects/src/testing/block.rs:589:31
    |
589 |         let prev_hash = rand::rand_array().into();
    |                               ^^^^^^^^^^ not found in `rand`
 ...
``` 

This is due to the recent refactor of the mock crate.  This PR adds some cfg guards in order to be able to compile for wasm.

