### PR TITLE
test: Remove calls by MAST root through account library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
@@ -190,18 +190,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1385,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags",
  "errno",
@@ -1472,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "supports-color"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
 dependencies = [
  "is_ci",
 ]

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{string::ToString, sync::Arc, vec::Vec};
 
 use miden_objects::{
-    accounts::AccountId,
+    accounts::{AccountCode, AccountId},
     assembly::{Assembler, DefaultSourceManager, KernelLibrary},
     transaction::{
         OutputNote, OutputNotes, TransactionArgs, TransactionInputs, TransactionOutputs,
@@ -267,7 +267,7 @@ impl TransactionKernel {
     /// The `kernel` library is added separately because even though the library (`api.masm`) and
     /// the kernel binary (`main.masm`) include this code, it is not exposed explicitly. By adding
     /// it separately, we can expose procedures from `/lib` and test them individually.
-    pub fn assembler_testing() -> Assembler {
+    pub fn testing_assembler() -> Assembler {
         let source_manager = Arc::new(DefaultSourceManager::default());
         let kernel_library = Self::kernel_as_library();
 
@@ -278,5 +278,13 @@ impl TransactionKernel {
             .expect("failed to load miden-lib")
             .with_library(kernel_library)
             .expect("failed to load kernel library (/lib)")
+    }
+
+    /// Returns the testing assembler, and additionally contains the library for
+    /// [AccountCode::mock_library()], which is a mock wallet used in tests.
+    pub fn testing_assembler_with_mock_account() -> Assembler {
+        let assembler = Self::testing_assembler();
+        let library = AccountCode::mock_library(assembler.clone());
+        assembler.with_library(library).expect("failed to add mock account code")
     }
 }

--- a/miden-tx/src/testing/executor.rs
+++ b/miden-tx/src/testing/executor.rs
@@ -37,7 +37,7 @@ impl<H: Host> CodeExecutor<H> {
 
     /// Compiles and runs the desired code in the host and returns the [Process] state
     pub fn run(self, code: &str) -> Result<Process<H>, ExecutionError> {
-        let program = TransactionKernel::assembler_testing().assemble_program(code).unwrap();
+        let program = TransactionKernel::testing_assembler().assemble_program(code).unwrap();
         self.execute_program(program)
     }
 

--- a/miden-tx/src/testing/mock_chain.rs
+++ b/miden-tx/src/testing/mock_chain.rs
@@ -301,7 +301,7 @@ impl MockChain {
 
     pub fn add_new_wallet(&mut self, auth_method: Auth, assets: Vec<Asset>) -> Account {
         let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
-            .default_code(TransactionKernel::assembler_testing())
+            .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ZERO)
             .add_assets(assets);
         self.add_from_account_builder(auth_method, account_builder)
@@ -309,7 +309,7 @@ impl MockChain {
 
     pub fn add_existing_wallet(&mut self, auth_method: Auth, assets: Vec<Asset>) -> Account {
         let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
-            .default_code(TransactionKernel::assembler_testing())
+            .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ONE)
             .add_assets(assets);
         self.add_from_account_builder(auth_method, account_builder)
@@ -331,7 +331,7 @@ impl MockChain {
         let faucet_metadata = SlotItem::new_value(1, 0, metadata);
 
         let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
-            .default_code(TransactionKernel::assembler_testing())
+            .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ZERO)
             .account_type(AccountType::FungibleFaucet)
             .add_storage_item(faucet_metadata);
@@ -357,7 +357,7 @@ impl MockChain {
         let faucet_metadata = SlotItem::new_value(1, 0, metadata);
 
         let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
-            .default_code(TransactionKernel::assembler_testing())
+            .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ONE)
             .account_type(AccountType::FungibleFaucet)
             .add_storage_item(faucet_metadata);

--- a/miden-tx/src/testing/tx_context/builder.rs
+++ b/miden-tx/src/testing/tx_context/builder.rs
@@ -14,10 +14,9 @@ use miden_objects::{
         Account, AccountId,
     },
     assembly::Assembler,
-    assets::{Asset, FungibleAsset},
+    assets::{Asset, FungibleAsset, NonFungibleAsset},
     notes::{Note, NoteExecutionHint, NoteId, NoteType},
     testing::{
-        account_code::ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT,
         constants::{
             CONSUMED_ASSET_1_AMOUNT, CONSUMED_ASSET_2_AMOUNT, CONSUMED_ASSET_3_AMOUNT,
             NON_FUNGIBLE_ASSET_DATA_2,
@@ -53,7 +52,7 @@ pub struct TransactionContextBuilder {
 impl TransactionContextBuilder {
     pub fn new(account: Account) -> Self {
         Self {
-            assembler: TransactionKernel::assembler_testing(),
+            assembler: TransactionKernel::testing_assembler(),
             account,
             account_seed: None,
             input_notes: Vec::new(),
@@ -69,12 +68,14 @@ impl TransactionContextBuilder {
     }
 
     pub fn with_standard_account(nonce: Felt) -> Self {
-        let assembler = TransactionKernel::assembler_testing();
+        // Build standard account with normal assembler because the testing one already contains it
         let account = Account::mock(
             ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
             nonce,
-            assembler.clone(),
+            TransactionKernel::testing_assembler(),
         );
+
+        let assembler = TransactionKernel::testing_assembler_with_mock_account();
 
         Self {
             assembler: assembler.clone(),
@@ -93,9 +94,13 @@ impl TransactionContextBuilder {
     }
 
     pub fn with_fungible_faucet(acct_id: u64, nonce: Felt, initial_balance: Felt) -> Self {
-        let assembler = TransactionKernel::assembler_testing();
-        let account =
-            Account::mock_fungible_faucet(acct_id, nonce, initial_balance, assembler.clone());
+        let account = Account::mock_fungible_faucet(
+            acct_id,
+            nonce,
+            initial_balance,
+            TransactionKernel::testing_assembler(),
+        );
+        let assembler = TransactionKernel::testing_assembler_with_mock_account();
 
         Self {
             assembler,
@@ -114,13 +119,13 @@ impl TransactionContextBuilder {
     }
 
     pub fn with_non_fungible_faucet(acct_id: u64, nonce: Felt, empty_reserved_slot: bool) -> Self {
-        let assembler = TransactionKernel::assembler_testing();
         let account = Account::mock_non_fungible_faucet(
             acct_id,
             nonce,
             empty_reserved_slot,
-            assembler.clone(),
+            TransactionKernel::testing_assembler(),
         );
+        let assembler = TransactionKernel::testing_assembler_with_mock_account();
 
         Self {
             assembler,
@@ -215,6 +220,7 @@ impl TransactionContextBuilder {
         let var_name = format!(
             "
             use.miden::contracts::wallets::basic->wallet
+            use.test::account
 
             begin
                 # NOTE
@@ -227,7 +233,7 @@ impl TransactionContextBuilder {
                 call.wallet::create_note
 
                 push.{asset}
-                call.{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT}
+                call.account::add_asset_to_note
                 dropw dropw dropw
             end
             ",
@@ -260,6 +266,7 @@ impl TransactionContextBuilder {
         let code = format!(
             "
             use.miden::contracts::wallets::basic->wallet
+            use.test::account
 
             begin
 
@@ -272,11 +279,10 @@ impl TransactionContextBuilder {
                 push.{aux0}
                 push.{tag0}
 
-
                 call.wallet::create_note
 
                 push.{asset0}
-                call.{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT}
+                call.account::add_asset_to_note
                 dropw dropw dropw
 
                 # NOTE 1
@@ -289,7 +295,7 @@ impl TransactionContextBuilder {
                 call.wallet::create_note
 
                 push.{asset1}
-                call.{ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT}
+                call.account::add_asset_to_note
                 dropw dropw dropw
             end
             ",
@@ -441,7 +447,7 @@ impl TransactionContextBuilder {
             FungibleAsset::new(faucet_id_2, CONSUMED_ASSET_2_AMOUNT).unwrap().into();
         let fungible_asset_3: Asset =
             FungibleAsset::new(faucet_id_3, CONSUMED_ASSET_3_AMOUNT).unwrap().into();
-        let nonfungible_asset_1: Asset = Asset::mock_non_fungible(
+        let nonfungible_asset_1: Asset = NonFungibleAsset::mock(
             ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             &NON_FUNGIBLE_ASSET_DATA_2,
         );
@@ -526,7 +532,7 @@ impl TransactionContextBuilder {
             FungibleAsset::new(faucet_id_2, CONSUMED_ASSET_2_AMOUNT).unwrap().into();
         let fungible_asset_3: Asset =
             FungibleAsset::new(faucet_id_3, CONSUMED_ASSET_3_AMOUNT).unwrap().into();
-        let nonfungible_asset_1: Asset = Asset::mock_non_fungible(
+        let nonfungible_asset_1: Asset = NonFungibleAsset::mock(
             ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             &NON_FUNGIBLE_ASSET_DATA_2,
         );

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -451,7 +451,7 @@ fn test_set_map_item() {
 #[test]
 fn test_storage_offset() {
     // setup assembler
-    let assembler = TransactionKernel::assembler_testing();
+    let assembler = TransactionKernel::testing_assembler();
 
     // The following code will execute the following logic that will be asserted during the test:
     //

--- a/miden-tx/src/tests/kernel_tests/test_asset.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset.rs
@@ -2,7 +2,7 @@ use miden_objects::{
     accounts::account_id::testing::{
         ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
     },
-    assets::Asset,
+    assets::NonFungibleAsset,
     testing::{
         constants::{
             FUNGIBLE_ASSET_AMOUNT, FUNGIBLE_FAUCET_INITIAL_BALANCE, NON_FUNGIBLE_ASSET_DATA,
@@ -62,7 +62,7 @@ fn test_create_non_fungible_asset_succeeds() {
     .build();
 
     let non_fungible_asset =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &NON_FUNGIBLE_ASSET_DATA);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &NON_FUNGIBLE_ASSET_DATA);
 
     let code = format!(
         "
@@ -95,7 +95,7 @@ fn test_validate_non_fungible_asset() {
     .build();
 
     let non_fungible_asset =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
     let encoded = Word::from(non_fungible_asset);
 
     let code = format!(

--- a/miden-tx/src/tests/kernel_tests/test_faucet.rs
+++ b/miden-tx/src/tests/kernel_tests/test_faucet.rs
@@ -3,7 +3,7 @@ use miden_objects::{
         ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1,
         ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1,
     },
-    assets::{Asset, FungibleAsset},
+    assets::{FungibleAsset, NonFungibleAsset},
     testing::{
         constants::{
             CONSUMED_ASSET_1_AMOUNT, FUNGIBLE_ASSET_AMOUNT, FUNGIBLE_FAUCET_INITIAL_BALANCE,
@@ -149,7 +149,7 @@ fn test_mint_non_fungible_asset_succeeds() {
     .build();
 
     let non_fungible_asset =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &NON_FUNGIBLE_ASSET_DATA);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &NON_FUNGIBLE_ASSET_DATA);
 
     let code = format!(
         "
@@ -197,7 +197,7 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() {
     let tx_context = TransactionContextBuilder::with_standard_account(ONE).build();
 
     let non_fungible_asset =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3, 4]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3, 4]);
 
     let code = format!(
         "
@@ -223,7 +223,7 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() {
     let tx_context = TransactionContextBuilder::with_standard_account(ONE).build();
 
     let non_fungible_asset =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1, &[1, 2, 3, 4]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1, &[1, 2, 3, 4]);
 
     let code = format!(
         "
@@ -253,10 +253,8 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() {
     )
     .build();
 
-    let non_fungible_asset = Asset::mock_non_fungible(
-        ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
-        &NON_FUNGIBLE_ASSET_DATA_2,
-    );
+    let non_fungible_asset =
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &NON_FUNGIBLE_ASSET_DATA_2);
 
     let code = format!(
         "
@@ -419,7 +417,7 @@ fn test_burn_non_fungible_asset_succeeds() {
     .build();
 
     let non_fungible_asset_burnt =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
 
     let code = format!(
         "
@@ -472,7 +470,7 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() {
     .build();
 
     let non_fungible_asset_burnt =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
 
     let code = format!(
         "
@@ -504,7 +502,7 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() {
     let tx_context = TransactionContextBuilder::with_standard_account(ONE).build();
 
     let non_fungible_asset_burnt =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
 
     let code = format!(
         "
@@ -541,7 +539,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() {
     .build();
 
     let non_fungible_asset_burnt =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1, &[1, 2, 3]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1, &[1, 2, 3]);
 
     let code = format!(
         "

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -357,7 +357,7 @@ fn input_notes_memory_assertions(
 #[test]
 pub fn test_prologue_create_account() {
     let (account, seed) = AccountBuilder::new(ChaCha20Rng::from_entropy())
-        .default_code(TransactionKernel::assembler_testing())
+        .default_code(TransactionKernel::testing_assembler())
         .build()
         .unwrap();
     let tx_context = TransactionContextBuilder::new(account).account_seed(Some(seed)).build();
@@ -482,7 +482,7 @@ pub fn test_prologue_create_account_invalid_non_fungible_faucet_reserved_slot() 
 #[test]
 pub fn test_prologue_create_account_invalid_seed() {
     let (acct, account_seed) = AccountBuilder::new(ChaCha20Rng::from_entropy())
-        .default_code(TransactionKernel::assembler_testing())
+        .default_code(TransactionKernel::testing_assembler())
         .account_type(miden_objects::accounts::AccountType::RegularAccountUpdatableCode)
         .build()
         .unwrap();

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -9,7 +9,7 @@ use miden_objects::{
         ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2,
         ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
     },
-    assets::Asset,
+    assets::NonFungibleAsset,
     notes::{
         Note, NoteAssets, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient, NoteType,
     },
@@ -378,10 +378,8 @@ fn test_create_note_and_add_multiple_assets() {
     let asset_3 = [Felt::new(30), ZERO, ZERO, Felt::new(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2)];
     let asset_2_and_3 =
         [Felt::new(50), ZERO, ZERO, Felt::new(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2)];
-    let non_fungible_asset = Asset::mock_non_fungible(
-        ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
-        &NON_FUNGIBLE_ASSET_DATA_2,
-    );
+    let non_fungible_asset =
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &NON_FUNGIBLE_ASSET_DATA_2);
     let non_fungible_asset_encoded = Word::from(non_fungible_asset);
 
     let code = format!(
@@ -460,7 +458,7 @@ fn test_create_note_and_add_same_nft_twice() {
     let recipient = [ZERO, ONE, Felt::new(2), Felt::new(3)];
     let tag = Felt::new(4);
     let non_fungible_asset =
-        Asset::mock_non_fungible(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
+        NonFungibleAsset::mock(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN, &[1, 2, 3]);
     let encoded = Word::from(non_fungible_asset);
 
     let code = format!(

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -359,7 +359,7 @@ fn create_new_account() -> (Account, Word, Rc<BasicAuthenticator<StdRng>>) {
 
     let (account, seed) = AccountBuilder::new(ChaCha20Rng::from_entropy())
         .add_storage_item(storage_item)
-        .default_code(TransactionKernel::assembler_testing())
+        .default_code(TransactionKernel::testing_assembler())
         .account_type(AccountType::RegularAccountUpdatableCode)
         .nonce(Felt::ZERO)
         .build()

--- a/objects/src/testing/account.rs
+++ b/objects/src/testing/account.rs
@@ -21,7 +21,7 @@ use crate::{
         Account, AccountCode, AccountId, AccountStorage, AccountStorageMode, AccountType, SlotItem,
         StorageMap, StorageSlot,
     },
-    assets::{Asset, AssetVault, FungibleAsset},
+    assets::{Asset, AssetVault, FungibleAsset, NonFungibleAsset},
     AccountError, AssetVaultError, Felt, Word, ZERO,
 };
 
@@ -239,7 +239,7 @@ impl Account {
         let entries = match empty_reserved_slot {
             true => vec![],
             false => {
-                let asset = Asset::mock_non_fungible(
+                let asset = NonFungibleAsset::mock(
                     ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
                     &constants::NON_FUNGIBLE_ASSET_DATA_2,
                 );
@@ -287,7 +287,7 @@ impl AssetVault {
         let fungible_asset_2 =
             Asset::Fungible(FungibleAsset::new(faucet_id_2, FUNGIBLE_ASSET_AMOUNT).unwrap());
 
-        let non_fungible_asset = Asset::mock_non_fungible(
+        let non_fungible_asset = NonFungibleAsset::mock(
             ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
             &NON_FUNGIBLE_ASSET_DATA,
         );

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -1,34 +1,8 @@
-use assembly::Assembler;
+use std::sync::Arc;
+
+use assembly::{ast::Module, Assembler, Library, LibraryPath};
 
 use crate::accounts::AccountCode;
-
-// The MAST root of the default account's interface. Use these constants to interact with the
-// account's procedures.
-const MASTS: [&str; 12] = [
-    "0xff06b90f849c4b262cbfbea67042c4ea017ea0e9c558848a951d44b23370bec5",
-    "0x8ef0092134469a1330e3c468f57c7f085ce611645d09cc7516c786fefc71d794",
-    "0xed87fcbdaf52f9d544d6362c0177f7294d917dfdbf48ee31b3df7b28be6f4ea0",
-    "0xf26ab9001bbe615e3f39e6bf5c12dd32754b99d9476c6dd003881c3c52a6bfc1",
-    "0x3f4b2dadf8a08e963898bc172f3fb1f4cbd7c560cb1d5f88eec582d0f9819edb",
-    "0x31c806646881424c912cf5af6ad8002fe1f24cdc83e769525dd6c68df94a8f3b",
-    "0x1b4fd4fc6d711276c4b25dc9e9b8dff6feb8f3762562fcecf45b85c7e4ed2437",
-    "0x8197f4791b030c86bd4e3e4a241de840de47fa1ec338b8668ddb37052eee00a6",
-    "0x16d574d4d5a70f83c86843a62a19ca647d2110c11cfd5cb2fc93a149f3c9c2c5",
-    "0x70573a57c1b809e6feacf3bfeda3c6a22e4ef018979d2a0f9d466e54ed9c44a5",
-    "0x60cc189b72db5eae2de193245a5c979bc8c322a98d3980bff068e1c80c066306",
-    "0x875149b782d20eeda59477e260c173fbb477d1f6f755820d0bfb214ce0ebe78b",
-];
-
-pub const ACCOUNT_ADD_ASSET_TO_NOTE_MAST_ROOT: &str = MASTS[2];
-pub const ACCOUNT_SEND_ASSET_MAST_ROOT: &str = MASTS[8];
-pub const ACCOUNT_INCR_NONCE_MAST_ROOT: &str = MASTS[4];
-pub const ACCOUNT_SET_ITEM_MAST_ROOT: &str = MASTS[10];
-pub const ACCOUNT_SET_MAP_ITEM_MAST_ROOT: &str = MASTS[11];
-pub const ACCOUNT_SET_CODE_MAST_ROOT: &str = MASTS[9];
-pub const ACCOUNT_REMOVE_ASSET_MAST_ROOT: &str = MASTS[7];
-
-pub const ACCOUNT_ACCOUNT_PROCEDURE_1_MAST_ROOT: &str = MASTS[0];
-pub const ACCOUNT_ACCOUNT_PROCEDURE_2_MAST_ROOT: &str = MASTS[1];
 
 pub const CODE: &str = "
     export.foo
@@ -58,106 +32,74 @@ pub const DEFAULT_AUTH_SCRIPT: &str = "
 impl AccountCode {
     /// Creates a mock [AccountCode] that exposes wallet interface
     pub fn mock_wallet(assembler: Assembler) -> AccountCode {
-        let account_code = "\
+        AccountCode::new(Self::mock_library(assembler)).unwrap()
+    }
+
+    /// Creates a mock [Library] which can be used to assemble programs and as a library to create a
+    /// mock [AccountCode] interface. Transaction and note scripts that make use of this interface
+    /// should be assembled with this.
+    pub fn mock_library(assembler: Assembler) -> Library {
+        let code = "
         use.miden::account
         use.miden::tx
-
-        # acct proc 0
         export.::miden::contracts::wallets::basic::receive_asset
-        # acct proc 1
         export.::miden::contracts::wallets::basic::send_asset
-        # acct proc 2
         export.::miden::contracts::wallets::basic::create_note
-        # acct proc 3
         export.::miden::contracts::wallets::basic::move_asset_to_note
-
-        # acct proc 4
         export.incr_nonce
             push.0 swap
             # => [value, 0]
-
             exec.account::incr_nonce
             # => [0]
         end
 
-        # acct proc 5
         export.set_item
             exec.account::set_item
             # => [R', V, 0, 0, 0]
-
             movup.8 drop movup.8 drop movup.8 drop
             # => [R', V]
         end
 
-        # acct proc 6
         export.set_map_item
             exec.account::set_map_item
             # => [R', V, 0, 0, 0]
-
             movup.8 drop movup.8 drop movup.8 drop
             # => [R', V]
         end
 
-        # acct proc 7
         export.set_code
             padw swapw
             # => [CODE_COMMITMENT, 0, 0, 0, 0]
-
             exec.account::set_code
             # => [0, 0, 0, 0]
         end
 
-        # acct proc 8
         export.add_asset_to_note
             exec.tx::add_asset_to_note
             # => [ASSET, note_idx]
         end
 
-        # acct proc 9
         export.remove_asset
             exec.account::remove_asset
             # => [ASSET]
         end
 
-        # acct proc 10
         export.account_procedure_1
             push.1.2
             add
         end
 
-        # acct proc 11
         export.account_procedure_2
             push.2.1
             sub
         end
         ";
+        let source_manager = Arc::new(assembly::DefaultSourceManager::default());
+        let module = Module::parser(assembly::ast::ModuleKind::Library)
+            .parse_str(LibraryPath::new("test::account").unwrap(), code, &source_manager)
+            .unwrap();
 
-        let code = AccountCode::compile(account_code, assembler).unwrap();
-        // Ensures the mast root constants match the latest version of the code.
-        //
-        // The constants will change if the library code changes, and need to be updated so that the
-        // tests will work properly. If these asserts fail, copy the value of the code (the left
-        // value), into the constants.
-        //
-        // Comparing all the values together, in case multiple of them change, a single test run
-        // will detect it.
-        let current = [
-            code.procedures()[0].mast_root().to_hex(),
-            code.procedures()[1].mast_root().to_hex(),
-            code.procedures()[2].mast_root().to_hex(),
-            code.procedures()[3].mast_root().to_hex(),
-            code.procedures()[4].mast_root().to_hex(),
-            code.procedures()[5].mast_root().to_hex(),
-            code.procedures()[6].mast_root().to_hex(),
-            code.procedures()[7].mast_root().to_hex(),
-            code.procedures()[8].mast_root().to_hex(),
-            code.procedures()[9].mast_root().to_hex(),
-            code.procedures()[10].mast_root().to_hex(),
-            code.procedures()[11].mast_root().to_hex(),
-        ];
-        assert!(current == MASTS, "const MASTS: [&str; 12] = {:?};", current);
-
-        code
+        assembler.assemble_library(&[*module]).unwrap()
     }
 
     /// Creates a mock [AccountCode] with specific code and assembler

--- a/objects/src/testing/assets.rs
+++ b/objects/src/testing/assets.rs
@@ -1,7 +1,7 @@
 use rand::{distributions::Standard, Rng};
 
 use crate::{
-    accounts::{AccountId, AccountType},
+    accounts::{account_id::testing::ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, AccountId, AccountType},
     assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     AssetError,
 };
@@ -84,8 +84,8 @@ impl FungibleAssetBuilder {
     }
 }
 
-impl Asset {
-    pub fn mock_non_fungible(account_id: u64, asset_data: &[u8]) -> Asset {
+impl NonFungibleAsset {
+    pub fn mock(account_id: u64, asset_data: &[u8]) -> Asset {
         let non_fungible_asset_details = NonFungibleAssetDetails::new(
             AccountId::try_from(account_id).unwrap(),
             asset_data.to_vec(),
@@ -93,5 +93,17 @@ impl Asset {
         .unwrap();
         let non_fungible_asset = NonFungibleAsset::new(&non_fungible_asset_details).unwrap();
         Asset::NonFungible(non_fungible_asset)
+    }
+}
+
+impl FungibleAsset {
+    pub fn mock(amount: u64) -> Asset {
+        Asset::Fungible(
+            FungibleAsset::new(
+                ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN.try_into().expect("id is valid"),
+                amount,
+            )
+            .expect("asset is valid"),
+        )
     }
 }


### PR DESCRIPTION
Closes #643
Moves mock account code into a library that can be used to call the mock interface, removing the need for using MAST roots and maintaining the MAST root array. This might actually be a little less "clear" because in the past you could just search for the MAST root variables and get a feel for how the flow had to play out, but hopefully the test code is at least more concise and not as confusing with the removed workarounds and wrappers.
Also includes minor refactors to make some tests a bit more readable in general.