### PR TITLE
feat: add `TransactionProver` trait, rename the `TransactionProver` struct to `LocalTransactionProver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 0.6.0 (TBD)
 
-- Adds the `TransactionProver` trait (#865).
-- [BREAKING] Renames the `TransactionProver` struct to `LocalTransactionProver` (#865).
+- [BREAKING] Renamed the `TransactionProver` struct to `LocalTransactionProver` and added the `TransactionProver` trait (#865).
 - Implemented `Display`, `TryFrom<&str>` and `FromStr` for `AccountStorageMode` (#861).
 - Implemented offset based storage access (#843).
 - [BREAKING] `AccountStorageType` enum was renamed to `AccountStorageMode` along with its variants (#854).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.0 (TBD)
 
+- Adds the `TransactionProver` trait (#865).
+- [BREAKING] Renames the `TransactionProver` struct to `LocalTransactionProver` (#865).
 - Implemented `Display`, `TryFrom<&str>` and `FromStr` for `AccountStorageMode` (#861).
 - Implemented offset based storage access (#843).
 - [BREAKING] `AccountStorageType` enum was renamed to `AccountStorageMode` along with its variants (#854).

--- a/miden-tx/README.md
+++ b/miden-tx/README.md
@@ -22,8 +22,8 @@ let executed_transaction = executor.execute_transaction(account_id, block_ref, n
 With the transaction execution done, it is then possible to create a proof:
 
 ```rust
-let prover = TransactionProver::new(ProvingOptions::default());
-let proven_transaction = prover.prove_transaction(executed_transaction);
+let prover = LocalTransactionProver::new(ProvingOptions::default());
+let proven_transaction = prover.prove(executed_transaction);
 ```
 
 And to verify a proof:

--- a/miden-tx/src/lib.rs
+++ b/miden-tx/src/lib.rs
@@ -15,7 +15,7 @@ pub mod host;
 pub use host::{TransactionHost, TransactionProgress};
 
 mod prover;
-pub use prover::{ProvingOptions, TransactionProver};
+pub use prover::{LocalTransactionProver, ProvingOptions, TransactionProver};
 
 mod verifier;
 pub use verifier::TransactionVerifier;

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -57,7 +57,10 @@ impl LocalTransactionProver {
 
 impl Default for LocalTransactionProver {
     fn default() -> Self {
-        Self { mast_store: Rc::new(TransactionMastStore::new()), proof_options: Default::default() }
+        Self {
+            mast_store: Rc::new(TransactionMastStore::new()),
+            proof_options: Default::default(),
+        }
     }
 }
 

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -56,6 +56,7 @@ impl LocalTransactionProver {
 }
 
 impl TransactionProver for LocalTransactionProver {
+    #[maybe_async]
     fn prove(
         &self,
         transaction: impl Into<TransactionWitness>,

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -55,6 +55,12 @@ impl LocalTransactionProver {
     }
 }
 
+impl Default for LocalTransactionProver {
+    fn default() -> Self {
+        Self { mast_store: Rc::new(TransactionMastStore::new()), proof_options: Default::default() }
+    }
+}
+
 impl TransactionProver for LocalTransactionProver {
     #[maybe_async]
     fn prove(

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -35,7 +35,10 @@ use vm_processor::{
     Digest, MemAdviceProvider, ONE,
 };
 
-use super::{TransactionExecutor, TransactionHost, TransactionProver, TransactionVerifier};
+use super::{
+    LocalTransactionProver, TransactionExecutor, TransactionHost, TransactionProver,
+    TransactionVerifier,
+};
 use crate::{testing::TransactionContextBuilder, TransactionMastStore};
 
 mod kernel_tests;
@@ -901,8 +904,8 @@ fn prove_witness_and_verify() {
     let executed_transaction_id = executed_transaction.id();
 
     let proof_options = ProvingOptions::default();
-    let prover = TransactionProver::new(proof_options);
-    let proven_transaction = prover.prove_transaction(executed_transaction).unwrap();
+    let prover = LocalTransactionProver::new(proof_options);
+    let proven_transaction = prover.prove(executed_transaction).unwrap();
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
 

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -15,7 +15,9 @@ use miden_objects::{
     Felt, Word, ZERO,
 };
 use miden_prover::ProvingOptions;
-use miden_tx::{TransactionProver, TransactionVerifier, TransactionVerifierError};
+use miden_tx::{
+    LocalTransactionProver, TransactionProver, TransactionVerifier, TransactionVerifierError,
+};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use vm_processor::utils::Deserializable;
 
@@ -30,8 +32,8 @@ pub fn prove_and_verify_transaction(
     // Prove the transaction
 
     let proof_options = ProvingOptions::default();
-    let prover = TransactionProver::new(proof_options);
-    let proven_transaction = prover.prove_transaction(executed_transaction).unwrap();
+    let prover = LocalTransactionProver::new(proof_options);
+    let proven_transaction = prover.prove(executed_transaction).unwrap();
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
 


### PR DESCRIPTION
Closes #859 