### PR TITLE
Type Annotations Error Fix for miden-wasm Crate

### DIFF
--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -135,7 +135,9 @@ impl<T: Rng> AccountBuilder<T> {
         let inner_storage = self.storage_builder.build();
 
         for (key, value) in inner_storage.slots().leaves() {
-            if key != AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX.into() {
+            // Explicitly cast to `u64` to silence "type annotations needed" error.
+            // Using `as u64` makes the intended type clear and avoids type inference issues.
+            if key != AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX as u64 {
                 // don't copy the reserved key
                 storage.set_item(key as u8, *value).map_err(AccountBuilderError::AccountError)?;
             }


### PR DESCRIPTION
When I build the `miden-wasm` crate, I get this error in `miden-base`. It seems that for some reason, rust is having trouble inferring the type when `.into()` is used. 

```
error[E0283]: type annotations needed
   --> /Users/dennisgarcia/Desktop/Work/polygon-miden/demox-miden-base/objects/src/testing/account.rs:138:68
    |
138 |             if key != AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX.into() {
    |                    -- type must be known at this point             ^^^^
    |
    = note: multiple `impl`s satisfying `u64: PartialEq<_>` found in the following crates: `core`, `serde_json`:
            - impl PartialEq<serde_json::value::Value> for u64;
            - impl<host> PartialEq for u64
              where the constant `host` has type `bool`;
help: try using a fully qualified path to specify the expected types
    |
138 |             if key != <u8 as Into<T>>::into(AccountStorage::SLOT_LAYOUT_COMMITMENT_INDEX) {
    |                       ++++++++++++++++++++++                                            ~
```

Not sure, why I'm only seeing this when including `miden-objects` as a dependency in my `miden-wasm` crate and not when building from the `miden-client` itself, but figured the fix was simple enough to create a PR for it to unblock. 