### PR TITLE
Change max number of account procedures back to 256

### DIFF
--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -76,7 +76,7 @@ const.SLOT_TYPES_COMMITMENT_STORAGE_SLOT=255
 const.MAX_SLOT_TYPE=64
 
 # The maximum number of account interface procedures.
-const.MAX_NUM_PROCEDURES=65535
+const.MAX_NUM_PROCEDURES=256
 
 # EVENTS
 # =================================================================================================

--- a/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -75,7 +75,7 @@ const.ERR_PROLOGUE_INPUT_NOTES_COMMITMENT_MISMATCH=0x0002001F
 # Computed account code hash does not match recorded account code hash
 const.ERR_ACCT_CODE_HASH_MISMATCH=0x0002004C
 
-# Number of account procedures exceeded the maximum limit of 65535
+# Number of account procedures exceeded the maximum limit of 256
 const.ERR_ACCT_TOO_MANY_PROCEDURES=0x0002004D
 
 # PUBLIC INPUTS

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -345,5 +345,5 @@ pub const KERNEL_ERRORS: [(u32, &str); 79] = [
     (ERR_PROC_NOT_PART_OF_ACCOUNT_CODE, "Provided procedure is not part of account code"),
     (ERR_PROC_INDEX_OUT_OF_BOUNDS, "Provided procedure index is out of bounds"),
     (ERR_ACCT_CODE_HASH_MISMATCH, "Provided account hash does not match stored account hash"),
-    (ERR_ACCT_TOO_MANY_PROCEDURES, "Number of account procedures exceeded the maximum limit of 65535")
+    (ERR_ACCT_TOO_MANY_PROCEDURES, "Number of account procedures exceeded the maximum limit of 256")
 ];

--- a/miden-tx/src/host/account_procs.rs
+++ b/miden-tx/src/host/account_procs.rs
@@ -10,14 +10,14 @@ use crate::error::TransactionHostError;
 // ================================================================================================
 
 /// A map of proc_root |-> proc_index for all known procedures of an account interface.
-pub struct AccountProcedureIndexMap(BTreeMap<Digest, u16>);
+pub struct AccountProcedureIndexMap(BTreeMap<Digest, u8>);
 
 impl AccountProcedureIndexMap {
     /// Returns a new [AccountProcedureIndexMap] instantiated with account procedures present in
     /// the provided advice provider.
-    pub fn new<A: AdviceProvider>(
+    pub fn new(
         account_code_commitment: Digest,
-        adv_provider: &A,
+        adv_provider: &impl AdviceProvider,
     ) -> Result<Self, TransactionHostError> {
         // get the account procedures from the advice_map
         let proc_data =
@@ -69,7 +69,7 @@ impl AccountProcedureIndexMap {
                 ))
             })?;
 
-            let proc_idx = u16::try_from(proc_idx).expect("Invalid procedure index.");
+            let proc_idx = u8::try_from(proc_idx).expect("Invalid procedure index.");
 
             result.insert(*procedure.mast_root(), proc_idx);
         }
@@ -83,10 +83,10 @@ impl AccountProcedureIndexMap {
     /// # Errors
     /// Returns an error if the procedure at the top of the operand stack is not present in this
     /// map.
-    pub fn get_proc_index<S: ProcessState>(
+    pub fn get_proc_index(
         &self,
-        process: &S,
-    ) -> Result<u16, TransactionKernelError> {
+        process: &impl ProcessState,
+    ) -> Result<u8, TransactionKernelError> {
         let proc_root = process.get_stack_word(0).into();
 
         // mock account method for testing from root context


### PR DESCRIPTION
This PR changes the number of account procedures back to 255. After thinking a bit more about it, I think 255 is probably large enough and will simplify dealing with potential edge cases.