### PR TITLE
feat: implement serialization and `Eq` for `TransactionScript`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [BREAKING] Changed the `NoteFile::NoteDetails` type to struct and added a `after_block_num` field (#823).
 - Implemented `cteate_note` and `move_asset_into_note` basic wallet procedures (#808).
 - [BREAKING] Interface of the `miden::tx::add_asset_to_note` procedure was changed (#808).
+- Added serialization and equality comparison for `TransactionScript` (#824).
 
 ## 0.4.0 (2024-07-03)
 


### PR DESCRIPTION
Addresses [this comment](https://github.com/0xPolygonMiden/miden-client/pull/471) from `miden-client`.

Implements `Serializable`, `Deserializable` and derives `PartialEq` and `Eq` for `TransactionScript`. These changes are needed to implement the serialization of `TransactionRequest` in `miden-client`.