### PR TITLE
feat: Add `after_block_num` field to `NoteFile::NoteDetails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Renamed `NoteExecutionHint` to `NoteExecutionMode` and added new `NoteExecutionHint` to `NoteMetadata` (#812).
 - [BREAKING] Refactored and simplified `NoteOrigin` and `NoteInclusionProof` structs (#810, #814).
 - Made `miden_lib::notes::build_swap_tag()` function public (#817).
+- [BREAKING] Changed the `NoteFile::NoteDetails` type to struct and added a `after_block_num` field (#823).
 
 ## 0.4.0 (2024-07-03)
 

--- a/objects/src/notes/file.rs
+++ b/objects/src/notes/file.rs
@@ -12,6 +12,7 @@ pub enum NoteFile {
     NoteId(NoteId),
     /// The note has not yet been recorded on chain.
     ///
+    /// A block number that works as a lower bound when checking for the note's inclusion.
     /// An optional tag is included for note tracking.
     NoteDetails {
         details: NoteDetails,

--- a/objects/src/notes/file.rs
+++ b/objects/src/notes/file.rs
@@ -10,10 +10,14 @@ use super::{Note, NoteDetails, NoteId, NoteInclusionProof, NoteTag};
 pub enum NoteFile {
     /// The note's details aren't known.
     NoteId(NoteId),
-    /// The note has not yet been recorded on chain.
+    /// The note may or may not have already been recorded on chain.
     ///
-    /// A block number that works as a lower bound when checking for the note's inclusion.
-    /// An optional tag is included for note tracking.
+    /// The `after_block_num` specifies the block after which the note is expected to appear on
+    /// chain. Though this should be treated as a hint (i.e., there is no guarantee that the note
+    /// will appear on chain or that it will in fact appear after the specified block).
+    ///
+    /// An optional tag specifies the tag associated with the note, though this also should be
+    /// treated as a hint.
     NoteDetails {
         details: NoteDetails,
         after_block_num: u32,


### PR DESCRIPTION
As described by @bobbinth in his [comment on the note importing issue](https://github.com/0xPolygonMiden/miden-client/issues/405#issuecomment-2241365540), a new field that kept track of a possible block number where a note was committed was needed. With this change we don't need to sync a note from block 0 and now have a lower bound.