### PR TITLE
Add warning for `CHANGELOG.md`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+# Runs changelog related jobs.
+# CI job heavily inspired by: https://github.com/tarides/changelog-check-action
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check for changes in changelog
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+        run: ./scripts/check-changelog.sh "${{ inputs.changelog }}"
+        shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,22 +51,3 @@ jobs:
           override: true
       - name: check rust versions
         run: ./scripts/check-rust-version.sh
-
-  changelog:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@main
-        with:
-          fetch-depth: 0
-      - name: Check if CHANGELOG.md is modified
-        run: |
-          # Get the list of changed files in the PR
-          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
-          # Check if CHANGELOG.md is in the list of changed files
-          if echo "$changed_files" | grep -q '^CHANGELOG.md$'; then
-            echo "CHANGELOG.md has been modified."
-          else
-            echo $'::warning file=CHANGELOG.md::CHANGELOG.md has not been modified.\n This warning can be ignored if is has been explicitely decided not to log changes.\n Except in this situation, make sure to add log changes.'
-            exit 1
-          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,16 +9,16 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  version:
-    name: check rust version consistency
+  clippy:
+    name: clippy nightly on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-        with:
-          profile: minimal
-          override: true
-      - name: check rust versions
-        run: ./scripts/check-rust-version.sh
+      - name: Clippy
+        run: |
+          rustup update --no-self-update nightly
+          rustup +nightly component add clippy
+          make clippy
 
   rustfmt:
     name: rustfmt check nightly on ubuntu-latest
@@ -31,17 +31,6 @@ jobs:
           rustup +nightly component add rustfmt
           make format-check
 
-  clippy:
-    name: clippy nightly on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - name: Clippy
-        run: |
-          rustup update --no-self-update nightly
-          rustup +nightly component add clippy
-          make clippy
-
   doc:
     name: doc stable on ubuntu-latest
     runs-on: ubuntu-latest
@@ -51,3 +40,33 @@ jobs:
         run: |
           rustup update --no-self-update
           make doc
+
+  version:
+    name: check rust version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+        with:
+          profile: minimal
+          override: true
+      - name: check rust versions
+        run: ./scripts/check-rust-version.sh
+
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check if CHANGELOG.md is modified
+        run: |
+          # Get the list of changed files in the PR
+          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
+          # Check if CHANGELOG.md is in the list of changed files
+          if echo "$changed_files" | grep -q '^CHANGELOG.md$'; then
+            echo "CHANGELOG.md has been modified."
+          else
+            echo $'::warning file=CHANGELOG.md::CHANGELOG.md has not been modified.\n This warning can be ignored if is has been explicitely decided not to log changes.\n Except in this situation, make sure to add log changes.'
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.0 (TBD)
 
+- Added `CHANGELOG.md` warning message on CI (#799).
 - Renamed "consumed" and "created" notes into "input" and "output" respectively (#791).
 - [BREAKING] Renamed `NoteType::OffChain` into `NoteType::Private`.
 - [BREAKING] Renamed public accessors of the `Block` struct to match the updated fields (#791).
@@ -42,9 +43,9 @@
 
 ## 0.3.1 (2024-06-12)
 
-* Replaced `cargo-make` with just `make` for running tasks (#696).
-* Made `DataStore` conditionally async using `winter-maybe-async` (#725)
-* Fixed `StorageMap`s implementation and included into apply_delta (#745)
+- Replaced `cargo-make` with just `make` for running tasks (#696).
+- Made `DataStore` conditionally async using `winter-maybe-async` (#725)
+- Fixed `StorageMap`s implementation and included into apply_delta (#745)
 
 ## 0.3.0 (2024-05-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 0.5.0 (TBD)
 
-- Added `CHANGELOG.md` warning message on CI (#799).
+- [BREAKING] Increase of nonce does not require changes in account state any more (#789).
 - Renamed "consumed" and "created" notes into "input" and "output" respectively (#791).
 - [BREAKING] Renamed `NoteType::OffChain` into `NoteType::Private`.
 - [BREAKING] Renamed public accessors of the `Block` struct to match the updated fields (#791).
 - [BREAKING] Changed the `TransactionArgs` to use `AdviceInputs` (#793).
 - Setters in `memory` module don't drop the setting `Word` anymore (#795).
-- [BREAKING] Increase of nonce does not require changes in account state any more (#789).
+- Added `CHANGELOG.md` warning message on CI (#799).
 
 ## 0.4.0 (2024-07-03)
 

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -uo pipefail
+
+CHANGELOG_FILE="${1:-CHANGELOG.md}"
+
+if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+    # 'no changelog' set, so finish successfully
+    echo "\"no changelog\" label has been set"
+    exit 0
+else
+    # a changelog check is required
+    # fail if the diff is empty
+    if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
+        >&2 echo "Changes should come with an entry in the \"CHANGELOG.md\" file. This behavior
+can be overridden by using the \"no changelog\" label, which is used for changes
+that are trivial / explicitely stated not to require a changelog entry."
+        exit 1
+    fi
+
+    echo "The \"CHANGELOG.md\" file has been updated."
+fi


### PR DESCRIPTION
In this PR I propose to add a warning if the `CHANGELOG.md` file has not been modified on PR.