### PR TITLE
fix: Conditionally import dependency and pass RNG as param

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,3 @@ miden-verifier = { version = "0.10", default-features = false }
 rand = { version = "0.8", default-features = false }
 vm-core = { package = "miden-core", version = "0.10", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.10", default-features = false }
-getrandom = { version = "0.2", features = ["js"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ miden-verifier = { version = "0.10", default-features = false }
 rand = { version = "0.8", default-features = false }
 vm-core = { package = "miden-core", version = "0.10", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.10", default-features = false }
+getrandom = { version = "0.2", features = ["js"]}

--- a/miden-tx/src/testing/mock_chain.rs
+++ b/miden-tx/src/testing/mock_chain.rs
@@ -369,8 +369,10 @@ impl MockChain {
     ) -> Account {
         let (account, seed, authenticator) = match auth_method {
             Auth::BasicAuth => {
+                let mut rng = StdRng::from_entropy();
+
                 let (acc, seed, auth) =
-                    account_builder.build_with_auth(&TransactionKernel::assembler()).unwrap();
+                    account_builder.build_with_auth(&TransactionKernel::assembler(), &mut rng).unwrap();
 
                 let authenticator = BasicAuthenticator::<StdRng>::new(&[(
                     auth.public_key().into(),

--- a/miden-tx/src/testing/mock_chain.rs
+++ b/miden-tx/src/testing/mock_chain.rs
@@ -371,8 +371,9 @@ impl MockChain {
             Auth::BasicAuth => {
                 let mut rng = StdRng::from_entropy();
 
-                let (acc, seed, auth) =
-                    account_builder.build_with_auth(&TransactionKernel::assembler(), &mut rng).unwrap();
+                let (acc, seed, auth) = account_builder
+                    .build_with_auth(&TransactionKernel::assembler(), &mut rng)
+                    .unwrap();
 
                 let authenticator = BasicAuthenticator::<StdRng>::new(&[(
                     auth.public_key().into(),

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -151,11 +151,17 @@ impl<T: Rng> AccountBuilder<T> {
         Ok(Account::from_parts(account_id, vault, storage, account_code, self.nonce))
     }
 
+    /// Build an account using the provided `seed` and `storage`.
+    /// This method also returns the seed and secret key generated for the account based on the 
+    /// provided RNG.
+    ///
+    /// The storage items added to this builder will added on top of `storage`.
     pub fn build_with_auth(
         self,
         assembler: &Assembler,
+        rng: &mut impl Rng
     ) -> Result<(Account, Word, SecretKey), AccountBuilderError> {
-        let sec_key = SecretKey::new();
+        let sec_key = SecretKey::with_rng(rng);
         let pub_key: Word = sec_key.public_key().into();
 
         let storage_item = SlotItem::new_value(0, 0, pub_key);

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -152,14 +152,14 @@ impl<T: Rng> AccountBuilder<T> {
     }
 
     /// Build an account using the provided `seed` and `storage`.
-    /// This method also returns the seed and secret key generated for the account based on the 
+    /// This method also returns the seed and secret key generated for the account based on the
     /// provided RNG.
     ///
     /// The storage items added to this builder will added on top of `storage`.
     pub fn build_with_auth(
         self,
         assembler: &Assembler,
-        rng: &mut impl Rng
+        rng: &mut impl Rng,
     ) -> Result<(Account, Word, SecretKey), AccountBuilderError> {
         let sec_key = SecretKey::with_rng(rng);
         let pub_key: Word = sec_key.public_key().into();

--- a/objects/src/testing/block.rs
+++ b/objects/src/testing/block.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use miden_crypto::merkle::SimpleSmt;
 use vm_core::Felt;
 use vm_processor::Digest;
+#[cfg(not(target_family = "wasm"))]
 use winter_rand_utils::{rand_array, rand_value};
 
 use crate::{accounts::Account, BlockHeader, ACCOUNT_TREE_DEPTH};


### PR DESCRIPTION
Based on [some errors building the new version of the client for `wasm32-unknown-unknown`](https://github.com/0xPolygonMiden/miden-client/actions/runs/10533088664/job/29188479185), I looked at how the features from dependencies were being used for the web crate of the client and found that there were unnecessary imports. After leaving only the correct features, I found that there was a build error for `miden-base` (which can be reproduced by doing `cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx --features testing`). This PR solves those errors.
```
error[E0432]: unresolved imports `winter_rand_utils::rand_array`, `winter_rand_utils::rand_value`
 --> objects/src/testing/block.rs:6:25
  |
6 | use winter_rand_utils::{rand_array, rand_value};
  |                         ^^^^^^^^^^  ^^^^^^^^^^ no `rand_value` in the root
  |                         |
  |                         no `rand_array` in the root

error[E0599]: no function or associated item named `new` found for struct `SecretKey` in the current scope
   --> objects/src/testing/account.rs:158:34
    |
158 |         let sec_key = SecretKey::new();
    |                                  ^^^ function or associated item not found in `SecretKey`
    |
note: if you're trying to build a new `SecretKey`, consider using `SecretKey::with_rng` which returns `SecretKey`
   --> /Users/ignacioamigo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/miden-crypto-0.10.0/src/dsa/rpo_falcon512/keys/secret_key.rs:73:5
    |
73  |     pub fn with_rng<R: Rng>(rng: &mut R) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```
With these changes the [client builds correctly](https://github.com/0xPolygonMiden/miden-client/pull/492/checks).