### PR TITLE
bugfix: fix the stack access

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -605,7 +605,7 @@ proc.process_input_note
     # => [NULLIFIER, note_ptr, idx]
 
     # save nullifier to memory
-    movup.6 exec.memory::get_consumed_note_nullifier_ptr
+    movup.5 exec.memory::get_consumed_note_nullifier_ptr
     mem_storew dropw
     # => [note_ptr]
 

--- a/miden-tx/src/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/kernel_tests/test_prologue.rs
@@ -18,6 +18,7 @@ use miden_lib::transaction::{
 };
 use miden_objects::{
     assembly::ProgramAst,
+    notes::Nullifier,
     testing::{
         account::MockAccountType,
         notes::AssetPreservationStatus,
@@ -273,8 +274,11 @@ fn consumed_notes_memory_assertions(
         let note = input_note.note();
 
         assert_eq!(
-            read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx),
-            note.nullifier().as_elements(),
+            Nullifier::from(read_root_mem_value(
+                process,
+                CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx
+            )),
+            note.nullifier(),
             "note nullifier should be computer and stored at the correct offset"
         );
 


### PR DESCRIPTION
The instruction movup.6 was accessing the parent's stack, the code worked because that value happened to be the same at position for movup.5. This change makes sure the `process_input_note` stays inside its declared stack.