### PR TITLE
Made `node_index_in_block` method return `u32`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added `CHANGELOG.md` warning message on CI (#799).
 - Account deltas can now be merged (#797).
 - Changed `AccountCode` procedures from merkle tree to sequential hash + added storage_offset support (#763).
-- [BREAKING] Refactored and simplified `NoteOrigin` and `NoteInclusionProof` structs (#810).
+- [BREAKING] Refactored and simplified `NoteOrigin` and `NoteInclusionProof` structs (#810, #814).
 
 ## 0.4.0 (2024-07-03)
 

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -338,19 +338,13 @@ fn add_input_notes_to_advice_inputs(
                 inputs.extend_merkle_store(
                     proof
                         .note_path()
-                        .inner_nodes(proof.location().node_index_in_block(), note.hash())
+                        .inner_nodes(proof.location().node_index_in_block().into(), note.hash())
                         .unwrap(),
                 );
                 note_data.push(proof.location().block_num().into());
                 note_data.extend(note_block_header.sub_hash());
                 note_data.extend(note_block_header.note_root());
-                note_data.push(
-                    proof
-                        .location()
-                        .node_index_in_block()
-                        .try_into()
-                        .expect("value is greater than or equal to the field modulus"),
-                );
+                note_data.push(proof.location().node_index_in_block().into());
             },
             InputNote::Unauthenticated { .. } => {
                 // NOTE: keep in sync with the `prologue::process_input_note` kernel procedure

--- a/objects/src/batches/note_tree.rs
+++ b/objects/src/batches/note_tree.rs
@@ -5,15 +5,15 @@ use miden_crypto::{
 
 use crate::{
     notes::{NoteId, NoteMetadata},
-    BATCH_OUTPUT_NOTES_TREE_DEPTH,
+    BATCH_NOTES_TREE_DEPTH,
 };
 
-/// Wrapper over [SimpleSmt<BATCH_OUTPUT_NOTES_TREE_DEPTH>] for batch note tree.
+/// Wrapper over [SimpleSmt<BATCH_NOTES_TREE_DEPTH>] for batch note tree.
 ///
 /// Each note is stored as two adjacent leaves: odd leaf for id, even leaf for metadata hash.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct BatchNoteTree(SimpleSmt<BATCH_OUTPUT_NOTES_TREE_DEPTH>);
+pub struct BatchNoteTree(SimpleSmt<BATCH_NOTES_TREE_DEPTH>);
 
 impl BatchNoteTree {
     /// Wrapper around [`SimpleSmt::with_contiguous_leaves`] which populates notes at contiguous indices

--- a/objects/src/block/note_tree.rs
+++ b/objects/src/block/note_tree.rs
@@ -8,17 +8,17 @@ use miden_crypto::{
 use crate::{
     notes::NoteMetadata,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    BLOCK_OUTPUT_NOTES_TREE_DEPTH, MAX_NOTES_PER_BATCH, MAX_OUTPUT_NOTES_PER_BLOCK,
+    BLOCK_NOTES_TREE_DEPTH, MAX_NOTES_PER_BATCH, MAX_NOTES_PER_BLOCK,
 };
 
-/// Wrapper over [SimpleSmt<BLOCK_OUTPUT_NOTES_TREE_DEPTH>] for notes tree.
+/// Wrapper over [SimpleSmt<BLOCK_NOTES_TREE_DEPTH>] for notes tree.
 ///
 /// Each note is stored as two adjacent leaves: odd leaf for id, even leaf for metadata hash.
 /// ID's leaf index is calculated as [(batch_idx * MAX_NOTES_PER_BATCH + note_idx_in_batch) * 2].
 /// Metadata hash leaf is stored the next after id leaf: [id_index + 1].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct BlockNoteTree(SimpleSmt<BLOCK_OUTPUT_NOTES_TREE_DEPTH>);
+pub struct BlockNoteTree(SimpleSmt<BLOCK_NOTES_TREE_DEPTH>);
 
 impl BlockNoteTree {
     /// Returns a new [BlockNoteTree] instantiated with entries set as specified by the provided entries.
@@ -93,13 +93,13 @@ impl BlockNoteIndex {
 
     /// Returns an index to the node which the parent of both the note and note metadata.
     pub fn to_absolute_index(&self) -> u32 {
-        const _: () = assert!(MAX_OUTPUT_NOTES_PER_BLOCK <= u32::MAX as usize);
+        const _: () = assert!(MAX_NOTES_PER_BLOCK <= u32::MAX as usize);
         (self.batch_idx() * MAX_NOTES_PER_BATCH + self.note_idx_in_batch()) as u32
     }
 
     /// Returns an index of the leaf containing the note.
     fn leaf_index(&self) -> u32 {
-        const _: () = assert!(MAX_OUTPUT_NOTES_PER_BLOCK * 2 <= u32::MAX as usize);
+        const _: () = assert!(MAX_NOTES_PER_BLOCK * 2 <= u32::MAX as usize);
         self.to_absolute_index() * 2
     }
 }

--- a/objects/src/constants.rs
+++ b/objects/src/constants.rs
@@ -29,13 +29,13 @@ pub const MIN_PROOF_SECURITY_LEVEL: u32 = 96;
 ///
 /// A single note uses two leaves in the tree. The even leaf is used to store the note's id, the
 /// odd leaf is used to store the note's metadata.
-pub const BATCH_OUTPUT_NOTES_TREE_DEPTH: u8 = 13;
+pub const BATCH_NOTES_TREE_DEPTH: u8 = 13;
 
 /// The maximum number of notes that can be created in a single batch.
 ///
 /// Because the tree used in a batch has fixed depth, and each note takes two leaves, the maximum
 /// number of notes is the number of leaves in the tree.
-pub const MAX_NOTES_PER_BATCH: usize = 2_usize.pow((BATCH_OUTPUT_NOTES_TREE_DEPTH - 1) as u32);
+pub const MAX_NOTES_PER_BATCH: usize = 2_usize.pow((BATCH_NOTES_TREE_DEPTH - 1) as u32);
 
 // BLOCK
 // ================================================================================================
@@ -47,17 +47,16 @@ pub const MAX_NOTES_PER_BATCH: usize = 2_usize.pow((BATCH_OUTPUT_NOTES_TREE_DEPT
 /// - The depth of a tree with the leaves set to a batch output note tree root.
 /// - The level at which the batches create note trees are merged, creating a new tree with this
 ///   many additional new levels.
-pub const BLOCK_OUTPUT_NOTES_BATCH_TREE_DEPTH: u8 = 8;
+pub const BLOCK_NOTES_BATCH_TREE_DEPTH: u8 = 8;
 
 /// The final depth of the Sparse Merkle Tree used to store all notes created in a block.
-pub const BLOCK_OUTPUT_NOTES_TREE_DEPTH: u8 =
-    BATCH_OUTPUT_NOTES_TREE_DEPTH + BLOCK_OUTPUT_NOTES_BATCH_TREE_DEPTH;
+pub const BLOCK_NOTES_TREE_DEPTH: u8 = BATCH_NOTES_TREE_DEPTH + BLOCK_NOTES_BATCH_TREE_DEPTH;
 
 /// Maximum number of batches that can be inserted into a single block.
-pub const MAX_BATCHES_PER_BLOCK: usize = 2_usize.pow(BLOCK_OUTPUT_NOTES_BATCH_TREE_DEPTH as u32);
+pub const MAX_BATCHES_PER_BLOCK: usize = 2_usize.pow(BLOCK_NOTES_BATCH_TREE_DEPTH as u32);
 
 /// Maximum number of output notes that can be created in a single block.
-pub const MAX_OUTPUT_NOTES_PER_BLOCK: usize = MAX_NOTES_PER_BATCH * MAX_BATCHES_PER_BLOCK;
+pub const MAX_NOTES_PER_BLOCK: usize = MAX_NOTES_PER_BATCH * MAX_BATCHES_PER_BLOCK;
 
 /// The block height of the genesis block
 pub const GENESIS_BLOCK: u32 = 0;

--- a/objects/src/notes/location.rs
+++ b/objects/src/notes/location.rs
@@ -26,8 +26,8 @@ impl NoteLocation {
     ///
     /// The height of the Merkle tree is `BLOCK_OUTPUT_NOTES_TREE_DEPTH`. Thus, the maximum index
     /// is `2 ^ BLOCK_OUTPUT_NOTES_TREE_DEPTH - 1`.
-    pub fn node_index_in_block(&self) -> u64 {
-        self.node_index_in_block as u64
+    pub fn node_index_in_block(&self) -> u32 {
+        self.node_index_in_block
     }
 }
 

--- a/objects/src/notes/location.rs
+++ b/objects/src/notes/location.rs
@@ -24,8 +24,8 @@ impl NoteLocation {
     ///
     /// # Note
     ///
-    /// The height of the Merkle tree is `BLOCK_OUTPUT_NOTES_TREE_DEPTH`. Thus, the maximum index
-    /// is `2 ^ BLOCK_OUTPUT_NOTES_TREE_DEPTH - 1`.
+    /// The height of the Merkle tree is [BLOCK_NOTES_TREE_DEPTH]. Thus, the maximum index
+    /// is `2 ^ BLOCK_NOTES_TREE_DEPTH - 1`.
     pub fn node_index_in_block(&self) -> u32 {
         self.node_index_in_block
     }

--- a/objects/src/notes/location.rs
+++ b/objects/src/notes/location.rs
@@ -24,8 +24,8 @@ impl NoteLocation {
     ///
     /// # Note
     ///
-    /// The height of the Merkle tree is [BLOCK_NOTES_TREE_DEPTH]. Thus, the maximum index
-    /// is `2 ^ BLOCK_NOTES_TREE_DEPTH - 1`.
+    /// The height of the Merkle tree is [crate::constants::BLOCK_NOTES_TREE_DEPTH].
+    /// Thus, the maximum index is `2 ^ BLOCK_NOTES_TREE_DEPTH - 1`.
     pub fn node_index_in_block(&self) -> u32 {
         self.node_index_in_block
     }

--- a/objects/src/transaction/inputs.rs
+++ b/objects/src/transaction/inputs.rs
@@ -377,7 +377,7 @@ impl InputNote {
 
 /// Returns true if this note belongs to the note tree of the specified block.
 fn is_in_block(note: &Note, proof: &NoteInclusionProof, block_header: &BlockHeader) -> bool {
-    let note_index = proof.location().node_index_in_block();
+    let note_index = proof.location().node_index_in_block().into();
     let note_hash = note.hash();
     proof.note_path().verify(note_index, note_hash, &block_header.note_root())
 }


### PR DESCRIPTION
We had changed construction of `node_index_in_block` to `u32`, but the getter still converts it to `u64`. This PR fixes that.