### PR TITLE
Rename account storage type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.0 (TBD)
 
 - Implemented offset based storage access (#843).
+- [BREAKING] `AccountStorageType` enum was renamed to `AccountStorageMode` along with its variants (#854).
 - [BREAKING] `AccountStub` structure was renamed to `AccountHeader` (#855).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only

--- a/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -22,7 +22,7 @@ const.ERR_PROLOGUE_ACCT_STORAGE_MISMATCH=0x0002000C
 const.ERR_PROLOGUE_ACCT_STORAGE_ARITY_TOO_HIGH=0x0002000D
 
 # Data store in account's storage contains invalid type discriminant
-const.ERR_PROLOGUE_ACCT_STORAGE_TYPE_INVALID=0x0002000E
+const.ERR_PROLOGUE_ACCT_STORAGE_MODE_INVALID=0x0002000E
 
 # New account must have an empty vault
 const.ERR_PROLOGUE_NEW_ACCT_VAULT_NOT_EMPTY=0x0002000F
@@ -265,8 +265,8 @@ proc.validate_storage_slot_types
             # => [type, ...]
 
             # assert the slot type is valid
-            u32split assertz.err=ERR_PROLOGUE_ACCT_STORAGE_TYPE_INVALID
-            exec.account::get_max_slot_type u32lte assert.err=ERR_PROLOGUE_ACCT_STORAGE_TYPE_INVALID
+            u32split assertz.err=ERR_PROLOGUE_ACCT_STORAGE_MODE_INVALID
+            exec.account::get_max_slot_type u32lte assert.err=ERR_PROLOGUE_ACCT_STORAGE_MODE_INVALID
             # => [...]
         end
         # => [slot_type_data_ptr]

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, string::ToString};
 
 use miden_objects::{
     accounts::{
-        Account, AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType, SlotItem,
+        Account, AccountCode, AccountId, AccountStorage, AccountStorageMode, AccountType, SlotItem,
     },
     assets::TokenSymbol,
     AccountError, Felt, Word, ZERO,
@@ -34,7 +34,7 @@ pub fn create_basic_fungible_faucet(
     symbol: TokenSymbol,
     decimals: u8,
     max_supply: Felt,
-    account_storage_type: AccountStorageType,
+    account_storage_mode: AccountStorageMode,
     auth_scheme: AuthScheme,
 ) -> Result<(Account, Word), AccountError> {
     // Atm we only have RpoFalcon512 as authentication scheme and this is also the default in the
@@ -80,7 +80,7 @@ pub fn create_basic_fungible_faucet(
     let account_seed = AccountId::get_account_seed(
         init_seed,
         AccountType::FungibleFaucet,
-        account_storage_type,
+        account_storage_mode,
         account_code.commitment(),
         account_storage.root(),
     )?;
@@ -96,7 +96,7 @@ mod tests {
     use miden_objects::{crypto::dsa::rpo_falcon512, ONE};
 
     use super::{
-        create_basic_fungible_faucet, AccountStorageType, AuthScheme, Felt, TokenSymbol, ZERO,
+        create_basic_fungible_faucet, AccountStorageMode, AuthScheme, Felt, TokenSymbol, ZERO,
     };
 
     #[test]
@@ -114,14 +114,14 @@ mod tests {
         let token_symbol_string = "POL";
         let token_symbol = TokenSymbol::try_from(token_symbol_string).unwrap();
         let decimals = 2u8;
-        let storage_type = AccountStorageType::OffChain;
+        let storage_mode = AccountStorageMode::Private;
 
         let (faucet_account, _) = create_basic_fungible_faucet(
             init_seed,
             token_symbol,
             decimals,
             max_supply,
-            storage_type,
+            storage_mode,
             auth_scheme,
         )
         .unwrap();

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -5,7 +5,7 @@ use alloc::{
 
 use miden_objects::{
     accounts::{
-        Account, AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType, SlotItem,
+        Account, AccountCode, AccountId, AccountStorage, AccountStorageMode, AccountType, SlotItem,
     },
     AccountError, Word,
 };
@@ -30,7 +30,7 @@ pub fn create_basic_wallet(
     init_seed: [u8; 32],
     auth_scheme: AuthScheme,
     account_type: AccountType,
-    account_storage_type: AccountStorageType,
+    account_storage_mode: AccountStorageMode,
 ) -> Result<(Account, Word), AccountError> {
     if matches!(account_type, AccountType::FungibleFaucet | AccountType::NonFungibleFaucet) {
         return Err(AccountError::AccountIdInvalidFieldElement(
@@ -59,7 +59,7 @@ pub fn create_basic_wallet(
     let account_seed = AccountId::get_account_seed(
         init_seed,
         account_type,
-        account_storage_type,
+        account_storage_mode,
         account_code.commitment(),
         account_storage.root(),
     )?;
@@ -76,7 +76,7 @@ mod tests {
     use miden_objects::{crypto::dsa::rpo_falcon512, ONE};
     use vm_processor::utils::{Deserializable, Serializable};
 
-    use super::{create_basic_wallet, Account, AccountStorageType, AccountType, AuthScheme};
+    use super::{create_basic_wallet, Account, AccountStorageMode, AccountType, AuthScheme};
 
     #[test]
     fn test_create_basic_wallet() {
@@ -85,7 +85,7 @@ mod tests {
             [1; 32],
             AuthScheme::RpoFalcon512 { pub_key },
             AccountType::RegularAccountImmutableCode,
-            AccountStorageType::OnChain,
+            AccountStorageMode::Public,
         );
 
         wallet.unwrap_or_else(|err| {
@@ -100,7 +100,7 @@ mod tests {
             [1; 32],
             AuthScheme::RpoFalcon512 { pub_key },
             AccountType::RegularAccountImmutableCode,
-            AccountStorageType::OnChain,
+            AccountStorageMode::Public,
         )
         .unwrap()
         .0;

--- a/miden-tx/src/error.rs
+++ b/miden-tx/src/error.rs
@@ -200,7 +200,7 @@ const ERR_EPILOGUE_ASSETS_DONT_ADD_UP: u32 = 131082;
 const ERR_PROLOGUE_GLOBAL_INPUTS_MISMATCH: u32 = 131083;
 const ERR_PROLOGUE_ACCT_STORAGE_MISMATCH: u32 = 131084;
 const ERR_PROLOGUE_ACCT_STORAGE_ARITY_TOO_HIGH: u32 = 131085;
-const ERR_PROLOGUE_ACCT_STORAGE_TYPE_INVALID: u32 = 131086;
+const ERR_PROLOGUE_ACCT_STORAGE_MODE_INVALID: u32 = 131086;
 const ERR_PROLOGUE_NEW_ACCT_VAULT_NOT_EMPTY: u32 = 131087;
 const ERR_PROLOGUE_NEW_ACCT_INVALID_SLOT_TYPE: u32 = 131088;
 const ERR_PROLOGUE_NEW_FUNGIBLE_FAUCET_NON_EMPTY_RESERVED_SLOT: u32 = 131089;
@@ -282,7 +282,7 @@ pub const KERNEL_ERRORS: [(u32, &str); 80] = [
     (ERR_PROLOGUE_GLOBAL_INPUTS_MISMATCH, "The global inputs provided do not match the block hash commitment"),
     (ERR_PROLOGUE_ACCT_STORAGE_MISMATCH, "The account storage data does not match its commitment"),
     (ERR_PROLOGUE_ACCT_STORAGE_ARITY_TOO_HIGH, "Data store in account's storage exceeds the maximum capacity of 256 elements"),
-    (ERR_PROLOGUE_ACCT_STORAGE_TYPE_INVALID, "Data store in account's storage contains invalid type discriminant"),
+    (ERR_PROLOGUE_ACCT_STORAGE_MODE_INVALID, "Data store in account's storage contains invalid type discriminant"),
     (ERR_PROLOGUE_NEW_ACCT_VAULT_NOT_EMPTY, "New account must have an empty vault"),
     (ERR_PROLOGUE_NEW_ACCT_INVALID_SLOT_TYPE, "New account must have valid slot types"),
     (ERR_PROLOGUE_NEW_FUNGIBLE_FAUCET_NON_EMPTY_RESERVED_SLOT, "Reserved slot for new fungible faucet is not empty"),

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -89,7 +89,7 @@ impl TransactionProver {
         .add_input_notes(input_notes)
         .add_output_notes(output_notes);
 
-        let builder = match account.is_on_chain() {
+        let builder = match account.is_public() {
             true => {
                 let account_update_details = if account.is_new() {
                     let mut account = account.clone();

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -182,7 +182,7 @@ fn prove_send_asset_via_wallet() {
 #[test]
 fn wallet_creation() {
     use miden_objects::accounts::{
-        account_id::testing::ACCOUNT_ID_SENDER, AccountStorageType, AccountType,
+        account_id::testing::ACCOUNT_ID_SENDER, AccountStorageMode, AccountType,
     };
 
     // we need a Falcon Public Key to create the wallet account
@@ -200,10 +200,10 @@ fn wallet_creation() {
     ];
 
     let account_type = AccountType::RegularAccountImmutableCode;
-    let storage_type = AccountStorageType::OffChain;
+    let storage_mode = AccountStorageMode::Private;
 
     let (wallet, _) =
-        create_basic_wallet(init_seed, auth_scheme, account_type, storage_type).unwrap();
+        create_basic_wallet(init_seed, auth_scheme, account_type, storage_mode).unwrap();
 
     // sender_account_id not relevant here, just to create a default account code
     let sender_account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();

--- a/objects/benches/account_seed.rs
+++ b/objects/benches/account_seed.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use miden_objects::{
-    accounts::{AccountId, AccountStorageType, AccountType},
+    accounts::{AccountId, AccountStorageMode, AccountType},
     Digest,
 };
 
@@ -15,7 +15,7 @@ fn grind_account_seed(c: &mut Criterion) {
             AccountId::get_account_seed(
                 init_seed,
                 AccountType::RegularAccountImmutableCode,
-                AccountStorageType::OnChain,
+                AccountStorageMode::Public,
                 Digest::default(),
                 Digest::default(),
             )
@@ -27,7 +27,7 @@ fn grind_account_seed(c: &mut Criterion) {
             AccountId::get_account_seed(
                 init_seed,
                 AccountType::FungibleFaucet,
-                AccountStorageType::OnChain,
+                AccountStorageMode::Public,
                 Digest::default(),
                 Digest::default(),
             )

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -76,15 +76,15 @@ impl From<u64> for AccountType {
 // ACCOUNT STORAGE TYPES
 // ================================================================================================
 
-pub const ON_CHAIN: u64 = 0b00;
-pub const OFF_CHAIN: u64 = 0b10;
+pub const PUBLIC: u64 = 0b00;
+pub const PRIVATE: u64 = 0b10;
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
-pub enum AccountStorageType {
-    OnChain = ON_CHAIN,
-    OffChain = OFF_CHAIN,
+pub enum AccountStorageMode {
+    Public = PUBLIC,
+    Private = PRIVATE,
 }
 
 // ACCOUNT ID
@@ -95,7 +95,7 @@ pub enum AccountStorageType {
 /// Account ID consists of 1 field element (~64 bits). The most significant bits in the id are used
 /// to encode the account' storage and type.
 ///
-/// The top two bits are used to encode the storage type. The values [OFF_CHAIN] and [ON_CHAIN]
+/// The top two bits are used to encode the storage type. The values [PRIVATE] and [PUBLIC]
 /// encode the account's storage type. The next two bits encode the account type. The values
 /// [FUNGIBLE_FAUCET], [NON_FUNGIBLE_FAUCET], [REGULAR_ACCOUNT_IMMUTABLE_CODE], and
 /// [REGULAR_ACCOUNT_UPDATABLE_CODE] encode the account's type.
@@ -171,7 +171,7 @@ impl AccountId {
         let seed = get_account_seed(
             init_seed,
             account_type,
-            AccountStorageType::OnChain,
+            AccountStorageMode::Public,
             code_commitment,
             storage_root,
         )
@@ -201,19 +201,19 @@ impl AccountId {
         is_regular_account(self.0.as_int())
     }
 
-    /// Returns the storage type of this account (e.g., on-chain or off-chain).
-    pub fn storage_type(&self) -> AccountStorageType {
+    /// Returns the storage type of this account (e.g., public or private).
+    pub fn storage_mode(&self) -> AccountStorageMode {
         let bits = (self.0.as_int() & ACCOUNT_STORAGE_MASK) >> ACCOUNT_STORAGE_MASK_SHIFT;
         match bits {
-            ON_CHAIN => AccountStorageType::OnChain,
-            OFF_CHAIN => AccountStorageType::OffChain,
+            PUBLIC => AccountStorageMode::Public,
+            PRIVATE => AccountStorageMode::Private,
             _ => panic!("Account with invalid storage bits created"),
         }
     }
 
-    /// Returns true if an account with this ID is an on-chain account.
-    pub fn is_on_chain(&self) -> bool {
-        self.storage_type() == AccountStorageType::OnChain
+    /// Returns true if an account with this ID is a public account.
+    pub fn is_public(&self) -> bool {
+        self.storage_mode() == AccountStorageMode::Public
     }
 
     /// Finds and returns a seed suitable for creating an account ID for the specified account type
@@ -221,11 +221,11 @@ impl AccountId {
     pub fn get_account_seed(
         init_seed: [u8; 32],
         account_type: AccountType,
-        storage_type: AccountStorageType,
+        storage_mode: AccountStorageMode,
         code_commitment: Digest,
         storage_root: Digest,
     ) -> Result<Word, AccountError> {
-        get_account_seed(init_seed, account_type, storage_type, code_commitment, storage_root)
+        get_account_seed(init_seed, account_type, storage_mode, code_commitment, storage_root)
     }
 
     /// Creates an Account Id from a hex string. Assumes the string starts with "0x" and
@@ -340,8 +340,8 @@ pub const fn account_id_from_felt(value: Felt) -> Result<AccountId, AccountError
 
     let bits = (int_value & ACCOUNT_STORAGE_MASK) >> ACCOUNT_STORAGE_MASK_SHIFT;
     match bits {
-        ON_CHAIN | OFF_CHAIN => (),
-        _ => return Err(AccountError::InvalidAccountStorageType),
+        PUBLIC | PRIVATE => (),
+        _ => return Err(AccountError::InvalidAccountStorageMode),
     };
 
     Ok(AccountId(value))
@@ -434,7 +434,7 @@ fn is_regular_account(account_id: u64) -> bool {
 #[cfg(any(feature = "testing", test))]
 pub mod testing {
     use super::{
-        AccountStorageType, AccountType, ACCOUNT_STORAGE_MASK_SHIFT, ACCOUNT_TYPE_MASK_SHIFT,
+        AccountStorageMode, AccountType, ACCOUNT_STORAGE_MASK_SHIFT, ACCOUNT_TYPE_MASK_SHIFT,
     };
 
     // CONSTANTS
@@ -443,76 +443,76 @@ pub mod testing {
     // REGULAR ACCOUNTS - OFF-CHAIN
     pub const ACCOUNT_ID_SENDER: u64 = account_id(
         AccountType::RegularAccountImmutableCode,
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
         0b0001_1111,
     );
     pub const ACCOUNT_ID_OFF_CHAIN_SENDER: u64 = account_id(
         AccountType::RegularAccountImmutableCode,
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
         0b0010_1111,
     );
     pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN: u64 = account_id(
         AccountType::RegularAccountUpdatableCode,
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
         0b0011_1111,
     );
     // REGULAR ACCOUNTS - ON-CHAIN
     pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u64 = account_id(
         AccountType::RegularAccountImmutableCode,
-        AccountStorageType::OnChain,
+        AccountStorageMode::Public,
         0b0001_1111,
     );
     pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN_2: u64 = account_id(
         AccountType::RegularAccountImmutableCode,
-        AccountStorageType::OnChain,
+        AccountStorageMode::Public,
         0b0010_1111,
     );
     pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u64 = account_id(
         AccountType::RegularAccountUpdatableCode,
-        AccountStorageType::OnChain,
+        AccountStorageMode::Public,
         0b0011_1111,
     );
     pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN_2: u64 = account_id(
         AccountType::RegularAccountUpdatableCode,
-        AccountStorageType::OnChain,
+        AccountStorageMode::Public,
         0b0100_1111,
     );
 
     // FUNGIBLE TOKENS - OFF-CHAIN
     pub const ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN: u64 =
-        account_id(AccountType::FungibleFaucet, AccountStorageType::OffChain, 0b0001_1111);
+        account_id(AccountType::FungibleFaucet, AccountStorageMode::Private, 0b0001_1111);
     // FUNGIBLE TOKENS - ON-CHAIN
     pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 =
-        account_id(AccountType::FungibleFaucet, AccountStorageType::OnChain, 0b0001_1111);
+        account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0b0001_1111);
     pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1: u64 =
-        account_id(AccountType::FungibleFaucet, AccountStorageType::OnChain, 0b0010_1111);
+        account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0b0010_1111);
     pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2: u64 =
-        account_id(AccountType::FungibleFaucet, AccountStorageType::OnChain, 0b0011_1111);
+        account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0b0011_1111);
     pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_3: u64 =
-        account_id(AccountType::FungibleFaucet, AccountStorageType::OnChain, 0b0100_1111);
+        account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0b0100_1111);
 
     // NON-FUNGIBLE TOKENS - OFF-CHAIN
     pub const ACCOUNT_ID_INSUFFICIENT_ONES: u64 =
-        account_id(AccountType::NonFungibleFaucet, AccountStorageType::OffChain, 0b0000_0000); // invalid
+        account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0b0000_0000); // invalid
     pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN: u64 =
-        account_id(AccountType::NonFungibleFaucet, AccountStorageType::OffChain, 0b0001_1111);
+        account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0b0001_1111);
     // NON-FUNGIBLE TOKENS - ON-CHAIN
     pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN: u64 =
-        account_id(AccountType::NonFungibleFaucet, AccountStorageType::OnChain, 0b0010_1111);
+        account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Public, 0b0010_1111);
     pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1: u64 =
-        account_id(AccountType::NonFungibleFaucet, AccountStorageType::OnChain, 0b0011_1111);
+        account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Public, 0b0011_1111);
 
     // UTILITIES
     // --------------------------------------------------------------------------------------------
 
     pub const fn account_id(
         account_type: AccountType,
-        storage: AccountStorageType,
+        storage_mode: AccountStorageMode,
         rest: u64,
     ) -> u64 {
         let mut id = 0;
 
-        id ^= (storage as u64) << ACCOUNT_STORAGE_MASK_SHIFT;
+        id ^= (storage_mode as u64) << ACCOUNT_STORAGE_MASK_SHIFT;
         id ^= (account_type as u64) << ACCOUNT_TYPE_MASK_SHIFT;
         id ^= rest;
 
@@ -527,7 +527,7 @@ mod tests {
     use miden_crypto::utils::{Deserializable, Serializable};
 
     use super::{
-        testing::*, AccountId, AccountStorageType, AccountType, ACCOUNT_ISFAUCET_MASK,
+        testing::*, AccountId, AccountStorageMode, AccountType, ACCOUNT_ISFAUCET_MASK,
         ACCOUNT_TYPE_MASK_SHIFT, FUNGIBLE_FAUCET, NON_FUNGIBLE_FAUCET,
         REGULAR_ACCOUNT_IMMUTABLE_CODE, REGULAR_ACCOUNT_UPDATABLE_CODE,
     };
@@ -542,11 +542,11 @@ mod tests {
             AccountType::NonFungibleFaucet,
             AccountType::FungibleFaucet,
         ] {
-            for storage_type in [AccountStorageType::OnChain, AccountStorageType::OffChain] {
-                let acc = AccountId::try_from(account_id(account_type, storage_type, 0b1111_1111))
+            for storage_mode in [AccountStorageMode::Public, AccountStorageMode::Private] {
+                let acc = AccountId::try_from(account_id(account_type, storage_mode, 0b1111_1111))
                     .unwrap();
                 assert_eq!(acc.account_type(), account_type);
-                assert_eq!(acc.storage_type(), storage_type);
+                assert_eq!(acc.storage_mode(), storage_mode);
             }
         }
     }
@@ -612,25 +612,25 @@ mod tests {
             .expect("Valid account ID");
         assert!(account_id.is_regular_account());
         assert_eq!(account_id.account_type(), AccountType::RegularAccountImmutableCode);
-        assert!(account_id.is_on_chain());
+        assert!(account_id.is_public());
 
         let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN)
             .expect("Valid account ID");
         assert!(account_id.is_regular_account());
         assert_eq!(account_id.account_type(), AccountType::RegularAccountUpdatableCode);
-        assert!(!account_id.is_on_chain());
+        assert!(!account_id.is_public());
 
         let account_id =
             AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).expect("Valid account ID");
         assert!(account_id.is_faucet());
         assert_eq!(account_id.account_type(), AccountType::FungibleFaucet);
-        assert!(account_id.is_on_chain());
+        assert!(account_id.is_public());
 
         let account_id = AccountId::try_from(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN)
             .expect("Valid account ID");
         assert!(account_id.is_faucet());
         assert_eq!(account_id.account_type(), AccountType::NonFungibleFaucet);
-        assert!(!account_id.is_on_chain());
+        assert!(!account_id.is_public());
     }
 
     /// The following test ensure there is a bit available to identify an account as a faucet or

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -201,7 +201,7 @@ impl AccountId {
         is_regular_account(self.0.as_int())
     }
 
-    /// Returns the storage type of this account (e.g., public or private).
+    /// Returns the storage mode of this account (e.g., public or private).
     pub fn storage_mode(&self) -> AccountStorageMode {
         let bits = (self.0.as_int() & ACCOUNT_STORAGE_MASK) >> ACCOUNT_STORAGE_MASK_SHIFT;
         match bits {

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 
 pub mod account_id;
 pub use account_id::{
-    AccountId, AccountStorageType, AccountType, ACCOUNT_ISFAUCET_MASK, ACCOUNT_STORAGE_MASK_SHIFT,
+    AccountId, AccountStorageMode, AccountType, ACCOUNT_ISFAUCET_MASK, ACCOUNT_STORAGE_MASK_SHIFT,
     ACCOUNT_TYPE_MASK_SHIFT,
 };
 
@@ -169,9 +169,9 @@ impl Account {
         self.id.is_regular_account()
     }
 
-    /// Returns true if this account is on-chain.
-    pub fn is_on_chain(&self) -> bool {
-        self.id.is_on_chain()
+    /// Returns true if this account is public.
+    pub fn is_public(&self) -> bool {
+        self.id.is_public()
     }
 
     /// Returns true if the account is new (i.e. it has not been initialized yet).

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use super::{
-    account_id::compute_digest, AccountError, AccountId, AccountStorageType, AccountType, Digest,
+    account_id::compute_digest, AccountError, AccountId, AccountStorageMode, AccountType, Digest,
     Felt, Word,
 };
 
@@ -22,7 +22,7 @@ use super::{
 pub fn get_account_seed(
     init_seed: [u8; 32],
     account_type: AccountType,
-    storage_type: AccountStorageType,
+    storage_mode: AccountStorageMode,
     code_commitment: Digest,
     storage_root: Digest,
 ) -> Result<Word, AccountError> {
@@ -42,7 +42,7 @@ pub fn get_account_seed(
                 stop,
                 init_seed,
                 account_type,
-                storage_type,
+                storage_mode,
                 code_commitment,
                 storage_root,
             )
@@ -72,7 +72,7 @@ pub fn get_account_seed_inner(
     stop: Arc<RwLock<bool>>,
     init_seed: [u8; 32],
     account_type: AccountType,
-    storage_type: AccountStorageType,
+    storage_mode: AccountStorageMode,
     code_commitment: Digest,
     storage_root: Digest,
 ) {
@@ -87,7 +87,7 @@ pub fn get_account_seed_inner(
     let mut current_digest = compute_digest(current_seed, code_commitment, storage_root);
 
     #[cfg(feature = "log")]
-    let mut log = log::Log::start(current_digest, current_seed, account_type, storage_type);
+    let mut log = log::Log::start(current_digest, current_seed, account_type, storage_mode);
 
     // loop until we have a seed that satisfies the specified account type.
     let mut count = 0;
@@ -105,7 +105,7 @@ pub fn get_account_seed_inner(
         if AccountId::validate_seed_digest(&current_digest).is_ok() {
             if let Ok(account_id) = AccountId::try_from(current_digest[0]) {
                 if account_id.account_type() == account_type
-                    && account_id.storage_type() == storage_type
+                    && account_id.storage_mode() == storage_mode
                 {
                     #[cfg(feature = "log")]
                     log.done(current_digest, current_seed, account_id);
@@ -124,11 +124,11 @@ pub fn get_account_seed_inner(
 pub fn get_account_seed(
     init_seed: [u8; 32],
     account_type: AccountType,
-    storage_type: AccountStorageType,
+    storage_mode: AccountStorageMode,
     code_commitment: Digest,
     storage_root: Digest,
 ) -> Result<Word, AccountError> {
-    get_account_seed_single(init_seed, account_type, storage_type, code_commitment, storage_root)
+    get_account_seed_single(init_seed, account_type, storage_mode, code_commitment, storage_root)
 }
 
 /// Finds and returns a seed suitable for creating an account ID for the specified account type
@@ -136,7 +136,7 @@ pub fn get_account_seed(
 pub fn get_account_seed_single(
     init_seed: [u8; 32],
     account_type: AccountType,
-    storage_type: AccountStorageType,
+    storage_mode: AccountStorageMode,
     code_commitment: Digest,
     storage_root: Digest,
 ) -> Result<Word, AccountError> {
@@ -151,7 +151,7 @@ pub fn get_account_seed_single(
     let mut current_digest = compute_digest(current_seed, code_commitment, storage_root);
 
     #[cfg(feature = "log")]
-    let mut log = log::Log::start(current_digest, current_seed, account_type, storage_type);
+    let mut log = log::Log::start(current_digest, current_seed, account_type, storage_mode);
 
     // loop until we have a seed that satisfies the specified account type.
     loop {
@@ -162,7 +162,7 @@ pub fn get_account_seed_single(
         if AccountId::validate_seed_digest(&current_digest).is_ok() {
             if let Ok(account_id) = AccountId::try_from(current_digest[0]) {
                 if account_id.account_type() == account_type
-                    && account_id.storage_type() == storage_type
+                    && account_id.storage_mode() == storage_mode
                 {
                     #[cfg(feature = "log")]
                     log.done(current_digest, current_seed, account_id);
@@ -187,7 +187,7 @@ mod log {
         super::{account_id::digest_pow, Digest, Word},
         AccountId, AccountType,
     };
-    use crate::accounts::AccountStorageType;
+    use crate::accounts::AccountStorageMode;
 
     /// Keeps track of the best digest found so far and count how many iterations have been done.
     pub struct Log {
@@ -212,7 +212,7 @@ mod log {
             digest: Digest,
             seed: Word,
             account_type: AccountType,
-            storage_type: AccountStorageType,
+            storage_mode: AccountStorageMode,
         ) -> Self {
             log::info!(
                 "Generating new account seed [pow={}, digest={}, seed={} type={:?} onchain={:?}]",
@@ -220,7 +220,7 @@ mod log {
                 digest_hex(digest),
                 word_hex(seed),
                 account_type,
-                storage_type,
+                storage_mode,
             );
 
             Self { digest, seed, count: 0, pow: 0 }
@@ -254,7 +254,7 @@ mod log {
                 digest_hex(digest),
                 word_hex(seed),
                 account_id.account_type(),
-                account_id.is_on_chain(),
+                account_id.is_public(),
             );
         }
     }

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -34,7 +34,7 @@ pub enum AccountError {
     FungibleFaucetInvalidMetadata(String),
     HeaderDataIncorrectLength(usize, usize),
     HexParseError(String),
-    InvalidAccountStorageType,
+    InvalidAccountStorageMode,
     MapsUpdateToNonMapsSlot(u8, StorageSlotType),
     NonceNotMonotonicallyIncreasing { current: u64, new: u64 },
     SeedDigestTooFewTrailingZeros { expected: u32, actual: u32 },

--- a/objects/src/notes/note_tag.rs
+++ b/objects/src/notes/note_tag.rs
@@ -80,11 +80,11 @@ impl NoteTag {
     /// - For network execution, the most significant bit is set to `0b0` and the remaining bits are
     ///   set to the 31 most significant bits of the account ID. Note that this results in the two
     ///   most significant bits of the tag being set to `0b00`, because the network execution
-    ///   requires an on-chain account which always have the high bit set to 0.
+    ///   requires a public account which always have the high bit set to 0.
     ///
     /// # Errors
     ///
-    /// This will return an error if the account_id is not for an on-chain account and the execution
+    /// This will return an error if the account_id is not for a public account and the execution
     /// hint is set to [NoteExecutionMode::Network].
     pub fn from_account_id(
         account_id: AccountId,
@@ -98,7 +98,7 @@ impl NoteTag {
                 Ok(Self(high_bits | LOCAL_EXECUTION_WITH_ALL_NOTE_TYPES_ALLOWED))
             },
             NoteExecutionMode::Network => {
-                if !account_id.is_on_chain() {
+                if !account_id.is_public() {
                     Err(NoteError::NetworkExecutionRequiresOnChainAccount)
                 } else {
                     let id: u64 = account_id.into();
@@ -550,7 +550,7 @@ mod tests {
             let onchain = highbit == 0;
 
             assert_eq!(
-                acct.is_on_chain(),
+                acct.is_public(),
                 onchain,
                 "The account_id encoding changed, this breaks the assumptions built in the NoteTag"
             );

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -18,7 +18,7 @@ use crate::{
             ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
             ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
         },
-        Account, AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType, SlotItem,
+        Account, AccountCode, AccountId, AccountStorage, AccountStorageMode, AccountType, SlotItem,
         StorageMap, StorageSlot,
     },
     assets::{Asset, AssetVault, FungibleAsset},
@@ -91,8 +91,8 @@ impl<T: Rng> AccountBuilder<T> {
         self
     }
 
-    pub fn storage_type(mut self, storage_type: AccountStorageType) -> Self {
-        self.account_id_builder.storage_type(storage_type);
+    pub fn storage_mode(mut self, storage_mode: AccountStorageMode) -> Self {
+        self.account_id_builder.storage_mode(storage_mode);
         self
     }
 

--- a/objects/src/testing/account_id.rs
+++ b/objects/src/testing/account_id.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 
 use super::{account::AccountBuilderError, account_code::DEFAULT_ACCOUNT_CODE};
 use crate::{
-    accounts::{AccountCode, AccountId, AccountStorageType, AccountType},
+    accounts::{AccountCode, AccountId, AccountStorageMode, AccountType},
     Digest, Word,
 };
 
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct AccountIdBuilder<T> {
     account_type: AccountType,
-    storage_type: AccountStorageType,
+    storage_mode: AccountStorageMode,
     code: Option<AccountCode>,
     storage_root: Digest,
     rng: T,
@@ -21,7 +21,7 @@ impl<T: Rng> AccountIdBuilder<T> {
     pub fn new(rng: T) -> Self {
         Self {
             account_type: AccountType::RegularAccountUpdatableCode,
-            storage_type: AccountStorageType::OffChain,
+            storage_mode: AccountStorageMode::Private,
             code: None,
             storage_root: Digest::default(),
             rng,
@@ -33,8 +33,8 @@ impl<T: Rng> AccountIdBuilder<T> {
         self
     }
 
-    pub fn storage_type(&mut self, storage_type: AccountStorageType) -> &mut Self {
-        self.storage_type = storage_type;
+    pub fn storage_mode(&mut self, storage_mode: AccountStorageMode) -> &mut Self {
+        self.storage_mode = storage_mode;
         self
     }
 
@@ -64,7 +64,7 @@ impl<T: Rng> AccountIdBuilder<T> {
             &mut self.rng,
             account_code,
             self.account_type,
-            self.storage_type,
+            self.storage_mode,
             self.storage_root,
         )?;
 
@@ -85,7 +85,7 @@ impl<T: Rng> AccountIdBuilder<T> {
             return Err(AccountBuilderError::SeedAndAccountTypeMismatch);
         }
 
-        if account_id.storage_type() != self.storage_type {
+        if account_id.storage_mode() != self.storage_mode {
             return Err(AccountBuilderError::SeedAndOnChainMismatch);
         }
 
@@ -103,7 +103,7 @@ pub fn account_id_build_details<T: Rng>(
     rng: &mut T,
     code: AccountCode,
     account_type: AccountType,
-    storage_type: AccountStorageType,
+    storage_mode: AccountStorageMode,
     storage_root: Digest,
 ) -> Result<(Word, Digest), AccountBuilderError> {
     let init_seed: [u8; 32] = rng.gen();
@@ -111,7 +111,7 @@ pub fn account_id_build_details<T: Rng>(
     let seed = AccountId::get_account_seed(
         init_seed,
         account_type,
-        storage_type,
+        storage_mode,
         code_commitment,
         storage_root,
     )

--- a/objects/src/testing/storage.rs
+++ b/objects/src/testing/storage.rs
@@ -15,7 +15,7 @@ use crate::{
             ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
         },
         get_account_seed_single, Account, AccountCode, AccountDelta, AccountId, AccountStorage,
-        AccountStorageDelta, AccountStorageType, AccountType, AccountVaultDelta, SlotItem,
+        AccountStorageDelta, AccountStorageMode, AccountType, AccountVaultDelta, SlotItem,
         StorageMap, StorageMapDelta, StorageSlot,
     },
     assets::{Asset, AssetVault, FungibleAsset},
@@ -242,7 +242,7 @@ pub fn generate_account_seed(
     let seed = get_account_seed_single(
         init_seed,
         account_type,
-        AccountStorageType::OnChain,
+        AccountStorageMode::Public,
         account.code().commitment(),
         account.storage().root(),
     )

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -92,7 +92,7 @@ impl ProvenTransaction {
     // --------------------------------------------------------------------------------------------
 
     fn validate(self) -> Result<Self, ProvenTransactionError> {
-        if self.account_id().is_on_chain() {
+        if self.account_id().is_public() {
             let is_new_account = self.account_update.init_state_hash() == Digest::default();
             match self.account_update.details() {
                 AccountUpdateDetails::Private => {


### PR DESCRIPTION
This small PR renames the account storage type enum from `AccountStorageType` to `AccountStorageMode`, and also renames its variants as it was stated in the related issue #848.