### PR TITLE
feat: Change `TransactionArgs` to use `AdviceInputs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0 (TBD)
 
-- Changed the `TransactionArgs` to use `AdviceInputs` (#793).
+- [BREAKING] Changed the `TransactionArgs` to use `AdviceInputs` (#793).
 
 ## 0.4.0 (2024-07-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.0 (TBD)
 
+- Changed the `TransactionArgs` to use `AdviceInputs` (#793).
+
 ## 0.4.0 (2024-07-03)
 
 ### Features

--- a/miden-lib/build.rs
+++ b/miden-lib/build.rs
@@ -76,7 +76,7 @@ fn compile_miden_lib(source_dir: &Path, target_dir: &Path) -> io::Result<()> {
 
                 for line in modified {
                     write.write_all(line.unwrap().as_bytes()).unwrap();
-                    write.write_all(&[b'\n']).unwrap();
+                    write.write_all(b"\n").unwrap();
                 }
                 write.flush().unwrap();
             }

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -93,7 +93,7 @@ fn extend_advice_inputs(
     add_chain_mmr_to_advice_inputs(tx_inputs.block_chain(), advice_inputs);
     add_account_to_advice_inputs(tx_inputs.account(), tx_inputs.account_seed(), advice_inputs);
     add_input_notes_to_advice_inputs(tx_inputs.input_notes(), tx_args, advice_inputs);
-    advice_inputs.extend_map(tx_args.advice_map().clone());
+    advice_inputs.extend(tx_args.advice_inputs().clone());
 }
 
 // ADVICE STACK BUILDER

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -367,8 +367,11 @@ fn test_note_script_and_note_args() {
         (tx_context.input_notes().get_note(1).note().id(), note_args[0]),
     ]);
 
-    let tx_args =
-        TransactionArgs::new(None, Some(note_args_map), tx_context.tx_args().advice_map().clone());
+    let tx_args = TransactionArgs::new(
+        None,
+        Some(note_args_map),
+        tx_context.tx_args().advice_inputs().clone(),
+    );
 
     tx_context.set_tx_args(tx_args);
     let process = tx_context.execute_code(code).unwrap();

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -370,7 +370,7 @@ fn test_note_script_and_note_args() {
     let tx_args = TransactionArgs::new(
         None,
         Some(note_args_map),
-        tx_context.tx_args().advice_inputs().clone(),
+        tx_context.tx_args().advice_inputs().clone().map,
     );
 
     tx_context.set_tx_args(tx_args);

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -80,7 +80,7 @@ fn test_transaction_prologue() {
     let tx_args = TransactionArgs::new(
         Some(tx_script),
         Some(note_args_map),
-        tx_context.tx_args().advice_inputs().clone(),
+        tx_context.tx_args().advice_inputs().clone().map,
     );
 
     tx_context.set_tx_args(tx_args);

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -80,7 +80,7 @@ fn test_transaction_prologue() {
     let tx_args = TransactionArgs::new(
         Some(tx_script),
         Some(note_args_map),
-        tx_context.tx_args().advice_map().clone(),
+        tx_context.tx_args().advice_inputs().clone(),
     );
 
     tx_context.set_tx_args(tx_args);

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -291,8 +291,11 @@ fn executed_transaction_account_delta() {
     );
     let tx_script_code = ProgramAst::parse(&tx_script).unwrap();
     let tx_script = executor.compile_tx_script(tx_script_code, vec![], vec![]).unwrap();
-    let tx_args =
-        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_inputs().clone());
+    let tx_args = TransactionArgs::new(
+        Some(tx_script),
+        None,
+        tx_context.tx_args().advice_inputs().clone().map,
+    );
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context
@@ -566,8 +569,11 @@ fn executed_transaction_output_notes() {
     );
     let tx_script_code = ProgramAst::parse(&tx_script).unwrap();
     let tx_script = executor.compile_tx_script(tx_script_code, vec![], vec![]).unwrap();
-    let mut tx_args =
-        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_inputs().clone());
+    let mut tx_args = TransactionArgs::new(
+        Some(tx_script),
+        None,
+        tx_context.tx_args().advice_inputs().clone().map,
+    );
 
     tx_args.add_expected_output_note(&expected_output_note_2);
     tx_args.add_expected_output_note(&expected_output_note_3);
@@ -701,8 +707,11 @@ fn test_tx_script() {
             vec![],
         )
         .unwrap();
-    let tx_args =
-        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_inputs().clone());
+    let tx_args = TransactionArgs::new(
+        Some(tx_script),
+        None,
+        tx_context.tx_args().advice_inputs().clone().map,
+    );
 
     let executed_transaction =
         executor.execute_transaction(account_id, block_ref, &note_ids, tx_args);

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -292,7 +292,7 @@ fn executed_transaction_account_delta() {
     let tx_script_code = ProgramAst::parse(&tx_script).unwrap();
     let tx_script = executor.compile_tx_script(tx_script_code, vec![], vec![]).unwrap();
     let tx_args =
-        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_map().clone());
+        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_inputs().clone());
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context
@@ -567,7 +567,7 @@ fn executed_transaction_output_notes() {
     let tx_script_code = ProgramAst::parse(&tx_script).unwrap();
     let tx_script = executor.compile_tx_script(tx_script_code, vec![], vec![]).unwrap();
     let mut tx_args =
-        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_map().clone());
+        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_inputs().clone());
 
     tx_args.add_expected_output_note(&expected_output_note_2);
     tx_args.add_expected_output_note(&expected_output_note_3);
@@ -702,7 +702,7 @@ fn test_tx_script() {
         )
         .unwrap();
     let tx_args =
-        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_map().clone());
+        TransactionArgs::new(Some(tx_script), None, tx_context.tx_args().advice_inputs().clone());
 
     let executed_transaction =
         executor.execute_transaction(account_id, block_ref, &note_ids, tx_args);

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -135,7 +135,7 @@ impl TransactionArgs {
         self.advice_inputs.extend_map(iter)
     }
 
-    /// Extends the internal advice inputs' map with the provided key-value pairs.
+    /// Extends the internal advice inputs' merkle store with the provided nodes.
     pub fn extend_merkle_store<I: Iterator<Item = InnerNodeInfo>>(&mut self, iter: I) {
         self.advice_inputs.extend_merkle_store(iter)
     }


### PR DESCRIPTION
This PR changes the `AdviceMap` inside `TransactionArgs` to `AdviceInputs`. This is needed so the `TransactionArgs` contain a `MerkleStore`, which was suggested in [this comment](https://github.com/0xPolygonMiden/miden-client/issues/243#issuecomment-2211464068) from `miden-client`.