### PR TITLE
Bugfix allow account code change

### DIFF
--- a/bench-tx/src/main.rs
+++ b/bench-tx/src/main.rs
@@ -87,7 +87,7 @@ pub fn benchmark_default_tx() -> Result<TransactionProgress, String> {
         .collect::<Vec<_>>();
 
     let transaction = executor
-        .prepare_transaction(account_id, block_ref, &note_ids, tx_context.tx_args().clone())
+        .prepare_transaction(account_id, block_ref, &note_ids, TransactionArgs::default())
         .map_err(|e| e.to_string())?;
 
     let (stack_inputs, advice_inputs) = transaction.get_kernel_inputs();

--- a/miden-lib/asm/miden/account.masm
+++ b/miden-lib/asm/miden/account.masm
@@ -86,7 +86,7 @@ end
 
 #! Sets an item in the account storage. Panics if the index is out of bounds.
 #!
-#! Stack: [index, V']
+#! Stack: [index, V', 0, 0, 0]
 #! Output: [R', V]
 #!
 #! - index is the index of the item to set.
@@ -94,9 +94,6 @@ end
 #! - V is the previous value of the item.
 #! - R' is the new storage root.
 export.set_item
-    push.0 movdn.5 push.0 movdn.5 push.0 movdn.5
-    # => [index, V', 0, 0, 0]
-
     syscall.set_account_item
     # => [R', V]
 end

--- a/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -73,3 +73,27 @@ export.send_asset.1
     # prepare the stack for return - stack has 6 elements too many
     movupw.3 dropw swap drop swap drop
 end
+
+#! Increments the account nonce by the provided value.
+#!
+#! Stack: [value]
+#! Output: []
+#!
+#! - value is the value to increment the nonce by. value can be at most 2^32 - 1 otherwise this
+#!   procedure panics.
+export.incr_nonce
+    exec.account::incr_nonce
+    # => []
+end
+
+#! Sets the code of the account the transaction is being executed against. This procedure can only
+#! executed on regular accounts with updatable code. Otherwise, this procedure fails.
+#!
+#! Stack: [CODE_ROOT]
+#! Output: []
+#!
+#! - CODE_ROOT is the hash of the code to set.
+export.set_code
+    exec.account::set_code
+    # => []
+end

--- a/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -73,27 +73,3 @@ export.send_asset.1
     # prepare the stack for return - stack has 6 elements too many
     movupw.3 dropw swap drop swap drop
 end
-
-#! Increments the account nonce by the provided value.
-#!
-#! Stack: [value]
-#! Output: []
-#!
-#! - value is the value to increment the nonce by. value can be at most 2^32 - 1 otherwise this
-#!   procedure panics.
-export.incr_nonce
-    exec.account::incr_nonce
-    # => []
-end
-
-#! Sets the code of the account the transaction is being executed against. This procedure can only
-#! executed on regular accounts with updatable code. Otherwise, this procedure fails.
-#!
-#! Stack: [CODE_ROOT]
-#! Output: []
-#!
-#! - CODE_ROOT is the hash of the code to set.
-export.set_code
-    exec.account::set_code
-    # => []
-end

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -633,8 +633,12 @@ end
 #! Where:
 #! - acct_nonce is the account nonce.
 export.set_acct_nonce
+    # load the data stored in the same word as the nonce
     padw push.ACCT_ID_AND_NONCE_PTR mem_loadw
+    # => [DATA, acct_nonce]
+
     drop movup.3 push.ACCT_ID_AND_NONCE_PTR mem_storew dropw
+    # => []
 end
 
 #! Sets the code root of the account.

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -98,7 +98,7 @@ impl fmt::Display for TransactionKernelError {
                 )
             },
             TransactionKernelError::UnknownAccountProcedure(proc_root) => {
-                write!(f, "account procedure with root {proc_root} is not in the advice provider")
+                write!(f, "Could not find account procedure with digest {proc_root} is in the advice provider, check the transactinon's account code")
             },
         }
     }

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -2,8 +2,9 @@ use alloc::string::String;
 use core::fmt::{self, Display};
 
 use miden_objects::{
-    assembly::AssemblyError, notes::NoteId, Felt, NoteError, ProvenTransactionError,
-    TransactionInputError, TransactionOutputError,
+    assembly::{AssemblyError, ParsingError},
+    notes::NoteId,
+    Felt, NoteError, ProvenTransactionError, TransactionInputError, TransactionOutputError,
 };
 use miden_verifier::VerificationError;
 
@@ -40,8 +41,8 @@ impl std::error::Error for TransactionCompilerError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransactionExecutorError {
     CompileNoteScriptFailed(TransactionCompilerError),
-    CompileTransactionScriptFailed(TransactionCompilerError),
     CompileTransactionFailed(TransactionCompilerError),
+    CompileTransactionScriptFailed(TransactionCompilerError),
     ExecuteTransactionProgramFailed(ExecutionError),
     FetchAccountCodeFailed(DataStoreError),
     FetchTransactionInputsFailed(DataStoreError),
@@ -55,6 +56,7 @@ pub enum TransactionExecutorError {
     },
     InvalidTransactionOutput(TransactionOutputError),
     LoadAccountFailed(TransactionCompilerError),
+    ParsingTransactionScriptFailed(ParsingError),
 }
 
 impl fmt::Display for TransactionExecutorError {

--- a/miden-tx/src/testing/executor.rs
+++ b/miden-tx/src/testing/executor.rs
@@ -43,18 +43,17 @@ impl<H: Host> CodeExecutor<H> {
     /// Otherwise, `self.imports` and `code` will be concatenated and the result will be executed.
     pub fn run(self, code: &str) -> Result<Process<H>, ExecutionError> {
         let assembler = TransactionKernel::assembler().with_debug_mode(true);
-
         let program = assembler.compile(code).unwrap();
-        self.execute_program(program)
+        self.execute_program(&program)
     }
 
-    pub fn execute_program(self, program: Program) -> Result<Process<H>, ExecutionError> {
+    pub fn execute_program(self, program: &Program) -> Result<Process<H>, ExecutionError> {
         let mut process = Process::new_debug(
             program.kernel().clone(),
             self.stack_inputs.unwrap_or_default(),
             self.host,
         );
-        process.execute(&program)?;
+        process.execute(program)?;
 
         Ok(process)
     }

--- a/miden-tx/src/testing/mod.rs
+++ b/miden-tx/src/testing/mod.rs
@@ -4,7 +4,7 @@ pub mod executor;
 pub use mock_host::MockHost;
 mod mock_host;
 
-pub use tx_context::{TransactionContext, TransactionContextBuilder};
+pub use tx_context::{ScriptAndInputs, TransactionContext, TransactionContextBuilder};
 mod tx_context;
 
 pub mod utils;

--- a/miden-tx/src/testing/tx_context.rs
+++ b/miden-tx/src/testing/tx_context.rs
@@ -144,20 +144,17 @@ pub struct TransactionContextBuilder {
     advice_inputs: Option<AdviceInputs>,
     input_notes: Vec<Note>,
     expected_output_notes: Vec<Note>,
-    tx_args: TransactionArgs,
     rng: ChaCha20Rng,
 }
 
 impl TransactionContextBuilder {
     pub fn new(account: Account) -> Self {
-        let tx_args = TransactionArgs::default();
         Self {
             assembler: TransactionKernel::assembler().with_debug_mode(true),
             account,
             account_seed: None,
             input_notes: Vec::new(),
             expected_output_notes: Vec::new(),
-            tx_args,
             advice_inputs: None,
             rng: ChaCha20Rng::from_seed([0_u8; 32]),
         }
@@ -173,7 +170,6 @@ impl TransactionContextBuilder {
             account_seed: None,
             input_notes: Vec::new(),
             expected_output_notes: Vec::new(),
-            tx_args: TransactionArgs::default(),
             advice_inputs: None,
             rng: ChaCha20Rng::from_seed([0_u8; 32]),
         }
@@ -189,7 +185,6 @@ impl TransactionContextBuilder {
             account_seed: None,
             input_notes: Vec::new(),
             expected_output_notes: Vec::new(),
-            tx_args: TransactionArgs::default(),
             advice_inputs: None,
             rng: ChaCha20Rng::from_seed([0_u8; 32]),
         }
@@ -206,7 +201,6 @@ impl TransactionContextBuilder {
             account_seed: None,
             input_notes: Vec::new(),
             expected_output_notes: Vec::new(),
-            tx_args: TransactionArgs::default(),
             advice_inputs: None,
             rng: ChaCha20Rng::from_seed([0_u8; 32]),
         }
@@ -603,7 +597,7 @@ impl TransactionContextBuilder {
         self.input_notes(vec![input_note1, input_note2, input_note4])
     }
 
-    pub fn build(mut self) -> TransactionContext {
+    pub fn build(self) -> TransactionContext {
         let mut mock_chain = MockChainBuilder::new().notes(self.input_notes.clone()).build();
         mock_chain.seal_block();
         mock_chain.seal_block();
@@ -618,12 +612,13 @@ impl TransactionContextBuilder {
             &input_note_ids,
         );
 
-        self.tx_args.extend_expected_output_notes(self.expected_output_notes.clone());
+        let mut tx_args = TransactionArgs::default();
+        tx_args.extend_expected_output_notes(self.expected_output_notes.clone());
 
         TransactionContext {
             mock_chain,
             expected_output_notes: self.expected_output_notes,
-            tx_args: self.tx_args,
+            tx_args,
             tx_inputs,
             advice_inputs: self.advice_inputs.unwrap_or_default(),
         }

--- a/miden-tx/src/testing/tx_context.rs
+++ b/miden-tx/src/testing/tx_context.rs
@@ -12,7 +12,7 @@ use miden_objects::{
     },
     assembly::{Assembler, ModuleAst, ProgramAst},
     assets::{Asset, FungibleAsset},
-    notes::{Note, NoteId, NoteType},
+    notes::{Note, NoteId, NoteTag, NoteType},
     testing::{
         account_code::{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT, ACCOUNT_CREATE_NOTE_MAST_ROOT},
         block::{MockChain, MockChainBuilder},
@@ -270,15 +270,17 @@ impl TransactionContextBuilder {
     }
 
     /// Creates a new output [Note] for the transaction corresponding to this context.
-    fn add_output_note(
+    pub fn add_output_note(
         &mut self,
         inputs: impl IntoIterator<Item = Felt>,
         assets: impl IntoIterator<Item = Asset>,
+        tag: NoteTag,
     ) -> Note {
         let note = NoteBuilder::new(self.account.id(), &mut self.rng)
             .note_inputs(inputs)
             .expect("The inputs should be valid")
             .add_assets(assets)
+            .tag(tag)
             .build(&self.assembler)
             .expect("The note details should be valid");
 
@@ -451,11 +453,11 @@ impl TransactionContextBuilder {
         let fungible_asset_3: Asset =
             FungibleAsset::new(faucet_id_3, CONSUMED_ASSET_3_AMOUNT).unwrap().into();
 
-        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1]);
-        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2]);
+        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1], 0.into());
+        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2], 0.into());
 
         // expected by `output_notes_data_procedure`
-        let _output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3]);
+        let _output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3], 0.into());
 
         let input_note1 = self.input_note_with_two_output_notes(
             sender,
@@ -485,9 +487,9 @@ impl TransactionContextBuilder {
         let fungible_asset_3: Asset =
             FungibleAsset::new(faucet_id_3, CONSUMED_ASSET_3_AMOUNT).unwrap().into();
 
-        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1]);
-        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2]);
-        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3]);
+        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1], 0.into());
+        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2], 0.into());
+        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3], 0.into());
 
         let input_note1 = self.input_note_with_two_output_notes(
             sender,
@@ -527,9 +529,9 @@ impl TransactionContextBuilder {
             &NON_FUNGIBLE_ASSET_DATA_2,
         );
 
-        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1]);
-        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2]);
-        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3]);
+        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1], 0.into());
+        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2], 0.into());
+        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3], 0.into());
 
         let input_note1 = self.input_note_with_two_output_notes(
             sender,
@@ -568,9 +570,9 @@ impl TransactionContextBuilder {
         let fungible_asset_3: Asset =
             FungibleAsset::new(faucet_id_3, CONSUMED_ASSET_3_AMOUNT).unwrap().into();
 
-        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1]);
-        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2]);
-        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3]);
+        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1], 0.into());
+        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2], 0.into());
+        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3], 0.into());
 
         let input_note1 = self.input_note_with_two_output_notes(
             sender,
@@ -612,9 +614,9 @@ impl TransactionContextBuilder {
             &NON_FUNGIBLE_ASSET_DATA_2,
         );
 
-        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1]);
-        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2]);
-        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3]);
+        let output_note0 = self.add_output_note([1u32.into()], [fungible_asset_1], 0.into());
+        let output_note1 = self.add_output_note([2u32.into()], [fungible_asset_2], 0.into());
+        let output_note2 = self.add_output_note([3u32.into()], [fungible_asset_3], 0.into());
 
         let input_note1 = self.input_note_with_two_output_notes(
             sender,

--- a/miden-tx/src/testing/tx_context.rs
+++ b/miden-tx/src/testing/tx_context.rs
@@ -51,6 +51,9 @@ pub struct TransactionContext {
 }
 
 /// Data required to compile the [miden_objects::transaction::TransactionScript] under the [TransactionContext].
+///
+/// This allows the account code to be loaded in the [Assembler] so that the transaction script can
+/// the account's procedures.
 pub enum ScriptAndInputs {
     Empty,
     Some {

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -40,7 +40,7 @@ pub fn test_set_code_is_not_immediate() {
         end
         ";
 
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, ACCT_CODE_ROOT_PTR),
@@ -90,7 +90,7 @@ pub fn test_set_code_succeeds() {
         "
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, ACCT_CODE_ROOT_PTR),
@@ -249,7 +249,7 @@ fn test_get_item() {
             item_value = prepare_word(&storage_item.slot.value)
         );
 
-        tx_context.execute_code(&code).unwrap();
+        tx_context.execute_with_custom_main(&code).unwrap();
     }
 }
 
@@ -298,7 +298,7 @@ fn test_set_item() {
         new_root = prepare_word(&account_smt.root()),
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 // Test different account storage types
@@ -333,7 +333,7 @@ fn test_get_storage_data_type() {
             item_index = storage_item.index,
         );
 
-        let process = tx_context.execute_code(&code).unwrap();
+        let process = tx_context.execute_with_custom_main(&code).unwrap();
 
         let storage_slot_data_type = match storage_item.slot.slot_type {
             StorageSlotType::Value { value_arity } => (value_arity, 0),
@@ -386,7 +386,7 @@ fn test_get_map_item() {
             item_index = storage_item.index,
             map_key = prepare_word(&key),
         );
-        let process = tx_context.execute_code(&code).unwrap();
+        let process = tx_context.execute_with_custom_main(&code).unwrap();
 
         assert_eq!(
             value,
@@ -450,7 +450,7 @@ fn test_set_map_item() {
         new_value = prepare_word(&new_value),
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     let mut new_storage_map = AccountStorage::mock_map_2();
     new_storage_map.insert(new_key, new_value);
@@ -496,7 +496,7 @@ fn test_get_vault_commitment() {
         expected_vault_commitment = prepare_word(&account.vault().commitment()),
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 // PROCEDURE AUTHENTICATION TESTS
@@ -543,7 +543,7 @@ fn test_authenticate_procedure() {
             root = prepare_word(&root)
         );
 
-        let process = tx_context.execute_code(&code);
+        let process = tx_context.execute_with_custom_main(&code);
 
         match valid {
             true => assert!(process.is_ok(), "A valid procedure must successfully authenticate"),

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -11,6 +11,7 @@ use miden_objects::{
     },
     crypto::{hash::rpo::RpoDigest, merkle::LeafIndex},
     testing::{prepare_word, storage::STORAGE_LEAVES_2},
+    transaction::TransactionArgs,
 };
 use vm_processor::{Felt, MemAdviceProvider};
 
@@ -40,7 +41,7 @@ pub fn test_set_code_is_not_immediate() {
         end
         ";
 
-    let process = tx_context.execute_with_custom_main(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, ACCT_CODE_ROOT_PTR),
@@ -90,7 +91,7 @@ pub fn test_set_code_succeeds() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, ACCT_CODE_ROOT_PTR),
@@ -249,7 +250,7 @@ fn test_get_item() {
             item_value = prepare_word(&storage_item.slot.value)
         );
 
-        tx_context.execute_with_custom_main(&code).unwrap();
+        tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
     }
 }
 
@@ -298,7 +299,7 @@ fn test_set_item() {
         new_root = prepare_word(&account_smt.root()),
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }
 
 // Test different account storage types
@@ -333,7 +334,8 @@ fn test_get_storage_data_type() {
             item_index = storage_item.index,
         );
 
-        let process = tx_context.execute_with_custom_main(&code).unwrap();
+        let process =
+            tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
         let storage_slot_data_type = match storage_item.slot.slot_type {
             StorageSlotType::Value { value_arity } => (value_arity, 0),
@@ -386,7 +388,8 @@ fn test_get_map_item() {
             item_index = storage_item.index,
             map_key = prepare_word(&key),
         );
-        let process = tx_context.execute_with_custom_main(&code).unwrap();
+        let process =
+            tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
         assert_eq!(
             value,
@@ -450,7 +453,7 @@ fn test_set_map_item() {
         new_value = prepare_word(&new_value),
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     let mut new_storage_map = AccountStorage::mock_map_2();
     new_storage_map.insert(new_key, new_value);
@@ -496,7 +499,7 @@ fn test_get_vault_commitment() {
         expected_vault_commitment = prepare_word(&account.vault().commitment()),
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }
 
 // PROCEDURE AUTHENTICATION TESTS
@@ -543,7 +546,7 @@ fn test_authenticate_procedure() {
             root = prepare_word(&root)
         );
 
-        let process = tx_context.execute_with_custom_main(&code);
+        let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
         match valid {
             true => assert!(process.is_ok(), "A valid procedure must successfully authenticate"),

--- a/miden-tx/src/tests/kernel_tests/test_asset.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset.rs
@@ -39,7 +39,7 @@ fn test_create_fungible_asset_succeeds() {
         "
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.get_stack_word(0),
@@ -80,7 +80,7 @@ fn test_create_non_fungible_asset_succeeds() {
         non_fungible_asset_data_hash = prepare_word(&Hasher::hash(&NON_FUNGIBLE_ASSET_DATA)),
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(process.get_stack_word(0), Word::from(non_fungible_asset));
 }
@@ -109,6 +109,6 @@ fn test_validate_non_fungible_asset() {
         asset = prepare_word(&encoded)
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
     assert_eq!(process.get_stack_word(0), encoded);
 }

--- a/miden-tx/src/tests/kernel_tests/test_asset.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset.rs
@@ -9,6 +9,7 @@ use miden_objects::{
         },
         prepare_word,
     },
+    transaction::TransactionArgs,
 };
 use vm_processor::ProcessState;
 
@@ -39,7 +40,7 @@ fn test_create_fungible_asset_succeeds() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.get_stack_word(0),
@@ -80,7 +81,7 @@ fn test_create_non_fungible_asset_succeeds() {
         non_fungible_asset_data_hash = prepare_word(&Hasher::hash(&NON_FUNGIBLE_ASSET_DATA)),
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(process.get_stack_word(0), Word::from(non_fungible_asset));
 }
@@ -109,6 +110,6 @@ fn test_validate_non_fungible_asset() {
         asset = prepare_word(&encoded)
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
     assert_eq!(process.get_stack_word(0), encoded);
 }

--- a/miden-tx/src/tests/kernel_tests/test_asset_vault.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset_vault.rs
@@ -41,7 +41,7 @@ fn test_get_balance() {
         "
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.stack.get(0).as_int(),
@@ -69,7 +69,7 @@ fn test_get_balance_non_fungible_fails() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -97,7 +97,7 @@ fn test_has_non_fungible_asset() {
         non_fungible_asset_key = prepare_word(&non_fungible_asset.vault_key())
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(process.stack.get(0), ONE);
 }
@@ -129,7 +129,7 @@ fn test_add_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&add_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -170,7 +170,7 @@ fn test_add_non_fungible_asset_fail_overflow() {
         FUNGIBLE_ASSET = prepare_word(&add_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
     assert!(account_vault.add_asset(add_fungible_asset).is_err());
@@ -206,7 +206,7 @@ fn test_add_non_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&add_non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -247,7 +247,7 @@ fn test_add_non_fungible_asset_fail_duplicate() {
         NON_FUNGIBLE_ASSET = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
     assert!(account_vault.add_asset(non_fungible_asset).is_err());
@@ -281,7 +281,7 @@ fn test_remove_fungible_asset_success_no_balance_remaining() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -320,7 +320,7 @@ fn test_remove_fungible_asset_fail_remove_too_much() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -353,7 +353,7 @@ fn test_remove_fungible_asset_success_balance_remaining() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -401,7 +401,7 @@ fn test_remove_inexisting_non_fungible_asset_fails() {
         FUNGIBLE_ASSET = prepare_word(&non_existent_non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
     assert_eq!(
@@ -439,7 +439,7 @@ fn test_remove_non_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),

--- a/miden-tx/src/tests/kernel_tests/test_asset_vault.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset_vault.rs
@@ -13,6 +13,7 @@ use miden_objects::{
         constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA},
         prepare_word,
     },
+    transaction::TransactionArgs,
     AssetVaultError,
 };
 
@@ -41,7 +42,7 @@ fn test_get_balance() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.stack.get(0).as_int(),
@@ -69,7 +70,7 @@ fn test_get_balance_non_fungible_fails() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -97,7 +98,7 @@ fn test_has_non_fungible_asset() {
         non_fungible_asset_key = prepare_word(&non_fungible_asset.vault_key())
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(process.stack.get(0), ONE);
 }
@@ -129,7 +130,7 @@ fn test_add_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&add_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -170,7 +171,7 @@ fn test_add_non_fungible_asset_fail_overflow() {
         FUNGIBLE_ASSET = prepare_word(&add_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
     assert!(account_vault.add_asset(add_fungible_asset).is_err());
@@ -206,7 +207,7 @@ fn test_add_non_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&add_non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -247,7 +248,7 @@ fn test_add_non_fungible_asset_fail_duplicate() {
         NON_FUNGIBLE_ASSET = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
     assert!(account_vault.add_asset(non_fungible_asset).is_err());
@@ -281,7 +282,7 @@ fn test_remove_fungible_asset_success_no_balance_remaining() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -320,7 +321,7 @@ fn test_remove_fungible_asset_fail_remove_too_much() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -353,7 +354,7 @@ fn test_remove_fungible_asset_success_balance_remaining() {
         FUNGIBLE_ASSET = prepare_word(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),
@@ -401,7 +402,7 @@ fn test_remove_inexisting_non_fungible_asset_fails() {
         FUNGIBLE_ASSET = prepare_word(&non_existent_non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
     assert_eq!(
@@ -439,7 +440,7 @@ fn test_remove_non_fungible_asset_success() {
         FUNGIBLE_ASSET = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         process.stack.get_word(0),

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -45,7 +45,7 @@ fn test_epilogue() {
         "
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     let final_account = Account::mock(
         tx_context.account().id().into(),
@@ -109,7 +109,7 @@ fn test_compute_created_note_id() {
             "
         );
 
-        let process = tx_context.execute_code(&code).unwrap();
+        let process = tx_context.execute_with_custom_main(&code).unwrap();
 
         assert_eq!(
             note.assets().commitment().as_elements(),
@@ -158,7 +158,7 @@ fn test_epilogue_asset_preservation_violation_too_few_input() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
     assert!(process.is_err(), "Violating asset preservation must result in a failure");
 }
 
@@ -192,7 +192,7 @@ fn test_epilogue_asset_preservation_violation_too_many_fungible_input() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
     assert!(process.is_err(), "Violating asset preservation must result in a failure");
 }
 
@@ -234,7 +234,7 @@ fn test_epilogue_increment_nonce_success() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
     assert!(process.is_ok(), "Calling incr_nonce should succeed");
 }
 
@@ -273,7 +273,7 @@ fn test_epilogue_increment_nonce_violation() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
     assert!(
         process.is_err(),
         "Not incrementing the nonce when the state changes must be an error",

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -5,7 +5,7 @@ use miden_lib::transaction::memory::{
 };
 use miden_objects::{
     accounts::{account_id::testing::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, Account},
-    transaction::{OutputNote, OutputNotes},
+    transaction::{OutputNote, OutputNotes, TransactionArgs},
 };
 use vm_processor::ONE;
 
@@ -45,7 +45,7 @@ fn test_epilogue() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     let final_account = Account::mock(
         tx_context.account().id().into(),
@@ -109,7 +109,8 @@ fn test_compute_created_note_id() {
             "
         );
 
-        let process = tx_context.execute_with_custom_main(&code).unwrap();
+        let process =
+            tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
         assert_eq!(
             note.assets().commitment().as_elements(),
@@ -158,7 +159,7 @@ fn test_epilogue_asset_preservation_violation_too_few_input() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
     assert!(process.is_err(), "Violating asset preservation must result in a failure");
 }
 
@@ -192,7 +193,7 @@ fn test_epilogue_asset_preservation_violation_too_many_fungible_input() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
     assert!(process.is_err(), "Violating asset preservation must result in a failure");
 }
 
@@ -234,7 +235,7 @@ fn test_epilogue_increment_nonce_success() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
     assert!(process.is_ok(), "Calling incr_nonce should succeed");
 }
 
@@ -273,7 +274,7 @@ fn test_epilogue_increment_nonce_violation() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
     assert!(
         process.is_err(),
         "Not incrementing the nonce when the state changes must be an error",

--- a/miden-tx/src/tests/kernel_tests/test_faucet.rs
+++ b/miden-tx/src/tests/kernel_tests/test_faucet.rs
@@ -65,7 +65,7 @@ fn test_mint_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_mint_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -115,7 +115,7 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -142,7 +142,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() {
         saturating_amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_FAUCET_INITIAL_BALANCE + 1
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -202,7 +202,7 @@ fn test_mint_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -260,7 +260,7 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -293,7 +293,7 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -346,7 +346,7 @@ fn test_burn_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 #[test]
@@ -370,7 +370,7 @@ fn test_burn_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -397,7 +397,7 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
     assert!(process.is_err());
 }
 
@@ -424,7 +424,7 @@ fn test_burn_fungible_asset_insufficient_input_amount() {
         saturating_amount = CONSUMED_ASSET_1_AMOUNT + 1
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -484,7 +484,7 @@ fn test_burn_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 #[test]
@@ -519,7 +519,7 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -555,7 +555,7 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -592,7 +592,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err());
 }
@@ -628,5 +628,5 @@ fn test_get_total_issuance_succeeds() {
         ",
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }

--- a/miden-tx/src/tests/kernel_tests/test_faucet.rs
+++ b/miden-tx/src/tests/kernel_tests/test_faucet.rs
@@ -13,6 +13,7 @@ use miden_objects::{
         prepare_word,
         storage::FAUCET_STORAGE_DATA_SLOT,
     },
+    transaction::TransactionArgs,
 };
 use vm_processor::Felt;
 
@@ -65,7 +66,7 @@ fn test_mint_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }
 
 #[test]
@@ -89,7 +90,7 @@ fn test_mint_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -115,7 +116,7 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -142,7 +143,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() {
         saturating_amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_FAUCET_INITIAL_BALANCE + 1
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -202,7 +203,7 @@ fn test_mint_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }
 
 #[test]
@@ -230,7 +231,7 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -260,7 +261,7 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -293,7 +294,7 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
         non_fungible_asset = prepare_word(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -346,7 +347,7 @@ fn test_burn_fungible_asset_succeeds() {
         expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }
 
 #[test]
@@ -370,7 +371,7 @@ fn test_burn_fungible_asset_fails_not_faucet_account() {
         "
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -397,7 +398,7 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() {
         ",
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
     assert!(process.is_err());
 }
 
@@ -424,7 +425,7 @@ fn test_burn_fungible_asset_insufficient_input_amount() {
         saturating_amount = CONSUMED_ASSET_1_AMOUNT + 1
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -484,7 +485,7 @@ fn test_burn_non_fungible_asset_succeeds() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }
 
 #[test]
@@ -519,7 +520,7 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -555,7 +556,7 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -592,7 +593,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
         non_fungible_asset = prepare_word(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err());
 }
@@ -628,5 +629,5 @@ fn test_get_total_issuance_succeeds() {
         ",
     );
 
-    tx_context.execute_with_custom_main(&code).unwrap();
+    tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 }

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -39,7 +39,7 @@ fn test_get_sender_no_sender() {
         end
         ";
 
-    let process = tx_context.execute_code(code);
+    let process = tx_context.execute_with_custom_main(code);
 
     assert!(process.is_err());
 }
@@ -67,7 +67,7 @@ fn test_get_sender() {
         end
         ";
 
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     let sender = tx_context.input_notes().get_note(0).note().metadata().sender().into();
     assert_eq!(process.stack.get(0), sender);
@@ -123,7 +123,7 @@ fn test_get_vault_data() {
         note_1_num_assets = notes.get_note(1).note().assets().num_assets(),
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 #[test]
 fn test_get_assets() {
@@ -232,7 +232,7 @@ fn test_get_assets() {
         NOTE_1_ASSET_ASSERTIONS = construct_asset_assertions(notes.get_note(1).note()),
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 #[test]
@@ -306,7 +306,7 @@ fn test_get_inputs() {
         NOTE_0_PTR = 100000000,
     );
 
-    tx_context.execute_code(&code).unwrap();
+    tx_context.execute_with_custom_main(&code).unwrap();
 }
 
 #[test]
@@ -328,7 +328,7 @@ fn test_note_setup() {
         end
         ";
 
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     note_setup_stack_assertions(&process, &tx_context);
     note_setup_memory_assertions(&process);
@@ -371,7 +371,7 @@ fn test_note_script_and_note_args() {
         TransactionArgs::new(None, Some(note_args_map), tx_context.tx_args().advice_map().clone());
 
     tx_context.set_tx_args(tx_args);
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     assert_eq!(process.stack.get_word(0), note_args[0]);
 
@@ -421,7 +421,7 @@ fn test_get_note_serial_number() {
         end
         ";
 
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     let serial_number = tx_context.input_notes().get_note(0).note().serial_num();
     assert_eq!(process.stack.get_word(0), serial_number);

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -85,7 +85,7 @@ fn test_transaction_prologue() {
     );
 
     tx_context.set_tx_args(tx_args);
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     global_input_memory_assertions(&process, &tx_context);
     block_data_memory_assertions(&process, &tx_context);
@@ -357,7 +357,7 @@ pub fn test_prologue_create_account() {
     end
     ";
 
-    tx_context.execute_code(code).unwrap();
+    tx_context.execute_with_custom_main(code).unwrap();
 }
 
 #[cfg_attr(not(feature = "testing"), ignore)]
@@ -381,7 +381,7 @@ pub fn test_prologue_create_account_valid_fungible_faucet_reserved_slot() {
     end
     ";
 
-    let process = tx_context.execute_code(code);
+    let process = tx_context.execute_with_custom_main(code);
     assert!(process.is_ok());
 }
 
@@ -409,7 +409,7 @@ pub fn test_prologue_create_account_invalid_fungible_faucet_reserved_slot() {
     end
     ";
 
-    let process = tx_context.execute_code(code);
+    let process = tx_context.execute_with_custom_main(code);
     assert!(process.is_err());
 }
 
@@ -434,7 +434,7 @@ pub fn test_prologue_create_account_valid_non_fungible_faucet_reserved_slot() {
     end
     ";
 
-    let process = tx_context.execute_code(code);
+    let process = tx_context.execute_with_custom_main(code);
 
     assert!(process.is_ok())
 }
@@ -460,7 +460,7 @@ pub fn test_prologue_create_account_invalid_non_fungible_faucet_reserved_slot() 
     end
     ";
 
-    let process = tx_context.execute_code(code);
+    let process = tx_context.execute_with_custom_main(code);
 
     assert!(process.is_err());
 }
@@ -491,7 +491,7 @@ pub fn test_prologue_create_account_invalid_seed() {
         .advice_inputs(adv_inputs)
         .build();
 
-    let process = tx_context.execute_code(code);
+    let process = tx_context.execute_with_custom_main(code);
     assert!(process.is_err());
 }
 
@@ -512,7 +512,7 @@ fn test_get_blk_version() {
     end
     ";
 
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     assert_eq!(process.stack.get(0), tx_context.tx_inputs().block_header().version().into());
 }
@@ -534,7 +534,7 @@ fn test_get_blk_timestamp() {
     end
     ";
 
-    let process = tx_context.execute_code(code).unwrap();
+    let process = tx_context.execute_with_custom_main(code).unwrap();
 
     assert_eq!(process.stack.get(0), tx_context.tx_inputs().block_header().timestamp().into());
 }

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -56,7 +56,7 @@ fn test_create_note() {
         tag = tag,
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
@@ -114,7 +114,7 @@ fn test_create_note_with_invalid_tag() {
         tag = tag,
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(process.is_err(), "Transaction should have failed because the tag is invalid");
 }
@@ -264,7 +264,7 @@ fn test_get_output_notes_hash() {
         )),
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
@@ -334,7 +334,7 @@ fn test_create_note_and_add_asset() {
         asset = prepare_word(&asset),
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
@@ -413,7 +413,7 @@ fn test_create_note_and_add_multiple_assets() {
         nft = prepare_word(&non_fungible_asset_encoded),
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
@@ -481,7 +481,7 @@ fn test_create_note_and_add_same_nft_twice() {
         nft = prepare_word(&encoded),
     );
 
-    let process = tx_context.execute_code(&code);
+    let process = tx_context.execute_with_custom_main(&code);
 
     assert!(
         process.is_err(),
@@ -537,7 +537,7 @@ fn test_build_recipient_hash() {
         aux = aux,
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -13,7 +13,7 @@ use miden_objects::{
     assets::Asset,
     notes::{Note, NoteAssets, NoteInputs, NoteMetadata, NoteRecipient, NoteType},
     testing::{constants::NON_FUNGIBLE_ASSET_DATA_2, prepare_word},
-    transaction::{OutputNote, OutputNotes},
+    transaction::{OutputNote, OutputNotes, TransactionArgs},
 };
 
 use super::{Felt, MemAdviceProvider, ProcessState, Word, ONE, ZERO};
@@ -56,7 +56,7 @@ fn test_create_note() {
         tag = tag,
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
@@ -114,7 +114,7 @@ fn test_create_note_with_invalid_tag() {
         tag = tag,
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(process.is_err(), "Transaction should have failed because the tag is invalid");
 }
@@ -264,7 +264,7 @@ fn test_get_output_notes_hash() {
         )),
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
@@ -334,7 +334,7 @@ fn test_create_note_and_add_asset() {
         asset = prepare_word(&asset),
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
@@ -413,7 +413,7 @@ fn test_create_note_and_add_multiple_assets() {
         nft = prepare_word(&non_fungible_asset_encoded),
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
@@ -481,7 +481,7 @@ fn test_create_note_and_add_same_nft_twice() {
         nft = prepare_word(&encoded),
     );
 
-    let process = tx_context.execute_with_custom_main(&code);
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default());
 
     assert!(
         process.is_err(),
@@ -537,7 +537,7 @@ fn test_build_recipient_hash() {
         aux = aux,
     );
 
-    let process = tx_context.execute_with_custom_main(&code).unwrap();
+    let process = tx_context.execute_with_custom_main(&code, TransactionArgs::default()).unwrap();
 
     assert_eq!(
         read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -45,6 +45,7 @@ mod kernel_tests;
 // TESTS
 // ================================================================================================
 
+/// [TransactionWitness] must produce the same result as its [miden_objects::transaction::PreparedTransaction].
 #[test]
 fn transaction_executor_witness() {
     let tx_context = TransactionContextBuilder::with_standard_account(
@@ -53,8 +54,7 @@ fn transaction_executor_witness() {
     )
     .with_mock_notes_preserved()
     .build();
-    let mut executor: TransactionExecutor<_, ()> =
-        TransactionExecutor::new(tx_context.clone(), None);
+    let mut executor = TransactionExecutor::<_, ()>::new(tx_context.clone(), None);
 
     let account_id = tx_context.account().id();
     executor.load_account(account_id).unwrap();

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -54,28 +54,13 @@ fn transaction_executor_witness() {
     )
     .with_mock_notes_preserved()
     .build();
-    let mut executor = TransactionExecutor::<_, ()>::new(tx_context.clone(), None);
 
-    let account_id = tx_context.account().id();
-    executor.load_account(account_id).unwrap();
-
-    let block_ref = tx_context.tx_inputs().block_header().block_num();
-    let note_ids = tx_context
-        .tx_inputs()
-        .input_notes()
-        .iter()
-        .map(|note| note.id())
-        .collect::<Vec<_>>();
-
-    let executed_transaction = executor
-        .execute_transaction(account_id, block_ref, &note_ids, tx_context.tx_args().clone())
-        .unwrap();
+    let executed_transaction = tx_context.execute_transaction().unwrap();
     let tx_witness: TransactionWitness = executed_transaction.clone().into();
 
     // use the witness to execute the transaction again
     let (stack_inputs, advice_inputs) = tx_witness.get_kernel_inputs();
     let mem_advice_provider: MemAdviceProvider = advice_inputs.into();
-    let _authenticator = ();
     let mut host: TransactionHost<MemAdviceProvider, ()> =
         TransactionHost::new(tx_witness.account().into(), mem_advice_provider, None);
     let result =
@@ -109,11 +94,11 @@ fn executed_transaction_account_delta() {
     let account_id = tx_context.tx_inputs().account().id();
     executor.load_account(account_id).unwrap();
 
-    let new_acct_code_src = "\
-    export.account_proc_1
-        push.9.9.9.9
-        dropw
-    end
+    let new_acct_code_src = "
+        export.account_proc_1
+            push.9.9.9.9
+            dropw
+        end
     ";
     let new_acct_code_ast = ModuleAst::parse(new_acct_code_src).unwrap();
     let new_acct_code = AccountCode::new(new_acct_code_ast.clone(), &Assembler::default()).unwrap();
@@ -164,7 +149,7 @@ fn executed_transaction_account_delta() {
     assert_eq!(tag2.validate(note_type2), Ok(tag2));
     assert_eq!(tag3.validate(note_type3), Ok(tag3));
     let tx_script = format!(
-        "\
+        "
         use.miden::account
         use.miden::contracts::wallets::basic->wallet
 
@@ -277,7 +262,7 @@ fn executed_transaction_account_delta() {
             push.1 exec.incr_nonce drop
             # => []
         end
-    ",
+        ",
         NEW_ACCOUNT_ROOT = prepare_word(&new_acct_code.root()),
         UPDATED_SLOT_VALUE = prepare_word(&Word::from(updated_slot_value)),
         UPDATED_MAP_VALUE = prepare_word(&Word::from(updated_map_value)),
@@ -462,7 +447,7 @@ fn executed_transaction_output_notes() {
     let expected_output_note_3 = Note::new(vault_3, metadata_3, recipient_3);
 
     let tx_script = format!(
-        "\
+        "
         use.miden::account
         use.miden::contracts::wallets::basic->wallet
 
@@ -553,7 +538,7 @@ fn executed_transaction_output_notes() {
             push.1 exec.incr_nonce drop
             # => []
         end
-    ",
+        ",
         REMOVED_ASSET_1 = prepare_word(&Word::from(removed_asset_1)),
         REMOVED_ASSET_2 = prepare_word(&Word::from(removed_asset_2)),
         REMOVED_ASSET_3 = prepare_word(&Word::from(removed_asset_3)),
@@ -679,17 +664,17 @@ fn test_tx_script() {
     let tx_script_input_value = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)];
     let tx_script_source = format!(
         "
-    begin
-        # push the tx script input key onto the stack
-        push.{key}
+        begin
+            # push the tx script input key onto the stack
+            push.{key}
 
-        # load the tx script input value from the map and read it onto the stack
-        adv.push_mapval adv_loadw
+            # load the tx script input value from the map and read it onto the stack
+            adv.push_mapval adv_loadw
 
-        # assert that the value is correct
-        push.{value} assert_eqw
-    end
-",
+            # assert that the value is correct
+            push.{value} assert_eqw
+        end
+        ",
         key = prepare_word(&tx_script_input_key),
         value = prepare_word(&tx_script_input_value)
     );

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -154,8 +154,8 @@ fn executed_transaction_account_delta() {
         use.miden::account
         use.miden::contracts::wallets::basic->wallet
 
-        ## ACCOUNT PROCEDURE WRAPPERS
-        ## ========================================================================================
+        # ACCOUNT PROCEDURE WRAPPERS
+        # =========================================================================================
         #TODO: Move this into an account library
         proc.set_item
             push.0 movdn.5 push.0 movdn.5 push.0 movdn.5
@@ -189,11 +189,11 @@ fn executed_transaction_account_delta() {
             # => []
         end
 
-        ## TRANSACTION SCRIPT
-        ## ========================================================================================
+        # TRANSACTION SCRIPT
+        # =========================================================================================
         begin
-            ## Update account storage item
-            ## ------------------------------------------------------------------------------------
+            # Update account storage item
+            # -------------------------------------------------------------------------------------
             # push a new value for the storage slot onto the stack
             push.{UPDATED_SLOT_VALUE}
             # => [13, 11, 9, 7]
@@ -206,8 +206,8 @@ fn executed_transaction_account_delta() {
             exec.set_item dropw dropw
             # => []
 
-            ## Update account storage map
-            ## ------------------------------------------------------------------------------------
+            # Update account storage map
+            # -------------------------------------------------------------------------------------
             # push a new VALUE for the storage map onto the stack
             push.{UPDATED_MAP_VALUE}
             # => [18, 19, 20, 21]
@@ -224,8 +224,8 @@ fn executed_transaction_account_delta() {
             exec.set_map_item dropw dropw dropw
             # => []
 
-            ## Send some assets from the account vault
-            ## ------------------------------------------------------------------------------------
+            # Send some assets from the account vault
+            # -------------------------------------------------------------------------------------
             # partially deplete fungible asset balance
             push.0.1.2.3            # recipient
             push.{NOTETYPE1}        # note_type
@@ -253,13 +253,13 @@ fn executed_transaction_account_delta() {
             call.wallet::send_asset dropw dropw dropw dropw
             # => []
 
-            ## Update account code
-            ## ------------------------------------------------------------------------------------
+            # Update account code
+            # -------------------------------------------------------------------------------------
             push.{NEW_ACCOUNT_ROOT} exec.set_code dropw
             # => []
 
-            ## Update the account nonce
-            ## ------------------------------------------------------------------------------------
+            # Update the account nonce
+            # -------------------------------------------------------------------------------------
             push.1 exec.incr_nonce drop
             # => []
         end
@@ -452,8 +452,8 @@ fn executed_transaction_output_notes() {
         use.miden::account
         use.miden::contracts::wallets::basic->wallet
 
-        ## ACCOUNT PROCEDURE WRAPPERS
-        ## ========================================================================================
+        # ACCOUNT PROCEDURE WRAPPERS
+        # =========================================================================================
         #TODO: Move this into an account library
         proc.create_note
             call.{ACCOUNT_CREATE_NOTE_MAST_ROOT}
@@ -481,11 +481,11 @@ fn executed_transaction_output_notes() {
             # => []
         end
 
-        ## TRANSACTION SCRIPT
-        ## ========================================================================================
+        # TRANSACTION SCRIPT
+        # =========================================================================================
         begin
-            ## Send some assets from the account vault
-            ## ------------------------------------------------------------------------------------
+            # Send some assets from the account vault
+            # -------------------------------------------------------------------------------------
             # partially deplete fungible asset balance
             push.0.1.2.3                        # recipient
             push.{NOTETYPE1}                    # note_type
@@ -534,8 +534,8 @@ fn executed_transaction_output_notes() {
 
             drop
 
-            ## Update the account nonce
-            ## ------------------------------------------------------------------------------------
+            # Update the account nonce
+            # -------------------------------------------------------------------------------------
             push.1 exec.incr_nonce drop
             # => []
         end

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -11,7 +11,7 @@ use miden_objects::{
         },
         AccountCode,
     },
-    assembly::{Assembler, ModuleAst, ProgramAst},
+    assembly::{Assembler, ProgramAst},
     assets::{Asset, FungibleAsset},
     notes::{
         Note, NoteAssets, NoteExecutionHint, NoteHeader, NoteId, NoteInputs, NoteMetadata,
@@ -94,14 +94,15 @@ fn executed_transaction_account_delta() {
     let account_id = tx_context.tx_inputs().account().id();
     executor.load_account(account_id).unwrap();
 
-    let new_acct_code_src = "
+    let new_acct_code = AccountCode::from_code(
+        "
         export.account_proc_1
             push.9.9.9.9
             dropw
         end
-    ";
-    let new_acct_code_ast = ModuleAst::parse(new_acct_code_src).unwrap();
-    let new_acct_code = AccountCode::new(new_acct_code_ast.clone(), &Assembler::default()).unwrap();
+        ",
+    )
+    .unwrap();
 
     // updated storage
     let updated_slot_value = [Felt::new(7), Felt::new(9), Felt::new(11), Felt::new(13)];

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -235,12 +235,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
 
     // Execute the transaction and get the witness
     let executed_transaction = executor
-        .execute_transaction(
-            faucet_account.id(),
-            block_ref,
-            &note_ids,
-            tx_context.tx_args().clone(),
-        )
+        .execute_transaction(faucet_account.id(), block_ref, &note_ids, TransactionArgs::default())
         .unwrap();
 
     // Prove, serialize/deserialize and verify the transaction

--- a/objects/src/accounts/code.rs
+++ b/objects/src/accounts/code.rs
@@ -92,6 +92,14 @@ impl AccountCode {
         }
     }
 
+    /// Compiles the source and returns a [AccountCode].
+    pub fn from_code(source: impl AsRef<str>) -> Result<Self, AccountError> {
+        let source = source.as_ref();
+        let new_acct_code_ast =
+            ModuleAst::parse(source).map_err(AccountError::AccountCodeParsingError)?;
+        AccountCode::new(new_acct_code_ast, &Assembler::default())
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -190,11 +190,13 @@ fn validate_nonce(
                 ))
             },
         }
-    } else if nonce.is_some() {
-        return Err(AccountDeltaError::InconsistentNonceUpdate(
-            "nonce updated for empty delta".to_string(),
-        ));
     }
+
+    // TODO: validate the nonce updates when the account code changes.
+    // 1. the nonce must be updated when the code changes
+    // 2. the nonce must not change if nothing changed
+    // 3. for now, since the code changes is not tracked, validation 2. can't be performed, since it
+    //    would prevent the execution of correct transaction scripts
 
     Ok(())
 }
@@ -222,7 +224,6 @@ mod tests {
         };
 
         assert!(AccountDelta::new(storage_delta.clone(), vault_delta.clone(), None).is_ok());
-        assert!(AccountDelta::new(storage_delta.clone(), vault_delta.clone(), Some(ONE)).is_err());
 
         // non-empty delta
         let storage_delta = AccountStorageDelta {

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -320,7 +320,7 @@ mod tests {
     };
     use vm_processor::Digest;
 
-    use super::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
+    use super::AccountDelta;
     use crate::{
         accounts::{
             delta::AccountStorageDeltaBuilder, Account, SlotItem, StorageMap, StorageMapDelta,
@@ -475,28 +475,6 @@ mod tests {
             .build()
             .unwrap();
         let account_delta = build_account_delta(vec![], vec![asset], final_nonce, storage_delta);
-
-        // apply delta
-        account.apply_delta(&account_delta).unwrap()
-    }
-
-    #[test]
-    #[should_panic]
-    fn empty_account_delta_with_incremented_nonce() {
-        // build account
-        let init_nonce = Felt::new(1);
-        let word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-        let slot_item = SlotItem::new_value(0, 0, word);
-        let mut account = build_account(vec![], init_nonce, vec![slot_item], None);
-
-        // build account delta
-        let final_nonce = Felt::new(2);
-        let account_delta = AccountDelta::new(
-            AccountStorageDelta::default(),
-            AccountVaultDelta::default(),
-            Some(final_nonce),
-        )
-        .unwrap();
 
         // apply delta
         account.apply_delta(&account_delta).unwrap()

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -1,7 +1,7 @@
 use alloc::{string::String, vec::Vec};
 use core::fmt;
 
-use assembly::AssemblyError;
+use assembly::{AssemblyError, ParsingError};
 use vm_processor::DeserializationError;
 
 use super::{
@@ -19,6 +19,7 @@ use crate::{accounts::AccountType, notes::NoteType};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccountError {
     AccountCodeAssemblerError(AssemblyError),
+    AccountCodeParsingError(ParsingError),
     AccountCodeNoProcedures,
     AccountCodeTooManyProcedures { max: usize, actual: usize },
     AccountIdInvalidFieldElement(String),

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -36,7 +36,7 @@ pub mod assembly {
     pub use assembly::{
         ast::{AstSerdeOptions, ModuleAst, ProgramAst},
         Assembler, AssemblyContext, AssemblyError, Library, LibraryNamespace, LibraryPath,
-        MaslLibrary, Version,
+        MaslLibrary, ParsingError, Version,
     };
 }
 

--- a/objects/src/notes/mod.rs
+++ b/objects/src/notes/mod.rs
@@ -93,7 +93,6 @@ pub const NOTE_LEAF_DEPTH: u8 = NOTE_TREE_DEPTH + 1;
 pub struct Note {
     header: NoteHeader,
     details: NoteDetails,
-
     nullifier: Nullifier,
 }
 

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -6,11 +6,11 @@ use crate::accounts::AccountCode;
 // account's procedures.
 const MASTS: [&str; 11] = [
     "0xbb58a032a1c1989079dcc73c279d69dcdf41dd7ee923d99dc3f86011663ec167",
-    "0x549d264f00f1a6e90d47284e99eab6d0f93a3d41bb5324743607b6902978a809",
-    "0x704ed1af80a3dae74cd4aabeb4c217924813c42334c2695a74e2702af80a4a35",
-    "0xc25558f483c13aa5be77de4b0987de6a3fab303146fe2fd8ab68b6be8fdcfe76",
-    "0x5dc65ccf6d32880a8eb47fab75b65d926b701ed80220fe5e88152efffcd656ad",
-    "0x73c14f65d2bab6f52eafc4397e104b3ab22a470f6b5cbc86d4aa4d3978c8b7d4",
+    "0x49c463b2b0888fc21973956b5bf93a62b09ad580169a392310e8b06fb16e7063",
+    "0x15cc8a22ff11a964556d2c0be7c34b8a6c8823aeae8b3fb85adf0debdbf8299c",
+    "0x4ce781587b60e18c13251445da6a24cf758bbb83726019f941d0555ef65a8b1b",
+    "0xff9b31930a10a0725f0e950f6f59c40e96799e67704103dc86ad04ce32526998",
+    "0x88a3caaf8117785b056dddcebad8f283cdc3f05e6b518ee841c2e7515df38ee1",
     "0x55036198d82d2af653935226c644427162f12e2a2c6b3baf007c9c6f47462872",
     "0xf484a84dad7f82e8eb1d5190b43243d02d9508437ff97522e14ebf9899758faa",
     "0xf17acfc7d1eff3ecadd7a17b6d91ff01af638aa9439d6c8603c55648328702ae",
@@ -18,6 +18,7 @@ const MASTS: [&str; 11] = [
     "0x8ef0092134469a1330e3c468f57c7f085ce611645d09cc7516c786fefc71d794",
 ];
 
+pub const ACCOUNT_RECEIVE_ASSET_MAST_ROOT: &str = MASTS[0];
 pub const ACCOUNT_SEND_ASSET_MAST_ROOT: &str = MASTS[1];
 pub const ACCOUNT_INCR_NONCE_MAST_ROOT: &str = MASTS[2];
 pub const ACCOUNT_SET_ITEM_MAST_ROOT: &str = MASTS[3];
@@ -67,45 +68,41 @@ impl AccountCode {
         use.miden::tx
         use.miden::contracts::wallets::basic->wallet
 
+        #######################################  IMPORTANT  #######################################
+        #                                                                                         #
+        #            Only use locally defined procedures below instead of re-exports              #
+        #                                see miden-vm/#1376                                       #
+        #                                                                                         #
+        ###########################################################################################
+
         # acct proc 0
-        export.wallet::receive_asset
+        export.receive_asset
+            exec.wallet::receive_asset
+        end
+
         # acct proc 1
-        export.wallet::send_asset
+        export.send_asset.1
+            exec.wallet::send_asset
+        end
 
         # acct proc 2
         export.incr_nonce
-            push.0 swap
-            # => [value, 0]
-
-            exec.account::incr_nonce
-            # => [0]
+            exec.wallet::incr_nonce
         end
 
         # acct proc 3
         export.set_item
             exec.account::set_item
-            # => [R', V, 0, 0, 0]
-
-            movup.8 drop movup.8 drop movup.8 drop
-            # => [R', V]
         end
 
         # acct proc 4
         export.set_map_item
             exec.account::set_map_item
-            # => [R', V, 0, 0, 0]
-
-            movup.8 drop movup.8 drop movup.8 drop
-            # => [R', V]
         end
 
         # acct proc 5
         export.set_code
-            padw swapw
-            # => [CODE_ROOT, 0, 0, 0, 0]
-
-            exec.account::set_code
-            # => [0, 0, 0, 0]
+            exec.wallet::set_code
         end
 
         # acct proc 6

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -86,8 +86,14 @@ impl AccountCode {
         end
 
         # acct proc 2
+        #
+        # NOTE: Procedure expose for testing purposes only. This procedure should not be part of the
+        # account's public API. An account must increment its nonce when its state change, but for a
+        # production account code implementation, the increment is expected to be done together with
+        # the transaction authencation. That is to say, the nonce is increment iff the transaction
+        # contains a valid signature.
         export.incr_nonce
-            exec.wallet::incr_nonce
+            exec.account::incr_nonce
         end
 
         # acct proc 3
@@ -102,7 +108,7 @@ impl AccountCode {
 
         # acct proc 5
         export.set_code
-            exec.wallet::set_code
+            exec.account::set_code
         end
 
         # acct proc 6

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -11,7 +11,7 @@ const MASTS: [&str; 11] = [
     "0x4ce781587b60e18c13251445da6a24cf758bbb83726019f941d0555ef65a8b1b",
     "0xff9b31930a10a0725f0e950f6f59c40e96799e67704103dc86ad04ce32526998",
     "0x88a3caaf8117785b056dddcebad8f283cdc3f05e6b518ee841c2e7515df38ee1",
-    "0x55036198d82d2af653935226c644427162f12e2a2c6b3baf007c9c6f47462872",
+    "0x686a897c14304aeee4b3047b7a217a3209d14f6530bd3bdf33fcd5c314c713e5",
     "0xf484a84dad7f82e8eb1d5190b43243d02d9508437ff97522e14ebf9899758faa",
     "0xf17acfc7d1eff3ecadd7a17b6d91ff01af638aa9439d6c8603c55648328702ae",
     "0xff06b90f849c4b262cbfbea67042c4ea017ea0e9c558848a951d44b23370bec5",
@@ -108,9 +108,6 @@ impl AccountCode {
         # acct proc 6
         export.create_note
             exec.tx::create_note
-            # => [note_idx]
-
-            swapw dropw swap drop
         end
 
         # acct proc 7

--- a/objects/src/testing/notes.rs
+++ b/objects/src/testing/notes.rs
@@ -74,8 +74,8 @@ impl NoteBuilder {
         self
     }
 
-    pub fn tag(mut self, tag: u32) -> Self {
-        self.tag = tag.into();
+    pub fn tag(mut self, tag: NoteTag) -> Self {
+        self.tag = tag;
         self
     }
 


### PR DESCRIPTION
The account delta check only allows the nonce to change if the storage or the vault changes. This is a problem, because it forbids changes to the account's code.

This relaxes the test, to fix the immediate issue, allowing the account code to change. In the future, however, the correct fix is to also track code changes in the account delta and include that in the nonce check.