### PR TITLE
feat: add `Display`, `FromStr` and `TryFrom<&str>` implementation to `AccountStorageMode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+- Implemented `Display` and `TryFrom<&str>` for `AccountStorageMode` (#???).
 - Implemented offset based storage access (#843).
 - [BREAKING] `AccountStorageType` enum was renamed to `AccountStorageMode` along with its variants (#854).
 - [BREAKING] `AccountStub` structure was renamed to `AccountHeader` (#855).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0 (TBD)
 
-- Implemented `Display` and `TryFrom<&str>` for `AccountStorageMode` (#???).
+- Implemented `Display`, `TryFrom<&str>` and `FromStr` for `AccountStorageMode` (#861).
 - Implemented offset based storage access (#843).
 - [BREAKING] `AccountStorageType` enum was renamed to `AccountStorageMode` along with its variants (#854).
 - [BREAKING] `AccountStub` structure was renamed to `AccountHeader` (#855).

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -2,7 +2,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::fmt;
+use core::{fmt, str::FromStr};
 
 use super::{
     get_account_seed, AccountError, ByteReader, Deserializable, DeserializationError, Digest, Felt,
@@ -108,7 +108,15 @@ impl TryFrom<&str> for AccountStorageMode {
     }
 }
 
-impl core::str::FromStr for AccountStorageMode {
+impl TryFrom<String> for AccountStorageMode {
+    type Error = AccountError;
+
+    fn try_from(value: String) -> Result<Self, AccountError> {
+        AccountStorageMode::from_str(&value)
+    }
+}
+
+impl FromStr for AccountStorageMode {
     type Err = AccountError;
 
     fn from_str(input: &str) -> Result<AccountStorageMode, AccountError> {

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -108,6 +108,14 @@ impl TryFrom<&str> for AccountStorageMode {
     }
 }
 
+impl std::str::FromStr for AccountStorageMode {
+    type Err = AccountError;
+
+    fn from_str(input: &str) -> Result<AccountStorageMode, AccountError> {
+        AccountStorageMode::try_from(input)
+    }
+}
+
 // ACCOUNT ID
 // ================================================================================================
 

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -108,7 +108,7 @@ impl TryFrom<&str> for AccountStorageMode {
     }
 }
 
-impl std::str::FromStr for AccountStorageMode {
+impl core::str::FromStr for AccountStorageMode {
     type Err = AccountError;
 
     fn from_str(input: &str) -> Result<AccountStorageMode, AccountError> {

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -87,6 +87,27 @@ pub enum AccountStorageMode {
     Private = PRIVATE,
 }
 
+impl fmt::Display for AccountStorageMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AccountStorageMode::Public => write!(f, "public"),
+            AccountStorageMode::Private => write!(f, "private"),
+        }
+    }
+}
+
+impl TryFrom<&str> for AccountStorageMode {
+    type Error = AccountError;
+
+    fn try_from(value: &str) -> Result<Self, AccountError> {
+        match value.to_lowercase().as_str() {
+            "public" => Ok(AccountStorageMode::Public),
+            "private" => Ok(AccountStorageMode::Private),
+            _ => Err(AccountError::InvalidAccountStorageMode),
+        }
+    }
+}
+
 // ACCOUNT ID
 // ================================================================================================
 


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/0xPolygonMiden/miden-client/pull/514#discussion_r1749293695), this PR adds the implementation of `Display` and `TryFrom<&str>` for AccountStorageMode.

