### PR TITLE
Implemented `OutputNote::hash`

### DIFF
--- a/objects/src/notes/header.rs
+++ b/objects/src/notes/header.rs
@@ -44,7 +44,7 @@ impl NoteHeader {
     /// This value is used primarily for authenticating notes consumed when they are consumed
     /// in a transaction.
     pub fn hash(&self) -> Digest {
-        note_hash(self.id(), self.metadata())
+        compute_note_hash(self.id(), self.metadata())
     }
 }
 
@@ -57,7 +57,7 @@ impl NoteHeader {
 ///
 /// This value is used primarily for authenticating notes consumed when they are consumed
 /// in a transaction.
-pub fn note_hash(id: NoteId, metadata: &NoteMetadata) -> Digest {
+pub fn compute_note_hash(id: NoteId, metadata: &NoteMetadata) -> Digest {
     Hasher::merge(&[id.inner(), Word::from(metadata).into()])
 }
 

--- a/objects/src/notes/header.rs
+++ b/objects/src/notes/header.rs
@@ -41,11 +41,24 @@ impl NoteHeader {
     ///
     /// > hash(NOTE_ID || NOTE_METADATA)
     ///
-    /// This value is used primarily for authenticating notes consumed when the are consumed
+    /// This value is used primarily for authenticating notes consumed when they are consumed
     /// in a transaction.
     pub fn hash(&self) -> Digest {
-        Hasher::merge(&[self.id().inner(), Word::from(self.metadata()).into()])
+        note_hash(self.id(), self.metadata())
     }
+}
+
+// UTILITIES
+// ================================================================================================
+
+/// Returns a commitment to the note and its metadata.
+///
+/// > hash(NOTE_ID || NOTE_METADATA)
+///
+/// This value is used primarily for authenticating notes consumed when they are consumed
+/// in a transaction.
+pub fn note_hash(id: NoteId, metadata: &NoteMetadata) -> Digest {
+    Hasher::merge(&[id.inner(), Word::from(metadata).into()])
 }
 
 // CONVERSIONS FROM NOTE HEADER

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -21,7 +21,7 @@ mod details;
 pub use details::NoteDetails;
 
 mod header;
-pub use header::NoteHeader;
+pub use header::{note_hash, NoteHeader};
 
 mod inputs;
 pub use inputs::NoteInputs;

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -21,7 +21,7 @@ mod details;
 pub use details::NoteDetails;
 
 mod header;
-pub use header::{note_hash, NoteHeader};
+pub use header::{compute_note_hash, NoteHeader};
 
 mod inputs;
 pub use inputs::NoteInputs;

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -6,7 +6,7 @@ use vm_processor::DeserializationError;
 
 use crate::{
     accounts::AccountStub,
-    notes::{note_hash, Note, NoteAssets, NoteHeader, NoteId, NoteMetadata, PartialNote},
+    notes::{compute_note_hash, Note, NoteAssets, NoteHeader, NoteId, NoteMetadata, PartialNote},
     Digest, Felt, Hasher, TransactionOutputError, Word, MAX_OUTPUT_NOTES_PER_TX,
 };
 // TRANSACTION OUTPUTS
@@ -208,11 +208,8 @@ impl OutputNote {
     /// Returns a commitment to the note and its metadata.
     ///
     /// > hash(NOTE_ID || NOTE_METADATA)
-    ///
-    /// This value is used primarily for authenticating notes consumed when they are consumed
-    /// in a transaction.
     pub fn hash(&self) -> Digest {
-        note_hash(self.id(), self.metadata())
+        compute_note_hash(self.id(), self.metadata())
     }
 }
 

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -6,10 +6,9 @@ use vm_processor::DeserializationError;
 
 use crate::{
     accounts::AccountStub,
-    notes::{Note, NoteAssets, NoteHeader, NoteId, NoteMetadata, PartialNote},
+    notes::{note_hash, Note, NoteAssets, NoteHeader, NoteId, NoteMetadata, PartialNote},
     Digest, Felt, Hasher, TransactionOutputError, Word, MAX_OUTPUT_NOTES_PER_TX,
 };
-
 // TRANSACTION OUTPUTS
 // ================================================================================================
 
@@ -204,6 +203,16 @@ impl OutputNote {
             OutputNote::Partial(note) => OutputNote::Header(note.into()),
             _ => self.clone(),
         }
+    }
+
+    /// Returns a commitment to the note and its metadata.
+    ///
+    /// > hash(NOTE_ID || NOTE_METADATA)
+    ///
+    /// This value is used primarily for authenticating notes consumed when they are consumed
+    /// in a transaction.
+    pub fn hash(&self) -> Digest {
+        note_hash(self.id(), self.metadata())
     }
 }
 


### PR DESCRIPTION
We need this method in order to easily calculate hash for output notes. Related to https://github.com/0xPolygonMiden/miden-node/pull/396