### PR TITLE
Make `build_swap_tag()` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Changed `AccountCode` procedures from merkle tree to sequential hash + added storage_offset support (#763).
 - Renamed `NoteExecutionHint` to `NoteExecutionMode` and added new `NoteExecutionHint` to `NoteMetadata` (#812).
 - [BREAKING] Refactored and simplified `NoteOrigin` and `NoteInclusionProof` structs (#810, #814).
+- Made `miden_lib::notes::build_swap_tag()` function public (#817).
 
 ## 0.4.0 (2024-07-03)
 

--- a/miden-lib/src/notes/mod.rs
+++ b/miden-lib/src/notes/mod.rs
@@ -150,7 +150,7 @@ pub fn create_swap_note<R: FeltRng>(
 /// together as offered_asset_tag + requested_asset tag.
 ///
 /// Network execution hint for the returned tag is set to `Local`.
-fn build_swap_tag(
+pub fn build_swap_tag(
     note_type: NoteType,
     offered_asset: &Asset,
     requested_asset: &Asset,


### PR DESCRIPTION
This tiny PR makes the `miden_lib::notes::build_swap_tag()` function public as it was requested in the corresponding issue: #806.