### PR TITLE
Remove asset commitment from note input

### DIFF
--- a/miden-lib/asm/miden/kernels/tx/prologue.masm
+++ b/miden-lib/asm/miden/kernels/tx/prologue.masm
@@ -62,9 +62,6 @@ const.ERR_PROLOGUE_NOTE_MMR_DIGEST_MISMATCH=0x0002001A
 # Number of note assets exceeded the maximum limit of 256
 const.ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS=0x0002001C
 
-# Provided info about assets of an input do not match its commitment
-const.ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH=0x0002001D
-
 # Number of input notes exceeded the kernel's maximum limit of 1023
 const.ERR_PROLOGUE_TOO_MANY_INPUT_NOTES=0x0002001E
 
@@ -561,12 +558,11 @@ end
 
 #! Copies the input note's details from the advice stack to memory and computes its nullifier.
 #!
-#! Stack: [note_ptr]
+#! Stack: [note_ptr, ASSETS_HASH]
 #! Advice stack: [
 #!      SERIAL_NUMBER,
 #!      SCRIPT_ROOT,
 #!      INPUTS_HASH,
-#!      ASSETS_HASH,
 #! ]
 #! Output: [NULLIFIER]
 #!
@@ -579,16 +575,31 @@ end
 #! - NULLIFIER result of `hash(SERIAL_NUMBER || SCRIPT_ROOT || INPUTS_HASH || ASSETS_HASH)`.
 proc.process_input_note_details
     exec.memory::get_input_note_core_ptr
-    # => [note_data_ptr]
+    # => [note_data_ptr, ASSETS_HASH]
 
     # read input note's data and compute its digest. See `Advice stack` above for details.
     padw padw padw
+    # compute hash from SERIAL_NUMBER and SCRIPT_ROOT
     adv_pipe hperm
-    adv_pipe hperm
-    exec.native::state_to_digest
-    # => [NULLIFIER, note_data_ptr + 4]
 
-    movup.4 drop
+    # load INPUTS_HASH to the stack 
+    dropw adv_loadw 
+    # => [INPUTS_HASH, C, note_data_ptr + 2, ASSETS_HASH]
+
+    # store INPUTS_HASH in the memory at the adress note_data_ptr + 2
+    dup.8 mem_storew
+    # => [INPUTS_HASH, C, note_data_ptr + 2, ASSETS_HASH]
+
+    # get the ASSETS_HASH and note data pointer to the top of the stack
+    movupw.2 movup.12 movdn.4
+    # => [note_data_ptr + 2, ASSETS_HASH, INPUTS_HASH, C]
+
+    # store ASSETS_HASH in the memory at the adress note_data_ptr + 3
+    add.1 mem_storew
+    # => [ASSETS_HASH, INPUTS_HASH, C]
+
+    hperm
+    exec.native::state_to_digest
     # => [NULLIFIER]
 end
 
@@ -629,7 +640,7 @@ end
 #!      assets_count,
 #!      ASSET_0, ..., ASSET_N,
 #! ]
-#! Output: []
+#! Output: [ASSET_HASH_COMPUTED]
 #!
 #! Where:
 #! - note_ptr, memory location for the input note.
@@ -696,13 +707,8 @@ proc.process_note_assets
     exec.native::state_to_digest
     # => [ASSET_HASH_COMPUTED, assets_ptr+n, note_ptr, counter+n, rounded_num_assets]
 
-    swapw drop movdn.2 drop drop
-    # => [note_ptr, ASSET_HASH_COMPUTED]
-
-    # VERIFY: computed ASSET_HASH matches the provided hash
-    exec.memory::get_input_note_assets_hash
-    assert_eqw.err=ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH
-    # => []
+    swapw dropw
+    # => [ASSET_HASH_COMPUTED]
 end
 
 #! Adds the assets of an input note to the input vault.
@@ -789,14 +795,13 @@ end
 #!
 #! Stack: [idx, HASHER_CAPACITY]
 #! Advice stack: [
+#!      assets_count,
+#!      ASSET_0, ..., ASSET_N,
 #!      SERIAL_NUMBER,
 #!      SCRIPT_ROOT,
 #!      INPUTS_HASH,
-#!      ASSETS_HASH,
 #!      ARGS,
 #!      NOTE_METADATA,
-#!      assets_count,
-#!      ASSET_0, ..., ASSET_N,
 #!      is_authenticated,
 #!      (
 #!          block_num,
@@ -809,14 +814,13 @@ end
 #! Where:
 #! - idx, the index of the input note.
 #! - HASHER_CAPACITY, state of the hasher capacity word, with the commitment to the previous notes.
+#! - assets_count, note's assets count.
+#! - ASSET_0, ..., ASSET_N, padded note's assets.
 #! - SERIAL_NUMBER, note's serial.
 #! - SCRIPT_ROOT, note's script root.
 #! - INPUTS_HASH, sequential hash of the padded note's inputs.
-#! - ASSETS_HASH, sequential hash of the padded note's assets.
 #! - NOTE_METADATA, note's metadata.
 #! - ARGS, user arguments passed to the note.
-#! - assets_count, note's assets count.
-#! - ASSET_0, ..., ASSET_N, padded note's assets.
 #! - is_authenticated, boolean indicating if the note contains an authentication proof.
 #!
 #! Optional values, required if `is_authenticated` is true:
@@ -826,11 +830,24 @@ end
 #! - NOTE_ROOT, the merkle root of the note's tree.
 #!
 proc.process_input_note
+    # get the note pointer
+    dup exec.memory::get_input_note_ptr
+    # => [note_ptr, idx, HASHER_CAPACITY]
+
+    # note assets
+    # ---------------------------------------------------------------------------------------------
+
+    dup exec.process_note_assets
+    # => [ASSET_HASH_COMPUTED, note_ptr, idx, HASHER_CAPACITY]
+
+    dup.4 exec.add_input_note_assets_to_vault
+    # => [ASSET_HASH_COMPUTED, note_ptr, idx, HASHER_CAPACITY]
+
     # note details
     # ---------------------------------------------------------------------------------------------
 
-    dup exec.memory::get_input_note_ptr dup
-    # => [note_ptr, note_ptr, idx, HASHER_CAPACITY]
+    dup.4 
+    # => [note_ptr, ASSET_HASH_COMPUTED, note_ptr, idx, HASHER_CAPACITY]
 
     exec.process_input_note_details
     # => [NULLIFIER, note_ptr, idx, HASHER_CAPACITY]
@@ -849,13 +866,6 @@ proc.process_input_note
     # => [NOTE_METADATA, note_ptr, NULLIFIER, HASHER_CAPACITY]
 
     movup.4
-    # => [note_ptr, NOTE_METADATA, NULLIFIER, HASHER_CAPACITY]
-
-    # note assets
-    # ---------------------------------------------------------------------------------------------
-
-    dup exec.process_note_assets
-    dup exec.add_input_note_assets_to_vault
     # => [note_ptr, NOTE_METADATA, NULLIFIER, HASHER_CAPACITY]
 
     # note id

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -265,11 +265,11 @@ fn add_account_to_advice_inputs(
 /// The advice provider is populated with:
 ///
 /// - For each note:
-///     - The note's details (serial number, script root, and its' input / assets hash).
+///     - The note's asset padded. Prefixed by its length and padded to an even word length.
+///     - The note's details (serial number, script root, and its' input hash).
 ///     - The note's private arguments.
 ///     - The note's public metadata.
 ///     - The note's public inputs data. Prefixed by its length and padded to an even word length.
-///     - The note's asset padded. Prefixed by its length and padded to an even word length.
 ///     - For autheticated notes (determined by the `is_authenticated` flag):
 ///         - The note's authentication path against its block's note tree.
 ///         - The block number, sub hash, note root.
@@ -301,19 +301,18 @@ fn add_input_notes_to_advice_inputs(
 
         inputs.extend_map([(assets.commitment(), assets.to_padded_assets())]);
 
+        // NOTE: keep in sync with the `prologue::process_note_assets` kernel procedure
+        note_data.push((assets.num_assets() as u32).into());
+        note_data.extend(assets.to_padded_assets());
+
         // NOTE: keep in sync with the `prologue::process_input_note_details` kernel procedure
         note_data.extend(recipient.serial_num());
         note_data.extend(*recipient.script().hash());
         note_data.extend(*recipient.inputs().commitment());
-        note_data.extend(*assets.commitment());
 
         // NOTE: keep in sync with the `prologue::process_note_args_and_metadata` kernel procedure
         note_data.extend(Word::from(*note_arg));
         note_data.extend(Word::from(note.metadata()));
-
-        // NOTE: keep in sync with the `prologue::process_note_assets` kernel procedure
-        note_data.push((assets.num_assets() as u32).into());
-        note_data.extend(assets.to_padded_assets());
 
         // insert note authentication path nodes into the Merkle store
         match input_note {

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -198,7 +198,6 @@ const ERR_PROLOGUE_ACCT_ID_MISMATCH: u32 = 131097;
 const ERR_PROLOGUE_NOTE_MMR_DIGEST_MISMATCH: u32 = 131098;
 const ERR_NOTE_TOO_MANY_INPUTS: u32 = 131099;
 const ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS: u32 = 131100;
-const ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH: u32 = 131101;
 const ERR_PROLOGUE_TOO_MANY_INPUT_NOTES: u32 = 131102;
 const ERR_PROLOGUE_INPUT_NOTES_COMMITMENT_MISMATCH: u32 = 131103;
 const ERR_TX_OUTPUT_NOTES_OVERFLOW: u32 = 131104;
@@ -245,7 +244,7 @@ const ERR_SETTING_NON_VALUE_ITEM_ON_VALUE_SLOT: u32 = 131143;
 const ERR_SETTING_MAP_ITEM_ON_NON_MAP_SLOT: u32 = 131144;
 const ERR_READING_MAP_VALUE_FROM_NON_MAP_SLOT: u32 = 131145;
 
-pub const KERNEL_ERRORS: [(u32, &str); 75] = [
+pub const KERNEL_ERRORS: [(u32, &str); 74] = [
     (ERR_FAUCET_RESERVED_DATA_SLOT, "For faucets, storage slot 254 is reserved and can not be used with set_account_item procedure"),
     (ERR_ACCT_MUST_BE_A_FAUCET, "Procedure can only be called from faucet accounts"),
     (ERR_P2ID_WRONG_NUMBER_OF_INPUTS, "P2ID scripts expect exactly 1 note input"),
@@ -275,7 +274,6 @@ pub const KERNEL_ERRORS: [(u32, &str); 75] = [
     (ERR_PROLOGUE_NOTE_MMR_DIGEST_MISMATCH, "Reference block MMR and note's authentication MMR must match"),
     (ERR_NOTE_TOO_MANY_INPUTS, "Number of note inputs exceeded the maximum limit of 128"),
     (ERR_PROLOGUE_NOTE_TOO_MANY_ASSETS, "Number of note assets exceeded the maximum limit of 256"),
-    (ERR_PROLOGUE_NOTE_CONSUMED_ASSETS_MISMATCH, "Provided info about assets of an input do not match its commitment"),
     (ERR_PROLOGUE_TOO_MANY_INPUT_NOTES, "Number of input notes exceeded the kernel's maximum limit of 1023"),
     (ERR_PROLOGUE_INPUT_NOTES_COMMITMENT_MISMATCH, "Commitment computed for input notes' from advice data doesn't match kernel inputs"),
     (ERR_TX_OUTPUT_NOTES_OVERFLOW, "Output notes exceeded the maximum limit of 4096"),


### PR DESCRIPTION
This PR removes the `ASSETS_HASH` from advice stack in the prologue. In order to get the nullifier the computed assets hash was used instead. 

Related issue: #704 