### PR TITLE
Rename `AccountStub` into `AccountHeader` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.6.0 (TBD)
 
-- Implemented offset based storage access (#843)
+- Implemented offset based storage access (#843).
+- [BREAKING] `AccountStub` structure was renamed to `AccountHeader` (#855).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -23,7 +23,7 @@ mod inputs;
 
 mod outputs;
 pub use outputs::{
-    parse_final_account_stub, FINAL_ACCOUNT_HASH_WORD_IDX, OUTPUT_NOTES_COMMITMENT_WORD_IDX,
+    parse_final_account_header, FINAL_ACCOUNT_HASH_WORD_IDX, OUTPUT_NOTES_COMMITMENT_WORD_IDX,
 };
 
 mod errors;
@@ -234,8 +234,8 @@ impl TransactionKernel {
                 .get(&final_acct_hash)
                 .ok_or(TransactionOutputError::FinalAccountDataNotFound)?,
         );
-        let account = parse_final_account_stub(final_account_data)
-            .map_err(TransactionOutputError::FinalAccountStubDataInvalid)?;
+        let account = parse_final_account_header(final_account_data)
+            .map_err(TransactionOutputError::FinalAccountHeaderDataInvalid)?;
 
         // validate output notes
         let output_notes = OutputNotes::new(output_notes)?;

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    accounts::{AccountId, AccountStub},
+    accounts::{AccountHeader, AccountId},
     AccountError, Word,
 };
 
@@ -17,14 +17,14 @@ pub const OUTPUT_NOTES_COMMITMENT_WORD_IDX: usize = 0;
 /// The index of the word at which the final account hash is stored on the output stack.
 pub const FINAL_ACCOUNT_HASH_WORD_IDX: usize = 1;
 
-// ACCOUNT STUB EXTRACTOR
+// ACCOUNT HEADER EXTRACTOR
 // ================================================================================================
 
-/// Parses the stub account data returned by the VM into individual account component commitments.
+/// Parses the account header data returned by the VM into individual account component commitments.
 /// Returns a tuple of account ID, vault root, storage root, code commitment, and nonce.
-pub fn parse_final_account_stub(elements: &[Word]) -> Result<AccountStub, AccountError> {
+pub fn parse_final_account_header(elements: &[Word]) -> Result<AccountHeader, AccountError> {
     if elements.len() != ACCT_DATA_MEM_SIZE {
-        return Err(AccountError::StubDataIncorrectLength(elements.len(), ACCT_DATA_MEM_SIZE));
+        return Err(AccountError::HeaderDataIncorrectLength(elements.len(), ACCT_DATA_MEM_SIZE));
     }
 
     let id = AccountId::try_from(elements[ACCT_ID_AND_NONCE_OFFSET as usize][ACCT_ID_IDX])?;
@@ -33,5 +33,5 @@ pub fn parse_final_account_stub(elements: &[Word]) -> Result<AccountStub, Accoun
     let storage_root = elements[ACCT_STORAGE_ROOT_OFFSET as usize].into();
     let code_commitment = elements[ACCT_CODE_COMMITMENT_OFFSET as usize].into();
 
-    Ok(AccountStub::new(id, nonce, vault_root, storage_root, code_commitment))
+    Ok(AccountHeader::new(id, nonce, vault_root, storage_root, code_commitment))
 }

--- a/miden-tx/src/host/account_delta_tracker.rs
+++ b/miden-tx/src/host/account_delta_tracker.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    accounts::{AccountDelta, AccountStorageDelta, AccountStub, AccountVaultDelta},
+    accounts::{AccountDelta, AccountHeader, AccountStorageDelta, AccountVaultDelta},
     Felt, ZERO,
 };
 // ACCOUNT DELTA TRACKER
@@ -25,7 +25,7 @@ pub struct AccountDeltaTracker {
 
 impl AccountDeltaTracker {
     /// Returns a new [AccountDeltaTracker] instantiated for the specified account.
-    pub fn new(account: &AccountStub) -> Self {
+    pub fn new(account: &AccountHeader) -> Self {
         Self {
             storage: AccountStorageDelta::default(),
             vault: AccountVaultDelta::default(),

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -4,7 +4,7 @@ use miden_lib::transaction::{
     memory::CURRENT_INPUT_NOTE_PTR, TransactionEvent, TransactionKernelError, TransactionTrace,
 };
 use miden_objects::{
-    accounts::{AccountDelta, AccountStorage, AccountStub},
+    accounts::{AccountDelta, AccountHeader, AccountStorage},
     assets::Asset,
     notes::NoteId,
     transaction::{OutputNote, TransactionMeasurements},
@@ -92,7 +92,7 @@ pub struct TransactionHost<A, T> {
 impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
     /// Returns a new [TransactionHost] instance with the provided [AdviceProvider].
     pub fn new(
-        account: AccountStub,
+        account: AccountHeader,
         adv_provider: A,
         mast_store: Rc<TransactionMastStore>,
         authenticator: Option<Rc<T>>,

--- a/miden-tx/src/testing/mock_host.rs
+++ b/miden-tx/src/testing/mock_host.rs
@@ -5,7 +5,7 @@ use alloc::{rc::Rc, string::ToString, sync::Arc};
 
 use miden_lib::transaction::TransactionEvent;
 use miden_objects::{
-    accounts::{AccountStub, AccountVaultDelta},
+    accounts::{AccountHeader, AccountVaultDelta},
     Digest,
 };
 use vm_processor::{
@@ -31,7 +31,7 @@ pub struct MockHost {
 impl MockHost {
     /// Returns a new [MockHost] instance with the provided [AdviceInputs].
     pub fn new(
-        account: AccountStub,
+        account: AccountHeader,
         advice_inputs: AdviceInputs,
         mast_store: Rc<TransactionMastStore>,
     ) -> Self {

--- a/objects/src/accounts/header.rs
+++ b/objects/src/accounts/header.rs
@@ -1,12 +1,12 @@
 use super::{hash_account, Account, AccountId, Digest, Felt};
 
-// ACCOUNT STUB
+// ACCOUNT HEADER
 // ================================================================================================
 
-/// A stub of an account which contains information that succinctly describes the state of the
+/// A header of an account which contains information that succinctly describes the state of the
 /// components of the account.
 ///
-/// The [AccountStub] is composed of:
+/// The [AccountHeader] is composed of:
 /// - id: the account id ([AccountId]) of the account.
 /// - nonce: the nonce of the account.
 /// - vault_root: a commitment to the account's vault ([super::AssetVault]).
@@ -14,7 +14,7 @@ use super::{hash_account, Account, AccountId, Digest, Felt};
 /// - code_commitment: a commitment to the account's code ([super::AccountCode]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct AccountStub {
+pub struct AccountHeader {
     id: AccountId,
     nonce: Felt,
     vault_root: Digest,
@@ -22,10 +22,10 @@ pub struct AccountStub {
     code_commitment: Digest,
 }
 
-impl AccountStub {
+impl AccountHeader {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
-    /// Creates a new [AccountStub].
+    /// Creates a new [AccountHeader].
     pub fn new(
         id: AccountId,
         nonce: Felt,
@@ -79,13 +79,13 @@ impl AccountStub {
     }
 }
 
-impl From<Account> for AccountStub {
+impl From<Account> for AccountHeader {
     fn from(account: Account) -> Self {
         (&account).into()
     }
 }
 
-impl From<&Account> for AccountStub {
+impl From<&Account> for AccountHeader {
     fn from(account: &Account) -> Self {
         Self {
             id: account.id(),

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -28,8 +28,8 @@ pub use seed::{get_account_seed, get_account_seed_single};
 mod storage;
 pub use storage::{AccountStorage, SlotItem, StorageMap, StorageSlot, StorageSlotType};
 
-mod stub;
-pub use stub::AccountStub;
+mod header;
+pub use header::AccountHeader;
 
 mod data;
 pub use data::AccountData;

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -32,6 +32,7 @@ pub enum AccountError {
     DuplicateStorageItems(MerkleError),
     FungibleFaucetIdInvalidFirstBit,
     FungibleFaucetInvalidMetadata(String),
+    HeaderDataIncorrectLength(usize, usize),
     HexParseError(String),
     InvalidAccountStorageType,
     MapsUpdateToNonMapsSlot(u8, StorageSlotType),
@@ -42,7 +43,6 @@ pub enum AccountError {
     StorageSlotMapOrArrayNotAllowed(u8, StorageSlotType),
     StorageMapNotFound(u8),
     StorageMapTooManyMaps { expected: usize, actual: usize },
-    StubDataIncorrectLength(usize, usize),
 }
 
 impl fmt::Display for AccountError {
@@ -274,7 +274,7 @@ impl std::error::Error for TransactionInputError {}
 pub enum TransactionOutputError {
     DuplicateOutputNote(NoteId),
     FinalAccountDataNotFound,
-    FinalAccountStubDataInvalid(AccountError),
+    FinalAccountHeaderDataInvalid(AccountError),
     OutputNoteDataNotFound,
     OutputNoteDataInvalid(NoteError),
     OutputNotesCommitmentInconsistent(Digest, Digest),

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::cell::OnceCell;
 
 use super::{
-    Account, AccountDelta, AccountId, AccountStub, AdviceInputs, BlockHeader, InputNote,
+    Account, AccountDelta, AccountHeader, AccountId, AdviceInputs, BlockHeader, InputNote,
     InputNotes, NoteId, OutputNotes, TransactionArgs, TransactionId, TransactionInputs,
     TransactionOutputs, TransactionWitness,
 };
@@ -80,7 +80,7 @@ impl ExecutedTransaction {
     }
 
     /// Returns description of the account after the transaction was executed.
-    pub fn final_account(&self) -> &AccountStub {
+    pub fn final_account(&self) -> &AccountHeader {
         &self.tx_outputs.account
     }
 

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    accounts::{Account, AccountDelta, AccountId, AccountStub},
+    accounts::{Account, AccountDelta, AccountHeader, AccountId},
     notes::{NoteId, Nullifier},
     vm::AdviceInputs,
     BlockHeader, Digest, Felt, Hasher, Word, WORD_SIZE, ZERO,

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -5,7 +5,7 @@ use miden_crypto::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use vm_processor::DeserializationError;
 
 use crate::{
-    accounts::AccountStub,
+    accounts::AccountHeader,
     notes::{compute_note_hash, Note, NoteAssets, NoteHeader, NoteId, NoteMetadata, PartialNote},
     Digest, Felt, Hasher, TransactionOutputError, Word, MAX_OUTPUT_NOTES_PER_TX,
 };
@@ -15,7 +15,7 @@ use crate::{
 /// Describes the result of executing a transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionOutputs {
-    pub account: AccountStub,
+    pub account: AccountHeader,
     pub output_notes: OutputNotes,
 }
 


### PR DESCRIPTION
This small PR renames the `AccountStub` struct into `AccountHeader`.

Corresponding issue: #849.