### PR TITLE
Allow increasing an account's nonce without changing its state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [BREAKING] Renamed public accessors of the `Block` struct to match the updated fields (#791).
 - [BREAKING] Changed the `TransactionArgs` to use `AdviceInputs` (#793).
 - Setters in `memory` module don't drop the setting `Word` anymore (#795).
+- [BREAKING] Increase of nonce does not require changes in account state any more (#789).
 
 ## 0.4.0 (2024-07-03)
 

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -392,26 +392,13 @@ fn test_empty_delta_nonce_update() {
 
     let tx_script = format!(
         "\
-        use.miden::account
-        use.miden::contracts::wallets::basic->wallet
-
-        ## ACCOUNT PROCEDURE WRAPPERS
-        ## ========================================================================================
-        #TODO: Move this into an account library
-        proc.incr_nonce
-            call.{ACCOUNT_INCR_NONCE_MAST_ROOT}
-            # => [0]
-
-            drop
-            # => []
-        end
-
-        ## TRANSACTION SCRIPT
-        ## ========================================================================================
         begin
-            ## Update the account nonce
-            ## ------------------------------------------------------------------------------------
-            push.1 exec.incr_nonce drop
+            push.1 
+            
+            call.{ACCOUNT_INCR_NONCE_MAST_ROOT}
+            # => [0, 1]
+            
+            drop drop
             # => []
         end
     "

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -41,7 +41,6 @@ impl AccountDelta {
     /// # Errors
     /// Returns an error if:
     /// - Storage or vault deltas are invalid.
-    /// - Storage and vault deltas are empty, and the nonce was updated.
     /// - Storage or vault deltas are not empty, but nonce was not updated.
     pub fn new(
         storage: AccountStorageDelta,
@@ -169,7 +168,6 @@ impl Deserializable for AccountUpdateDetails {
 /// # Errors
 /// Returns an error if:
 /// - Storage or vault were updated, but the nonce was either not updated or set to 0.
-/// - Storage and vault were not updated, but the nonce was updated.
 fn validate_nonce(
     nonce: Option<Felt>,
     storage: &AccountStorageDelta,
@@ -190,10 +188,6 @@ fn validate_nonce(
                 ))
             },
         }
-    } else if nonce.is_some() {
-        return Err(AccountDeltaError::InconsistentNonceUpdate(
-            "nonce updated for empty delta".to_string(),
-        ));
     }
 
     Ok(())
@@ -222,7 +216,7 @@ mod tests {
         };
 
         assert!(AccountDelta::new(storage_delta.clone(), vault_delta.clone(), None).is_ok());
-        assert!(AccountDelta::new(storage_delta.clone(), vault_delta.clone(), Some(ONE)).is_err());
+        assert!(AccountDelta::new(storage_delta.clone(), vault_delta.clone(), Some(ONE)).is_ok());
 
         // non-empty delta
         let storage_delta = AccountStorageDelta {

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -51,7 +51,7 @@ impl AccountDelta {
         storage.validate()?;
         vault.validate()?;
 
-        // nonce must be updated if and only if either account storage or vault were updated
+        // nonce must be updated if either account storage or vault were updated
         validate_nonce(nonce, &storage, &vault)?;
 
         Ok(Self { storage, vault, nonce })

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -481,7 +481,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn empty_account_delta_with_incremented_nonce() {
         // build account
         let init_nonce = Felt::new(1);


### PR DESCRIPTION
This small PR removes the restriction from nonce to be changed without changing the account state, which was suggested in the related issue: #765.