### PR TITLE
Remove `send_asset` procedure from the basic wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Set all procedures storage offsets of faucet accounts to `1` (#875).
 - Added `AccountStorageHeader` (#876).
 - Implemented generation of transaction kernel procedure hashes in build.rs (#887).
+- [BREAKING] `send_asset` procedure was removed from the basic wallet (#829).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/bench-tx/src/utils.rs
+++ b/bench-tx/src/utils.rs
@@ -108,14 +108,14 @@ pub fn write_bench_results_to_json(
     let benchmark_file = read_to_string(path).map_err(|e| e.to_string())?;
     let mut benchmark_json: Value = from_str(&benchmark_file).map_err(|e| e.to_string())?;
 
-    // fill becnhmarks JSON with results of each benchmark
+    // fill benchmarks JSON with results of each benchmark
     for (bench_type, tx_progress) in tx_benchmarks {
         let tx_benchmark_json = serde_json::to_value(tx_progress).map_err(|e| e.to_string())?;
 
         benchmark_json[bench_type.to_string()] = tx_benchmark_json;
     }
 
-    // write the becnhmarks JSON to the results file
+    // write the benchmarks JSON to the results file
     write(
         path,
         to_string_pretty(&benchmark_json).expect("failed to convert json to String"),

--- a/docs/architecture/accounts.md
+++ b/docs/architecture/accounts.md
@@ -91,17 +91,18 @@ There is a standard for a basic user account. It exposes three functions via its
     use.miden::contracts::auth::basic
 
     export.basic_wallet::receive_asset
-    export.basic_wallet::send_asset
+    export.basic_wallet::create_note
+    export.basic_wallet::move_asset_to_note
     export.basic::auth_tx_rpo_falcon512
   ```
 </details>
 
-[Note scripts](notes.md#the-note-script) or transaction scripts can call `receive_asset` and `send_asset`. 
+[Note scripts](notes.md#the-note-script) or transaction scripts can call `receive_asset`, `create_note` and `move_asset_to_note` procedures.
 
-Transaction scripts can also call `auth_tx_rpo_falcon512` and authenticate the transaction. 
+Transaction scripts can also call `auth_tx_rpo_falcon512` and authenticate the transaction.
 
 !!! warning
-    Without correct authentication, i.e. knowing the correct private key, a note cannot successfully invoke `receive_asset` or `send_asset`. 
+    Without correct authentication, i.e. knowing the correct private key, a note cannot successfully invoke `receive_asset`, `create_note` or `move_asset_to_note`.
 
 ##### Basic fungible faucet (faucet for fungible assets)
 

--- a/docs/architecture/transactions/overview.md
+++ b/docs/architecture/transactions/overview.md
@@ -50,7 +50,7 @@ Transferring assets between accounts requires two transactions as shown in the d
 ![Transaction flow](../../img/architecture/transaction/transaction-flow.png)
 </center>
 
-The first transaction invokes a function on `account_a` (e.g. a `send_asset` function) which creates a new note and also updates the internal state of `account_a`. The second transaction consumes the note which invokes a function on `account_b` (e.g. a `receive_asset` function) which updates the internal state of `account_b`.
+The first transaction invokes some functions on `account_a` (e.g. `create_note` and `move_asset_to_note` functions) which creates a new note and also updates the internal state of `account_a`. The second transaction consumes the note which invokes a function on `account_b` (e.g. a `receive_asset` function) which updates the internal state of `account_b`.
 
 ### Asynchronous execution
 

--- a/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -40,6 +40,8 @@ export.auth_tx_rpo_falcon512
     push.1 exec.account::incr_nonce
     # => []
 
+    debug.stack
+
     # Verify the signature against the public key and the message. The procedure gets as
     # inputs the hash of the public key and the hash of the message via the operand
     # stack. The signature is provided via the advice stack. The signature is valid if and

--- a/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -40,8 +40,6 @@ export.auth_tx_rpo_falcon512
     push.1 exec.account::incr_nonce
     # => []
 
-    debug.stack
-
     # Verify the signature against the public key and the message. The procedure gets as
     # inputs the hash of the public key and the hash of the message via the operand
     # stack. The signature is provided via the advice stack. The signature is valid if and

--- a/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -21,44 +21,6 @@ export.receive_asset
     padw swapw dropw
 end
 
-#! Creates a note which sends the specified asset out of the current account
-#! to the specified recipient.
-#!
-#! Inputs: [ASSET, tag, aux, note_type, execution_hint, RECIPIENT, ...]
-#! Outputs: [note_idx, EMPTY_WORD, EMPTY_WORD, 0, 0, 0, ...]
-#!
-#! - ASSET is the non-fungible asset of interest.
-#! - tag is the tag to be included in the note.
-#! - aux is the auxiliary data to be included in the note.
-#! - note_type is the note's storage type
-#! - execution_hint is the note's execution hint
-#! - RECIPIENT is the recipient of the note, i.e.,
-#!   hash(hash(hash(serial_num, [0; 4]), script_hash), input_hash)
-#! - note_idx is the index of the output note.
-#!   This cannot directly be accessed from another context.
-#!
-#! Panics:
-#! - The fungible asset is not found in the vault.
-#! - The amount of the fungible asset in the vault is less than the amount to be removed.
-#! - The non-fungible asset is not found in the vault.
-export.send_asset.1
-    exec.account::remove_asset
-    # => [ASSET, tag, aux, note_type, execution_hint, RECIPIENT, PAD(4)]
-
-    # Store the ASSET for later
-    loc_storew.0 dropw
-    # => [tag, aux, note_type, execution_hint, RECIPIENT, PAD(8)]
-
-    exec.tx::create_note
-    # => [note_idx, PAD(15)]
-
-    movdn.4 loc_loadw.0
-    # => [ASSET, note_idx, PAD(11)]
-
-    exec.tx::add_asset_to_note movup.4
-    # => [note_idx, PAD(15)]
-end
-
 #! Creates a new note.
 #! 
 #! The created note will not have any assets attached to it. To add assets to this note use the
@@ -81,7 +43,6 @@ export.create_note
     exec.tx::create_note
     # => [note_idx, PAD(15) ...]
 end
-
 
 #! Removes the specified asset from the account and adds it to the output note with the specified
 #! index.

--- a/miden-lib/asm/note_scripts/SWAP.masm
+++ b/miden-lib/asm/note_scripts/SWAP.masm
@@ -30,7 +30,8 @@ const.ERR_SWAP_WRONG_NUMBER_OF_ASSETS=0x00020008
 #
 # FAILS if:
 # - Account does not expose miden::contracts::wallets::basic::receive_asset procedure
-# - Account does not expose miden::contracts::wallets::basic::send_asset procedure
+# - Account does not expose miden::contracts::wallets::basic::create_note procedure
+# - Account does not expose miden::contracts::wallets::basic::move_asset_to_note procedure
 # - Account vault does not contain the requested asset
 # - Adding a fungible asset would result in amount overflow, i.e., the total amount would be
 #   greater than 2^63
@@ -79,10 +80,19 @@ begin
     # => [ASSET, tag, aux, note_type, execution_hint, RECIPIENT]
 
     # create a note using inputs
-    call.wallet::send_asset
-    # => [ptr, EMPTY_WORD, EMPTY_WORD, 0]
+    padw swapdw padw movdnw.2
+    # => [tag, aux, note_type, execution_hint, RECIPIENT, PAD(8), ASSET]
+    call.wallet::create_note
+    # => [note_idx, PAD(15), ASSET]
+
+    swapw dropw movupw.3 
+    # => [ASSET, note_idx, PAD(11)]
+
+    # move asset to the note
+    call.wallet::move_asset_to_note
+    # => [ASSET, note_idx, PAD(11)]
 
     # clean stack
-    dropw dropw drop drop drop
+    dropw dropw dropw dropw
     # => []
 end

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -16,12 +16,13 @@ use super::{AuthScheme, TransactionKernel};
 /// Creates a new account with basic wallet interface, the specified authentication scheme and the
 /// account storage type. Basic wallets can be specified to have either mutable or immutable code.
 ///
-/// The basic wallet interface exposes two procedures:
+/// The basic wallet interface exposes three procedures:
 /// - `receive_asset`, which can be used to add an asset to the account.
-/// - `send_asset`, which can be used to remove an asset from the account and put into a note
-///   addressed to the specified recipient.
+/// - `create_note`, which can be used to create a new note without any assets attached to it.
+/// - `move_asset_to_note`, which can be used to remove the specified asset from the account and add
+///   it to the output note with the specified index.
 ///
-/// Both methods require authentication. The authentication procedure is defined by the specified
+/// All methods require authentication. The authentication procedure is defined by the specified
 /// authentication scheme. Public key information for the scheme is stored in the account storage
 /// at slot 0.
 pub fn create_basic_wallet(
@@ -43,7 +44,8 @@ pub fn create_basic_wallet(
     let source_code: String = format!(
         "
         export.::miden::contracts::wallets::basic::receive_asset
-        export.::miden::contracts::wallets::basic::send_asset
+        export.::miden::contracts::wallets::basic::create_note
+        export.::miden::contracts::wallets::basic::move_asset_to_note
         export.::miden::contracts::auth::basic::{auth_scheme_procedure}
     "
     );

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -145,18 +145,58 @@ fn executed_transaction_account_delta() {
     .unwrap();
     let tag2 = NoteTag::for_local_use_case(0, 0).unwrap();
     let tag3 = NoteTag::for_local_use_case(0, 0).unwrap();
+    let tags = [tag1, tag2, tag3];
 
-    let aux1 = Felt::new(27);
-    let aux2 = Felt::new(28);
-    let aux3 = Felt::new(29);
+    let aux_array = [Felt::new(27), Felt::new(28), Felt::new(29)];
 
-    let note_type1 = NoteType::Private;
-    let note_type2 = NoteType::Private;
-    let note_type3 = NoteType::Private;
+    let note_types = [NoteType::Private; 3];
 
-    assert_eq!(tag1.validate(note_type1), Ok(tag1));
-    assert_eq!(tag2.validate(note_type2), Ok(tag2));
-    assert_eq!(tag3.validate(note_type3), Ok(tag3));
+    assert_eq!(tag1.validate(NoteType::Private), Ok(tag1));
+    assert_eq!(tag2.validate(NoteType::Private), Ok(tag2));
+    assert_eq!(tag3.validate(NoteType::Private), Ok(tag3));
+
+    let execution_hint_1 = Felt::from(NoteExecutionHint::always());
+    let execution_hint_2 = Felt::from(NoteExecutionHint::none());
+    let execution_hint_3 = Felt::from(NoteExecutionHint::on_block_slot(1, 1, 1));
+    let hints = [execution_hint_1, execution_hint_2, execution_hint_3];
+
+    let mut send_asset_script = String::new();
+    for i in 0..3 {
+        send_asset_script.push_str(&format!(
+            "
+            ### note {i}
+            # prepare the stack for a new note creation 
+            push.0.1.2.3            # recipient
+            push.{EXECUTION_HINT} # note_execution_hint
+            push.{NOTETYPE}        # note_type
+            push.{aux}             # aux
+            push.{tag}             # tag
+            # => [tag, aux, note_type, execution_hint, RECIPIENT]
+
+            # pad the stack before calling the `create_note`
+            padw padw swapdw
+            # => [tag, aux, note_type, execution_hint, RECIPIENT, PAD(8)]
+
+            # create the note
+            call.::miden::contracts::wallets::basic::create_note
+            # => [note_idx, PAD(15)]
+
+            # move an asset to the created note to partially deplete fungible asset balance
+            swapw dropw push.{REMOVED_ASSET}
+            call.::miden::contracts::wallets::basic::move_asset_to_note
+            # => [ASSET, note_idx, PAD(11)]
+
+            # clear the stack
+            dropw dropw dropw dropw
+
+        ",
+            EXECUTION_HINT = hints[i],
+            NOTETYPE = note_types[i] as u8,
+            aux = aux_array[i],
+            tag = tags[i],
+            REMOVED_ASSET = prepare_word(&Word::from(removed_assets[i]))
+        ));
+    }
 
     let tx_script_src = format!(
         "\
@@ -198,41 +238,7 @@ fn executed_transaction_account_delta() {
 
             ## Send some assets from the account vault
             ## ------------------------------------------------------------------------------------
-            # partially deplete fungible asset balance
-            push.0.1.2.3            # recipient
-            push.{EXECUTION_HINT_1} # note_execution_hint
-            push.{NOTETYPE1}        # note_type
-            push.{aux1}             # aux
-            push.{tag1}             # tag
-            push.{REMOVED_ASSET_1}  # asset
-            # => [ASSET, tag, aux, note_type, RECIPIENT]
-
-            call.::miden::contracts::wallets::basic::send_asset dropw dropw dropw dropw
-            # => []
-
-            # totally deplete fungible asset balance
-            push.0.1.2.3            # recipient
-            push.{EXECUTION_HINT_2} # note_execution_hint
-            push.{NOTETYPE2}        # note_type
-            push.{aux2}             # aux
-            push.{tag2}             # tag
-            push.{REMOVED_ASSET_2}  # asset
-            # => [ASSET, tag, aux, note_type, RECIPIENT]
-
-            call.::miden::contracts::wallets::basic::send_asset dropw dropw dropw dropw
-            # => []
-
-            # send non-fungible asset
-            push.0.1.2.3            # recipient
-            push.{EXECUTION_HINT_3} # note_execution_hint
-            push.{NOTETYPE3}        # note_type
-            push.{aux3}             # aux
-            push.{tag3}             # tag
-            push.{REMOVED_ASSET_3}  # asset
-            # => [ASSET, tag, aux, note_type, RECIPIENT]
-
-            call.::miden::contracts::wallets::basic::send_asset dropw dropw dropw dropw
-            # => []
+            {send_asset_script}
 
             ## Update account code
             ## ------------------------------------------------------------------------------------
@@ -249,15 +255,6 @@ fn executed_transaction_account_delta() {
         UPDATED_SLOT_VALUE = prepare_word(&Word::from(updated_slot_value)),
         UPDATED_MAP_VALUE = prepare_word(&Word::from(updated_map_value)),
         UPDATED_MAP_KEY = prepare_word(&Word::from(updated_map_key)),
-        REMOVED_ASSET_1 = prepare_word(&Word::from(removed_asset_1)),
-        REMOVED_ASSET_2 = prepare_word(&Word::from(removed_asset_2)),
-        REMOVED_ASSET_3 = prepare_word(&Word::from(removed_asset_3)),
-        NOTETYPE1 = note_type1 as u8,
-        NOTETYPE2 = note_type2 as u8,
-        NOTETYPE3 = note_type3 as u8,
-        EXECUTION_HINT_1 = Felt::from(NoteExecutionHint::always()),
-        EXECUTION_HINT_2 = Felt::from(NoteExecutionHint::none()),
-        EXECUTION_HINT_3 = Felt::from(NoteExecutionHint::on_block_slot(1, 1, 1)),
     );
 
     let tx_script = TransactionScript::compile(

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     prove_and_verify_transaction,
 };
 
-#[test]
 // Testing the basic Miden wallet - receiving an asset
+#[test]
 fn prove_receive_asset_via_wallet() {
     // Create assets
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
@@ -99,9 +99,9 @@ fn prove_receive_asset_via_wallet() {
     assert_eq!(executed_transaction.final_account().hash(), target_account_after.hash());
 }
 
+/// Testing sending a note without assets from the basic wallet
 #[test]
-/// Testing the basic Miden wallet - creating a note
-fn prove_create_note_via_wallet() {
+fn prove_send_note_without_asset_via_wallet() {
     let sender_account_id = AccountId::try_from(ACCOUNT_ID_OFF_CHAIN_SENDER).unwrap();
     let (sender_pub_key, sender_falcon_auth) = get_new_pk_and_authenticator();
     let sender_account =
@@ -130,9 +130,6 @@ fn prove_create_note_via_wallet() {
 
     let tx_script_src = &format!(
         "
-        use.miden::contracts::auth::basic->auth_tx
-        use.miden::contracts::wallets::basic->wallet
-
         begin
             padw padw
             push.{recipient}
@@ -142,7 +139,6 @@ fn prove_create_note_via_wallet() {
             push.{tag}
             call.::miden::contracts::wallets::basic::create_note
             dropw dropw dropw dropw
-            call.::miden::contracts::auth::basic::auth_tx_rpo_falcon512
         end
         ",
         recipient = prepare_word(&recipient),
@@ -160,10 +156,8 @@ fn prove_create_note_via_wallet() {
 
     // clones account info
     let sender_account_storage = AccountStorage::new(vec![
-        StorageSlot::Value(Word::default()),
-        StorageSlot::Value(Word::default()),
-        StorageSlot::Value(Word::default()),
         StorageSlot::Value(sender_pub_key),
+        StorageSlot::Value(Word::default()),
         StorageSlot::Map(StorageMap::default()),
     ])
     .unwrap();
@@ -175,15 +169,16 @@ fn prove_create_note_via_wallet() {
         AssetVault::new(&[]).unwrap(),
         sender_account_storage,
         sender_account_code,
-        Felt::new(2),
+        // state of the account did not change, so nonce should remain the same
+        Felt::new(1),
     );
 
     assert_eq!(executed_transaction.final_account().hash(), sender_account_after.hash());
 }
 
-#[test]
 /// Testing the basic Miden wallet - creating a note and moving asset to it
-fn prove_move_asset_to_note_via_wallet() {
+#[test]
+fn prove_send_note_with_asset_via_wallet() {
     let faucet_id_1 = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
     let fungible_asset_1: Asset = FungibleAsset::new(faucet_id_1, 100).unwrap().into();
 

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -19,7 +19,8 @@ pub const CODE: &str = "
 
 pub const DEFAULT_ACCOUNT_CODE: &str = "
     export.::miden::contracts::wallets::basic::receive_asset
-    export.::miden::contracts::wallets::basic::send_asset
+    export.::miden::contracts::wallets::basic::create_note
+    export.::miden::contracts::wallets::basic::move_asset_to_note
     export.::miden::contracts::auth::basic::auth_tx_rpo_falcon512
 ";
 
@@ -43,8 +44,8 @@ impl AccountCode {
         use.miden::account
         use.miden::faucet
         use.miden::tx
+
         export.::miden::contracts::wallets::basic::receive_asset
-        export.::miden::contracts::wallets::basic::send_asset
         export.::miden::contracts::wallets::basic::create_note
         export.::miden::contracts::wallets::basic::move_asset_to_note
 


### PR DESCRIPTION
This PR removes the `send_asset` procedure from the basic wallet. 
To send a note with some assets `create_note` and `move_asset_to_note` procedures should be used instead. 