### PR TITLE
Fit typo in `create_note` wallet procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [BREAKING] Refactored and simplified `NoteOrigin` and `NoteInclusionProof` structs (#810, #814).
 - Made `miden_lib::notes::build_swap_tag()` function public (#817).
 - [BREAKING] Changed the `NoteFile::NoteDetails` type to struct and added a `after_block_num` field (#823).
-- Implemented `cteate_note` and `move_asset_into_note` basic wallet procedures (#808).
+- Implemented `create_note` and `move_asset_into_note` basic wallet procedures (#808).
 - [BREAKING] Interface of the `miden::tx::add_asset_to_note` procedure was changed (#808).
 - Added serialization and equality comparison for `TransactionScript` (#824).
 

--- a/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -77,7 +77,7 @@ end
 #! - execution_hint is the note's execution hint
 #! - RECIPIENT is the recipient of the note, i.e.,
 #!   hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
-export.cteate_note
+export.create_note
     exec.tx::create_note
     # => [note_idx, PAD(15) ...]
 end

--- a/miden-tx/src/testing/tx_context.rs
+++ b/miden-tx/src/testing/tx_context.rs
@@ -14,7 +14,7 @@ use miden_objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteExecutionHint, NoteId, NoteType},
     testing::{
-        account_code::{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT, ACCOUNT_CREATE_NOTE_MAST_ROOT},
+        account_code::ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT,
         block::{MockChain, MockChainBuilder},
         constants::{
             CONSUMED_ASSET_1_AMOUNT, CONSUMED_ASSET_2_AMOUNT, CONSUMED_ASSET_3_AMOUNT,
@@ -258,6 +258,8 @@ impl TransactionContextBuilder {
     ) -> Note {
         let code = format!(
             "
+            use.miden::contracts::wallets::basic->wallet
+
             begin
                 # NOTE
                 # ---------------------------------------------------------------------------------
@@ -266,7 +268,7 @@ impl TransactionContextBuilder {
                 push.{PUBLIC_NOTE}
                 push.{aux}
                 push.{tag}
-                call.{ACCOUNT_CREATE_NOTE_MAST_ROOT}
+                call.wallet::create_note
 
                 push.{asset}
                 call.{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT}
@@ -300,6 +302,8 @@ impl TransactionContextBuilder {
     ) -> Note {
         let code = format!(
             "
+            use.miden::contracts::wallets::basic->wallet
+
             begin
                 # NOTE 0
                 # ---------------------------------------------------------------------------------
@@ -308,7 +312,7 @@ impl TransactionContextBuilder {
                 push.{PUBLIC_NOTE}
                 push.{aux0}
                 push.{tag0}
-                call.{ACCOUNT_CREATE_NOTE_MAST_ROOT}
+                call.wallet::create_note
 
                 push.{asset0}
                 call.{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT}
@@ -321,7 +325,7 @@ impl TransactionContextBuilder {
                 push.{PUBLIC_NOTE}
                 push.{aux1}
                 push.{tag1}
-                call.{ACCOUNT_CREATE_NOTE_MAST_ROOT}
+                call.wallet::create_note
 
                 push.{asset1}
                 call.{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT}

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -18,9 +18,9 @@ use miden_objects::{
     },
     testing::{
         account_code::{
-            ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT, ACCOUNT_CREATE_NOTE_MAST_ROOT,
-            ACCOUNT_INCR_NONCE_MAST_ROOT, ACCOUNT_REMOVE_ASSET_MAST_ROOT,
-            ACCOUNT_SET_CODE_MAST_ROOT, ACCOUNT_SET_ITEM_MAST_ROOT, ACCOUNT_SET_MAP_ITEM_MAST_ROOT,
+            ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT, ACCOUNT_INCR_NONCE_MAST_ROOT,
+            ACCOUNT_REMOVE_ASSET_MAST_ROOT, ACCOUNT_SET_CODE_MAST_ROOT, ACCOUNT_SET_ITEM_MAST_ROOT,
+            ACCOUNT_SET_MAP_ITEM_MAST_ROOT,
         },
         constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA},
         notes::DEFAULT_NOTE_CODE,
@@ -533,11 +533,11 @@ fn test_send_note_proc() {
                 push.{tag}        # tag
                 # => [tag, aux, note_type, RECIPIENT, ...]
 
-                # pad the stack with zeros before calling the `cteate_note`.
+                # pad the stack with zeros before calling the `create_note`.
                 padw padw swapdw
                 # => [tag, aux, execution_hint, note_type, RECIPIENT, PAD(8) ...]
 
-                call.wallet::cteate_note
+                call.wallet::create_note
                 # => [note_idx, GARBAGE(15)]
 
                 movdn.4
@@ -703,7 +703,7 @@ fn executed_transaction_output_notes() {
             padw padw swapdw
             # => [tag, aux, execution_hint, note_type, RECIPIENT, PAD(8)]
 
-            call.{ACCOUNT_CREATE_NOTE_MAST_ROOT}
+            call.wallet::create_note
             # => [note_idx, PAD(15)]
 
             # remove excess PADs from the stack 
@@ -729,8 +729,8 @@ fn executed_transaction_output_notes() {
         end
 
         proc.remove_asset
-        call.{ACCOUNT_REMOVE_ASSET_MAST_ROOT}
-        # => [note_ptr]
+            call.{ACCOUNT_REMOVE_ASSET_MAST_ROOT}
+            # => [note_ptr]
         end
 
         proc.incr_nonce

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -4,7 +4,7 @@ use crate::accounts::AccountCode;
 
 // The MAST root of the default account's interface. Use these constants to interact with the
 // account's procedures.
-const MASTS: [&str; 13] = [
+const MASTS: [&str; 12] = [
     "0x2558089a129e273cb80886d9845bf6b844fa0a552b9007807d5e3f95f07cfca6",
     "0x996a35ee99d675fec9dbbe8156f53357b1d42b3105ab4dc24172d779d818c1c8",
     "0xe3c24a1109379344874ac5dec91a6311e5563d0194ded29b44ed71535e78b34a",
@@ -13,7 +13,6 @@ const MASTS: [&str; 13] = [
     "0xa61cdf8c75943d293ffcfca73ea07a6639dad1820d64586a2a292bb9f80a4296",
     "0x6877f03ef52e490f7c9e41b297fb79bb78075ff28c6e018aaa1ee30f73e7ea4b",
     "0x24e0a1587d4d1ddff74313518f5187f6042ffbe8f2ddc97d367a5c3da4b17d82",
-    "0x2558089a129e273cb80886d9845bf6b844fa0a552b9007807d5e3f95f07cfca6",
     "0x8f66a752fed49ee97ef9281ec7e3d5d1ffad7b229aac7a96f91f5e50fd391607",
     "0xcd34115714cdcda24f1d6968cbfb67b8b51c1751a2e25e9d6b4e18c35323e5ba",
     "0xff06b90f849c4b262cbfbea67042c4ea017ea0e9c558848a951d44b23370bec5",
@@ -25,11 +24,10 @@ pub const ACCOUNT_INCR_NONCE_MAST_ROOT: &str = MASTS[4];
 pub const ACCOUNT_SET_ITEM_MAST_ROOT: &str = MASTS[5];
 pub const ACCOUNT_SET_MAP_ITEM_MAST_ROOT: &str = MASTS[6];
 pub const ACCOUNT_SET_CODE_MAST_ROOT: &str = MASTS[7];
-pub const ACCOUNT_CREATE_NOTE_MAST_ROOT: &str = MASTS[8];
-pub const ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT: &str = MASTS[9];
-pub const ACCOUNT_REMOVE_ASSET_MAST_ROOT: &str = MASTS[10];
-pub const ACCOUNT_ACCOUNT_PROCEDURE_1_MAST_ROOT: &str = MASTS[11];
-pub const ACCOUNT_ACCOUNT_PROCEDURE_2_MAST_ROOT: &str = MASTS[12];
+pub const ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT: &str = MASTS[8];
+pub const ACCOUNT_REMOVE_ASSET_MAST_ROOT: &str = MASTS[9];
+pub const ACCOUNT_ACCOUNT_PROCEDURE_1_MAST_ROOT: &str = MASTS[10];
+pub const ACCOUNT_ACCOUNT_PROCEDURE_2_MAST_ROOT: &str = MASTS[11];
 
 pub const CODE: &str = "
     export.foo
@@ -74,7 +72,7 @@ impl AccountCode {
         # acct proc 1
         export.wallet::send_asset
         # acct proc 2
-        export.wallet::cteate_note
+        export.wallet::create_note
         # acct proc 3
         export.wallet::move_asset_to_note
 
@@ -115,30 +113,24 @@ impl AccountCode {
         end
 
         # acct proc 8
-        export.create_note
-            exec.tx::create_note
-            # => [note_idx]
-        end
-
-        # acct proc 9
         export.add_asset_to_note
             exec.tx::add_asset_to_note
             # => [ASSET, note_idx]
         end
 
-        # acct proc 10
+        # acct proc 9
         export.remove_asset
             exec.account::remove_asset
             # => [ASSET]
         end
 
-        # acct proc 11
+        # acct proc 10
         export.account_procedure_1
             push.1.2
             add
         end
 
-        # acct proc 12
+        # acct proc 11
         export.account_procedure_2
             push.2.1
             sub
@@ -168,9 +160,8 @@ impl AccountCode {
             code.procedures()[9].mast_root().to_hex(),
             code.procedures()[10].mast_root().to_hex(),
             code.procedures()[11].mast_root().to_hex(),
-            code.procedures()[12].mast_root().to_hex(),
         ];
-        assert!(current == MASTS, "const MASTS: [&str; 13] = {:?};", current);
+        assert!(current == MASTS, "const MASTS: [&str; 12] = {:?};", current);
 
         code
     }


### PR DESCRIPTION
This small PR renames procedure in basic wallet from `cteate_note` to `create_note`. It also removes the duplicated `create_note` procedure from the account code. 