### PR TITLE
feat: add wallet_creation_with_custom_code function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Added `create_wallet_with_custom_code` wallet helper function in miden-lib
 - Created `get_serial_number` procedure to get the serial num of the currently processed note(#760)
 - Generalized `build_recipient_hash` procedure to build recipient hash for custom notes (#706)
 - Added ability for users to set the aux field when creating a note (#752)

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -73,3 +73,53 @@ pub fn create_basic_wallet(
 
     Ok((Account::new(account_seed, account_code, account_storage)?, account_seed))
 }
+
+// CUSTOM WALLET
+// ================================================================================================
+
+/// Creates a new account with a custom wallet interface, the specified authentication scheme, and the account storage type.
+///
+pub fn create_wallet_with_custom_code(
+    init_seed: [u8; 32],
+    auth_scheme: AuthScheme,
+    account_type: AccountType,
+    account_storage_type: AccountStorageType,
+    custom_code: String,
+) -> Result<(Account, Word), AccountError> {
+    if matches!(account_type, AccountType::FungibleFaucet | AccountType::NonFungibleFaucet) {
+        return Err(AccountError::AccountIdInvalidFieldElement(
+            "Basic wallet accounts cannot have a faucet account type".to_string(),
+        ));
+    }
+
+    let (auth_scheme_procedure, storage_slot_0_data): (&str, Word) = match auth_scheme {
+        AuthScheme::RpoFalcon512 { pub_key } => ("basic::auth_tx_rpo_falcon512", pub_key.into()),
+    };
+
+    let account_code_string: String = format!(
+        "
+        {custom_code}
+
+        export.{auth_scheme_procedure}
+    "
+    );
+    let account_code_src: &str = &account_code_string;
+
+    let account_code_ast = ModuleAst::parse(account_code_src)
+        .map_err(|e| AccountError::AccountCodeAssemblerError(e.into()))?;
+    let account_assembler = TransactionKernel::assembler();
+    let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler)?;
+
+    let account_storage =
+        AccountStorage::new(vec![SlotItem::new_value(0, 0, storage_slot_0_data)], BTreeMap::new())?;
+
+    let account_seed = AccountId::get_account_seed(
+        init_seed,
+        account_type,
+        account_storage_type,
+        account_code.root(),
+        account_storage.root(),
+    )?;
+
+    Ok((Account::new(account_seed, account_code, account_storage)?, account_seed))
+}

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
+use miden_lib::{
+    accounts::wallets::{create_basic_wallet, create_wallet_with_custom_code},
+    AuthScheme,
+};
 use miden_objects::{
     accounts::{
         account_id::testing::{
@@ -218,6 +221,62 @@ fn wallet_creation() {
 
     let (wallet, _) =
         create_basic_wallet(init_seed, auth_scheme, account_type, storage_type).unwrap();
+
+    // sender_account_id not relevant here, just to create a default account code
+    let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+    let expected_code_root =
+        get_account_with_default_account_code(sender_account_id, pub_key.into(), None)
+            .code()
+            .root();
+
+    assert!(wallet.is_regular_account());
+    assert_eq!(wallet.code().root(), expected_code_root);
+    let pub_key_word: Word = pub_key.into();
+    assert_eq!(wallet.storage().get_item(0).as_elements(), pub_key_word);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn wallet_creation_with_custom_code() {
+    use miden_objects::accounts::{
+        account_id::testing::ACCOUNT_ID_SENDER, AccountStorageType, AccountType,
+    };
+
+    // we need a Falcon Public Key to create the wallet account
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let sec_key = SecretKey::with_rng(&mut rng);
+    let pub_key = sec_key.public_key();
+    let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 { pub_key };
+
+    // we need to use an initial seed to create the wallet account
+    let init_seed: [u8; 32] = [
+        95, 113, 209, 94, 84, 105, 250, 242, 223, 203, 216, 124, 22, 159, 14, 132, 215, 85, 183,
+        204, 149, 90, 166, 68, 100, 73, 106, 168, 125, 237, 138, 16,
+    ];
+
+    let account_type = AccountType::RegularAccountImmutableCode;
+    let storage_type = AccountStorageType::OffChain;
+
+    // Example custom code, for this example this is the same as the default wallet
+    let custom_code = "
+        use.miden::contracts::wallets::basic->basic_wallet
+        use.miden::contracts::auth::basic
+
+        export.basic_wallet::receive_asset
+        export.basic_wallet::send_asset
+    "
+    .to_string();
+
+    let (wallet, _) = create_wallet_with_custom_code(
+        init_seed,
+        auth_scheme,
+        account_type,
+        storage_type,
+        custom_code,
+    )
+    .unwrap();
 
     // sender_account_id not relevant here, just to create a default account code
     let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();


### PR DESCRIPTION
Adding a create_wallet_with_custom_code function makes it easier to create wallets with custom code when using the miden-client