### PR TITLE
Added conversion from `Nullifier` for `InputNoteCommitment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added ability for users to set the aux field when creating a note (#752).
 - Created `get_serial_number` procedure to get the serial num of the currently processed note (#760).
 - [BREAKING] Added support for input notes with delayed verification of inclusion proofs (#724, #732, #759, #770, #772).
+- [BREAKING] Added support for conversion from `Nullifier` to `InputNoteCommitment`, commitment header return reference (#774).
 
 ## 0.3.0 (2024-05-14)
 

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -142,7 +142,7 @@ impl TransactionInputs {
 /// The commitment is composed of:
 ///
 /// - nullifier, which prevents double spend and provides unlinkability.
-/// - an optional note_id, which allows for delayed note authentication.
+/// - an optional note hash, which allows for delayed note authentication.
 pub trait ToInputNoteCommitments {
     fn nullifier(&self) -> Nullifier;
     fn note_hash(&self) -> Option<Digest>;
@@ -304,11 +304,11 @@ fn build_input_note_commitment<T: ToInputNoteCommitments>(notes: &[T]) -> Digest
     let mut elements: Vec<Felt> = Vec::with_capacity(notes.len() * 2);
     for commitment_data in notes {
         let nullifier = commitment_data.nullifier();
-        let zero_or_notehash =
+        let zero_or_note_hash =
             &commitment_data.note_hash().map_or(Word::default(), |note_id| note_id.into());
 
         elements.extend_from_slice(nullifier.as_elements());
-        elements.extend_from_slice(zero_or_notehash);
+        elements.extend_from_slice(zero_or_note_hash);
     }
     Hasher::hash_elements(&elements)
 }

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -76,11 +76,16 @@ impl ProvenTransaction {
         self.block_ref
     }
 
-    /// Returns and iterator over the unauthenticated input notes in this transaction.
+    /// Returns an iterator over the unauthenticated input notes in this transaction.
     pub fn get_unauthenticated_notes(&self) -> impl Iterator<Item = NoteId> + '_ {
         self.input_notes
             .iter()
             .filter_map(|note| note.header().map(|header| header.id()))
+    }
+
+    /// Returns an iterator over the nullifiers of input notes in this transaction.
+    pub fn get_nullifiers(&self) -> impl Iterator<Item = Nullifier> + '_ {
+        self.input_notes.iter().map(InputNoteCommitment::nullifier)
     }
 
     // HELPER METHODS

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -5,7 +5,7 @@ use miden_verifier::ExecutionProof;
 use super::{InputNote, ToInputNoteCommitments};
 use crate::{
     accounts::delta::AccountUpdateDetails,
-    notes::{NoteHeader, NoteId},
+    notes::NoteHeader,
     transaction::{
         AccountId, Digest, InputNotes, Nullifier, OutputNote, OutputNotes, TransactionId,
     },
@@ -76,14 +76,14 @@ impl ProvenTransaction {
         self.block_ref
     }
 
-    /// Returns an iterator over the unauthenticated input notes in this transaction.
-    pub fn get_unauthenticated_notes(&self) -> impl Iterator<Item = NoteId> + '_ {
-        self.input_notes
-            .iter()
-            .filter_map(|note| note.header().map(|header| header.id()))
+    /// Returns an iterator of the headers of unauthenticated input notes in this transaction.
+    pub fn get_unauthenticated_notes(&self) -> impl Iterator<Item = &NoteHeader> {
+        self.input_notes.iter().filter_map(|note| note.header())
     }
 
-    /// Returns an iterator over the nullifiers of input notes in this transaction.
+    /// Returns an iterator over the nullifiers of all input notes in this transaction.
+    ///
+    /// This includes both authenticated and unauthenticated notes.
     pub fn get_nullifiers(&self) -> impl Iterator<Item = Nullifier> + '_ {
         self.input_notes.iter().map(InputNoteCommitment::nullifier)
     }


### PR DESCRIPTION
This is needed for testing simplification (it's so hard to construct new authenticated note just for testing purposes). With this change we can simply convert nullifier to authenticated input note commitment.

Related to https://github.com/0xPolygonMiden/miden-node/pull/390