### PR TITLE
kernel: add support for delayed note inclusion checks

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -183,15 +183,21 @@ end
 #! Returns a pointer to the consumed note being executed.
 #!
 #! Stack: []
-#! Output: [ptr]
+#! Output: [note_ptr]
+#!
+#! Where:
+#! - note_ptr, the memory address of the data segment for the current consumed note.
 export.get_current_consumed_note_ptr
     push.CURRENT_CONSUMED_NOTE_PTR mem_load
 end
 
 #! Sets the current consumed note pointer to the consumed note being executed.
 #!
-#! Stack: [ptr]
+#! Stack: [note_ptr]
 #! Output: []
+#!
+#! Where:
+#! - note_ptr, the new memory address of the data segment for the consumed note.
 export.set_current_consumed_note_ptr
     push.CURRENT_CONSUMED_NOTE_PTR mem_store
 end
@@ -201,6 +207,7 @@ end
 #! Stack: []
 #! Output: [input_vault_root_ptr]
 #!
+#! Where:
 #! - input_vault_root_ptr is a pointer to the memory address at which the input vault root is stored
 export.get_input_vault_root_ptr
     push.INPUT_VAULT_ROOT_PTR
@@ -211,6 +218,7 @@ end
 #! Stack: []
 #! Output: [INPUT_VAULT_ROOT]
 #!
+#! Where:
 #! - INPUT_VAULT_ROOT is the input vault root.
 export.get_input_vault_root
     padw push.INPUT_VAULT_ROOT_PTR mem_loadw
@@ -221,6 +229,7 @@ end
 #! Stack: [INPUT_VAULT_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - INPUT_VAULT_ROOT is the input vault root.
 export.set_input_vault_root
     push.INPUT_VAULT_ROOT_PTR mem_storew dropw
@@ -231,6 +240,7 @@ end
 #! Stack: []
 #! Output: [output_vault_root_ptr]
 #!
+#! Where:
 #! - output_vault_root_ptr is a pointer to the memory address at which the output vault root is stored.
 export.get_output_vault_root_ptr
     push.OUTPUT_VAULT_ROOT_PTR
@@ -241,6 +251,7 @@ end
 #! Stack: []
 #! Output: [OUTPUT_VAULT_ROOT]
 #!
+#! Where:
 #! - OUTPUT_VAULT_ROOT is the output vault root.
 export.get_output_vault_root
     padw push.OUTPUT_VAULT_ROOT_PTR mem_loadw
@@ -251,6 +262,7 @@ end
 #! Stack: [OUTPUT_VAULT_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - OUTPUT_VAULT_ROOT is the output vault root.
 export.set_output_vault_root
     push.OUTPUT_VAULT_ROOT_PTR mem_storew dropw
@@ -287,6 +299,7 @@ end
 #! Stack: [acct_id]
 #! Output: []
 #!
+#! Where:
 #! - acct_id is the account id.
 export.set_global_acct_id
     push.ACCT_ID_PTR mem_store
@@ -307,6 +320,7 @@ end
 #! Stack: [INIT_ACCT_HASH]
 #! Output: []
 #!
+#! Where:
 #! - INIT_ACCT_HASH is the initial account hash.
 export.set_init_acct_hash
     push.INIT_ACCT_HASH_PTR mem_storew dropw
@@ -317,6 +331,7 @@ end
 #! Stack: []
 #! Output: [INIT_ACCT_HASH]
 #!
+#! Where:
 #! - INIT_ACCT_HASH is the initial account hash.
 export.get_init_acct_hash
     padw push.INIT_ACCT_HASH_PTR mem_loadw
@@ -351,6 +366,7 @@ end
 #! Stack: []
 #! Output: [init_nonce]
 #!
+#! Where:
 #! - init_nonce is the initial account nonce.
 export.get_init_nonce
     push.INIT_NONCE_PTR mem_load
@@ -371,6 +387,7 @@ end
 #! Stack: []
 #! Output: [TX_SCRIPT_ROOT]
 #!
+#! Where:
 #! - TX_SCRIPT_ROOT is the transaction script root.
 export.get_tx_script_root
     padw push.TX_SCRIPT_ROOT_PTR mem_loadw
@@ -382,6 +399,7 @@ end
 #! Stack: [TX_SCRIPT_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - TX_SCRIPT_ROOT is the transaction script root.
 export.set_tx_script_root
     push.TX_SCRIPT_ROOT_PTR mem_storew dropw
@@ -395,6 +413,7 @@ end
 #! Stack: []
 #! Output: [ptr]
 #!
+#! Where:
 #! - ptr is a pointer to the block data section.
 export.get_block_data_ptr
     push.BLOCK_DATA_SECTION_OFFSET
@@ -405,6 +424,7 @@ end
 #! Stack: []
 #! Output: [PRV_BLK_HASH]
 #!
+#! Where:
 #! - PRV_BLK_HASH is the previous block hash of the last known block.
 export.get_prv_blk_hash
     padw push.PREV_BLOCK_HASH_PTR mem_loadw
@@ -415,6 +435,7 @@ end
 #! Stack: []
 #! Output: [blk_num]
 #!
+#! Where:
 #! - blk_num is the block number of the last known block.
 export.get_blk_num
     push.BLOCK_METADATA_PTR mem_load
@@ -425,6 +446,7 @@ end
 #! Stack: []
 #! Output: [version]
 #!
+#! Where:
 #! - version is the protocol version of the last known block.
 export.get_blk_version
     padw push.BLOCK_METADATA_PTR mem_loadw drop drop swap drop
@@ -435,6 +457,7 @@ end
 #! Stack: []
 #! Output: [timestamp]
 #!
+#! Where:
 #! - timestamp is the block timestamp of the last known block.
 export.get_blk_timestamp
     padw push.BLOCK_METADATA_PTR mem_loadw drop movdn.2 drop drop
@@ -446,6 +469,7 @@ end
 #! Stack: []
 #! Output: [CHAIN_ROOT]
 #!
+#! Where:
 #! - CHAIN_ROOT is the chain root of the last known block.
 export.get_chain_root
     padw push.CHAIN_ROOT_PTR mem_loadw
@@ -456,6 +480,7 @@ end
 #! Stack: []
 #! Output: [ACCT_ROOT]
 #!
+#! Where:
 #! - ACCT_ROOT is the account root of the last known block.
 export.get_account_db_root
     padw push.ACCT_DB_ROOT_PTR mem_loadw
@@ -466,6 +491,7 @@ end
 #! Stack: []
 #! Output: [NULLIFIER_ROOT]
 #!
+#! Where:
 #! - NULLIFIER_ROOT is the nullifier root of the last known block.
 export.get_nullifier_db_root
     padw push.NULLIFIER_ROOT_PTR mem_loadw
@@ -476,6 +502,7 @@ end
 #! Stack: []
 #! Output: [TX_HASH]
 #!
+#! Where:
 #! - TX_HASH is the tx hash of the last known block.
 export.get_tx_hash
     padw push.TX_HASH_PTR mem_loadw
@@ -486,6 +513,7 @@ end
 #! Stack: []
 #! Output: [PROOF_HASH]
 #!
+#! Where:
 #! - PROOF_HASH is the proof hash of the last known block.
 export.get_proof_hash
     padw push.PROOF_HASH_PTR mem_loadw
@@ -496,6 +524,7 @@ end
 #! Stack: []
 #! Output: [NOTE_ROOT]
 #!
+#! Where:
 #! - NOTE_ROOT is the note root of the last known block.
 export.get_note_root
     padw push.NOTE_ROOT_PTR mem_loadw
@@ -506,6 +535,7 @@ end
 #! Stack: [NOTE_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - NOTE_ROOT is the note root of the last known block.
 export.set_note_root
     push.NOTE_ROOT_PTR mem_storew dropw
@@ -519,6 +549,7 @@ end
 #! Stack: []
 #! Output: [ptr]
 #!
+#! Where:
 #! - ptr is a pointer to the chain MMR section.
 export.get_chain_mmr_ptr
     push.CHAIN_MMR_PTR
@@ -529,6 +560,7 @@ end
 #! Stack: [num_leaves]
 #! Output: []
 #!
+#! Where:
 #! - num_leaves is the number of leaves in the chain MMR.
 export.set_chain_mmr_num_leaves
     push.CHAIN_MMR_NUM_LEAVES_PTR mem_store
@@ -539,6 +571,7 @@ end
 #! Stack: []
 #! Output: [ptr]
 #!
+#! Where:
 #! - ptr is a pointer to the start of the chain MMR peaks section.
 export.get_chain_mmr_peaks_ptr
     push.CHAIN_MMR_PEAKS_PTR
@@ -552,6 +585,7 @@ end
 #! Stack: []
 #! Output: [ptr]
 #!
+#! Where:
 #! - ptr is the memory address at which the account data begins.
 export.get_acct_data_ptr
     push.ACCT_DATA_SECTION_OFFSET
@@ -562,6 +596,7 @@ end
 #! Stack: []
 #! Output: [ptr]
 #!
+#! Where:
 #! - ptr is the memory address at which the account data ends.
 export.get_core_acct_data_end_ptr
     push.ACCT_CORE_DATA_SECTION_END_OFFSET
@@ -572,6 +607,7 @@ end
 #! Stack: []
 #! Output: [acct_id]
 #!
+#! Where:
 #! - acct_id is the account id.
 export.get_acct_id
     push.ACCT_ID_AND_NONCE_PTR mem_load
@@ -582,6 +618,7 @@ end
 #! Stack: []
 #! Output: [acct_nonce]
 #!
+#! Where:
 #! - acct_nonce is the account nonce.
 export.get_acct_nonce
     padw push.ACCT_ID_AND_NONCE_PTR mem_loadw
@@ -593,6 +630,7 @@ end
 #! Stack: [acct_nonce]
 #! Output: []
 #!
+#! Where:
 #! - acct_nonce is the account nonce.
 export.set_acct_nonce
     padw push.ACCT_ID_AND_NONCE_PTR mem_loadw
@@ -604,6 +642,7 @@ end
 #! Stack: [CODE_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - CODE_ROOT is the code root to be set.
 export.set_acct_code_root
     push.ACCT_CODE_ROOT_PTR mem_storew dropw
@@ -614,6 +653,7 @@ end
 #! Stack: []
 #! Output: [CODE_ROOT]
 #!
+#! Where:
 #! - CODE_ROOT is the code root of the account.
 export.get_acct_code_root
     padw push.ACCT_CODE_ROOT_PTR mem_loadw
@@ -624,6 +664,7 @@ end
 #! Stack: [CODE_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - CODE_ROOT is the new account code root.
 export.set_new_acct_code_root
     push.ACCT_NEW_CODE_ROOT_PTR mem_storew dropw
@@ -634,6 +675,7 @@ end
 #! Stack: []
 #! Output: [CODE_ROOT]
 #!
+#! Where:
 #! - CODE_ROOT is the new account code root.
 export.get_new_acct_code_root
     padw push.ACCT_NEW_CODE_ROOT_PTR mem_loadw
@@ -644,6 +686,7 @@ end
 #! Stack: []
 #! Output: [STORAGE_ROOT]
 #!
+#! Where:
 #! - STORAGE_ROOT is the account storage root.
 export.get_acct_storage_root
     padw push.ACCT_STORAGE_ROOT_PTR mem_loadw
@@ -654,6 +697,7 @@ end
 #! Stack: [STORAGE_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - STORAGE_ROOT is the account storage root.
 export.set_acct_storage_root
     push.ACCT_STORAGE_ROOT_PTR mem_storew dropw
@@ -664,6 +708,7 @@ end
 #! Stack: []
 #! Output: [output_vault_root_ptr]
 #!
+#! Where:
 #! - output_vault_root_ptr is a pointer to the memory address at which the account vault root is stored.
 export.get_acct_vault_root_ptr
     push.ACCT_VAULT_ROOT_PTR
@@ -674,6 +719,7 @@ end
 #! Stack: []
 #! Output: [ACCT_VAULT_ROOT]
 #!
+#! Where:
 #! - ACCT_VAULT_ROOT is the account asset vault root.
 export.get_acct_vault_root
     padw push.ACCT_VAULT_ROOT_PTR mem_loadw
@@ -684,6 +730,7 @@ end
 #! Stack: [ACCT_VAULT_ROOT]
 #! Output: []
 #!
+#! Where:
 #! - ACCT_VAULT_ROOT is the account vault root to be set.
 export.set_acct_vault_root
     push.ACCT_VAULT_ROOT_PTR mem_storew dropw
@@ -694,6 +741,7 @@ end
 #! Stack: []
 #! Output: [ptr]
 #!
+#! Where:
 #! - ptr is a pointer to the memory address at which the account storage slot type data begins.
 export.get_acct_storage_slot_type_data_ptr
     push.ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET
@@ -705,6 +753,7 @@ end
 #! Stack: [idx]
 #! Output: [slot_type_info]
 #!
+#! Where:
 #! - idx is the index of the storage slot.
 #! - slot_type_info contains the slot type and entry arity.
 export.get_acct_storage_slot_type_data
@@ -745,6 +794,7 @@ end
 #! Stack: []
 #! Output: [num_consumed_notes]
 #!
+#! Where:
 #! - num_consumed_notes is the total number of consumed notes in the transaction.
 export.get_total_num_consumed_notes
     push.CONSUMED_NOTE_NUM_PTR mem_load
@@ -755,54 +805,58 @@ end
 #! Stack: [num_consumed_notes]
 #! Output: []
 #!
+#! Where:
 #! - num_consumed_notes is the total number of consumed notes in the transaction.
 export.set_total_num_consumed_notes
     push.CONSUMED_NOTE_NUM_PTR mem_store
 end
 
 #! Computes a pointer to the memory address at which the data associated with a consumed note with
-#! index i is stored.
+#! index `idx` is stored.
 #!
-#! Stack: [i]
-#! Output: [ptr]
+#! Stack: [idx]
+#! Output: [note_ptr]
 #!
-#! - i is the index of the consumed note.
-#! - ptr is the memory address of the data segment for consumed note i.
+#! Where:
+#! - idx, the index of the consumed note.
+#! - note_ptr, the memory address of the data segment for the consumed note with idx.
 export.get_consumed_note_ptr
     exec.constants::get_note_mem_size mul push.CONSUMED_NOTE_DATA_SECTION_OFFSET add
 end
 
 #! Set the note id of the consumed note.
 #!
-#! Stack: [consumed_note_ptr, NOTE_ID]
+#! Stack: [note_ptr, NOTE_ID]
 #! Output: [NOTE_ID]
 #!
 #! Where:
-#! - consumed_note_ptr, the consumed note's the memory address.
+#! - note_ptr, the consumed note's the memory address.
 #! - NOTE_ID, the note's id.
 export.set_consumed_note_id
     mem_storew
 end
 
-#! Computes a pointer to the memory address at which the nullifier associated a note with index i
+#! Computes a pointer to the memory address at which the nullifier associated a note with `idx`
 #! is stored.
 #!
-#! Stack: [i]
-#! Output: [ptr]
+#! Stack: [idx]
+#! Output: [nullifier_ptr]
 #!
-#! - i is the index of the consumed note.
-#! - ptr is the nullifier memory address for note i.
+#! Where:
+#! - idx, the index of the consumed note.
+#! - nullifier_ptr, the memory address of the nullifier for note idx.
 export.get_consumed_note_nullifier_ptr
     push.CONSUMED_NOTE_SECTION_OFFSET.1 add add
 end
 
-#! Returns the nullifier of a consumed note with index i.
+#! Returns the nullifier of a consumed note with `idx`.
 #!
-#! Stack: [i]
+#! Stack: [idx]
 #! Output: [nullifier]
 #!
-#! - i is the index of the consumed note.
-#! - nullifier is the nullifier of the consumed note.
+#! Where:
+#! - idx, the index of the consumed note.
+#! - nullifier, the nullifier of the consumed note.
 export.get_consumed_note_nullifier
     padw movup.4 push.CONSUMED_NOTE_SECTION_OFFSET.1 add add mem_loadw
 end
@@ -810,22 +864,24 @@ end
 #! Returns a pointer to the start of the consumed note core data segment for the note located at
 #! the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
-#! Output: [ptr]
+#! Stack: [note_ptr]
+#! Output: [note_data_ptr]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - ptr is the memory address at which the consumed note core data begins.
+#! Where:
+#! - note_ptr, the memory address at which the consumed note data begins.
+#! - note_data_ptr, the memory address at which the consumed note core data begins.
 export.get_consumed_note_core_ptr
     push.CONSUMED_NOTE_CORE_DATA_OFFSET add
 end
 
 #! Returns the script root of a consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
-#! Output: [R]
+#! Stack: [note_ptr]
+#! Output: [SCRIPT_HASH]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - R is the script root of the consumed note.
+#! Where:
+#! - note_ptr, the memory address at which the consumed note data begins.
+#! - SCRIPT_HASH, the script root of the consumed note.
 export.get_consumed_note_script_root
     padw
     movup.4 push.CONSUMED_NOTE_SCRIPT_ROOT_OFFSET add
@@ -834,11 +890,12 @@ end
 
 #! Returns the inputs hash of a consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
-#! Output: [I]
+#! Stack: [note_ptr]
+#! Output: [INPUTS_HASH]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - I is the inputs hash of the consumed note.
+#! Where:
+#! - note_ptr, the memory address at which the consumed note data begins.
+#! - INPUTS_HASH, the inputs hash of the consumed note.
 export.get_consumed_note_inputs_hash
     padw
     movup.4 push.CONSUMED_NOTE_INPUTS_HASH_OFFSET add
@@ -847,11 +904,12 @@ end
 
 #! Returns the metadata of a consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
-#! Output: [M]
+#! Stack: [note_ptr]
+#! Output: [METADATA]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - M is the metadata of the consumed note.
+#! Where:
+#! - note_ptr, the memory address at which the consumed note data begins.
+#! - METADATA, the metadata of the consumed note.
 export.get_consumed_note_metadata
     padw
     movup.4 push.CONSUMED_NOTE_METADATA_OFFSET add
@@ -860,11 +918,12 @@ end
 
 #! Sets the metadata for a consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr, M]
+#! Stack: [note_ptr, METADATA]
 #! Output: []
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - M is the metadata of the consumed note.
+#! Where:
+#! - note_ptr, the memory address at which the consumed note data begins.
+#! - METADATA, the metadata of the consumed note.
 export.set_consumed_note_metadata
     push.CONSUMED_NOTE_METADATA_OFFSET add
     mem_storew dropw
@@ -872,11 +931,11 @@ end
 
 #! Returns the note's args.
 #!
-#! Stack: [consumed_note_ptr]
+#! Stack: [note_ptr]
 #! Output: [NOTE_ARGS]
 #!
 #! Where:
-#! - consumed_note_ptr, the start memory address of the note.
+#! - note_ptr, the start memory address of the note.
 #! - NOTE_ARGS, the note's args.
 export.get_consumed_note_args
     padw
@@ -886,10 +945,11 @@ end
 
 #! Sets the note args for a consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr, NOTE_ARGS]
+#! Stack: [note_ptr, NOTE_ARGS]
 #! Output: []
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
 #! - NOTE_ARGS are optional note args of the consumed note.
 export.set_consumed_note_args
     push.CONSUMED_NOTE_ARGS_OFFSET add
@@ -898,10 +958,11 @@ end
 
 #! Returns the number of assets in the consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
+#! Stack: [note_ptr]
 #! Output: [num_assets]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
 #! - num_assets is the number of assets in the consumed note.
 export.get_consumed_note_num_assets
     push.CONSUMED_NOTE_NUM_ASSETS_OFFSET add
@@ -910,10 +971,11 @@ end
 
 #! Sets the number of assets for a consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr, num_assets]
+#! Stack: [note_ptr, num_assets]
 #! Output: []
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
 #! - num_assets is the number of assets in the consumed note.
 export.set_consumed_note_num_assets
     push.CONSUMED_NOTE_NUM_ASSETS_OFFSET add
@@ -923,10 +985,11 @@ end
 #! Returns a pointer to the start of the assets segment for the consumed note located at
 #! the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
+#! Stack: [note_ptr]
 #! Output: [assets_ptr]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
 #! - assets_ptr is the memory address at which the assets segment for the consumed note begins.
 export.get_consumed_note_assets_ptr
     push.CONSUMED_NOTE_ASSETS_OFFSET add
@@ -934,11 +997,12 @@ end
 
 #! Returns the assets hash for the consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
-#! Output: [AH]
+#! Stack: [note_ptr]
+#! Output: [ASSET_HASH]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - AH is the assets root for the consumed note.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
+#! - ASSET_HASH, sequential hash of the padded assets of a consumed note.
 export.get_consumed_note_assets_hash
     padw
     movup.4 push.CONSUMED_NOTE_ASSETS_HASH_OFFSET add
@@ -947,11 +1011,12 @@ end
 
 #! Returns the serial number for the consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
-#! Output: [S]
+#! Stack: [note_ptr]
+#! Output: [SERIAL_NUMBER]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
-#! - S is the serial number for the consumed note.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
+#! - SERIAL_NUMBER, the input note's serial number.
 export.get_consumed_note_serial_num
     padw
     movup.4 push.CONSUMED_NOTE_SERIAL_NUM_OFFSET add
@@ -960,10 +1025,11 @@ end
 
 #! Returns the sender for the consumed note located at the specified memory address.
 #!
-#! Stack: [consumed_note_ptr]
+#! Stack: [note_ptr]
 #! Output: [sender]
 #!
-#! - consumed_note_ptr is the memory address at which the consumed note data begins.
+#! Where:
+#! - note_ptr is the memory address at which the consumed note data begins.
 #! - sender is the sender for the consumed note.
 export.get_consumed_note_sender
     padw
@@ -983,6 +1049,7 @@ end
 #! Stack: []
 #! Output: [offset]
 #!
+#! Where:
 #! - offset is the offset of the created note data segment.
 export.get_created_note_data_offset
     push.CREATED_NOTE_SECTION_OFFSET
@@ -994,6 +1061,7 @@ end
 #! Stack: [i]
 #! Output: [ptr]
 #!
+#! Where:
 #! - i is the index of the created note.
 #! - ptr is the memory address of the data segment for created note i.
 export.get_created_note_ptr
@@ -1005,6 +1073,7 @@ end
 #! Stack: [created_note_data_ptr]
 #! Output: [R]
 #!
+#! Where:
 #! - created_note_data_ptr is the memory address at which the created note data begins.
 #! - R is the recipient of the created note.
 export.get_created_note_recipient
@@ -1018,6 +1087,7 @@ end
 #! Stack: [note_ptr, RECIPIENT]
 #! Output: []
 #!
+#! Where:
 #! - recipient is the recipient of the note
 #! - note_ptr is the memory address at which the created note data begins.
 export.set_created_note_recipient
@@ -1029,6 +1099,7 @@ end
 #! Stack: [note_ptr, METADATA]
 #! Output: []
 #!
+#! Where:
 #! - METADATA is the note metadata
 #! - note_ptr is the memory address at which the created note data begins.
 export.set_created_note_metadata
@@ -1040,6 +1111,7 @@ end
 #! Stack: [note_ptr]
 #! Output: [num_assets]
 #!
+#! Where:
 #! - note_ptr is a pointer to the memory address at which the created note is stored.
 #! - num_assets is the number of assets in the created note.
 export.get_created_note_num_assets
@@ -1052,6 +1124,8 @@ end
 #! Output: []
 #!
 #! Panics: if the number of assets exceeds the maximum allowed number of assets per note.
+#!
+#! Where:
 #! - note_ptr is the memory address at which the created note data begins.
 #! - num_assets is the number of assets in the created note.
 export.set_created_note_num_assets
@@ -1069,6 +1143,7 @@ end
 #! Stack: [created_note_data_ptr]
 #! Output: [asset_data_ptr]
 #!
+#! Where:
 #! - created_note_data_ptr is the memory address at which the created note data begins.
 #! - asset_data_ptr is the memory address at which the created note asset data begins.
 export.get_created_note_asset_data_ptr
@@ -1077,11 +1152,12 @@ end
 
 #! Sets the created note assets hash.
 #!
-#! Stack: [created_note_data_ptr, AH]
+#! Stack: [created_note_data_ptr, ASSET_HASH]
 #! Output: []
 #!
+#! Where:
 #! - created_note_data_ptr is the memory address at which the created note data begins.
-#! - AH is the assets hash of the created note.
+#! - ASSET_HASH, sequential hash of the padded assets of a created note.
 export.set_created_note_assets_hash
     push.CREATED_NOTE_ASSETS_HASH_OFFSET add mem_storew
 end

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -886,8 +886,9 @@ end
 
 #! Process the input notes data provided via the advice provider. This involves reading the data
 #! from the advice provider and storing it at the appropriate memory addresses. As each note is
-#! processed its hash and nullifier are computed. The transaction nullifier commitment is computed via
-#! a sequential hash of all (nullifier, NOTEID_OR_EMPTY_WORD) pairs for all input notes.
+#! processed its hash and nullifier are computed. The transaction input notes commitment is
+#! computed via a sequential hash of all (nullifier, NOTEID_OR_EMPTY_WORD) pairs for all input
+#! notes.
 #!
 #! Stack: []
 #! Advice stack: [num_notes],

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -297,7 +297,7 @@ proc.validate_new_account
     # => []
 
     # Assert the initial vault is empty
-    # -----------------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------------------
     # get the account vault root
     exec.memory::get_acct_vault_root
     # => [ACCT_VAULT_ROOT]
@@ -310,13 +310,13 @@ proc.validate_new_account
     # => []
 
     # Assert storage slot types are well formed
-    # -----------------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------------------
     # validate storage slot types
     exec.validate_storage_slot_types
     # => []
 
     # Assert slot types reserved slot is correctly initialized
-    # -----------------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------------------
     exec.account::get_slot_types_commitment_storage_slot exec.account::get_storage_slot_type_info
     # => [entry_arity, storage_type]
 
@@ -329,7 +329,7 @@ proc.validate_new_account
     drop drop
 
     # Assert faucet reserved slot is correctly initialized
-    # -----------------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------------------
     # check if the account is a faucet
     exec.account::get_id dup exec.account::is_faucet
     # => [is_faucet, acct_id]
@@ -379,7 +379,7 @@ proc.validate_new_account
     end
 
     # Assert the provided account seed satisfies the seed requirements
-    # -----------------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------------------
     exec.account::validate_seed
     # => []
 end
@@ -549,11 +549,230 @@ proc.authenticate_note.2
     # => []
 end
 
-#! Reads data for the ith input note from the advice provider and stores it in memory at the
-#! appropriate memory address. This includes computing and storing the nullifier and the
-#! note hash.
+#! Copies the input note's details from the advice stack to memory and computes its nullifier.
 #!
-#! Stack: [idx]
+#! Stack: [note_ptr]
+#! Advice stack: [
+#!      SERIAL_NUMBER,
+#!      SCRIPT_ROOT,
+#!      INPUTS_HASH,
+#!      ASSETS_HASH,
+#! ]
+#! Output: [NULLIFIER]
+#!
+#! Where:
+#! - note_ptr, memory location for the input note.
+#! - SERIAL_NUMBER, note's serial.
+#! - SCRIPT_ROOT, note's script root.
+#! - INPUTS_HASH, sequential hash of the padded note's inputs.
+#! - ASSETS_HASH, sequential hash of the padded note's assets.
+#! - NULLIFIER result of `hash(SERIAL_NUMBER || SCRIPT_ROOT || INPUTS_HASH || ASSETS_HASH)`.
+proc.process_input_note_details
+    exec.memory::get_consumed_note_core_ptr
+    # => [note_data_ptr]
+
+    # read note details (SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH)
+    padw padw padw
+    adv_pipe hperm
+    adv_pipe hperm
+    exec.native::state_to_digest
+    # => [NULLIFIER, note_data_ptr + 4]
+
+    movup.4 drop
+    # => [NULLIFIER]
+end
+
+#! Copies the note's metadata and args from the advice stack to memory.
+#!
+#! Note: The note's metadata is validated when the note is authenticated, since
+#! the authentication is `hash(NOTE_ID || NOTE_METADATA)`. This is either done
+#! by the procedure `authenticate_note` for or delayed to another kernel.
+#!
+#! Stack: [note_ptr]
+#! Advice stack: [
+#!      METADATA,
+#!      ARGS,
+#! ]
+#! Output: []
+#!
+#! Where:
+#! - note_ptr, memory location for the input note.
+#! - METADATA, note's metadata.
+#! - ARGS, user arguments passed to the note.
+proc.process_note_metadata
+    padw adv_loadw dup.4 exec.memory::set_consumed_note_metadata
+    # => [note_ptr]
+
+    padw adv_loadw movup.4 exec.memory::set_consumed_note_args
+    # => []
+end
+
+#! Copies the note's assets the advice stack to memory and verifies the commitment.
+#!
+#! Stack: [note_ptr]
+#! Advice stack: [
+#!      assets_count,
+#!      ASSET_0, ..., ASSET_N,
+#! ]
+#! Output: []
+#!
+#! Where:
+#! - note_ptr, memory location for the input note.
+#! - assets_count, note's assets count.
+#! - ASSET_0, ..., ASSET_N, padded note's assets.
+proc.process_note_assets
+    # verify and save the assets count
+    # ---------------------------------------------------------------------------------------------
+
+    adv_push.1
+    # => [assets_count, note_ptr]
+
+    dup exec.constants::get_max_assets_per_note lte assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS
+    # => [assets_count, note_ptr]
+
+    dup dup.2 exec.memory::set_consumed_note_num_assets
+    # => [assets_count, note_ptr]
+
+    # round up the number of assets, to the its padded length
+    dup push.1 u32and add
+    # => [rounded_num_assets, note_ptr]
+
+    # read the note's assets
+    # ---------------------------------------------------------------------------------------------
+
+    # Stack organization:
+    # - Top of the stack contains the hash state. The complete state is needed to extract the final
+    #   hash.
+    # - Followed by the assets_ptr, with the target address used to pipe data from the advice
+    #   provider.
+    # - Followed by a copy of the note_ptr for later use.
+    # - Followed by the loop variables, the current counter and rounded_num_assets, laid at this
+    #   depth because dup.15 is an efficient operation.
+
+    push.0 movup.2
+    # => [note_ptr, counter, rounded_num_assets]
+
+    dup exec.memory::get_consumed_note_assets_ptr
+    # => [assets_ptr, note_ptr, counter, rounded_num_assets]
+
+    padw padw padw
+    # => [PERM, PERM, PERM, assets_ptr, note_ptr, counter, rounded_num_assets]
+
+    # loop condition: counter != rounded_num_assets
+    dup.15 dup.15 neq
+    # => [should_loop, PERM, PERM, PERM, assets_ptr, note_ptr, counter, rounded_num_assets]
+
+    # loop and read assets from the advice provider
+    while.true
+        # read assets (ASSET_n, ASSET_n+1)
+        adv_pipe hperm
+        # => [PERM, PERM, PERM, assets_ptr+2, note_ptr, counter, rounded_num_assets]
+
+        # update counter
+        swapw.3 movup.2 add.2 movdn.2 swapw.3
+        # => [PERM, PERM, PERM, assets_ptr+2, note_ptr, counter+2, rounded_num_assets]
+
+        # loop condition: counter != rounded_num_assets
+        dup.15 dup.15 neq
+        # => [should_loop, PERM, PERM, PERM, assets_ptr+2, note_ptr, counter+2, rounded_num_assets]
+    end
+    # => [PERM, PERM, PERM, assets_ptr+n, note_ptr, counter+n, rounded_num_assets]
+
+    exec.native::state_to_digest
+    # => [ASSET_HASH_COMPUTED, assets_ptr+n, note_ptr, counter+n, rounded_num_assets]
+
+    swapw drop movdn.2 drop drop
+    # => [note_ptr, ASSET_HASH_COMPUTED]
+
+    # VERIFY: computed ASSET_HASH matches the provided hash
+    exec.memory::get_consumed_note_assets_hash
+    assert_eqw.err=ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH
+    # => []
+end
+
+#! Adds the assets of an input note to the input vault.
+#!
+#! Stack: [note_ptr]
+#! Output: []
+#!
+#! Where:
+#! - note_ptr, memory location for the input note.
+proc.add_input_note_assets_to_vault
+    # prepare the stack
+    # ---------------------------------------------------------------------------------------------
+
+    exec.memory::get_input_vault_root_ptr
+    # => [input_vault_root_ptr, note_ptr]
+
+    dup.1 exec.memory::get_consumed_note_assets_ptr
+    # => [assets_start_ptr, input_vault_root_ptr, note_ptr]
+
+    dup movup.3 exec.memory::get_consumed_note_num_assets add swap
+    # => [assets_start_ptr, assets_end_ptr, input_vault_root_ptr]
+
+    # add input note's assets to input vault
+    # ---------------------------------------------------------------------------------------------
+
+    # loop condition: assets_start_ptr != assets_end_ptr
+    dup.1 dup.1 neq
+    # => [should_loop, assets_start_ptr, assets_end_ptr, input_vault_root_ptr]
+
+    while.true
+        dup.2
+        # => [input_vault_root_ptr, assets_start_ptr, assets_end_ptr, input_vault_root_ptr]
+
+        padw dup.5 mem_loadw
+        # => [ASSET, input_vault_root_ptr, assets_start_ptr, assets_end_ptr, input_vault_root_ptr]
+
+        exec.asset_vault::add_asset dropw
+        # => [assets_start_ptr, assets_end_ptr, input_vault_root_ptr]
+
+        add.1
+        # => [assets_start_ptr+1, assets_end_ptr, input_vault_root_ptr]
+
+        # loop condition: assets_start_ptr != assets_end_ptr
+        dup.1 dup.1 neq
+        # => [should_loop, assets_start_ptr+1, assets_end_ptr, input_vault_root_ptr]
+    end
+
+    drop drop drop
+    # => []
+end
+
+#! Computes the inpute note's id.
+#!
+#! Stack: [note_ptr]
+#! Output: [NOTE_ID]
+#!
+#! Where:
+#! - note_ptr, memory location for the input note.
+#! - NOTE_ID, the note's id, i.e. `hash(RECIPIENT || ASSET_HASH)`.
+proc.compute_note_id
+    # compute SERIAL_HASH: hash(SERIAL_NUMBER || EMPTY_WORD)
+    dup exec.memory::get_consumed_note_serial_num padw hmerge
+    # => [SERIAL_HASH, note_ptr]
+
+    # compute MERGE_SCRIPT: hash(SERIAL_HASH || SCRIPT_HASH)
+    dup.4 exec.memory::get_consumed_note_script_root hmerge
+    # => [MERGE_SCRIPT, note_ptr]
+
+    # compute RECIPIENT: hash(MERGE_SCRIPT || INPUT_HASH)
+    dup.4 exec.memory::get_consumed_note_inputs_hash hmerge
+    # => [RECIPIENT, note_ptr]
+
+    # compute NOTE_ID: hash(RECIPIENT || ASSET_HASH)
+    movup.4 exec.memory::get_consumed_note_assets_hash hmerge
+    # => [NOTE_ID]
+end
+
+#! Reads data for the input note from the advice provider and stores it in memory at the appropriate
+#! memory address.
+#!
+#! This procedures will also compute the note's nullifier. Store the note's nullifier, metadata,
+#! args, assets, id, and hash to memory. And return the hasher state in the stack so that the
+#! commitment can be extracted.
+#!
+#! Stack: [idx, HASHER_CAPACITY]
 #! Advice stack: [
 #!      SERIAL_NUMBER,
 #!      SCRIPT_ROOT,
@@ -564,14 +783,17 @@ end
 #!      assets_count,
 #!      ASSET_0, ..., ASSET_N,
 #!      is_authenticated,
-#!      block_num,
-#!      SUB_HASH,
-#!      NOTE_ROOT,
+#!      (
+#!          block_num,
+#!          SUB_HASH,
+#!          NOTE_ROOT,
+#!      )?
 #! ]
-#! Output: []
+#! Output: [PERM, PERM, PERM]
 #!
 #! Where:
-#! - idx is the index of the input note.
+#! - idx, the index of the input note.
+#! - HASHER_CAPACITY, state of the hasher capacity word, with the commitment to the previous notes.
 #! - SERIAL_NUMBER, note's serial.
 #! - SCRIPT_ROOT, note's script root.
 #! - INPUTS_HASH, sequential hash of the padded note's inputs.
@@ -581,173 +803,91 @@ end
 #! - assets_count, note's assets count.
 #! - ASSET_0, ..., ASSET_N, padded note's assets.
 #! - is_authenticated, boolean indicating if the note contains an authentication proof.
+#!
+#! Optional values, required if `is_authenticated` is true:
+#!
 #! - block_num, note's creation block number.
 #! - SUB_HASH, the block's sub_hash for which the note was created.
 #! - NOTE_ROOT, the merkle root of the note's tree.
+#!
 proc.process_input_note
     # note details
     # ---------------------------------------------------------------------------------------------
 
-    dup exec.memory::get_consumed_note_ptr
-    # => [note_ptr, idx]
+    dup exec.memory::get_consumed_note_ptr dup
+    # => [note_ptr, note_ptr, idx, HASHER_CAPACITY]
 
-    dup exec.memory::get_consumed_note_core_ptr
-    # => [note_data_ptr, note_ptr, idx]
-
-    # read note details (SERIAL_NUMBER, SCRIPT_ROOT, INPUTS_HASH, ASSETS_HASH)
-    padw padw padw
-    adv_pipe hperm
-    adv_pipe hperm
-    exec.native::state_to_digest
-    # => [NULLIFIER, note_data_ptr + 4, note_ptr, idx]
-
-    movup.4 drop
-    # => [NULLIFIER, note_ptr, idx]
+    exec.process_input_note_details
+    # => [NULLIFIER, note_ptr, idx, HASHER_CAPACITY]
 
     # save nullifier to memory
-    movup.5 exec.memory::get_consumed_note_nullifier_ptr
-    mem_storew dropw
-    # => [note_ptr]
+    movup.5 exec.memory::get_consumed_note_nullifier_ptr mem_storew
+    # => [NULLIFIER, note_ptr, HASHER_CAPACITY]
 
-    # metadata & args
+    # note metadata & args
     # ---------------------------------------------------------------------------------------------
 
-    padw adv_loadw dup.4 exec.memory::set_consumed_note_metadata
-    # => [note_ptr]
+    movup.4
+    # => [note_ptr, NULLIFIER, HASHER_CAPACITY]
 
-    padw adv_loadw dup.4 exec.memory::set_consumed_note_args
-    # => [note_ptr]
+    dup exec.process_note_metadata
+    # => [note_ptr, NULLIFIER, HASHER_CAPACITY]
 
-    # assets
+    # note assets
     # ---------------------------------------------------------------------------------------------
 
-    adv_push.1
-    # => [num_assets, note_ptr]
+    dup exec.process_note_assets
+    dup exec.add_input_note_assets_to_vault
+    # => [note_ptr, NULLIFIER, HASHER_CAPACITY]
 
-    dup exec.constants::get_max_assets_per_note lte assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS
-    # => [num_assets, note_ptr]
-
-    dup dup.2 exec.memory::set_consumed_note_num_assets
-    # => [num_assets, note_ptr]
-
-    # round up the number of assets, to the its padded length
-    dup push.1 u32and add
-    # => [rounded_num_assets, note_ptr]
-
-    push.0
-    # => [counter, rounded_num_assets, note_ptr]
-
-    # prepare address and stack for reading assets
-    dup.2 exec.memory::get_consumed_note_assets_ptr padw padw padw
-    # => [PAD, PAD, PADW, assets_ptr, counter, rounded_num_assets, note_ptr]
-
-    # check if the number of assets is greater then 0
-    dup.14 dup.14 neq
-    # => [should_loop, PAD, PAD, PAD, assets_ptr, counter, rounded_num_assets, note_ptr]
-
-    # loop and read assets from the advice provider
-    while.true
-        # read assets from advice provider
-        adv_pipe hperm
-        # => [PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
-
-        # check if we should loop again
-        movup.13 push.2 add dup movdn.14 dup.15 neq
-        # => [should_loop, PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
-    end
-    # => [PERM, PERM, PERM, assets_ptr, counter, rounded_num_assets, note_ptr]
-
-    exec.native::state_to_digest
-    # => [ASSET_HASH_COMPUTED, assets_ptr, counter, rounded_num_assets, note_ptr]
-
-    # clean and rearrange stack
-    swapw drop drop drop dup movdn.5
-    # => [note_ptr, ASSET_HASH_COMPUTED, note_ptr]
-
-    # get expected note vault from memory
-    exec.memory::get_consumed_note_assets_hash
-    # => [ASSET_HASH, ASSET_HASH_COMPUTED, note_ptr]
-
-    # assert that the computed hash matches the expected hash
-    assert_eqw.err=ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH
-    # => [note_ptr]
-
-    # add the note assets into the input vault
-    # ---------------------------------------------------------------------------------------------
-    # prepare stack for iteration over note assets
-    exec.memory::get_input_vault_root_ptr dup.1 exec.memory::get_consumed_note_assets_ptr
-    # => [assets_start_ptr, input_vault_root_ptr, note_ptr]
-
-    # calculate assets end ptr
-    dup dup.3 exec.memory::get_consumed_note_num_assets add swap
-    # => [assets_start_ptr, assets_end_ptr, input_vault_root_ptr, note_ptr]
-
-    # loop over assets and insert them into input vault
-
-    # assess if we should loop
-    dup.1 dup.1 neq
-    # => [should_loop, assets_start_ptr, assets_end_ptr, input_vault_root_ptr, note_ptr]
-
-    while.true
-        # duplicate input_vault_root_ptr
-        dup.2
-        # => [input_vault_root_ptr, assets_start_ptr, assets_end_ptr, input_vault_root_ptr, note_ptr]
-
-        # read the asset from memory
-        padw dup.5 mem_loadw
-        # => [ASSET, input_vault_root_ptr, assets_start_ptr, assets_end_ptr, input_vault_root_ptr, note_ptr]
-
-        # insert asset into input vault
-        exec.asset_vault::add_asset dropw
-        # => [assets_start_ptr, assets_end_ptr, input_vault_root_ptr, note_ptr]
-
-        # increment assets_start_ptr and asses if we should loop again
-        add.1 dup.1 dup.1 neq
-        # => [should_loop, assets_start_ptr, assets_end_ptr, input_vault_root_ptr, note_ptr]
-    end
-
-    # clean stack
-    drop drop drop
-
-    # authentication hash
+    # note id
     # ---------------------------------------------------------------------------------------------
 
-    # compute the serial hash: hash(SERIAL_NUMBER, EMPTY_WORD)
-    dup exec.memory::get_consumed_note_serial_num padw hmerge
-    # => [SERIAL_HASH, note_ptr]
+    dup exec.compute_note_id
+    # => [NOTE_ID, note_ptr, NULLIFIER, HASHER_CAPACITY]
 
-    # compute merge script hash: hash(hash(serial_num, EMPTY_WORD), script_hash)
-    dup.4 exec.memory::get_consumed_note_script_root hmerge
-    # => [MERGE_SCRIPT, note_ptr]
-
-    # compute recipient: hash(hash(hash(serial_num, EMPTY_WORD), script_hash), input_hash)
-    dup.4 exec.memory::get_consumed_note_inputs_hash hmerge
-    # => [RECIPIENT, note_ptr]
-
-    # compute the note's id: hash(recipient, asset_hash)
-    dup.4 exec.memory::get_consumed_note_assets_hash hmerge
-    # => [NOTE_ID, note_ptr]
-
-    # store note id in memory and clear stack
+    # save note id to memory
     dup.4 exec.memory::set_consumed_note_id
-    # => [NOTE_ID]
+    # => [NOTE_ID, note_ptr, NULLIFIER, HASHER_CAPACITY]
 
-    # compute the authentication hash: hash(note_id, note_metadata)
-    movup.4 exec.memory::get_consumed_note_metadata hmerge
-    # => [AUTH_DIGEST]
+    # note authentication
+    # ---------------------------------------------------------------------------------------------
 
     adv_push.1
+    # => [authenticated, NOTE_ID, note_ptr, NULLIFIER, HASHER_CAPACITY]
+
     if.true
+        # if the note is authenticated
+        # -----------------------------------------------------------------------------------------
+
+        # compute AUTH_DIGEST: hash(NOTE_ID || NOTE_METADATA)
+        movup.4 exec.memory::get_consumed_note_metadata hmerge
+        # => [AUTH_DIGEST, NULLIFIER, HASHER_CAPACITY]
+
         exec.authenticate_note
+        # => [NULLIFIER, HASHER_CAPACITY]
+
+        padw
+        # => [EMPTY_WORD, NULLIFIER, HASHER_CAPACITY]
+
     else
-        dropw
+        # if the note authentication is delayed
+        # -----------------------------------------------------------------------------------------
+
+        movup.4 drop
+        # => [NOTE_ID, NULLIFIER, HASHER_CAPACITY]
     end
+    # => [EMPTY_WORD_OR_NOTEID, NULLIFIER, HASHER_CAPACITY]
+
+    # update the input note commitment
+    hperm
+    # => [PERM, PERM, PERM]
 end
 
 #! Process the input notes data provided via the advice provider. This involves reading the data
 #! from the advice provider and storing it at the appropriate memory addresses. As each note is
 #! processed its hash and nullifier are computed. The transaction nullifier commitment is computed via
-#! a sequential hash of all (nullifier, EMPTY_WORD) pairs for all input notes.
+#! a sequential hash of all (nullifier, NOTEID_OR_EMPTY_WORD) pairs for all input notes.
 #!
 #! Stack: []
 #! Advice stack: [num_notes],
@@ -757,101 +897,86 @@ end
 #! Where:
 #! - num_notes is the number of input notes.
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
-#! - NOTE_DATA, input notes' details, for format see prologue::process_input_note.
+#! - NOTE_DATA, input notes' details, for format see `prologue::process_input_note`.
 proc.process_input_notes_data
     # get the number of input notes from the advice stack
     adv_push.1
-    # => [num_notes, ...]
+    # => [num_notes]
 
     # assert the number of input notes is within limits; since max number of input notes is
     # expected to be smaller than 2^32, we can use a more efficient u32 comparison
     dup
     exec.constants::get_max_num_consumed_notes u32assert2.err=ERR_PROLOGUE_TOO_MANY_INPUT_NOTES
     u32lte assert.err=ERR_PROLOGUE_TOO_MANY_INPUT_NOTES
-    # => [num_notes, ...]
+    # => [num_notes]
 
     # if there are input notes, load input notes data from the advice map onto the advice stack
     dup neq.0
     if.true
         exec.memory::get_input_notes_commitment adv.push_mapval dropw
     end
-    # => [num_notes, ...]
+    # => [num_notes]
 
     # store the number of input notes into kernel memory
     dup exec.memory::set_total_num_consumed_notes
-    # => [num_notes, ...]
+    # => [num_notes]
 
     # loop over input notes and read data
     # ---------------------------------------------------------------------------------------------
 
-    # initialize counter of already processed notes
-    push.0
-    # => [num_processed_notes = 0, num_notes, ...]
+    # Stack organization:
+    # - On the top of the stack is the hasher state containing the input notes commitment. The
+    #   hasher state will be updated by `process_input_note`. After the loop the commitment is
+    #   extracted.
+    # - Below the hasher state in the stack is the current note index. This number is used for two
+    #   purposes:
+    #   1. Compute the input note's memory addresses, the index works as an offset.
+    #   2. Determine the loop condition. The loop below runs until all inpute notes have been
+    #      processed.
+    # - The num_notes is kept at position 13, because dup.13 is cheap.
+    # - The [idx, num_notes] pair is kept in a word boundary, so that its word can be swapped with a
+    #   cheap mov intructions to update the `idx` counter.
 
-    # check if the number of input notes is greater then 0. Conditional for the while loop.
-    dup.1 dup.1 neq
-    # => [has_more_notes, num_processed_notes, num_notes, ...]
+    push.0 padw padw padw
+    # => [PERM, PERM, PERM, idx, num_notes]
 
-    # loop and read note data from the advice provider
-    while.true
-        dup exec.process_input_note
-        # => [num_processed_notes, num_notes, ...]
-
-        # increment processed note counter and check if we should loop again
-        add.1 dup.1 dup.1 neq
-        # => [has_more_notes, num_processed_notes + 1, num_notes, ...]
-    end
-
-    # drop counter
-    drop
-    # => [num_notes, ...]
-
-    # compute nullifier commitment
-    # ---------------------------------------------------------------------------------------------
-
-    # initiate counter of notes processed for nullifier hashing
-    push.0
-    # => [num_processed_notes = 0, num_notes, ...]
-
-    # initialize the hasher's state
-    padw padw padw
-    # => [R1, R0, CAP, num_processed_notes, num_notes, ...]
-
-    # check if the number of input notes is greater then 0. Conditional for the while loop.
+    # loop condition: idx != num_notes
     dup.13 dup.13 neq
-    # => [has_more_notes, R1, R0, CAP, num_processed_notes, num_notes, ...]
+    # => [has_more_notes, PERM, PERM, PERM, idx, num_notes]
 
-    # compute the nullifier commitment from the advice stack data
     while.true
-        # hasher operates in overwrite mode, drop rate words
+        # the hasher operates in overwrite mode, so discard the rate words, and keep the capacity
         dropw dropw
+        # => [HASHER_CAPACITY, idx, num_notes]
 
-        # ingest next pair `(NULLIFIER, EMPTY_WORD)`
-        dup.4 exec.memory::get_consumed_note_nullifier padw hperm
-        # => [PERM, PERM, CAP, num_processed_notes, num_notes, ...]
+        # process the note
+        dup.4 exec.process_input_note
+        # => [PERM, PERM, PERM, idx, num_notes]
 
-        # increment processed note counter and check if we should loop again
-        movup.12 add.1 dup movdn.13 dup.14 neq
-        # => [has_more_notes, PERM, PERM, CAP, num_processed_notes + 1, num_notes, ...]
+        # update the idx counter
+        swapw.3 add.1 swapw.3
+        # => [PERM, PERM, PERM, idx+1, num_notes]
+
+        # loop condition: idx != num_notes
+        dup.13 dup.13 neq
+        # => [has_more_notes, PERM, PERM, PERM, idx+1, num_notes]
     end
 
-    # extract nullifier hash
     exec.native::state_to_digest
-    # => [INPUT_NOTES_COMMITMENT, num_processed_notes + 1, num_notes, ...]
+    # => [INPUT_NOTES_COMMITMENT, idx+1, num_notes]
 
-    # assert nullifier hash is what we would expect; when there are no input notes, the nullifier
-    # hash should be EMPTY_WORD because the while loop above was not entered and, thus, hperm
-    # instruction was not executed.
+    # assert the input notes and the commitment matches
     exec.memory::get_input_notes_commitment
     assert_eqw.err=ERR_PROLOGUE_INPUT_NOTES_COMMITMENT_MISMATCH
-    # => [num_processed_notes + 1, num_notes, ...]
+    # => [idx+1, num_notes]
 
-    # clear stack
+    # set the current input note ptr to the address of the first input note
+    push.0
+    exec.memory::get_consumed_note_ptr
+    exec.memory::set_current_consumed_note_ptr
+    # => [idx+1, num_notes]
+
     drop drop
-    # => [...]
-
-    # set the current input note pointer to the first input note
-    push.0 exec.memory::get_consumed_note_ptr exec.memory::set_current_consumed_note_ptr
     # => [...]
 end
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -268,7 +268,7 @@ fn add_account_to_advice_inputs(
 ///     - The note's authentication path against its block's note tree.
 ///     - The note's input padded prefixed by its length.
 ///     - The note's asset padded.
-/// - And all notes details together under the nullifier commitment.
+/// - And all notes details together under the input notes' commitment.
 ///
 fn add_input_notes_to_advice_inputs(
     notes: &InputNotes<InputNote>,
@@ -295,7 +295,7 @@ fn add_input_notes_to_advice_inputs(
 
         inputs.extend_map([(assets.commitment(), assets.to_padded_assets())]);
 
-        // Note: keep in sync with the process_input_node kernel procedure
+        // NOTE: keep in sync with the `prologue::process_input_node` kernel procedure
         note_data.extend(recipient.serial_num());
         note_data.extend(*recipient.script().hash());
         note_data.extend(*recipient.inputs().commitment());
@@ -336,6 +336,6 @@ fn add_input_notes_to_advice_inputs(
         }
     }
 
-    // NOTE: keep map in sync with the `process_input_notes_data` kernel procedure
+    // NOTE: keep map in sync with the `prologue::process_input_notes_data` kernel procedure
     inputs.extend_map([(notes.commitment(), note_data)]);
 }

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -302,10 +302,13 @@ fn build_input_note_commitment<T: ToInputNoteCommitments>(notes: &[T]) -> Digest
     }
 
     let mut elements: Vec<Felt> = Vec::with_capacity(notes.len() * 2);
-    for note in notes {
-        elements.extend_from_slice(note.nullifier().as_elements());
-        elements
-            .extend_from_slice(&note.note_id().map_or(Word::default(), |note_id| note_id.into()));
+    for commitment_data in notes {
+        let nullifier = commitment_data.nullifier();
+        let zero_or_noteid =
+            &commitment_data.note_id().map_or(Word::default(), |note_id| note_id.into());
+
+        elements.extend_from_slice(nullifier.as_elements());
+        elements.extend_from_slice(zero_or_noteid);
     }
     Hasher::hash_elements(&elements)
 }


### PR DESCRIPTION
Implements the changes to the kernel's prologue, which are necessary to support delayed note inclusion. Along side some code and documentation improvements.

closes #353

Currently marked as a draft because this PR is lacking tests.