### PR TITLE
Update names used for input/output notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Created `get_serial_number` procedure to get the serial num of the currently processed note (#760).
 - [BREAKING] Added support for conversion from `Nullifier` to `InputNoteCommitment`, commitment header return reference (#774).
 - Added `compute_inputs_hash` procedure for hash computation of the arbitrary number of note inputs (#750).
+- Notion of "consumed" and "created" notes changed to "input" and "output" respectively (#791).
+- [BREAKING] "OffChain" variant of `NoteType` was renamed to "Private", public accessors of the `Block` struct were renamed to match the updated fields (#791). 
 
 ## 0.3.1 (2024-06-12)
 

--- a/docs/architecture/transactions/execution.md
+++ b/docs/architecture/transactions/execution.md
@@ -23,7 +23,7 @@ The data store defines the interface that transaction objects use to fetch the d
 
 - `Account` data which includes the [AccountID](../accounts.md#account-id) and the [AccountCode](../accounts.md#code) that is executed during the transaction.
 - A `BlockHeader` which contains metadata about the block, commitments to the current state of the chain, and the hash of the proof that attests to the integrity of the chain.
-- A `ChainMmr` which authenticates consumed notes during transaction execution. Authentication is achieved by providing an inclusion-proof for the transaction's consumed notes against the `ChainMmr`-root associated with the latest block known at the time of transaction execution.
+- A `ChainMmr` which authenticates input notes during transaction execution. Authentication is achieved by providing an inclusion-proof for the transaction's input notes against the `ChainMmr`-root associated with the latest block known at the time of transaction execution.
 - `InputNotes` consumed by the transaction that include the corresponding note data, e.g. the [note script](../notes.md#the-note-script) and serial number.
 
 !!! note

--- a/docs/architecture/transactions/execution.md
+++ b/docs/architecture/transactions/execution.md
@@ -23,7 +23,7 @@ The data store defines the interface that transaction objects use to fetch the d
 
 - `Account` data which includes the [AccountID](../accounts.md#account-id) and the [AccountCode](../accounts.md#code) that is executed during the transaction.
 - A `BlockHeader` which contains metadata about the block, commitments to the current state of the chain, and the hash of the proof that attests to the integrity of the chain.
-- A `ChainMmr` which authenticates input notes during transaction execution. Authentication is achieved by providing an inclusion-proof for the transaction's input notes against the `ChainMmr`-root associated with the latest block known at the time of transaction execution.
+- A `ChainMmr` which authenticates input notes during transaction execution. Authentication is achieved by providing an inclusion proof for the transaction's input notes against the `ChainMmr`-root associated with the latest block known at the time of transaction execution.
 - `InputNotes` consumed by the transaction that include the corresponding note data, e.g. the [note script](../notes.md#the-note-script) and serial number.
 
 !!! note

--- a/docs/architecture/transactions/kernel.md
+++ b/docs/architecture/transactions/kernel.md
@@ -16,7 +16,7 @@ The kernel has a well-defined structure which does the following:
 1. The [prologue](#prologue) prepares the transaction for processing by parsing the transaction data and setting up the root context.
 2. Note processing executes the note processing loop which consumes each `InputNote` and invokes the note script of each note.
 3. Transaction script processing executes the optional transaction script.
-4. The [epilogue](#epilogue) finalizes the transaction by computing the created notes commitment, the final account hash, asserting asset invariant conditions, and asserting the nonce rules are upheld.
+4. The [epilogue](#epilogue) finalizes the transaction by computing the output notes commitment, the final account hash, asserting asset invariant conditions, and asserting the nonce rules are upheld.
 
 <center>
 ![Transaction program](../../img/architecture/transaction/transaction-program.png)
@@ -76,11 +76,11 @@ As the account data is read from the advice provider, the account hash is comput
 
 Input note processing involves the kernel reading the data from each note and storing it at the appropriate memory addresses. All the data (note, account, and blockchain data) comes from the advice provider and global inputs. 
 
-Next to the total number of consumed notes, input note data consists of a serial number, the roots of the script, the inputs and asset vault, its metadata, and all its assets. 
+Next to the total number of input notes, input note data consists of a serial number, the roots of the script, the inputs and asset vault, its metadata, and all its assets. 
 
 As each note is consumed, its hash and nullifier are computed. 
 
-The transaction nullifier commitment is computed via a sequential hash of `(nullifier, ZERO)` pairs for all consumed notes. This step involves authentication such that the input note data provided via the advice provider is consistent with the chain history.
+The transaction nullifier commitment is computed via a sequential hash of `(nullifier, ZERO)` pairs for all input notes. This step involves authentication such that the input note data provided via the advice provider is consistent with the chain history.
 
 !!! info
     - Note data is required for computing the nullifier, e.g. the [note script](../notes.md#main-script) and the serial number. 
@@ -111,7 +111,7 @@ For every note, the [MAST root](https://0xpolygonmiden.github.io/miden-vm/design
         # => []
 
         # check if we have more notes to consume and should loop again
-        exec.note::increment_current_consumed_note_ptr
+        exec.note::increment_current_input_note_ptr
         loc_load.0
         neq
         # => [should_loop]
@@ -147,7 +147,7 @@ The epilogue finalizes the transaction. It does the following:
 
 1. Computes the final account hash.
 2. If the account has changed, it asserts that the final account nonce is greater than the initial account nonce.
-3. Computes the created notes commitment.
+3. Computes the output notes commitment.
 4. Asserts that the input and output vault roots are equal.
 
 There is an exception for special accounts, called faucets, which can mint or burn assets. In these cases, input and output vault roots are not equal.

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -389,22 +389,22 @@ export.account_vault_remove_asset
     # => [ASSET]
 end
 
-#! Returns the number of assets and vault hash of the note currently being processed. Panics if a
-#! note is not being processed.
+#! Returns the number of assets and the assets hash of the note currently being processed. Panics
+#! if a note is not being processed.
 #!
 #! Inputs: [0, 0, 0, 0, 0]
-#! Outputs: [VAULT_HASH, num_assets]
+#! Outputs: [ASSETS_HASH, num_assets]
 #!
 #! - num_assets is the number of assets in the note currently being processed.
-#! - VAULT_HASH is the vault hash of the note currently being processed.
-export.get_note_vault_info
-    # get the vault info
-    exec.note::get_vault_info
-    # => [VAULT_HASH, num_assets, 0, 0, 0, 0, 0]
+#! - ASSETS_HASH is the assets hash of the note currently being processed.
+export.get_note_assets_info
+    # get the assets info
+    exec.note::get_assets_info
+    # => [ASSETS_HASH, num_assets, 0, 0, 0, 0, 0]
 
     # organize the stack for return
     movup.5 drop movup.5 drop movup.5 drop movup.5 drop movup.5 drop
-    # => [VAULT_HASH, num_assets]
+    # => [ASSETS_HASH, num_assets]
 end
 
 #! Returns the current note's inputs hash.

--- a/miden-lib/asm/kernels/transaction/main.masm
+++ b/miden-lib/asm/kernels/transaction/main.masm
@@ -77,7 +77,7 @@ proc.main.1
     push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.NOTES_PROCESSING_START
 
-    exec.memory::get_total_num_input_notes
+    exec.memory::get_num_input_notes
     # => [num_input_notes]
 
     # compute the memory location after all input notes, i.e. the exit condition

--- a/miden-lib/asm/kernels/transaction/main.masm
+++ b/miden-lib/asm/kernels/transaction/main.masm
@@ -50,14 +50,14 @@ const.EPILOGUE_END=131081
 #! advice provider.
 #!
 #! Stack:   [BLOCK_HASH, account_id, INITIAL_ACCOUNT_HASH, INPUT_NOTES_COMMITMENT]
-#! Output:  [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+#! Output:  [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 #!
 #! Where:
 #! - BLOCK_HASH, reference block for the transaction execution.
 #! - account_id, the account that the transaction is being executed against.
 #! - INITIAL_ACCOUNT_HASH, account state prior to the transaction, EMPTY_WORD for new accounts.
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
-#! - CREATED_NOTES_COMMITMENT, commitment to the notes created by the transaction.
+#! - OUTPUT_NOTES_COMMITMENT, commitment to the notes created by the transaction.
 #! - FINAL_ACCOUNT_HASH, account's hash after execution the transaction.
 proc.main.1
     # Prologue
@@ -77,12 +77,12 @@ proc.main.1
     push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.NOTES_PROCESSING_START
 
-    exec.memory::get_total_num_consumed_notes
-    # => [num_consumed_notes]
+    exec.memory::get_total_num_input_notes
+    # => [num_input_notes]
 
     # compute the memory location after all input notes, i.e. the exit condition
-    dup exec.memory::get_consumed_note_ptr loc_store.0
-    # => [num_consumed_notes]
+    dup exec.memory::get_input_note_ptr loc_store.0
+    # => [num_input_notes]
 
     eq.0 not
     # => [should_loop]
@@ -103,8 +103,8 @@ proc.main.1
         dropw dropw dropw dropw
         # => []
 
-        exec.note::increment_current_consumed_note_ptr
-        # => [current_consumed_note_ptr]
+        exec.note::increment_current_input_note_ptr
+        # => [current_input_note_ptr]
 
         # loop condition, exit when the memory ptr is after all input notes
         loc_load.0 neq
@@ -158,11 +158,11 @@ proc.main.1
 
     # execute the transaction epilogue
     exec.epilogue::finalize_transaction
-    # => [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 
     push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.EPILOGUE_END
-    # => [CREATED_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+    # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 end
 
 begin

--- a/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -13,7 +13,7 @@ const.PUBLIC_KEY_SLOT=0
 #! Output: []
 #!
 export.auth_tx_rpo_falcon512
-    # Get commitments to created notes
+    # Get commitments to output notes
     exec.tx::get_output_notes_hash
     # => [OUTPUT_NOTES_HASH, ...]
 

--- a/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
+++ b/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
@@ -15,7 +15,7 @@ use.miden::contracts::auth::basic
 
 # CONSTANTS
 # =================================================================================================
-const.OFFCHAIN_NOTE=2
+const.PRIVATE_NOTE=2
 
 # ERRORS
 # =================================================================================================
@@ -42,7 +42,7 @@ export.basic::auth_tx_rpo_falcon512
 #! - note_type is the type of the note that holds the asset.
 #! - RECIPIENT is the recipient of the asset, i.e.,
 #!   hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash).
-#! - note_idx is the index of the created note.
+#! - note_idx is the index of the output note.
 #!   This cannot directly be accessed from another context.
 #!
 #! FAILS if:

--- a/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -33,7 +33,7 @@ end
 #! - note_type is the note's storage type
 #! - RECIPIENT is the recipient of the note, i.e.,
 #!   hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
-#! - note_idx is the index of the created note.
+#! - note_idx is the index of the output note.
 #!   This cannot directly be accessed from another context.
 #!
 #! Panics:

--- a/miden-lib/asm/miden/kernels/tx/constants.masm
+++ b/miden-lib/asm/miden/kernels/tx/constants.masm
@@ -71,7 +71,7 @@ export.get_max_assets_per_note
     push.MAX_ASSETS_PER_NOTE
 end
 
-#! Returns the max allow number of input notes.
+#! Returns the maximum number of notes that can be consumed in a single transaction.
 #!
 #! Stack: []
 #! Output: [max_num_input_notes]
@@ -101,7 +101,7 @@ export.get_note_tree_depth
     push.NOTE_TREE_DEPTH
 end
 
-#! Returns the max number of notes that can be created in a single transaction.
+#! Returns the maximum number of notes that can be created in a single transaction.
 #!
 #! Stack: []
 #! Output: [max_num_output_notes]

--- a/miden-lib/asm/miden/kernels/tx/constants.masm
+++ b/miden-lib/asm/miden/kernels/tx/constants.masm
@@ -71,13 +71,13 @@ export.get_max_assets_per_note
     push.MAX_ASSETS_PER_NOTE
 end
 
-#! Returns the max allow number of consumed notes.
+#! Returns the max allow number of input notes.
 #!
 #! Stack: []
-#! Output: [max_num_consumed_notes]
+#! Output: [max_num_input_notes]
 #!
-#! - max_num_consumed_notes is the max number of consumed notes.
-export.get_max_num_consumed_notes
+#! - max_num_input_notes is the max number of input notes.
+export.get_max_num_input_notes
     push.MAX_INPUT_NOTES_PER_TX
 end
 
@@ -104,10 +104,10 @@ end
 #! Returns the max number of notes that can be created in a single transaction.
 #!
 #! Stack: []
-#! Output: [max_num_created_notes]
+#! Output: [max_num_output_notes]
 #!
-#! - max_num_created_notes is the max number of notes that can be created in a single transaction.
-export.get_max_num_created_notes
+#! - max_num_output_notes is the max number of notes that can be created in a single transaction.
+export.get_max_num_output_notes
     push.MAX_OUTPUT_NOTES_PER_TX
 end
 

--- a/miden-lib/asm/miden/kernels/tx/epilogue.masm
+++ b/miden-lib/asm/miden/kernels/tx/epilogue.masm
@@ -23,28 +23,28 @@ const.ERR_EPILOGUE_ASSETS_DONT_ADD_UP=0x0002000A
 #! Output: [OUTPUT_NOTES_COMMITMENT, ...]
 proc.copy_output_notes_to_advice_map
     # get the number of notes created by the transaction
-    exec.memory::get_num_created_notes
+    exec.memory::get_num_output_notes
     # => [num_notes, OUTPUT_NOTES_COMMITMENT, ...]
 
-    # if there are created notes, add them to the advice map
+    # if there are output notes, add them to the advice map
     dup eq.0
     if.true
         # drop num_notes
         drop
     else
-        # compute the end boundary of the created notes section
-        exec.memory::get_created_note_ptr movdn.4
-        # => [OUTPUT_NOTES_COMMITMENT, created_notes_end_ptr, ...]
+        # compute the end boundary of the output notes section
+        exec.memory::get_output_note_ptr movdn.4
+        # => [OUTPUT_NOTES_COMMITMENT, output_notes_end_ptr, ...]
 
-        # compute the start boundary of the created notes section
-        exec.memory::get_created_note_data_offset movdn.4
-        # => [OUTPUT_NOTES_COMMITMENT, created_note_ptr, created_notes_end_ptr, ...]
+        # compute the start boundary of the output notes section
+        exec.memory::get_output_note_data_offset movdn.4
+        # => [OUTPUT_NOTES_COMMITMENT, output_note_ptr, output_notes_end_ptr, ...]
 
         # insert created data into the advice map
         adv.insert_mem
-        # => [OUTPUT_NOTES_COMMITMENT, created_note_ptr, created_notes_end_ptr, ...]
+        # => [OUTPUT_NOTES_COMMITMENT, output_note_ptr, output_notes_end_ptr, ...]
 
-        # drop created note pointers
+        # drop output note pointers
         movup.4 drop movup.4 drop
     end
     # => [OUTPUT_NOTES_COMMITMENT, ...]
@@ -54,11 +54,11 @@ end
 # =================================================================================================
 
 #! Builds the output vault which is combination of the assets in the account vault at the end of
-#! the transaction and all the assets from the created notes.
+#! the transaction and all the assets from the output notes.
 #!
 #! The output vault is built as follows:
 #! - we first copy the account vault root to the output vault root.
-#! - we then loop over the created notes and insert the assets into the output vault.
+#! - we then loop over the output notes and insert the assets into the output vault.
 #!
 #! Stack: []
 #! Output: []
@@ -67,73 +67,73 @@ proc.build_output_vault
     exec.memory::get_acct_vault_root exec.memory::set_output_vault_root
     # => []
 
-    # get the number of created notes from memory
-    exec.memory::get_num_created_notes
-    # => [num_created_notes]
+    # get the number of output notes from memory
+    exec.memory::get_num_output_notes
+    # => [num_output_notes]
 
     # calculate the address at which we should stop looping
-    exec.memory::get_created_note_ptr
-    # => [created_notes_end_ptr]
+    exec.memory::get_output_note_ptr
+    # => [output_notes_end_ptr]
 
-    # compute pointer for the first created note
-    push.0 exec.memory::get_created_note_ptr
-    # => [created_note_ptr, created_notes_end_ptr]
+    # compute pointer for the first output note
+    push.0 exec.memory::get_output_note_ptr
+    # => [output_note_ptr, output_notes_end_ptr]
 
-    # check if the number of created notes is greater then 0. Conditional for the while loop.
+    # check if the number of output notes is greater then 0. Conditional for the while loop.
     dup.1 dup.1 neq
-    # => [should_loop, created_note_ptr, created_notes_end_ptr]
+    # => [should_loop, output_note_ptr, output_notes_end_ptr]
 
-    # loop over created notes and add assets to output vault
+    # loop over output notes and add assets to output vault
     while.true
-        # get the number of assets for the created note from memory
-        dup exec.memory::get_created_note_num_assets
-        # => [num_assets, note_data_ptr, created_notes_end_ptr]
+        # get the number of assets for the output note from memory
+        dup exec.memory::get_output_note_num_assets
+        # => [num_assets, note_data_ptr, output_notes_end_ptr]
 
-        # prepare stack for reading created note assets
-        exec.memory::get_output_vault_root_ptr dup.2 exec.memory::get_created_note_asset_data_ptr dup
-        # => [assets_start_ptr, assets_start_ptr, output_vault_root_ptr, num_assets, note_data_ptr.
-        #     created_notes_end_ptr]
+        # prepare stack for reading output note assets
+        exec.memory::get_output_vault_root_ptr dup.2 exec.memory::get_output_note_asset_data_ptr dup
+        # => [assets_start_ptr, assets_start_ptr, output_vault_root_ptr, num_assets, note_data_ptr,
+        #     output_notes_end_ptr]
 
-        # compute the end pointer for created note asset looping
+        # compute the end pointer for output note asset looping
         dup.3 add swap
         # => [assets_start_ptr, assets_end_ptr, output_vault_root_ptr, num_assets, note_data_ptr,
-        #     created_notes_end_ptr]
+        #     output_notes_end_ptr]
 
         # assess if we should loop
         dup.1 dup.1 neq
         # => [should_loop, assets_start_ptr, assets_end_ptr, output_vault_root_ptr, num_assets,
-        #     note_data_ptr, created_notes_end_ptr]
+        #     note_data_ptr, output_notes_end_ptr]
 
-        # loop over created note assets and insert them into the output vault
+        # loop over output note assets and insert them into the output vault
         while.true
             # duplicate output_vault_root_ptr
             dup.2
             # => [output_vault_root_ptr, assets_start_ptr, assets_end_ptr, output_vault_root_ptr,
-            #     num_assets, note_data_ptr, created_notes_end_ptr]
+            #     num_assets, note_data_ptr, output_notes_end_ptr]
 
-            # read the created note asset from memory
+            # read the output note asset from memory
             padw dup.5 mem_loadw
             # => [ASSET, output_vault_root_ptr, assets_start_ptr, assets_end_ptr, output_vault_root_ptr,
-            #     num_assets, note_data_ptr, created_notes_end_ptr]
+            #     num_assets, note_data_ptr, output_notes_end_ptr]
 
-            # insert created note asset into output vault
+            # insert output note asset into output vault
             exec.asset_vault::add_asset dropw
             # => [assets_start_ptr, assets_end_ptr, output_vault_root_ptr, num_assets, note_data_ptr,
-            #     created_notes_end_ptr]
+            #     output_notes_end_ptr]
 
             # increment assets_start_ptr and asses if we should loop again
             add.1 dup.1 dup.1 neq
             # => [should_loop, assets_start_ptr, assets_end_ptr, output_vault_root_ptr, num_assets,
-            #     note_data_ptr, created_notes_end_ptr]
+            #     note_data_ptr, output_notes_end_ptr]
         end
 
         # clean stack
         drop drop drop drop
-        # => [note_data_ptr, created_note_end_ptr]
+        # => [note_data_ptr, output_note_end_ptr]
 
-        # increment created note pointer and check if we should loop again
+        # increment output note pointer and check if we should loop again
         exec.constants::get_note_mem_size add dup.1 dup.1 neq
-        # => [should_loop, created_note_ptr, created_notes_end_ptr]
+        # => [should_loop, output_note_ptr, output_notes_end_ptr]
     end
 
     # clean stack
@@ -168,13 +168,13 @@ end
 #! - computes the final account hash
 #! - if the account has changed, assert that the final account nonce is greater than the initial
 #!   account nonce
-#! - computes the created notes commitment
+#! - computes the output notes commitment
 #! - asserts that the input and output vault roots are equal
 #!
 #! Stack: []
 #! Output: [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 #!
-#! - OUTPUT_NOTES_COMMITMENT is the commitment of the created notes
+#! - OUTPUT_NOTES_COMMITMENT is the commitment of the output notes
 #! - FINAL_ACCOUNT_HASH is the final account hash
 export.finalize_transaction
     # update account code
@@ -232,7 +232,7 @@ export.finalize_transaction
     exec.build_output_vault
     # => [FINAL_ACCOUNT_HASH]
 
-    # compute created note hash
+    # compute output note hash
     exec.note::compute_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 

--- a/miden-lib/asm/miden/kernels/tx/epilogue.masm
+++ b/miden-lib/asm/miden/kernels/tx/epilogue.masm
@@ -54,11 +54,11 @@ end
 # =================================================================================================
 
 #! Builds the output vault which is combination of the assets in the account vault at the end of
-#! the transaction and all the assets from the output notes.
+#! the transaction and all the assets in the output notes.
 #!
 #! The output vault is built as follows:
 #! - we first copy the account vault root to the output vault root.
-#! - we then loop over the output notes and insert the assets into the output vault.
+#! - we then loop over the output notes and insert their assets into the output vault.
 #!
 #! Stack: []
 #! Output: []
@@ -232,7 +232,7 @@ export.finalize_transaction
     exec.build_output_vault
     # => [FINAL_ACCOUNT_HASH]
 
-    # compute output note hash
+    # compute output notes commitment
     exec.note::compute_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
 

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -130,7 +130,7 @@ const.INPUT_NOTE_SECTION_OFFSET=1048576
 const.INPUT_NOTE_DATA_SECTION_OFFSET=1064960
 
 # The memory address at which the number of input notes is stored.
-const.INPUT_NOTE_NUM_PTR=1048576
+const.NUM_INPUT_NOTES_PTR=1048576
 
 # The offsets at which data of a input note is stored relative to the start of its data segment
 const.INPUT_NOTE_ID_OFFSET=0
@@ -796,8 +796,8 @@ end
 #!
 #! Where:
 #! - num_input_notes is the total number of input notes in the transaction.
-export.get_total_num_input_notes
-    push.INPUT_NOTE_NUM_PTR mem_load
+export.get_num_input_notes
+    push.NUM_INPUT_NOTES_PTR mem_load
 end
 
 #! Sets the total number of input notes in the transaction.
@@ -807,8 +807,8 @@ end
 #!
 #! Where:
 #! - num_input_notes is the total number of input notes in the transaction.
-export.set_total_num_input_notes
-    push.INPUT_NOTE_NUM_PTR mem_store
+export.set_num_input_notes
+    push.NUM_INPUT_NOTES_PTR mem_store
 end
 
 #! Computes a pointer to the memory address at which the data associated with a input note with

--- a/miden-lib/asm/miden/kernels/tx/memory.masm
+++ b/miden-lib/asm/miden/kernels/tx/memory.masm
@@ -13,11 +13,11 @@ const.ERR_NOTE_TOO_MANY_ASSETS=0x0002002A
 # The memory address at which the transaction vault root is stored
 const.TX_VAULT_ROOT_PTR=0
 
-# The memory address at which a pointer to the consumed note being executed is stored.
-const.CURRENT_CONSUMED_NOTE_PTR=1
+# The memory address at which a pointer to the input note being executed is stored.
+const.CURRENT_INPUT_NOTE_PTR=1
 
-# The memory address at which the number of created notes is stored.
-const.NUM_CREATED_NOTES_PTR=2
+# The memory address at which the number of output notes is stored.
+const.NUM_OUTPUT_NOTES_PTR=2
 
 # The memory address at which the input vault root is stored
 const.INPUT_VAULT_ROOT_PTR=3
@@ -120,43 +120,43 @@ const.ACCT_CORE_DATA_SECTION_END_OFFSET=404
 # The memory address at which the account storage slot type data beings
 const.ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET=405
 
-# CONSUMED NOTES DATA
+# INPUT NOTES DATA
 # -------------------------------------------------------------------------------------------------
 
-# The memory address at which the consumed note section begins.
-const.CONSUMED_NOTE_SECTION_OFFSET=1048576
+# The memory address at which the input note section begins.
+const.INPUT_NOTE_SECTION_OFFSET=1048576
 
-# The memory address at which the consumed note data section begins.
-const.CONSUMED_NOTE_DATA_SECTION_OFFSET=1064960
+# The memory address at which the input note data section begins.
+const.INPUT_NOTE_DATA_SECTION_OFFSET=1064960
 
-# The memory address at which the number of consumed notes is stored.
-const.CONSUMED_NOTE_NUM_PTR=1048576
+# The memory address at which the number of input notes is stored.
+const.INPUT_NOTE_NUM_PTR=1048576
 
-# The offsets at which data of a consumed note is stored relative to the start of its data segment
-const.CONSUMED_NOTE_ID_OFFSET=0
-const.CONSUMED_NOTE_CORE_DATA_OFFSET=1
-const.CONSUMED_NOTE_SERIAL_NUM_OFFSET=1
-const.CONSUMED_NOTE_SCRIPT_ROOT_OFFSET=2
-const.CONSUMED_NOTE_INPUTS_HASH_OFFSET=3
-const.CONSUMED_NOTE_ASSETS_HASH_OFFSET=4
-const.CONSUMED_NOTE_METADATA_OFFSET=5
-const.CONSUMED_NOTE_ARGS_OFFSET=6
-const.CONSUMED_NOTE_NUM_ASSETS_OFFSET=7
-const.CONSUMED_NOTE_ASSETS_OFFSET=8
+# The offsets at which data of a input note is stored relative to the start of its data segment
+const.INPUT_NOTE_ID_OFFSET=0
+const.INPUT_NOTE_CORE_DATA_OFFSET=1
+const.INPUT_NOTE_SERIAL_NUM_OFFSET=1
+const.INPUT_NOTE_SCRIPT_ROOT_OFFSET=2
+const.INPUT_NOTE_INPUTS_HASH_OFFSET=3
+const.INPUT_NOTE_ASSETS_HASH_OFFSET=4
+const.INPUT_NOTE_METADATA_OFFSET=5
+const.INPUT_NOTE_ARGS_OFFSET=6
+const.INPUT_NOTE_NUM_ASSETS_OFFSET=7
+const.INPUT_NOTE_ASSETS_OFFSET=8
 
-# CREATED NOTES
+# OUTPUT NOTES
 # -------------------------------------------------------------------------------------------------
 
-# The memory address at which the created notes section begins.
-const.CREATED_NOTE_SECTION_OFFSET=4194304
+# The memory address at which the output notes section begins.
+const.OUTPUT_NOTE_SECTION_OFFSET=4194304
 
-# The offsets at which data of a created note is stored relative to the start of its data segment.
-const.CREATED_NOTE_ID_OFFSET=0
-const.CREATED_NOTE_METADATA_OFFSET=1
-const.CREATED_NOTE_RECIPIENT_OFFSET=2
-const.CREATED_NOTE_ASSETS_HASH_OFFSET=3
-const.CREATED_NOTE_NUM_ASSETS_OFFSET=4
-const.CREATED_NOTE_ASSETS_OFFSET=5
+# The offsets at which data of a output note is stored relative to the start of its data segment.
+const.OUTPUT_NOTE_ID_OFFSET=0
+const.OUTPUT_NOTE_METADATA_OFFSET=1
+const.OUTPUT_NOTE_RECIPIENT_OFFSET=2
+const.OUTPUT_NOTE_ASSETS_HASH_OFFSET=3
+const.OUTPUT_NOTE_NUM_ASSETS_OFFSET=4
+const.OUTPUT_NOTE_ASSETS_OFFSET=5
 
 # MEMORY PROCEDURES
 # =================================================================================================
@@ -164,42 +164,42 @@ const.CREATED_NOTE_ASSETS_OFFSET=5
 # BOOK KEEPING
 # -------------------------------------------------------------------------------------------------
 
-#! Returns the number of created notes.
+#! Returns the number of output notes.
 #!
 #! Stack: []
-#! Output: [num_created_notes]
-export.get_num_created_notes
-    push.NUM_CREATED_NOTES_PTR mem_load
+#! Output: [num_output_notes]
+export.get_num_output_notes
+    push.NUM_OUTPUT_NOTES_PTR mem_load
 end
 
-#! Sets the number of created notes.
+#! Sets the number of output notes.
 #!
-#! Stack: [num_created_notes]
+#! Stack: [num_output_notes]
 #! Output: []
-export.set_num_created_notes
-    push.NUM_CREATED_NOTES_PTR mem_store
+export.set_num_output_notes
+    push.NUM_OUTPUT_NOTES_PTR mem_store
 end
 
-#! Returns a pointer to the consumed note being executed.
+#! Returns a pointer to the input note being executed.
 #!
 #! Stack: []
 #! Output: [note_ptr]
 #!
 #! Where:
-#! - note_ptr, the memory address of the data segment for the current consumed note.
-export.get_current_consumed_note_ptr
-    push.CURRENT_CONSUMED_NOTE_PTR mem_load
+#! - note_ptr, the memory address of the data segment for the current input note.
+export.get_current_input_note_ptr
+    push.CURRENT_INPUT_NOTE_PTR mem_load
 end
 
-#! Sets the current consumed note pointer to the consumed note being executed.
+#! Sets the current input note pointer to the input note being executed.
 #!
 #! Stack: [note_ptr]
 #! Output: []
 #!
 #! Where:
-#! - note_ptr, the new memory address of the data segment for the consumed note.
-export.set_current_consumed_note_ptr
-    push.CURRENT_CONSUMED_NOTE_PTR mem_store
+#! - note_ptr, the new memory address of the data segment for the input note.
+export.set_current_input_note_ptr
+    push.CURRENT_INPUT_NOTE_PTR mem_store
 end
 
 #! Returns a pointer to the memory address at which the input vault root is stored
@@ -786,53 +786,53 @@ export.get_acct_storage_slot_type_data
     # => [slot_type_info]
 end
 
-# CONSUMED NOTES
+# INPUT NOTES
 # -------------------------------------------------------------------------------------------------
 
-#! Gets the total number of consumed notes in the transaction.
+#! Gets the total number of input notes in the transaction.
 #!
 #! Stack: []
-#! Output: [num_consumed_notes]
+#! Output: [num_input_notes]
 #!
 #! Where:
-#! - num_consumed_notes is the total number of consumed notes in the transaction.
-export.get_total_num_consumed_notes
-    push.CONSUMED_NOTE_NUM_PTR mem_load
+#! - num_input_notes is the total number of input notes in the transaction.
+export.get_total_num_input_notes
+    push.INPUT_NOTE_NUM_PTR mem_load
 end
 
-#! Sets the total number of consumed notes in the transaction.
+#! Sets the total number of input notes in the transaction.
 #!
-#! Stack: [num_consumed_notes]
+#! Stack: [num_input_notes]
 #! Output: []
 #!
 #! Where:
-#! - num_consumed_notes is the total number of consumed notes in the transaction.
-export.set_total_num_consumed_notes
-    push.CONSUMED_NOTE_NUM_PTR mem_store
+#! - num_input_notes is the total number of input notes in the transaction.
+export.set_total_num_input_notes
+    push.INPUT_NOTE_NUM_PTR mem_store
 end
 
-#! Computes a pointer to the memory address at which the data associated with a consumed note with
+#! Computes a pointer to the memory address at which the data associated with a input note with
 #! index `idx` is stored.
 #!
 #! Stack: [idx]
 #! Output: [note_ptr]
 #!
 #! Where:
-#! - idx, the index of the consumed note.
-#! - note_ptr, the memory address of the data segment for the consumed note with idx.
-export.get_consumed_note_ptr
-    exec.constants::get_note_mem_size mul push.CONSUMED_NOTE_DATA_SECTION_OFFSET add
+#! - idx, the index of the input note.
+#! - note_ptr, the memory address of the data segment for the input note with `idx`.
+export.get_input_note_ptr
+    exec.constants::get_note_mem_size mul push.INPUT_NOTE_DATA_SECTION_OFFSET add
 end
 
-#! Set the note id of the consumed note.
+#! Set the note id of the input note.
 #!
 #! Stack: [note_ptr, NOTE_ID]
 #! Output: [NOTE_ID]
 #!
 #! Where:
-#! - note_ptr, the consumed note's the memory address.
+#! - note_ptr, the input note's the memory address.
 #! - NOTE_ID, the note's id.
-export.set_consumed_note_id
+export.set_input_note_id
     mem_storew
 end
 
@@ -843,89 +843,89 @@ end
 #! Output: [nullifier_ptr]
 #!
 #! Where:
-#! - idx, the index of the consumed note.
+#! - idx, the index of the input note.
 #! - nullifier_ptr, the memory address of the nullifier for note idx.
-export.get_consumed_note_nullifier_ptr
-    push.CONSUMED_NOTE_SECTION_OFFSET.1 add add
+export.get_input_note_nullifier_ptr
+    push.INPUT_NOTE_SECTION_OFFSET.1 add add
 end
 
-#! Returns the nullifier of a consumed note with `idx`.
+#! Returns the nullifier of a input note with `idx`.
 #!
 #! Stack: [idx]
 #! Output: [nullifier]
 #!
 #! Where:
-#! - idx, the index of the consumed note.
-#! - nullifier, the nullifier of the consumed note.
-export.get_consumed_note_nullifier
-    padw movup.4 push.CONSUMED_NOTE_SECTION_OFFSET.1 add add mem_loadw
+#! - idx, the index of the input note.
+#! - nullifier, the nullifier of the input note.
+export.get_input_note_nullifier
+    padw movup.4 push.INPUT_NOTE_SECTION_OFFSET.1 add add mem_loadw
 end
 
-#! Returns a pointer to the start of the consumed note core data segment for the note located at
+#! Returns a pointer to the start of the input note core data segment for the note located at
 #! the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [note_data_ptr]
 #!
 #! Where:
-#! - note_ptr, the memory address at which the consumed note data begins.
-#! - note_data_ptr, the memory address at which the consumed note core data begins.
-export.get_consumed_note_core_ptr
-    push.CONSUMED_NOTE_CORE_DATA_OFFSET add
+#! - note_ptr, the memory address at which the input note data begins.
+#! - note_data_ptr, the memory address at which the input note core data begins.
+export.get_input_note_core_ptr
+    push.INPUT_NOTE_CORE_DATA_OFFSET add
 end
 
-#! Returns the script root of a consumed note located at the specified memory address.
+#! Returns the script root of a input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [SCRIPT_HASH]
 #!
 #! Where:
-#! - note_ptr, the memory address at which the consumed note data begins.
-#! - SCRIPT_HASH, the script root of the consumed note.
-export.get_consumed_note_script_root
+#! - note_ptr, the memory address at which the input note data begins.
+#! - SCRIPT_HASH, the script root of the input note.
+export.get_input_note_script_root
     padw
-    movup.4 push.CONSUMED_NOTE_SCRIPT_ROOT_OFFSET add
+    movup.4 push.INPUT_NOTE_SCRIPT_ROOT_OFFSET add
     mem_loadw
 end
 
-#! Returns the inputs hash of a consumed note located at the specified memory address.
+#! Returns the inputs hash of a input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [INPUTS_HASH]
 #!
 #! Where:
-#! - note_ptr, the memory address at which the consumed note data begins.
-#! - INPUTS_HASH, the inputs hash of the consumed note.
-export.get_consumed_note_inputs_hash
+#! - note_ptr, the memory address at which the input note data begins.
+#! - INPUTS_HASH, the inputs hash of the input note.
+export.get_input_note_inputs_hash
     padw
-    movup.4 push.CONSUMED_NOTE_INPUTS_HASH_OFFSET add
+    movup.4 push.INPUT_NOTE_INPUTS_HASH_OFFSET add
     mem_loadw
 end
 
-#! Returns the metadata of a consumed note located at the specified memory address.
+#! Returns the metadata of a input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [METADATA]
 #!
 #! Where:
-#! - note_ptr, the memory address at which the consumed note data begins.
-#! - METADATA, the metadata of the consumed note.
-export.get_consumed_note_metadata
+#! - note_ptr, the memory address at which the input note data begins.
+#! - METADATA, the metadata of the input note.
+export.get_input_note_metadata
     padw
-    movup.4 push.CONSUMED_NOTE_METADATA_OFFSET add
+    movup.4 push.INPUT_NOTE_METADATA_OFFSET add
     mem_loadw
 end
 
-#! Sets the metadata for a consumed note located at the specified memory address.
+#! Sets the metadata for a input note located at the specified memory address.
 #!
 #! Stack: [note_ptr, NOTE_METADATA]
 #! Output: [NOTE_METADATA]
 #!
 #! Where:
-#! - note_ptr, the memory address at which the consumed note data begins.
-#! - NOTE_METADATA, the metadata of the consumed note.
-export.set_consumed_note_metadata
-    push.CONSUMED_NOTE_METADATA_OFFSET add
+#! - note_ptr, the memory address at which the input note data begins.
+#! - NOTE_METADATA, the metadata of the input note.
+export.set_input_note_metadata
+    push.INPUT_NOTE_METADATA_OFFSET add
     mem_storew
 end
 
@@ -937,103 +937,103 @@ end
 #! Where:
 #! - note_ptr, the start memory address of the note.
 #! - NOTE_ARGS, the note's args.
-export.get_consumed_note_args
+export.get_input_note_args
     padw
-    movup.4 push.CONSUMED_NOTE_ARGS_OFFSET add
+    movup.4 push.INPUT_NOTE_ARGS_OFFSET add
     mem_loadw
 end
 
-#! Sets the note args for a consumed note located at the specified memory address.
+#! Sets the note args for a input note located at the specified memory address.
 #!
 #! Stack: [note_ptr, NOTE_ARGS]
 #! Output: []
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
-#! - NOTE_ARGS are optional note args of the consumed note.
-export.set_consumed_note_args
-    push.CONSUMED_NOTE_ARGS_OFFSET add
+#! - note_ptr is the memory address at which the input note data begins.
+#! - NOTE_ARGS are optional note args of the input note.
+export.set_input_note_args
+    push.INPUT_NOTE_ARGS_OFFSET add
     mem_storew dropw
 end
 
-#! Returns the number of assets in the consumed note located at the specified memory address.
+#! Returns the number of assets in the input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [num_assets]
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
-#! - num_assets is the number of assets in the consumed note.
-export.get_consumed_note_num_assets
-    push.CONSUMED_NOTE_NUM_ASSETS_OFFSET add
+#! - note_ptr is the memory address at which the input note data begins.
+#! - num_assets is the number of assets in the input note.
+export.get_input_note_num_assets
+    push.INPUT_NOTE_NUM_ASSETS_OFFSET add
     mem_load
 end
 
-#! Sets the number of assets for a consumed note located at the specified memory address.
+#! Sets the number of assets for a input note located at the specified memory address.
 #!
 #! Stack: [note_ptr, num_assets]
 #! Output: []
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
-#! - num_assets is the number of assets in the consumed note.
-export.set_consumed_note_num_assets
-    push.CONSUMED_NOTE_NUM_ASSETS_OFFSET add
+#! - note_ptr is the memory address at which the input note data begins.
+#! - num_assets is the number of assets in the input note.
+export.set_input_note_num_assets
+    push.INPUT_NOTE_NUM_ASSETS_OFFSET add
     mem_store
 end
 
-#! Returns a pointer to the start of the assets segment for the consumed note located at
+#! Returns a pointer to the start of the assets segment for the input note located at
 #! the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [assets_ptr]
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
-#! - assets_ptr is the memory address at which the assets segment for the consumed note begins.
-export.get_consumed_note_assets_ptr
-    push.CONSUMED_NOTE_ASSETS_OFFSET add
+#! - note_ptr is the memory address at which the input note data begins.
+#! - assets_ptr is the memory address at which the assets segment for the input note begins.
+export.get_input_note_assets_ptr
+    push.INPUT_NOTE_ASSETS_OFFSET add
 end
 
-#! Returns the assets hash for the consumed note located at the specified memory address.
+#! Returns the assets hash for the input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [ASSET_HASH]
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
-#! - ASSET_HASH, sequential hash of the padded assets of a consumed note.
-export.get_consumed_note_assets_hash
+#! - note_ptr is the memory address at which the input note data begins.
+#! - ASSET_HASH, sequential hash of the padded assets of a input note.
+export.get_input_note_assets_hash
     padw
-    movup.4 push.CONSUMED_NOTE_ASSETS_HASH_OFFSET add
+    movup.4 push.INPUT_NOTE_ASSETS_HASH_OFFSET add
     mem_loadw
 end
 
-#! Returns the serial number for the consumed note located at the specified memory address.
+#! Returns the serial number for the input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [SERIAL_NUMBER]
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
+#! - note_ptr is the memory address at which the input note data begins.
 #! - SERIAL_NUMBER, the input note's serial number.
-export.get_consumed_note_serial_num
+export.get_input_note_serial_num
     padw
-    movup.4 push.CONSUMED_NOTE_SERIAL_NUM_OFFSET add
+    movup.4 push.INPUT_NOTE_SERIAL_NUM_OFFSET add
     mem_loadw
 end
 
-#! Returns the sender for the consumed note located at the specified memory address.
+#! Returns the sender for the input note located at the specified memory address.
 #!
 #! Stack: [note_ptr]
 #! Output: [sender]
 #!
 #! Where:
-#! - note_ptr is the memory address at which the consumed note data begins.
-#! - sender is the sender for the consumed note.
-export.get_consumed_note_sender
+#! - note_ptr is the memory address at which the input note data begins.
+#! - sender is the sender for the input note.
+export.get_input_note_sender
     padw
-    movup.4 push.CONSUMED_NOTE_METADATA_OFFSET add
+    movup.4 push.INPUT_NOTE_METADATA_OFFSET add
     mem_loadw
     # => [0, 0, sender, tag]
 
@@ -1041,84 +1041,84 @@ export.get_consumed_note_sender
     # => [sender]
 end
 
-# CREATED NOTES
+# OUTPUT NOTES
 # -------------------------------------------------------------------------------------------------
 
-#! Returns the offset of the created note data segment.
+#! Returns the offset of the output note data segment.
 #!
 #! Stack: []
 #! Output: [offset]
 #!
 #! Where:
-#! - offset is the offset of the created note data segment.
-export.get_created_note_data_offset
-    push.CREATED_NOTE_SECTION_OFFSET
+#! - offset is the offset of the output note data segment.
+export.get_output_note_data_offset
+    push.OUTPUT_NOTE_SECTION_OFFSET
 end
 
-#! Computes a pointer to the memory address at which the data associated with a created note with
-#! index i is stored.
+#! Computes a pointer to the memory address at which the data associated with a output note with
+#! index `i` is stored.
 #!
 #! Stack: [i]
 #! Output: [ptr]
 #!
 #! Where:
-#! - i is the index of the created note.
-#! - ptr is the memory address of the data segment for created note i.
-export.get_created_note_ptr
-    exec.constants::get_note_mem_size mul push.CREATED_NOTE_SECTION_OFFSET add
+#! - i is the index of the output note.
+#! - ptr is the memory address of the data segment for output note i.
+export.get_output_note_ptr
+    exec.constants::get_note_mem_size mul push.OUTPUT_NOTE_SECTION_OFFSET add
 end
 
-#! Returns the created note recipient
+#! Returns the output note recipient
 #!
-#! Stack: [created_note_data_ptr]
+#! Stack: [output_note_data_ptr]
 #! Output: [R]
 #!
 #! Where:
-#! - created_note_data_ptr is the memory address at which the created note data begins.
-#! - R is the recipient of the created note.
-export.get_created_note_recipient
+#! - output_note_data_ptr is the memory address at which the output note data begins.
+#! - R is the recipient of the output note.
+export.get_output_note_recipient
     padw
-    movup.4 push.CREATED_NOTE_RECIPIENT_OFFSET add
+    movup.4 push.OUTPUT_NOTE_RECIPIENT_OFFSET add
     mem_loadw
 end
 
-#! Sets the created note's recipient
+#! Sets the output note's recipient
 #!
 #! Stack: [note_ptr, RECIPIENT]
 #! Output: []
 #!
 #! Where:
 #! - recipient is the recipient of the note
-#! - note_ptr is the memory address at which the created note data begins.
-export.set_created_note_recipient
-    push.CREATED_NOTE_RECIPIENT_OFFSET add mem_storew dropw
+#! - note_ptr is the memory address at which the output note data begins.
+export.set_output_note_recipient
+    push.OUTPUT_NOTE_RECIPIENT_OFFSET add mem_storew dropw
 end
 
-#! Sets the created note's metadata
+#! Sets the output note's metadata
 #!
 #! Stack: [note_ptr, METADATA]
 #! Output: []
 #!
 #! Where:
 #! - METADATA is the note metadata
-#! - note_ptr is the memory address at which the created note data begins.
-export.set_created_note_metadata
-    push.CREATED_NOTE_METADATA_OFFSET add mem_storew dropw
+#! - note_ptr is the memory address at which the output note data begins.
+export.set_output_note_metadata
+    push.OUTPUT_NOTE_METADATA_OFFSET add mem_storew dropw
 end
 
-#! Returns the number of assets in the created note
+#! Returns the number of assets in the output note
 #!
 #! Stack: [note_ptr]
 #! Output: [num_assets]
 #!
 #! Where:
-#! - note_ptr is a pointer to the memory address at which the created note is stored.
-#! - num_assets is the number of assets in the created note.
-export.get_created_note_num_assets
-    push.CREATED_NOTE_NUM_ASSETS_OFFSET add mem_load
+#! - note_ptr is a pointer to the memory address at which the output note is stored.
+#! - num_assets is the number of assets in the output note.
+export.get_output_note_num_assets
+    push.OUTPUT_NOTE_NUM_ASSETS_OFFSET add mem_load
 end
 
-#! Sets the number of assets in the created note
+#! Sets the number of assets in the output note
 #!
 #! Stack: [note_ptr, num_assets]
 #! Output: []
@@ -1126,10 +1126,10 @@ end
 #! Panics: if the number of assets exceeds the maximum allowed number of assets per note.
 #!
 #! Where:
-#! - note_ptr is the memory address at which the created note data begins.
-#! - num_assets is the number of assets in the created note.
-export.set_created_note_num_assets
-    push.CREATED_NOTE_NUM_ASSETS_OFFSET add
+#! - note_ptr is the memory address at which the output note data begins.
+#! - num_assets is the number of assets in the output note.
+export.set_output_note_num_assets
+    push.OUTPUT_NOTE_NUM_ASSETS_OFFSET add
     # => [note_ptr + offset, num_assets]
 
     # check note number of assets limit
@@ -1138,26 +1138,26 @@ export.set_created_note_num_assets
     mem_store
 end
 
-#! Returns a pointer to the created note asset data
+#! Returns a pointer to the output note asset data
 #!
-#! Stack: [created_note_data_ptr]
+#! Stack: [output_note_data_ptr]
 #! Output: [asset_data_ptr]
 #!
 #! Where:
-#! - created_note_data_ptr is the memory address at which the created note data begins.
-#! - asset_data_ptr is the memory address at which the created note asset data begins.
-export.get_created_note_asset_data_ptr
-    push.CREATED_NOTE_ASSETS_OFFSET add
+#! - output_note_data_ptr is the memory address at which the output note data begins.
+#! - asset_data_ptr is the memory address at which the output note asset data begins.
+export.get_output_note_asset_data_ptr
+    push.OUTPUT_NOTE_ASSETS_OFFSET add
 end
 
-#! Sets the created note assets hash.
+#! Sets the output note assets hash.
 #!
-#! Stack: [created_note_data_ptr, ASSET_HASH]
+#! Stack: [output_note_data_ptr, ASSET_HASH]
 #! Output: []
 #!
 #! Where:
-#! - created_note_data_ptr is the memory address at which the created note data begins.
-#! - ASSET_HASH, sequential hash of the padded assets of a created note.
-export.set_created_note_assets_hash
-    push.CREATED_NOTE_ASSETS_HASH_OFFSET add mem_storew
+#! - output_note_data_ptr is the memory address at which the output note data begins.
+#! - ASSET_HASH, sequential hash of the padded assets of a output note.
+export.set_output_note_assets_hash
+    push.OUTPUT_NOTE_ASSETS_HASH_OFFSET add mem_storew
 end

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -36,8 +36,8 @@ const.OUTPUT_NOTE_HASHING_MEM_DIFF=510
 #!
 #! - sender is the sender of the note currently being processed.
 export.get_sender
-    # get the current consumed note pointer
-    exec.memory::get_current_consumed_note_ptr
+    # get the current input note pointer
+    exec.memory::get_current_input_note_ptr
     # => [ptr]
 
     # assert the pointer is not zero - this would suggest the procedure has been called from an
@@ -46,7 +46,7 @@ export.get_sender
     # => [ptr]
 
     # get the sender from the note pointer
-    exec.memory::get_consumed_note_sender
+    exec.memory::get_input_note_sender
     # => [sender]
 end
 
@@ -59,8 +59,8 @@ end
 #! - num_assets is the number of assets in the note currently being processed.
 #! - VAULT_HASH is the vault hash of the note currently being processed.
 export.get_vault_info
-    # get the current consumed note pointer
-    exec.memory::get_current_consumed_note_ptr
+    # get the current input note pointer
+    exec.memory::get_current_input_note_ptr
     # => [ptr]
 
     # assert the pointer is not zero - this would suggest the procedure has been called from an
@@ -69,11 +69,11 @@ export.get_vault_info
     # => [ptr]
 
     # get the number of assets in the note
-    dup exec.memory::get_consumed_note_num_assets
+    dup exec.memory::get_input_note_num_assets
     # => [num_assets, ptr]
 
     # get the vault hash from the note pointer
-    swap exec.memory::get_consumed_note_assets_hash
+    swap exec.memory::get_input_note_assets_hash
     # => [VAULT_HASH, num_assets]
 end
 
@@ -87,7 +87,7 @@ end
 #! Where:
 #! - NOTE_INPUTS_HASH is the note inputs hash of the note currently being processed.
 export.get_note_inputs_hash
-    exec.memory::get_current_consumed_note_ptr
+    exec.memory::get_current_input_note_ptr
     # => [ptr]
 
     # The kernel memory is initialized by prologue::process_input_notes_data, and reset by
@@ -96,39 +96,39 @@ export.get_note_inputs_hash
     dup neq.0 assert.err=ERR_NOTE_INVALID_INPUTS
     # => [ptr]
 
-    exec.memory::get_consumed_note_inputs_hash
+    exec.memory::get_input_note_inputs_hash
     # => [NOTE_INPUTS_HASH]
 end
 
-#! Increment current consumed note pointer to the next note and returns the pointer value.
+#! Increment current input note pointer to the next note and returns the pointer value.
 #!
 #! Inputs: []
-#! Outputs: [current_consumed_note_ptr]
+#! Outputs: [current_input_note_ptr]
 #!
 #! Where:
-#! - current_consumed_note_ptr is the pointer to the next note to be processed.
-export.increment_current_consumed_note_ptr
-    # get the current consumed note pointer
-    exec.memory::get_current_consumed_note_ptr
-    # => [orig_consumed_note_ptr]
+#! - current_input_note_ptr is the pointer to the next note to be processed.
+export.increment_current_input_note_ptr
+    # get the current input note pointer
+    exec.memory::get_current_input_note_ptr
+    # => [orig_input_note_ptr]
 
     # increment the pointer
     exec.constants::get_note_mem_size add
-    # => [current_consumed_note_ptr]
+    # => [current_input_note_ptr]
 
-    # set the current consumed note pointer to the incremented value
-    dup exec.memory::set_current_consumed_note_ptr
-    # => [current_consumed_note_ptr]
+    # set the current input note pointer to the incremented value
+    dup exec.memory::set_current_input_note_ptr
+    # => [current_input_note_ptr]
 end
 
-#! Sets the current consumed note pointer to 0. This should be called after all consumed notes have
+#! Sets the current input note pointer to 0. This should be called after all input notes have
 #! been processed.
 #!
 #! Inputs: []
 #! Outputs: []
 export.note_processing_teardown
-    # set the current consumed note pointer to 0
-    push.0 exec.memory::set_current_consumed_note_ptr
+    # set the current input note pointer to 0
+    push.0 exec.memory::set_current_input_note_ptr
     # => []
 end
 
@@ -143,13 +143,13 @@ end
 #! - NOTE_SCRIPT_ROOT, the note's script root.
 #! - NOTE_ARGS, the note's arguments.
 export.prepare_note
-    exec.memory::get_current_consumed_note_ptr
+    exec.memory::get_current_input_note_ptr
     # => [note_ptr]
 
-    dup exec.memory::get_consumed_note_args movup.4
+    dup exec.memory::get_input_note_args movup.4
     # => [note_ptr, NOTE_ARGS]
 
-    exec.memory::get_consumed_note_script_root
+    exec.memory::get_input_note_script_root
     # => [NOTE_SCRIPT_ROOT, NOTE_ARGS]
 end
 
@@ -169,7 +169,7 @@ end
 #! - ASSETS_HASH is the hash of the assets of the output note located at note_data_ptr.
 proc.compute_output_note_assets_hash
     # duplicate note pointer and fetch num_assets
-    dup dup exec.memory::get_created_note_num_assets
+    dup dup exec.memory::get_output_note_num_assets
     # => [num_assets, note_data_ptr, note_data_ptr]
 
     # calculate the number of pairs of assets (takes ceiling if we have an odd number)
@@ -183,7 +183,7 @@ proc.compute_output_note_assets_hash
     # => [asset_counter, num_asset_pairs, note_data_ptr, note_data_ptr]
 
     # prepare address and stack for reading assets
-    movup.2 exec.memory::get_created_note_asset_data_ptr padw padw padw
+    movup.2 exec.memory::get_output_note_asset_data_ptr padw padw padw
     # => [PAD, PAD, PAD, asset_data_ptr, asset_counter, num_asset_pairs, note_data_ptr]
 
     # check if we should loop
@@ -215,7 +215,7 @@ proc.compute_output_note_assets_hash
     # => [ASSETS_HASH, note_data_ptr]
 
     # save vault hash to memory
-    movup.4 exec.memory::set_created_note_assets_hash
+    movup.4 exec.memory::set_output_note_assets_hash
     # => []
 end
 
@@ -237,7 +237,7 @@ proc.compute_output_note_id
     padw
 
     # insert output note recipient into the first four elements of the hasher rate
-    dup.4 exec.memory::get_created_note_recipient
+    dup.4 exec.memory::get_output_note_recipient
 
     # populate the last four elements of the hasher rate with the output note's asset hash
     dup.8 exec.compute_output_note_assets_hash
@@ -255,18 +255,18 @@ end
 #! Stack: []
 #! Output: [OUTPUT_NOTES_COMMITMENT]
 #!
-#! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes created by the transaction.
+#! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes output by the transaction.
 export.compute_output_notes_commitment
     # get the number of output notes from memory
-    exec.memory::get_num_created_notes
+    exec.memory::get_num_output_notes
     # => [num_notes, ...]
 
     # calculate the address at which we should stop looping
-    exec.memory::get_created_note_ptr
+    exec.memory::get_output_note_ptr
     # => [end_ptr, ...]
 
     # compute pointer for first address
-    push.0 exec.memory::get_created_note_ptr
+    push.0 exec.memory::get_output_note_ptr
     # => [first_note_ptr, end_ptr, ...]
 
     # prepare stack for hashing
@@ -318,9 +318,9 @@ end
 #!
 #! - SERIAL_NUMBER is the serial number of the note currently being processed.
 export.get_serial_number
-    exec.memory::get_current_consumed_note_ptr
+    exec.memory::get_current_input_note_ptr
     # => [note_ptr, ...]
 
-    exec.memory::get_consumed_note_serial_num
+    exec.memory::get_input_note_serial_num
     # => [SERIAL_NUMBER, ...]
 end

--- a/miden-lib/asm/miden/kernels/tx/note.masm
+++ b/miden-lib/asm/miden/kernels/tx/note.masm
@@ -50,15 +50,15 @@ export.get_sender
     # => [sender]
 end
 
-#! Returns the number of assets and vault hash of the note currently being processed. Panics if a
-#! note is not being processed.
+#! Returns the number of assets and the assets hash of the note currently being processed. Panics
+#! if a note is not being processed.
 #!
 #! Inputs: []
-#! Outputs: [VAULT_HASH, num_assets]
+#! Outputs: [ASSETS_HASH, num_assets]
 #!
 #! - num_assets is the number of assets in the note currently being processed.
-#! - VAULT_HASH is the vault hash of the note currently being processed.
-export.get_vault_info
+#! - ASSETS_HASH is the vault hash of the note currently being processed.
+export.get_assets_info
     # get the current input note pointer
     exec.memory::get_current_input_note_ptr
     # => [ptr]
@@ -72,9 +72,9 @@ export.get_vault_info
     dup exec.memory::get_input_note_num_assets
     # => [num_assets, ptr]
 
-    # get the vault hash from the note pointer
+    # get the assets hash from the note pointer
     swap exec.memory::get_input_note_assets_hash
-    # => [VAULT_HASH, num_assets]
+    # => [ASSETS_HASH, num_assets]
 end
 
 #! Returns the commitment to the note's inputs.
@@ -100,7 +100,7 @@ export.get_note_inputs_hash
     # => [NOTE_INPUTS_HASH]
 end
 
-#! Increment current input note pointer to the next note and returns the pointer value.
+#! Move the current input note pointer to the next note and returns the pointer value.
 #!
 #! Inputs: []
 #! Outputs: [current_input_note_ptr]
@@ -242,10 +242,10 @@ proc.compute_output_note_id
     # populate the last four elements of the hasher rate with the output note's asset hash
     dup.8 exec.compute_output_note_assets_hash
 
-    # compute output note hash and extract digest
+    # compute output note commitment and extract digest
     hperm exec.native::state_to_digest
 
-    # save output note hash to memory
+    # save the output notes commitment to memory
     movup.4 mem_storew
 end
 

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -113,14 +113,14 @@ end
 #! Where:
 #! - PREVIOUS_BLOCK_HASH, hash of the previous block.
 #! - CHAIN_MMR_HASH, sequential hash of the reference MMR.
-#! - ACCOUNT_ROOT, rollup tree with latest account states.
-#! - NULLIFIER_ROOT, epoch tree with the nullifiers of input notes.
+#! - ACCOUNT_ROOT, root of the tree with latest account states for all accounts.
+#! - NULLIFIER_ROOT, root of the tree with nullifiers of all notes that have ever been consumed.
 #! - TX_HASH, commitment to a set of IDs of transactions which affected accounts in the block.
 #! - PROOF_HASH, hash of the block's stark proof.
 #! - block_num, the reference block number.
 #! - version, current protocol version.
 #! - timestamp, current timestamp.
-#! - NOTE_ROOT, epoch tree with output notes.
+#! - NOTE_ROOT, root of the tree with all notes created in the block.
 proc.process_block_data
     exec.memory::get_block_data_ptr
     # => [block_data_ptr]
@@ -754,7 +754,7 @@ proc.add_input_note_assets_to_vault
     # => []
 end
 
-#! Computes the inpute note's id.
+#! Computes an input note's id.
 #!
 #! Stack: [note_ptr]
 #! Output: [NOTE_ID]
@@ -762,7 +762,7 @@ end
 #! Where:
 #! - note_ptr, memory location for the input note.
 #! - NOTE_ID, the note's id, i.e. `hash(RECIPIENT || ASSET_HASH)`.
-proc.compute_note_id
+proc.compute_input_note_id
     # compute SERIAL_HASH: hash(SERIAL_NUMBER || EMPTY_WORD)
     dup exec.memory::get_input_note_serial_num padw hmerge
     # => [SERIAL_HASH, note_ptr]
@@ -861,7 +861,7 @@ proc.process_input_note
     # note id
     # ---------------------------------------------------------------------------------------------
 
-    dup exec.compute_note_id
+    dup exec.compute_input_note_id
     # => [NOTE_ID, note_ptr, NOTE_METADATA, NULLIFIER, HASHER_CAPACITY]
 
     # save note id to memory
@@ -929,7 +929,7 @@ proc.process_input_notes_data
     # => [num_notes]
 
     # store the number of input notes into kernel memory
-    dup exec.memory::set_total_num_input_notes
+    dup exec.memory::set_num_input_notes
     # => [num_notes]
 
     # loop over input notes and read data
@@ -1057,14 +1057,14 @@ end
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
 #! - PREVIOUS_BLOCK_HASH, hash of the previous block.
 #! - CHAIN_MMR_HASH, sequential hash of the reference MMR.
-#! - ACCOUNT_ROOT, tree with latest account states.
-#! - NULLIFIER_ROOT, epoch tree with nullifiers of input notes.
+#! - ACCOUNT_ROOT, root of the tree with latest account states for all accounts.
+#! - NULLIFIER_ROOT, root of the tree with nullifiers of all notes that have ever been consumed.
 #! - TX_HASH, commitment to a set of IDs of transactions which affected accounts in the block.
 #! - PROOF_HASH, hash of the block's stark proof.
 #! - block_num, the reference block number.
 #! - version, the current protocol version.
 #! - timestamp, the current timestamp.
-#! - NOTE_ROOT, tree with output notes.
+#! - NOTE_ROOT, root of the tree with all notes created in the block.
 #! - account_nonce, account's nonce.
 #! - ACCOUNT_VAULT_ROOT, account's vault root.
 #! - ACCOUNT_STORAGE_ROOT, account's storage root.

--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -114,13 +114,13 @@ end
 #! - PREVIOUS_BLOCK_HASH, hash of the previous block.
 #! - CHAIN_MMR_HASH, sequential hash of the reference MMR.
 #! - ACCOUNT_ROOT, rollup tree with latest account states.
-#! - NULLIFIER_ROOT, epoch tree with the nullifiers of consumed notes.
+#! - NULLIFIER_ROOT, epoch tree with the nullifiers of input notes.
 #! - TX_HASH, commitment to a set of IDs of transactions which affected accounts in the block.
 #! - PROOF_HASH, hash of the block's stark proof.
 #! - block_num, the reference block number.
 #! - version, current protocol version.
 #! - timestamp, current timestamp.
-#! - NOTE_ROOT, epoch tree with created notes.
+#! - NOTE_ROOT, epoch tree with output notes.
 proc.process_block_data
     exec.memory::get_block_data_ptr
     # => [block_data_ptr]
@@ -578,7 +578,7 @@ end
 #! - ASSETS_HASH, sequential hash of the padded note's assets.
 #! - NULLIFIER result of `hash(SERIAL_NUMBER || SCRIPT_ROOT || INPUTS_HASH || ASSETS_HASH)`.
 proc.process_input_note_details
-    exec.memory::get_consumed_note_core_ptr
+    exec.memory::get_input_note_core_ptr
     # => [note_data_ptr]
 
     # read input note's data and compute its digest. See `Advice stack` above for details.
@@ -615,10 +615,10 @@ end
 #! - NOTE_ARGS, user arguments passed to the note.
 #! - NOTE_METADATA, note's metadata.
 proc.process_note_args_and_metadata
-    padw adv_loadw dup.4 exec.memory::set_consumed_note_args
+    padw adv_loadw dup.4 exec.memory::set_input_note_args
     # => [note_ptr]
 
-    padw adv_loadw movup.4 exec.memory::set_consumed_note_metadata
+    padw adv_loadw movup.4 exec.memory::set_input_note_metadata
     # => [NOTE_METADATA]
 end
 
@@ -645,7 +645,7 @@ proc.process_note_assets
     dup exec.constants::get_max_assets_per_note lte assert.err=ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS
     # => [assets_count, note_ptr]
 
-    dup dup.2 exec.memory::set_consumed_note_num_assets
+    dup dup.2 exec.memory::set_input_note_num_assets
     # => [assets_count, note_ptr]
 
     # round up the number of assets, to the its padded length
@@ -667,7 +667,7 @@ proc.process_note_assets
     push.0 movup.2
     # => [note_ptr, counter, rounded_num_assets]
 
-    dup exec.memory::get_consumed_note_assets_ptr
+    dup exec.memory::get_input_note_assets_ptr
     # => [assets_ptr, note_ptr, counter, rounded_num_assets]
 
     padw padw padw
@@ -700,7 +700,7 @@ proc.process_note_assets
     # => [note_ptr, ASSET_HASH_COMPUTED]
 
     # VERIFY: computed ASSET_HASH matches the provided hash
-    exec.memory::get_consumed_note_assets_hash
+    exec.memory::get_input_note_assets_hash
     assert_eqw.err=ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH
     # => []
 end
@@ -719,10 +719,10 @@ proc.add_input_note_assets_to_vault
     exec.memory::get_input_vault_root_ptr
     # => [input_vault_root_ptr, note_ptr]
 
-    dup.1 exec.memory::get_consumed_note_assets_ptr
+    dup.1 exec.memory::get_input_note_assets_ptr
     # => [assets_start_ptr, input_vault_root_ptr, note_ptr]
 
-    dup movup.3 exec.memory::get_consumed_note_num_assets add swap
+    dup movup.3 exec.memory::get_input_note_num_assets add swap
     # => [assets_start_ptr, assets_end_ptr, input_vault_root_ptr]
 
     # add input note's assets to input vault
@@ -764,19 +764,19 @@ end
 #! - NOTE_ID, the note's id, i.e. `hash(RECIPIENT || ASSET_HASH)`.
 proc.compute_note_id
     # compute SERIAL_HASH: hash(SERIAL_NUMBER || EMPTY_WORD)
-    dup exec.memory::get_consumed_note_serial_num padw hmerge
+    dup exec.memory::get_input_note_serial_num padw hmerge
     # => [SERIAL_HASH, note_ptr]
 
     # compute MERGE_SCRIPT: hash(SERIAL_HASH || SCRIPT_HASH)
-    dup.4 exec.memory::get_consumed_note_script_root hmerge
+    dup.4 exec.memory::get_input_note_script_root hmerge
     # => [MERGE_SCRIPT, note_ptr]
 
     # compute RECIPIENT: hash(MERGE_SCRIPT || INPUT_HASH)
-    dup.4 exec.memory::get_consumed_note_inputs_hash hmerge
+    dup.4 exec.memory::get_input_note_inputs_hash hmerge
     # => [RECIPIENT, note_ptr]
 
     # compute NOTE_ID: hash(RECIPIENT || ASSET_HASH)
-    movup.4 exec.memory::get_consumed_note_assets_hash hmerge
+    movup.4 exec.memory::get_input_note_assets_hash hmerge
     # => [NOTE_ID]
 end
 
@@ -829,14 +829,14 @@ proc.process_input_note
     # note details
     # ---------------------------------------------------------------------------------------------
 
-    dup exec.memory::get_consumed_note_ptr dup
+    dup exec.memory::get_input_note_ptr dup
     # => [note_ptr, note_ptr, idx, HASHER_CAPACITY]
 
     exec.process_input_note_details
     # => [NULLIFIER, note_ptr, idx, HASHER_CAPACITY]
 
     # save NULLIFIER to memory
-    movup.5 exec.memory::get_consumed_note_nullifier_ptr mem_storew
+    movup.5 exec.memory::get_input_note_nullifier_ptr mem_storew
     # => [NULLIFIER, note_ptr, HASHER_CAPACITY]
 
     # note metadata & args
@@ -865,7 +865,7 @@ proc.process_input_note
     # => [NOTE_ID, note_ptr, NOTE_METADATA, NULLIFIER, HASHER_CAPACITY]
 
     # save note id to memory
-    movup.4 exec.memory::set_consumed_note_id
+    movup.4 exec.memory::set_input_note_id
     # => [NOTE_ID, NOTE_METADATA, NULLIFIER, HASHER_CAPACITY]
 
     # note authentication
@@ -917,7 +917,7 @@ proc.process_input_notes_data
     # assert the number of input notes is within limits; since max number of input notes is
     # expected to be smaller than 2^32, we can use a more efficient u32 comparison
     dup
-    exec.constants::get_max_num_consumed_notes u32assert2.err=ERR_PROLOGUE_TOO_MANY_INPUT_NOTES
+    exec.constants::get_max_num_input_notes u32assert2.err=ERR_PROLOGUE_TOO_MANY_INPUT_NOTES
     u32lte assert.err=ERR_PROLOGUE_TOO_MANY_INPUT_NOTES
     # => [num_notes]
 
@@ -929,7 +929,7 @@ proc.process_input_notes_data
     # => [num_notes]
 
     # store the number of input notes into kernel memory
-    dup exec.memory::set_total_num_consumed_notes
+    dup exec.memory::set_total_num_input_notes
     # => [num_notes]
 
     # loop over input notes and read data
@@ -983,8 +983,8 @@ proc.process_input_notes_data
 
     # set the current input note ptr to the address of the first input note
     push.0
-    exec.memory::get_consumed_note_ptr
-    exec.memory::set_current_consumed_note_ptr
+    exec.memory::get_input_note_ptr
+    exec.memory::set_current_input_note_ptr
     # => [idx+1, num_notes]
 
     drop drop
@@ -1058,13 +1058,13 @@ end
 #! - PREVIOUS_BLOCK_HASH, hash of the previous block.
 #! - CHAIN_MMR_HASH, sequential hash of the reference MMR.
 #! - ACCOUNT_ROOT, tree with latest account states.
-#! - NULLIFIER_ROOT, epoch tree with nullifiers of consumed notes.
+#! - NULLIFIER_ROOT, epoch tree with nullifiers of input notes.
 #! - TX_HASH, commitment to a set of IDs of transactions which affected accounts in the block.
 #! - PROOF_HASH, hash of the block's stark proof.
 #! - block_num, the reference block number.
 #! - version, the current protocol version.
 #! - timestamp, the current timestamp.
-#! - NOTE_ROOT, tree with created notes.
+#! - NOTE_ROOT, tree with output notes.
 #! - account_nonce, account's nonce.
 #! - ACCOUNT_VAULT_ROOT, account's vault root.
 #! - ACCOUNT_STORAGE_ROOT, account's storage root.

--- a/miden-lib/asm/miden/kernels/tx/tx.masm
+++ b/miden-lib/asm/miden/kernels/tx/tx.masm
@@ -9,7 +9,7 @@ use.miden::kernels::tx::note
 
 # Constants for different note types
 const.PUBLIC_NOTE=1     # 0b01
-const.OFFCHAIN_NOTE=2   # 0b10
+const.PRIVATE_NOTE=2   # 0b10
 const.ENCRYPTED_NOTE=3  # 0b11
 
 # ERRORS
@@ -108,21 +108,21 @@ export.memory::get_input_notes_commitment
 #! COM is the output notes hash.
 export.note::compute_output_notes_commitment->get_output_notes_hash
 
-#! Increments the number of created notes by one. Returns the index of the next note to be created.
+#! Increments the number of output notes by one. Returns the index of the next note to be created.
 #!
 #! Inputs: []
 #! Outputs: [note_idx]
-proc.increment_num_created_notes
-    # get the current number of created notes
-    exec.memory::get_num_created_notes
+proc.increment_num_output_notes
+    # get the current number of output notes
+    exec.memory::get_num_output_notes
     # => [note_idx]
 
     # assert that there is space for a new note
-    dup exec.constants::get_max_num_created_notes lt assert.err=ERR_TX_OUTPUT_NOTES_OVERFLOW
+    dup exec.constants::get_max_num_output_notes lt assert.err=ERR_TX_OUTPUT_NOTES_OVERFLOW
     # => [note_idx]
 
-    # increment the number of created notes
-    dup add.1 exec.memory::set_num_created_notes
+    # increment the number of output notes
+    dup add.1 exec.memory::set_num_output_notes
     # => [note_idx]
 end
 
@@ -133,7 +133,7 @@ end
 #! Inputs: [ASSET, note_ptr, num_of_assets, note_idx]
 #! Outputs: [note_ptr, note_idx]
 proc.add_non_fungible_asset_to_note
-    dup.4 exec.memory::get_created_note_asset_data_ptr
+    dup.4 exec.memory::get_output_note_asset_data_ptr
     # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
 
     # compute the pointer at which we should stop iterating
@@ -171,7 +171,7 @@ proc.add_non_fungible_asset_to_note
     # => [note_ptr, num_of_assets, note_idx]
 
     # increase the number of assets in the note
-    swap add.1 dup.1 exec.memory::set_created_note_num_assets
+    swap add.1 dup.1 exec.memory::set_output_note_num_assets
     # => [note_ptr, note_idx]
 end
 
@@ -184,7 +184,7 @@ end
 #! Inputs: [ASSET, note_ptr, num_of_assets, note_idx]
 #! Outputs: [note_ptr]
 proc.add_fungible_asset_to_note
-    dup.4 exec.memory::get_created_note_asset_data_ptr
+    dup.4 exec.memory::get_output_note_asset_data_ptr
     # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
 
     # compute the pointer at which we should stop iterating
@@ -247,7 +247,7 @@ proc.add_fungible_asset_to_note
     # => [note_ptr, num_of_assets, note_idx]
 
     # increase the number of assets in the note
-    swap add.1 dup.1 exec.memory::set_created_note_num_assets
+    swap add.1 dup.1 exec.memory::set_output_note_num_assets
     # => [note_ptr, note_idx]
 end
 
@@ -266,14 +266,14 @@ end
 #! - the note_type is not valid.
 #! - the note_tag is not an u32.
 #! - if note_tag starts with anything but 0b11 and note_type is not public.
-#! - the number of created notes exceeds the maximum limit of 4096.
+#! - the number of output notes exceeds the maximum limit of 4096.
 export.create_note
     push.0 drop                                             # TODO: remove line, see miden-vm/#1122
     emit.NOTE_BEFORE_CREATED_EVENT
 
     # validate the note type
     # NOTE: encrypted notes are currently unsupported
-    dup.2 push.OFFCHAIN_NOTE eq dup.3 push.PUBLIC_NOTE eq or assert.err=ERR_INVALID_NOTE_TYPE
+    dup.2 push.PRIVATE_NOTE eq dup.3 push.PUBLIC_NOTE eq or assert.err=ERR_INVALID_NOTE_TYPE
     # => [tag, aux, note_type, RECIPIENT]
 
     # copy data to validate the tag
@@ -288,11 +288,11 @@ export.create_note
     # => [tag, aux, note_type, RECIPIENT]
 
     # get the index for the next note to be created and increment counter
-    exec.increment_num_created_notes dup movdn.8
+    exec.increment_num_output_notes dup movdn.8
     # => [note_idx, tag, aux, note_type, RECIPIENT, note_idx]
 
     # get a pointer to the memory address at which the note will be stored
-    exec.memory::get_created_note_ptr
+    exec.memory::get_output_note_ptr
     # => [note_ptr, tag, aux, note_type, RECIPIENT, note_idx]
 
     # populate the metadata
@@ -302,12 +302,12 @@ export.create_note
     # emit event to signal that a new note is created
     emit.NOTE_AFTER_CREATED_EVENT
 
-    # set the metadata for the created note
-    dup.4 exec.memory::set_created_note_metadata
+    # set the metadata for the output note
+    dup.4 exec.memory::set_output_note_metadata
     # => [note_ptr, RECIPIENT, note_idx]
 
-    # set the RECIPIENT for the created note
-    exec.memory::set_created_note_recipient
+    # set the RECIPIENT for the output note
+    exec.memory::set_output_note_recipient
     # => [note_idx]
 end
 
@@ -326,15 +326,15 @@ end
 #! - the total number of ASSETs exceeds the maximum of 256.
 export.add_asset_to_note
     # check if the note exists, it must be within [0, num_of_notes]
-    dup exec.memory::get_num_created_notes lte assert.err=ERR_INVALID_NOTE_IDX
+    dup exec.memory::get_num_output_notes lte assert.err=ERR_INVALID_NOTE_IDX
     # => [note_idx, ASSET]
 
     # get a pointer to the memory address of the note at which the asset will be stored
-    dup movdn.5 exec.memory::get_created_note_ptr
+    dup movdn.5 exec.memory::get_output_note_ptr
     # => [note_ptr, ASSET, note_idx]
 
     # get current num of assets
-    dup exec.memory::get_created_note_num_assets movdn.5
+    dup exec.memory::get_output_note_num_assets movdn.5
     # => [note_ptr, ASSET, num_of_assets, note_idx]
 
     # validate the ASSET

--- a/miden-lib/asm/miden/kernels/tx/tx.masm
+++ b/miden-lib/asm/miden/kernels/tx/tx.masm
@@ -9,7 +9,7 @@ use.miden::kernels::tx::note
 
 # Constants for different note types
 const.PUBLIC_NOTE=1     # 0b01
-const.PRIVATE_NOTE=2   # 0b10
+const.PRIVATE_NOTE=2    # 0b10
 const.ENCRYPTED_NOTE=3  # 0b11
 
 # ERRORS

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -49,21 +49,21 @@ export.get_assets
     padw push.0
     # => [0, 0, 0, 0, 0, dest_ptr]
 
-    # get the current input note vault hash
-    syscall.get_note_vault_info
-    # => [VAULT_HASH, num_assets, dest_ptr]
+    # get the current input note assets info
+    syscall.get_note_assets_info
+    # => [ASSETS_HASH, num_assets, dest_ptr]
 
-    # load the vault data from the advice map to the advice stack
+    # load the asset data from the advice map to the advice stack
     adv.push_mapval
-    # => [VAULT_HASH, num_assets, dest_ptr]
+    # => [ASSETS_HASH, num_assets, dest_ptr]
 
     # calculate number of assets rounded up to an even number
     dup.4 dup is_odd add
-    # => [even_num_assets, VAULT_HASH, num_assets, dest_ptr]
+    # => [even_num_assets, ASSETS_HASH, num_assets, dest_ptr]
 
     # calculate the start and end pointer for reading to memory
     dup.6 add dup.6
-    # => [start_ptr, end_ptr, VAULT_HASH, num_assets, dest_ptr]
+    # => [start_ptr, end_ptr, ASSETS_HASH, num_assets, dest_ptr]
 
     # write the data from the advice stack into memory
     exec.write_advice_data_to_memory

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -49,7 +49,7 @@ export.get_assets
     padw push.0
     # => [0, 0, 0, 0, 0, dest_ptr]
 
-    # get the current consumed note vault hash
+    # get the current input note vault hash
     syscall.get_note_vault_info
     # => [VAULT_HASH, num_assets, dest_ptr]
 

--- a/miden-lib/asm/note_scripts/SWAP.masm
+++ b/miden-lib/asm/note_scripts/SWAP.masm
@@ -4,7 +4,7 @@ use.miden::contracts::wallets::basic->wallet
 # CONSTANTS
 # =================================================================================================
 
-const.OFFCHAIN_NOTE=2
+const.PRIVATE_NOTE=2
 
 # ERRORS
 # =================================================================================================
@@ -68,7 +68,7 @@ begin
     drop drop drop movdn.4
     # => [ASSET, tag, RECIPIENT]
 
-    push.OFFCHAIN_NOTE movdn.5
+    push.PRIVATE_NOTE movdn.5
     # => [ASSET, tag, note_type, RECIPIENT]
 
     # we add aux = 0 to the note assuming we don't need it for the second leg of the SWAP

--- a/miden-lib/src/tests/mod.rs
+++ b/miden-lib/src/tests/mod.rs
@@ -8,7 +8,7 @@ use miden_objects::assembly::Library;
 
 #[test]
 fn test_compile() {
-    let path = "miden::kernels::tx::memory::get_consumed_note_ptr";
+    let path = "miden::kernels::tx::memory::get_input_note_ptr";
     let miden = super::MidenLib::default();
     let exists = miden.modules().any(|module| {
         module

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -27,11 +27,11 @@ pub const SLOT_TYPES_COMMITMENT_STORAGE_SLOT: StorageSlot = 255;
 /// The memory address at which the transaction vault root is stored.
 pub const TX_VAULT_ROOT_PTR: MemoryAddress = 0;
 
-/// The memory address at which a pointer to the consumed note being executed is stored.
-pub const CURRENT_CONSUMED_NOTE_PTR: MemoryAddress = 1;
+/// The memory address at which a pointer to the input note being executed is stored.
+pub const CURRENT_INPUT_NOTE_PTR: MemoryAddress = 1;
 
-/// The memory address at which the number of created notes is stored.
-pub const NUM_CREATED_NOTES_PTR: MemoryAddress = 2;
+/// The memory address at which the number of output notes is stored.
+pub const NUM_OUTPUT_NOTES_PTR: MemoryAddress = 2;
 
 /// The memory address at which the input vault root is stored
 pub const INPUT_VAULT_ROOT_PTR: MemoryAddress = 3;
@@ -203,25 +203,25 @@ pub const NOTE_MEM_SIZE: MemoryAddress = 512;
 // - INPUTS_HASH is the key to look up note inputs in the advice map.
 // - ASSETS_HASH is the key to look up note assets in the advice map.
 
-/// The memory address at which the consumed note section begins.
-pub const CONSUMED_NOTE_SECTION_OFFSET: MemoryOffset = 1_048_576;
+/// The memory address at which the input note section begins.
+pub const INPUT_NOTE_SECTION_OFFSET: MemoryOffset = 1_048_576;
 
-/// The memory address at which the consumed note data section begins.
-pub const CONSUMED_NOTE_DATA_SECTION_OFFSET: MemoryAddress = 1_064_960;
+/// The memory address at which the input note data section begins.
+pub const INPUT_NOTE_DATA_SECTION_OFFSET: MemoryAddress = 1_064_960;
 
-/// The memory address at which the number of consumed notes is stored.
-pub const CONSUMED_NOTE_NUM_PTR: MemoryAddress = CONSUMED_NOTE_SECTION_OFFSET;
+/// The memory address at which the number of input notes is stored.
+pub const INPUT_NOTE_NUM_PTR: MemoryAddress = INPUT_NOTE_SECTION_OFFSET;
 
-/// The offsets at which data of a consumed note is stored relative to the start of its data segment.
-pub const CONSUMED_NOTE_ID_OFFSET: MemoryOffset = 0;
-pub const CONSUMED_NOTE_SERIAL_NUM_OFFSET: MemoryOffset = 1;
-pub const CONSUMED_NOTE_SCRIPT_ROOT_OFFSET: MemoryOffset = 2;
-pub const CONSUMED_NOTE_INPUTS_HASH_OFFSET: MemoryOffset = 3;
-pub const CONSUMED_NOTE_ASSETS_HASH_OFFSET: MemoryOffset = 4;
-pub const CONSUMED_NOTE_METADATA_OFFSET: MemoryOffset = 5;
-pub const CONSUMED_NOTE_ARGS_OFFSET: MemoryOffset = 6;
-pub const CONSUMED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 7;
-pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 8;
+/// The offsets at which data of a input note is stored relative to the start of its data segment.
+pub const INPUT_NOTE_ID_OFFSET: MemoryOffset = 0;
+pub const INPUT_NOTE_SERIAL_NUM_OFFSET: MemoryOffset = 1;
+pub const INPUT_NOTE_SCRIPT_ROOT_OFFSET: MemoryOffset = 2;
+pub const INPUT_NOTE_INPUTS_HASH_OFFSET: MemoryOffset = 3;
+pub const INPUT_NOTE_ASSETS_HASH_OFFSET: MemoryOffset = 4;
+pub const INPUT_NOTE_METADATA_OFFSET: MemoryOffset = 5;
+pub const INPUT_NOTE_ARGS_OFFSET: MemoryOffset = 6;
+pub const INPUT_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 7;
+pub const INPUT_NOTE_ASSETS_OFFSET: MemoryOffset = 8;
 
 // OUTPUT NOTES DATA
 // ------------------------------------------------------------------------------------------------
@@ -244,16 +244,16 @@ pub const CONSUMED_NOTE_ASSETS_OFFSET: MemoryOffset = 8;
 // Even though NUM_ASSETS takes up a while word, the actual value of this variable is stored in the
 // first element of the word.
 
-/// The memory address at which the created notes section begins.
-pub const CREATED_NOTE_SECTION_OFFSET: MemoryOffset = 4_194_304;
+/// The memory address at which the output notes section begins.
+pub const OUTPUT_NOTE_SECTION_OFFSET: MemoryOffset = 4_194_304;
 
-/// The size of the core created note data segment.
-pub const CREATED_NOTE_CORE_DATA_SIZE: MemSize = 4;
+/// The size of the core output note data segment.
+pub const OUTPUT_NOTE_CORE_DATA_SIZE: MemSize = 4;
 
-/// The offsets at which data of a created note is stored relative to the start of its data segment.
-pub const CREATED_NOTE_ID_OFFSET: MemoryOffset = 0;
-pub const CREATED_NOTE_METADATA_OFFSET: MemoryOffset = 1;
-pub const CREATED_NOTE_RECIPIENT_OFFSET: MemoryOffset = 2;
-pub const CREATED_NOTE_ASSET_HASH_OFFSET: MemoryOffset = 3;
-pub const CREATED_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 4;
-pub const CREATED_NOTE_ASSETS_OFFSET: MemoryOffset = 5;
+/// The offsets at which data of a output note is stored relative to the start of its data segment.
+pub const OUTPUT_NOTE_ID_OFFSET: MemoryOffset = 0;
+pub const OUTPUT_NOTE_METADATA_OFFSET: MemoryOffset = 1;
+pub const OUTPUT_NOTE_RECIPIENT_OFFSET: MemoryOffset = 2;
+pub const OUTPUT_NOTE_ASSET_HASH_OFFSET: MemoryOffset = 3;
+pub const OUTPUT_NOTE_NUM_ASSETS_OFFSET: MemoryOffset = 4;
+pub const OUTPUT_NOTE_ASSETS_OFFSET: MemoryOffset = 5;

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -210,7 +210,7 @@ pub const INPUT_NOTE_SECTION_OFFSET: MemoryOffset = 1_048_576;
 pub const INPUT_NOTE_DATA_SECTION_OFFSET: MemoryAddress = 1_064_960;
 
 /// The memory address at which the number of input notes is stored.
-pub const INPUT_NOTE_NUM_PTR: MemoryAddress = INPUT_NOTE_SECTION_OFFSET;
+pub const NUM_INPUT_NOTES_PTR: MemoryAddress = INPUT_NOTE_SECTION_OFFSET;
 
 /// The offsets at which data of a input note is stored relative to the start of its data segment.
 pub const INPUT_NOTE_ID_OFFSET: MemoryOffset = 0;

--- a/miden-tx/src/compiler/tests.rs
+++ b/miden-tx/src/compiler/tests.rs
@@ -135,10 +135,7 @@ fn test_compile_valid_note_script() {
     }
 }
 
-fn mock_consumed_notes(
-    tx_compiler: &mut TransactionCompiler,
-    target_account: AccountId,
-) -> Vec<Note> {
+fn mock_input_notes(tx_compiler: &mut TransactionCompiler, target_account: AccountId) -> Vec<Note> {
     // Note Assets
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
     let faucet_id_2 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1).unwrap();
@@ -156,7 +153,7 @@ fn mock_consumed_notes(
         .compile_note_script(note_program_ast, vec![ScriptTarget::AccountId(target_account)])
         .unwrap();
 
-    // Consumed Notes
+    // Input Notes
     const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
     let vault =
         NoteAssets::new(vec![fungible_asset_1, fungible_asset_2, fungible_asset_3]).unwrap();
@@ -184,7 +181,7 @@ fn test_transaction_compilation_succeeds() {
     let account_code_ast = ModuleAst::parse(ACCOUNT_CODE_MASM).unwrap();
     let _account_code = tx_compiler.load_account(account_id, account_code_ast).unwrap();
 
-    let notes = mock_consumed_notes(&mut tx_compiler, account_id);
+    let notes = mock_input_notes(&mut tx_compiler, account_id);
     let mock_inclusion_proof = NoteInclusionProof::new(
         Default::default(),
         Default::default(),

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{collections::BTreeMap, rc::Rc, string::ToString, vec::Vec};
 
 use miden_lib::transaction::{
-    memory::CURRENT_CONSUMED_NOTE_PTR, TransactionEvent, TransactionKernelError, TransactionTrace,
+    memory::CURRENT_INPUT_NOTE_PTR, TransactionEvent, TransactionKernelError, TransactionTrace,
 };
 use miden_objects::{
     accounts::{AccountDelta, AccountId, AccountStorage, AccountStub},
@@ -351,7 +351,7 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
     /// greater than `u32::MAX`).
     fn get_current_note_id<S: ProcessState>(process: &S) -> Result<Option<NoteId>, ExecutionError> {
         // get the word where note address is stored
-        let note_address_word = process.get_mem_value(process.ctx(), CURRENT_CONSUMED_NOTE_PTR);
+        let note_address_word = process.get_mem_value(process.ctx(), CURRENT_INPUT_NOTE_PTR);
         // get the note address in `Felt` from or return `None` if the address hasn't been accessed
         // previously.
         let note_address_felt = match note_address_word {

--- a/miden-tx/src/host/note_builder.rs
+++ b/miden-tx/src/host/note_builder.rs
@@ -107,7 +107,7 @@ impl OutputNoteBuilder {
             let recipient = NoteRecipient::new(serial_num, script, inputs);
 
             Some(recipient)
-        } else if metadata.is_offchain() {
+        } else if metadata.is_private() {
             None
         } else {
             // if there are no recipient details and the note is not private, return an error

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -33,7 +33,7 @@ impl TransactionProver {
     /// Proves the provided transaction and returns a [ProvenTransaction].
     ///
     /// # Errors
-    /// - If the consumed note data in the transaction witness is corrupt.
+    /// - If the input note data in the transaction witness is corrupt.
     /// - If the transaction program cannot be proven.
     /// - If the transaction result is corrupt.
     pub fn prove_transaction<T: Into<TransactionWitness>>(

--- a/miden-tx/src/testing/utils.rs
+++ b/miden-tx/src/testing/utils.rs
@@ -3,6 +3,6 @@ use miden_lib::transaction::memory;
 // TEST HELPERS
 // ================================================================================================
 
-pub fn consumed_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
-    memory::CONSUMED_NOTE_DATA_SECTION_OFFSET + note_idx * memory::NOTE_MEM_SIZE
+pub fn input_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
+    memory::INPUT_NOTE_DATA_SECTION_OFFSET + note_idx * memory::NOTE_MEM_SIZE
 }

--- a/miden-tx/src/tests/kernel_tests/mod.rs
+++ b/miden-tx/src/tests/kernel_tests/mod.rs
@@ -1,9 +1,8 @@
 use alloc::string::String;
 
 use miden_lib::transaction::memory::{
-    CREATED_NOTE_ASSETS_OFFSET, CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_NUM_ASSETS_OFFSET,
-    CREATED_NOTE_RECIPIENT_OFFSET, CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE,
-    NUM_CREATED_NOTES_PTR,
+    NOTE_MEM_SIZE, NUM_OUTPUT_NOTES_PTR, OUTPUT_NOTE_ASSETS_OFFSET, OUTPUT_NOTE_METADATA_OFFSET,
+    OUTPUT_NOTE_NUM_ASSETS_OFFSET, OUTPUT_NOTE_RECIPIENT_OFFSET, OUTPUT_NOTE_SECTION_OFFSET,
 };
 use miden_objects::{
     notes::Note,
@@ -56,45 +55,45 @@ pub fn output_notes_data_procedure(notes: &[Note]) -> String {
 
             # populate note 0
             push.{note_0_metadata}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_METADATA_OFFSET} add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{OUTPUT_NOTE_METADATA_OFFSET} add mem_storew dropw
 
             push.{note_0_recipient}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{OUTPUT_NOTE_RECIPIENT_OFFSET} add mem_storew dropw
 
             push.{note_0_num_assets}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add mem_store
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{OUTPUT_NOTE_NUM_ASSETS_OFFSET} add mem_store
 
             push.{}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{CREATED_NOTE_ASSETS_OFFSET} add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{OUTPUT_NOTE_ASSETS_OFFSET} add mem_storew dropw
 
             # populate note 1
             push.{note_1_metadata}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_METADATA_OFFSET} add add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{OUTPUT_NOTE_METADATA_OFFSET} add add mem_storew dropw
 
             push.{note_1_recipient}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{OUTPUT_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
 
             push.{note_1_num_assets}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add add mem_store
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{OUTPUT_NOTE_NUM_ASSETS_OFFSET} add add mem_store
 
             push.{}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{CREATED_NOTE_ASSETS_OFFSET} add add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_1_OFFSET}.{OUTPUT_NOTE_ASSETS_OFFSET} add add mem_storew dropw
 
             # populate note 2
             push.{note_2_metadata}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_METADATA_OFFSET} add add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{OUTPUT_NOTE_METADATA_OFFSET} add add mem_storew dropw
 
             push.{note_2_recipient}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{OUTPUT_NOTE_RECIPIENT_OFFSET} add add mem_storew dropw
 
             push.{note_2_num_assets}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_NUM_ASSETS_OFFSET} add add mem_store
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{OUTPUT_NOTE_NUM_ASSETS_OFFSET} add add mem_store
 
             push.{}
-            push.{CREATED_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{CREATED_NOTE_ASSETS_OFFSET} add add mem_storew dropw
+            push.{OUTPUT_NOTE_SECTION_OFFSET}.{NOTE_2_OFFSET}.{OUTPUT_NOTE_ASSETS_OFFSET} add add mem_storew dropw
 
-            # set num created notes
-            push.{}.{NUM_CREATED_NOTES_PTR} mem_store
+            # set num output notes
+            push.{}.{NUM_OUTPUT_NOTES_PTR} mem_store
         end
         ",
         note_0_assets[0],

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use miden_lib::transaction::memory::{
-    CREATED_NOTE_ASSET_HASH_OFFSET, CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE,
+    NOTE_MEM_SIZE, OUTPUT_NOTE_ASSET_HASH_OFFSET, OUTPUT_NOTE_SECTION_OFFSET,
 };
 use miden_objects::{
     accounts::{account_id::testing::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, Account},
@@ -82,7 +82,7 @@ fn test_epilogue() {
 }
 
 #[test]
-fn test_compute_created_note_id() {
+fn test_compute_output_note_id() {
     let tx_context = TransactionContextBuilder::with_standard_account(
         ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
         ONE,
@@ -115,14 +115,14 @@ fn test_compute_created_note_id() {
             note.assets().commitment().as_elements(),
             read_root_mem_value(
                 &process,
-                CREATED_NOTE_SECTION_OFFSET + i * NOTE_MEM_SIZE + CREATED_NOTE_ASSET_HASH_OFFSET
+                OUTPUT_NOTE_SECTION_OFFSET + i * NOTE_MEM_SIZE + OUTPUT_NOTE_ASSET_HASH_OFFSET
             ),
             "ASSET_HASH didn't match expected value",
         );
 
         assert_eq!(
             note.id().as_elements(),
-            &read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + i * NOTE_MEM_SIZE),
+            &read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + i * NOTE_MEM_SIZE),
             "NOTE_ID didn't match expected value",
         );
     }

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeMap, string::String};
 
-use miden_lib::transaction::memory::CURRENT_CONSUMED_NOTE_PTR;
+use miden_lib::transaction::memory::CURRENT_INPUT_NOTE_PTR;
 use miden_objects::{
     accounts::account_id::testing::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
     notes::Note, testing::prepare_word, transaction::TransactionArgs, Hasher, WORD_SIZE,
@@ -10,7 +10,7 @@ use vm_processor::{ProcessState, EMPTY_WORD, ONE};
 use super::{Felt, Process, ZERO};
 use crate::{
     testing::{
-        utils::consumed_note_data_ptr, MockHost, TransactionContext, TransactionContextBuilder,
+        utils::input_note_data_ptr, MockHost, TransactionContext, TransactionContextBuilder,
     },
     tests::kernel_tests::read_root_mem_value,
 };
@@ -31,8 +31,8 @@ fn test_get_sender_no_sender() {
         begin
             exec.prologue::prepare_transaction
 
-            # force the current consumed note pointer to 0
-            push.0 exec.memory::set_current_consumed_note_ptr
+            # force the current input note pointer to 0
+            push.0 exec.memory::set_current_input_note_ptr
 
             # get the sender
             exec.note::get_sender
@@ -103,8 +103,8 @@ fn test_get_vault_data() {
             push.{note_0_asset_hash} assert_eqw
             push.{note_0_num_assets} assert_eq
 
-            # increment current consumed note pointer
-            exec.note::increment_current_consumed_note_ptr
+            # increment current input note pointer
+            exec.note::increment_current_input_note_ptr
 
             # prepare note 1
             exec.note::prepare_note
@@ -216,8 +216,8 @@ fn test_get_assets() {
             # process note 0
             call.process_note_0
 
-            # increment current consumed note pointer
-            exec.note_internal::increment_current_consumed_note_ptr
+            # increment current input note pointer
+            exec.note_internal::increment_current_input_note_ptr
 
             # prepare note 1
             exec.note_internal::prepare_note
@@ -355,9 +355,9 @@ fn test_note_script_and_note_args() {
 
         begin
             exec.prologue::prepare_transaction
-            exec.memory::get_total_num_consumed_notes push.2 assert_eq
+            exec.memory::get_total_num_input_notes push.2 assert_eq
             exec.note::prepare_note dropw
-            exec.note::increment_current_consumed_note_ptr drop
+            exec.note::increment_current_input_note_ptr drop
             exec.note::prepare_note dropw
         end
         ";
@@ -393,8 +393,8 @@ fn note_setup_stack_assertions(process: &Process<MockHost>, inputs: &Transaction
 fn note_setup_memory_assertions(process: &Process<MockHost>) {
     // assert that the correct pointer is stored in bookkeeping memory
     assert_eq!(
-        read_root_mem_value(process, CURRENT_CONSUMED_NOTE_PTR)[0],
-        Felt::from(consumed_note_data_ptr(0))
+        read_root_mem_value(process, CURRENT_INPUT_NOTE_PTR)[0],
+        Felt::from(input_note_data_ptr(0))
     );
 }
 

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -84,7 +84,7 @@ fn test_get_vault_data() {
 
     let notes = tx_context.input_notes();
 
-    // calling get_vault_info should return vault info
+    // calling get_assets_info should return assets info
     let code = format!(
         "
         use.miden::kernels::tx::prologue
@@ -96,10 +96,10 @@ fn test_get_vault_data() {
             # prepare note 0
             exec.note::prepare_note
 
-            # get the vault data
-            exec.note::get_vault_info
+            # get the assets info
+            exec.note::get_assets_info
 
-            # assert the vault data is correct
+            # assert the assets data is correct
             push.{note_0_asset_hash} assert_eqw
             push.{note_0_num_assets} assert_eq
 
@@ -109,10 +109,10 @@ fn test_get_vault_data() {
             # prepare note 1
             exec.note::prepare_note
 
-            # get the vault data
-            exec.note::get_vault_info
+            # get the assets data
+            exec.note::get_assets_info
 
-            # assert the vault data is correct
+            # assert the assets data is correct
             push.{note_1_asset_hash} assert_eqw
             push.{note_1_num_assets} assert_eq
         end
@@ -355,7 +355,7 @@ fn test_note_script_and_note_args() {
 
         begin
             exec.prologue::prepare_transaction
-            exec.memory::get_total_num_input_notes push.2 assert_eq
+            exec.memory::get_num_input_notes push.2 assert_eq
             exec.note::prepare_note dropw
             exec.note::increment_current_input_note_ptr drop
             exec.note::prepare_note dropw

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -5,14 +5,13 @@ use miden_lib::transaction::{
         MemoryOffset, ACCT_CODE_ROOT_PTR, ACCT_DB_ROOT_PTR, ACCT_ID_AND_NONCE_PTR, ACCT_ID_PTR,
         ACCT_STORAGE_ROOT_PTR, ACCT_STORAGE_SLOT_TYPE_DATA_OFFSET, ACCT_VAULT_ROOT_PTR,
         BLK_HASH_PTR, BLOCK_METADATA_PTR, BLOCK_NUMBER_IDX, CHAIN_MMR_NUM_LEAVES_PTR,
-        CHAIN_MMR_PEAKS_PTR, CHAIN_ROOT_PTR, CONSUMED_NOTE_ARGS_OFFSET,
-        CONSUMED_NOTE_ASSETS_HASH_OFFSET, CONSUMED_NOTE_ASSETS_OFFSET, CONSUMED_NOTE_ID_OFFSET,
-        CONSUMED_NOTE_INPUTS_HASH_OFFSET, CONSUMED_NOTE_METADATA_OFFSET,
-        CONSUMED_NOTE_NUM_ASSETS_OFFSET, CONSUMED_NOTE_SCRIPT_ROOT_OFFSET,
-        CONSUMED_NOTE_SECTION_OFFSET, CONSUMED_NOTE_SERIAL_NUM_OFFSET, INIT_ACCT_HASH_PTR,
-        INIT_NONCE_PTR, INPUT_NOTES_COMMITMENT_PTR, NOTE_ROOT_PTR, NULLIFIER_DB_ROOT_PTR,
-        PREV_BLOCK_HASH_PTR, PROOF_HASH_PTR, PROTOCOL_VERSION_IDX, TIMESTAMP_IDX, TX_HASH_PTR,
-        TX_SCRIPT_ROOT_PTR,
+        CHAIN_MMR_PEAKS_PTR, CHAIN_ROOT_PTR, INIT_ACCT_HASH_PTR, INIT_NONCE_PTR,
+        INPUT_NOTES_COMMITMENT_PTR, INPUT_NOTE_ARGS_OFFSET, INPUT_NOTE_ASSETS_HASH_OFFSET,
+        INPUT_NOTE_ASSETS_OFFSET, INPUT_NOTE_ID_OFFSET, INPUT_NOTE_INPUTS_HASH_OFFSET,
+        INPUT_NOTE_METADATA_OFFSET, INPUT_NOTE_NUM_ASSETS_OFFSET, INPUT_NOTE_SCRIPT_ROOT_OFFSET,
+        INPUT_NOTE_SECTION_OFFSET, INPUT_NOTE_SERIAL_NUM_OFFSET, NOTE_ROOT_PTR,
+        NULLIFIER_DB_ROOT_PTR, PREV_BLOCK_HASH_PTR, PROOF_HASH_PTR, PROTOCOL_VERSION_IDX,
+        TIMESTAMP_IDX, TX_HASH_PTR, TX_SCRIPT_ROOT_PTR,
     },
     TransactionKernel,
 };
@@ -31,7 +30,7 @@ use vm_processor::{AdviceInputs, ONE};
 use super::{Felt, Process, Word, ZERO};
 use crate::{
     testing::{
-        utils::consumed_note_data_ptr, MockHost, TransactionContext, TransactionContextBuilder,
+        utils::input_note_data_ptr, MockHost, TransactionContext, TransactionContextBuilder,
     },
     tests::kernel_tests::read_root_mem_value,
 };
@@ -91,7 +90,7 @@ fn test_transaction_prologue() {
     block_data_memory_assertions(&process, &tx_context);
     chain_mmr_memory_assertions(&process, &tx_context);
     account_data_memory_assertions(&process, &tx_context);
-    consumed_notes_memory_assertions(&process, &tx_context, &note_args);
+    input_notes_memory_assertions(&process, &tx_context, &note_args);
 }
 
 fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &TransactionContext) {
@@ -260,70 +259,70 @@ fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &Transact
     }
 }
 
-fn consumed_notes_memory_assertions(
+fn input_notes_memory_assertions(
     process: &Process<MockHost>,
     inputs: &TransactionContext,
     note_args: &[[Felt; 4]],
 ) {
     assert_eq!(
-        read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET),
+        read_root_mem_value(process, INPUT_NOTE_SECTION_OFFSET),
         [Felt::new(inputs.input_notes().num_notes() as u64), ZERO, ZERO, ZERO],
-        "number of consumed notes should be stored at the CONSUMED_NOTES_OFFSET"
+        "number of input notes should be stored at the INPUT_NOTES_OFFSET"
     );
 
     for (input_note, note_idx) in inputs.input_notes().iter().zip(0_u32..) {
         let note = input_note.note();
 
         assert_eq!(
-            read_root_mem_value(process, CONSUMED_NOTE_SECTION_OFFSET + 1 + note_idx),
+            read_root_mem_value(process, INPUT_NOTE_SECTION_OFFSET + 1 + note_idx),
             note.nullifier().as_elements(),
             "note nullifier should be computer and stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_ID_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_ID_OFFSET),
             note.id().as_elements(),
             "ID hash should be computed and stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_SERIAL_NUM_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_SERIAL_NUM_OFFSET),
             note.serial_num(),
             "note serial num should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_SCRIPT_ROOT_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_SCRIPT_ROOT_OFFSET),
             note.script().hash().as_elements(),
             "note script hash should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_INPUTS_HASH_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_INPUTS_HASH_OFFSET),
             note.inputs().commitment().as_elements(),
             "note input hash should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_ASSETS_HASH_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_ASSETS_HASH_OFFSET),
             note.assets().commitment().as_elements(),
             "note asset hash should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_METADATA_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_METADATA_OFFSET),
             Word::from(note.metadata()),
             "note metadata should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_ARGS_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_ARGS_OFFSET),
             Word::from(note_args[note_idx as usize]),
             "note args should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, CONSUMED_NOTE_NUM_ASSETS_OFFSET),
+            read_note_element(process, note_idx, INPUT_NOTE_NUM_ASSETS_OFFSET),
             [Felt::from(note.assets().num_assets() as u32), ZERO, ZERO, ZERO],
             "number of assets should be stored at the correct offset"
         );
@@ -331,8 +330,9 @@ fn consumed_notes_memory_assertions(
         for (asset, asset_idx) in note.assets().iter().cloned().zip(0_u32..) {
             let word: Word = asset.into();
             assert_eq!(
-                read_note_element(process, note_idx, CONSUMED_NOTE_ASSETS_OFFSET + asset_idx),
-                word, "assets should be stored at (CONSUMED_NOTES_OFFSET + (note_index + 1) * 1024 + 7..)"
+                read_note_element(process, note_idx, INPUT_NOTE_ASSETS_OFFSET + asset_idx),
+                word,
+                "assets should be stored at (INPUT_NOTES_OFFSET + (note_index + 1) * 1024 + 7..)"
             );
         }
     }
@@ -543,5 +543,5 @@ fn test_get_blk_timestamp() {
 // ================================================================================================
 
 fn read_note_element(process: &Process<MockHost>, note_idx: u32, offset: MemoryOffset) -> Word {
-    read_root_mem_value(process, consumed_note_data_ptr(note_idx) + offset)
+    read_root_mem_value(process, input_note_data_ptr(note_idx) + offset)
 }

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
 
 use miden_lib::transaction::memory::{
-    CREATED_NOTE_ASSETS_OFFSET, CREATED_NOTE_METADATA_OFFSET, CREATED_NOTE_RECIPIENT_OFFSET,
-    CREATED_NOTE_SECTION_OFFSET, NOTE_MEM_SIZE, NUM_CREATED_NOTES_PTR,
+    NOTE_MEM_SIZE, NUM_OUTPUT_NOTES_PTR, OUTPUT_NOTE_ASSETS_OFFSET, OUTPUT_NOTE_METADATA_OFFSET,
+    OUTPUT_NOTE_RECIPIENT_OFFSET, OUTPUT_NOTE_SECTION_OFFSET,
 };
 use miden_objects::{
     accounts::account_id::testing::{
@@ -59,19 +59,19 @@ fn test_create_note() {
     let process = tx_context.execute_code(&code).unwrap();
 
     assert_eq!(
-        read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
+        read_root_mem_value(&process, NUM_OUTPUT_NOTES_PTR),
         [ONE, ZERO, ZERO, ZERO],
-        "number of created notes must increment by 1",
+        "number of output notes must increment by 1",
     );
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_RECIPIENT_OFFSET),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_RECIPIENT_OFFSET),
         recipient,
         "recipient must be stored at the correct memory location",
     );
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_METADATA_OFFSET),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET),
         [tag, Felt::from(account_id), NoteType::Public.into(), Felt::new(27)],
         "metadata must be stored at the correct memory location",
     );
@@ -79,7 +79,7 @@ fn test_create_note() {
     assert_eq!(
         process.stack.get(0),
         ZERO,
-        "top item on the stack is the index of the created note"
+        "top item on the stack is the index of the output note"
     );
 }
 
@@ -131,8 +131,8 @@ fn test_create_note_too_many_notes() {
         use.miden::tx
 
         begin
-            exec.constants::get_max_num_created_notes
-            exec.memory::set_num_created_notes
+            exec.constants::get_max_num_output_notes
+            exec.memory::set_num_output_notes
 
             push.{recipient}
             push.{PUBLIC_NOTE}
@@ -267,14 +267,14 @@ fn test_get_output_notes_hash() {
     let process = tx_context.execute_code(&code).unwrap();
 
     assert_eq!(
-        read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
+        read_root_mem_value(&process, NUM_OUTPUT_NOTES_PTR),
         [Felt::new(2), ZERO, ZERO, ZERO],
         "The test creates two notes",
     );
     assert_eq!(
         NoteMetadata::try_from(read_root_mem_value(
             &process,
-            CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_METADATA_OFFSET
+            OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET
         ))
         .unwrap(),
         *output_note_1.metadata(),
@@ -283,7 +283,7 @@ fn test_get_output_notes_hash() {
     assert_eq!(
         NoteMetadata::try_from(read_root_mem_value(
             &process,
-            CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_METADATA_OFFSET + NOTE_MEM_SIZE
+            OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET + NOTE_MEM_SIZE
         ))
         .unwrap(),
         *output_note_2.metadata(),
@@ -337,7 +337,7 @@ fn test_create_note_and_add_asset() {
     let process = tx_context.execute_code(&code).unwrap();
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
         asset,
         "asset must be stored at the correct memory location",
     );
@@ -345,7 +345,7 @@ fn test_create_note_and_add_asset() {
     assert_eq!(
         process.stack.get(0),
         ZERO,
-        "top item on the stack is the index to the created note"
+        "top item on the stack is the index to the output note"
     );
 }
 
@@ -416,19 +416,19 @@ fn test_create_note_and_add_multiple_assets() {
     let process = tx_context.execute_code(&code).unwrap();
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
         asset,
         "asset must be stored at the correct memory location",
     );
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET + 1),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET + 1),
         asset_2_and_3,
         "asset_2 and asset_3 must be stored at the same correct memory location",
     );
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_ASSETS_OFFSET + 2),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET + 2),
         Word::from(non_fungible_asset_encoded),
         "non_fungible_asset must be stored at the correct memory location",
     );
@@ -436,7 +436,7 @@ fn test_create_note_and_add_multiple_assets() {
     assert_eq!(
         process.stack.get(0),
         ZERO,
-        "top item on the stack is the index to the created note"
+        "top item on the stack is the index to the output note"
     );
 }
 
@@ -540,15 +540,15 @@ fn test_build_recipient_hash() {
     let process = tx_context.execute_code(&code).unwrap();
 
     assert_eq!(
-        read_root_mem_value(&process, NUM_CREATED_NOTES_PTR),
+        read_root_mem_value(&process, NUM_OUTPUT_NOTES_PTR),
         [ONE, ZERO, ZERO, ZERO],
-        "number of created notes must increment by 1",
+        "number of output notes must increment by 1",
     );
 
     let recipient_digest: Vec<Felt> = recipient.clone().digest().to_vec();
 
     assert_eq!(
-        read_root_mem_value(&process, CREATED_NOTE_SECTION_OFFSET + CREATED_NOTE_RECIPIENT_OFFSET),
+        read_root_mem_value(&process, OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_RECIPIENT_OFFSET),
         recipient_digest.as_slice(),
         "recipient hash not correct",
     );

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -156,9 +156,9 @@ fn executed_transaction_account_delta() {
     let aux2 = Felt::new(28);
     let aux3 = Felt::new(29);
 
-    let note_type1 = NoteType::OffChain;
-    let note_type2 = NoteType::OffChain;
-    let note_type3 = NoteType::OffChain;
+    let note_type1 = NoteType::Private;
+    let note_type2 = NoteType::Private;
+    let note_type3 = NoteType::Private;
 
     assert_eq!(tag1.validate(note_type1), Ok(tag1));
     assert_eq!(tag2.validate(note_type2), Ok(tag2));
@@ -431,7 +431,7 @@ fn executed_transaction_output_notes() {
     let aux2 = Felt::new(28);
     let aux3 = Felt::new(29);
 
-    let note_type1 = NoteType::OffChain;
+    let note_type1 = NoteType::Private;
     let note_type2 = NoteType::Public;
     let note_type3 = NoteType::Public;
 
@@ -593,22 +593,22 @@ fn executed_transaction_output_notes() {
     // NOTE: the mock state already contains 3 output notes
     assert_eq!(output_notes.num_notes(), 6);
 
-    let created_note_id_3 = executed_transaction.output_notes().get_note(3).id();
+    let output_note_id_3 = executed_transaction.output_notes().get_note(3).id();
     let recipient_3 = Digest::from([Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)]);
     let note_assets_3 = NoteAssets::new(vec![combined_asset]).unwrap();
     let expected_note_id_3 = NoteId::new(recipient_3, note_assets_3.commitment());
-    assert_eq!(created_note_id_3, expected_note_id_3);
+    assert_eq!(output_note_id_3, expected_note_id_3);
 
     // assert that the expected output note 2 is present
-    let created_note = executed_transaction.output_notes().get_note(4);
+    let output_note = executed_transaction.output_notes().get_note(4);
     let note_id = expected_output_note_2.id();
     let note_metadata = expected_output_note_2.metadata();
-    assert_eq!(NoteHeader::from(created_note), NoteHeader::new(note_id, *note_metadata));
+    assert_eq!(NoteHeader::from(output_note), NoteHeader::new(note_id, *note_metadata));
 
     // assert that the expected output note 3 is present and has no assets
-    let created_note_3 = executed_transaction.output_notes().get_note(5);
-    assert_eq!(expected_output_note_3.id(), created_note_3.id());
-    assert_eq!(expected_output_note_3.assets(), created_note_3.assets().unwrap());
+    let output_note_3 = executed_transaction.output_notes().get_note(5);
+    assert_eq!(expected_output_note_3.id(), output_note_3.id());
+    assert_eq!(expected_output_note_3.assets(), output_note_3.assets().unwrap());
 }
 
 #[test]

--- a/miden-tx/tests/integration/assets/test.masm
+++ b/miden-tx/tests/integration/assets/test.masm
@@ -5,10 +5,10 @@ use.miden::kernels::utils
 # CONSTANTS
 # =================================================================================================
 
-const.CREATED_NOTES_OFFSET=10000
+const.OUTPUT_NOTES_OFFSET=10000
 
-# The memory address at the number of created notes is stored.
-const.NUM_CREATED_NOTES_PTR=2
+# The memory address at which the number of output notes is stored.
+const.NUM_OUTPUT_NOTES_PTR=2
 
 # TEST UTILS
 # =================================================================================================
@@ -68,7 +68,7 @@ proc.create_mock_notes
     push.100.0.0.12033618204333965332
     push.10000.2048.7 add add mem_storew dropw
 
-    # set num created notes
+    # set num output notes
     push.3.2 mem_store
 end
 

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -55,7 +55,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     let recipient = [Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)];
     let tag = NoteTag::for_local_use_case(0, 0).unwrap();
     let aux = Felt::new(27);
-    let note_type = NoteType::OffChain;
+    let note_type = NoteType::Private;
     let amount = Felt::new(100);
 
     assert_eq!(tag.validate(note_type), Ok(tag));
@@ -101,15 +101,15 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     let fungible_asset: Asset =
         FungibleAsset::new(faucet_account.id(), amount.into()).unwrap().into();
 
-    let created_note = executed_transaction.output_notes().get_note(0).clone();
+    let output_note = executed_transaction.output_notes().get_note(0).clone();
 
     let assets = NoteAssets::new(vec![fungible_asset]).unwrap();
     let id = NoteId::new(recipient.into(), assets.commitment());
 
-    assert_eq!(created_note.id(), id);
+    assert_eq!(output_note.id(), id);
     assert_eq!(
-        created_note.metadata(),
-        &NoteMetadata::new(faucet_account.id(), NoteType::OffChain, tag, aux).unwrap()
+        output_note.metadata(),
+        &NoteMetadata::new(faucet_account.id(), NoteType::Private, tag, aux).unwrap()
     );
 }
 
@@ -159,7 +159,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
 
             end
             ",
-            note_type = NoteType::OffChain as u8,
+            note_type = NoteType::Private as u8,
             recipient = prepare_word(&recipient),
         )
         .as_str(),

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -100,16 +100,15 @@ fn prove_swap_script() {
     // Check if only one `Note` has been created
     assert_eq!(executed_transaction.output_notes().num_notes(), 1);
 
-    // Check if the created `Note` is what we expect
+    // Check if the output `Note` is what we expect
     let recipient = payback_note.recipient().clone();
     let tag = NoteTag::from_account_id(sender_account_id, NoteExecutionHint::Local).unwrap();
-    let note_metadata =
-        NoteMetadata::new(target_account_id, NoteType::OffChain, tag, ZERO).unwrap();
+    let note_metadata = NoteMetadata::new(target_account_id, NoteType::Private, tag, ZERO).unwrap();
     let assets = NoteAssets::new(vec![requested_asset]).unwrap();
     let note_id = NoteId::new(recipient.digest(), assets.commitment());
 
-    let created_note = executed_transaction.output_notes().get_note(0);
-    assert_eq!(NoteHeader::from(created_note), NoteHeader::new(note_id, note_metadata));
+    let output_note = executed_transaction.output_notes().get_note(0);
+    assert_eq!(NoteHeader::from(output_note), NoteHeader::new(note_id, note_metadata));
 
     // Prove, serialize/deserialize and verify the transaction
     assert!(prove_and_verify_transaction(executed_transaction.clone()).is_ok());

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -142,7 +142,7 @@ fn prove_send_asset_via_wallet() {
     let recipient = [ZERO, ONE, Felt::new(2), Felt::new(3)];
     let aux = Felt::new(27);
     let tag = NoteTag::for_local_use_case(0, 0).unwrap();
-    let note_type = NoteType::OffChain;
+    let note_type = NoteType::Private;
 
     assert_eq!(tag.validate(note_type), Ok(tag));
 

--- a/objects/src/block/mod.rs
+++ b/objects/src/block/mod.rs
@@ -44,11 +44,11 @@ pub struct Block {
     /// Account updates for the block.
     updated_accounts: Vec<BlockAccountUpdate>,
 
-    /// Note batches created in transactions in the block.
+    /// Note batches created by the transactions in this block.
     output_note_batches: Vec<NoteBatch>,
 
-    /// Nullifiers produced in transactions in the block.
-    created_nullifiers: Vec<Nullifier>,
+    /// Nullifiers produced by the transactions in this block.
+    nullifiers: Vec<Nullifier>,
     //
     // TODO: add zk proof
 }
@@ -61,13 +61,13 @@ impl Block {
         header: BlockHeader,
         updated_accounts: Vec<BlockAccountUpdate>,
         output_note_batches: Vec<NoteBatch>,
-        created_nullifiers: Vec<Nullifier>,
+        nullifiers: Vec<Nullifier>,
     ) -> Result<Self, BlockError> {
         let block = Self {
             header,
             updated_accounts,
             output_note_batches,
-            created_nullifiers,
+            nullifiers,
         };
 
         block.validate()?;
@@ -98,7 +98,7 @@ impl Block {
     /// Returns an iterator over all notes created in this block.
     ///
     /// Each note is accompanied by a corresponding index specifying where the note is located
-    /// in the blocks note tree.
+    /// in the block's note tree.
     pub fn notes(&self) -> impl Iterator<Item = (BlockNoteIndex, &OutputNote)> {
         self.output_note_batches.iter().enumerate().flat_map(|(batch_idx, notes)| {
             notes.iter().enumerate().map(move |(note_idx_in_batch, note)| {
@@ -118,11 +118,12 @@ impl Block {
     }
 
     /// Returns a set of nullifiers for all notes consumed in the block.
-    pub fn created_nullifiers(&self) -> &[Nullifier] {
-        &self.created_nullifiers
+    pub fn nullifiers(&self) -> &[Nullifier] {
+        &self.nullifiers
     }
 
-    /// Returns an iterator over all transactions which affected accounts in the block with corresponding account IDs.
+    /// Returns an iterator over all transactions which affected accounts in the block with
+    /// corresponding account IDs.
     pub fn transactions(&self) -> impl Iterator<Item = (TransactionId, AccountId)> + '_ {
         self.updated_accounts.iter().flat_map(|update| {
             update
@@ -170,7 +171,7 @@ impl Serializable for Block {
         self.header.write_into(target);
         self.updated_accounts.write_into(target);
         self.output_note_batches.write_into(target);
-        self.created_nullifiers.write_into(target);
+        self.nullifiers.write_into(target);
     }
 }
 
@@ -180,7 +181,7 @@ impl Deserializable for Block {
             header: BlockHeader::read_from(source)?,
             updated_accounts: <Vec<BlockAccountUpdate>>::read_from(source)?,
             output_note_batches: <Vec<NoteBatch>>::read_from(source)?,
-            created_nullifiers: <Vec<Nullifier>>::read_from(source)?,
+            nullifiers: <Vec<Nullifier>>::read_from(source)?,
         };
 
         block

--- a/objects/src/constants.rs
+++ b/objects/src/constants.rs
@@ -25,7 +25,7 @@ pub const MIN_PROOF_SECURITY_LEVEL: u32 = 96;
 // TRANSACTION BATCH
 // ================================================================================================
 
-/// The depth of the Sparse Merkle Tree used to store created notes in a single batch.
+/// The depth of the Sparse Merkle Tree used to store output notes in a single batch.
 ///
 /// A single note uses two leaves in the tree. The even leaf is used to store the note's id, the
 /// odd leaf is used to store the note's metadata.
@@ -47,7 +47,7 @@ pub const MAX_TRANSACTIONS_PER_BATCH: usize = MAX_NOTES_PER_BATCH / MAX_OUTPUT_N
 ///
 /// This value can be interpreted as:
 ///
-/// - The depth of a tree with the leaves set to a batch created note tree root.
+/// - The depth of a tree with the leaves set to a batch output note tree root.
 /// - The level at which the batches create note trees are merged, creating a new tree with this many
 ///   additional new levels.
 pub const BLOCK_OUTPUT_NOTES_BATCH_TREE_DEPTH: u8 = 8;

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -67,9 +67,9 @@ impl NoteMetadata {
         self.aux
     }
 
-    /// Returns `true` if the note is off-chain.
-    pub fn is_offchain(&self) -> bool {
-        self.note_type == NoteType::OffChain
+    /// Returns `true` if the note is private.
+    pub fn is_private(&self) -> bool {
+        self.note_type == NoteType::Private
     }
 }
 

--- a/objects/src/notes/note_tag.rs
+++ b/objects/src/notes/note_tag.rs
@@ -146,7 +146,7 @@ impl NoteTag {
 
     /// Returns a new [NoteTag] instantiated for a custom local use case.
     ///
-    /// The local use_case tag is the only tag type that allows for [NoteType::OffChain] notes.
+    /// The local use_case tag is the only tag type that allows for [NoteType::Private] notes.
     ///
     /// The two high bits are set to the `b11`, the next 14 bits are set to the `use_case_id`, and
     /// the low 16 bits are set to `payload`.
@@ -350,8 +350,8 @@ mod tests {
                 "Network execution requires public notes"
             );
             assert_eq!(
-                tag.validate(NoteType::OffChain),
-                Err(NoteError::NetworkExecutionRequiresPublicNote(NoteType::OffChain))
+                tag.validate(NoteType::Private),
+                Err(NoteError::NetworkExecutionRequiresPublicNote(NoteType::Private))
             );
             assert_eq!(
                 tag.validate(NoteType::Encrypted),
@@ -371,9 +371,9 @@ mod tests {
                 "Local execution supports public notes"
             );
             assert_eq!(
-                tag.validate(NoteType::OffChain),
+                tag.validate(NoteType::Private),
                 Ok(tag),
-                "Local execution supports offchain notes"
+                "Local execution supports private notes"
             );
             assert_eq!(
                 tag.validate(NoteType::Encrypted),
@@ -394,9 +394,9 @@ mod tests {
                 "Local execution supports public notes"
             );
             assert_eq!(
-                tag.validate(NoteType::OffChain),
+                tag.validate(NoteType::Private),
                 Ok(tag),
-                "Local execution supports offchain notes"
+                "Local execution supports private notes"
             );
             assert_eq!(
                 tag.validate(NoteType::Encrypted),
@@ -439,8 +439,8 @@ mod tests {
         let tag = tag.unwrap();
         assert_eq!(tag.validate(NoteType::Public), Ok(tag));
         assert_eq!(
-            tag.validate(NoteType::OffChain),
-            Err(NoteError::NetworkExecutionRequiresPublicNote(NoteType::OffChain))
+            tag.validate(NoteType::Private),
+            Err(NoteError::NetworkExecutionRequiresPublicNote(NoteType::Private))
         );
         assert_eq!(
             tag.validate(NoteType::Encrypted),
@@ -464,8 +464,8 @@ mod tests {
         let tag = tag.unwrap();
         assert_eq!(tag.validate(NoteType::Public), Ok(tag));
         assert_eq!(
-            tag.validate(NoteType::OffChain),
-            Err(NoteError::PublicUseCaseRequiresPublicNote(NoteType::OffChain))
+            tag.validate(NoteType::Private),
+            Err(NoteError::PublicUseCaseRequiresPublicNote(NoteType::Private))
         );
         assert_eq!(
             tag.validate(NoteType::Encrypted),
@@ -497,9 +497,9 @@ mod tests {
             "Local execution supports private notes"
         );
         assert_eq!(
-            tag.validate(NoteType::OffChain),
+            tag.validate(NoteType::Private),
             Ok(tag),
-            "Local execution supports offchain notes"
+            "Local execution supports private notes"
         );
         assert_eq!(
             tag.validate(NoteType::Encrypted),

--- a/objects/src/notes/note_type.rs
+++ b/objects/src/notes/note_type.rs
@@ -8,7 +8,7 @@ use crate::{
 
 // Keep these masks in sync with `miden-lib/asm/miden/kernels/tx/tx.masm`
 const PUBLIC: u8 = 0b01;
-const OFF_CHAIN: u8 = 0b10;
+const PRIVATE: u8 = 0b10;
 const ENCRYPTED: u8 = 0b11;
 
 // NOTE TYPE
@@ -19,7 +19,7 @@ const ENCRYPTED: u8 = 0b11;
 #[repr(u8)]
 pub enum NoteType {
     /// Notes with this type have only their hash published to the network.
-    OffChain = OFF_CHAIN,
+    Private = PRIVATE,
 
     /// Notes with type are shared with the network encrypted.
     Encrypted = ENCRYPTED,
@@ -45,7 +45,7 @@ impl TryFrom<u8> for NoteType {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            OFF_CHAIN => Ok(NoteType::OffChain),
+            PRIVATE => Ok(NoteType::Private),
             ENCRYPTED => Ok(NoteType::Encrypted),
             PUBLIC => Ok(NoteType::Public),
             _ => Err(NoteError::InvalidNoteTypeValue(value.into())),
@@ -100,7 +100,7 @@ impl Deserializable for NoteType {
         let discriminat = u8::read_from(source)?;
 
         let note_type = match discriminat {
-            OFF_CHAIN => NoteType::OffChain,
+            PRIVATE => NoteType::Private,
             ENCRYPTED => NoteType::Encrypted,
             PUBLIC => NoteType::Public,
             v => {

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -197,7 +197,7 @@ impl OutputNote {
     /// - All partial notes are converted into note headers.
     pub fn shrink(&self) -> Self {
         match self {
-            OutputNote::Full(note) if note.metadata().is_offchain() => {
+            OutputNote::Full(note) if note.metadata().is_private() => {
                 OutputNote::Header(*note.header())
             },
             OutputNote::Partial(note) => OutputNote::Header(note.into()),


### PR DESCRIPTION
This PR updates the nodes naming, changing "consumed" / "created" notes to "input" / "output" notes as it was suggested in the related issue: #778.

Also `OffChain` enum variant of the `NoteType` was renamed to `Private`. 