### PR TITLE
fix: Add testing feature flag to no-std build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,5 @@ jobs:
           rustup update --no-self-update
           rustup target add wasm32-unknown-unknown
           make build-no-std
+          make build-no-std-testing
+

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ doc-serve: ## Serves documentation site
 test-build: ## Build the test binary
 	$(DEBUG_ASSERTIONS) cargo nextest run --cargo-profile test-release --features concurrent,testing --no-run
 
+
 .PHONY: test-default
 test-default: ## Run default tests excluding `prove`
 	$(DEBUG_ASSERTIONS) cargo nextest run --profile default --cargo-profile test-release --features concurrent,testing --filter-expr "not test(prove)"
@@ -81,6 +82,12 @@ build: ## By default we should build in release mode
 .PHONY: build-no-std
 build-no-std: ## Build without the standard library
 	cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx
+
+
+.PHONY: build-no-std-testing
+build-no-std-testing: ## Build without the standard library. Includes the `testing` feature
+	cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx --features testing
+
 
 .PHONY: build-async
 build-async: ## Build with the `async` feature enabled (only libraries)

--- a/miden-tx/src/testing/executor.rs
+++ b/miden-tx/src/testing/executor.rs
@@ -1,5 +1,4 @@
 use miden_lib::transaction::TransactionKernel;
-#[cfg(feature = "std")]
 use vm_processor::{
     AdviceInputs, AdviceProvider, DefaultHost, ExecutionError, Host, Process, Program, StackInputs,
 };

--- a/miden-tx/src/testing/mock_chain.rs
+++ b/miden-tx/src/testing/mock_chain.rs
@@ -18,7 +18,7 @@ use miden_objects::{
     },
     AccountError, BlockHeader, FieldElement, NoteError, ACCOUNT_TREE_DEPTH,
 };
-use rand::{rngs::StdRng, SeedableRng};
+use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use vm_processor::{
     crypto::{RpoRandomCoin, SimpleSmt},
@@ -36,7 +36,7 @@ const TIMESTAMP_START: u32 = 1693348223;
 /// Timestamp of timestamp on each new block
 const TIMESTAMP_STEP: u32 = 10;
 
-pub type MockAuthenticator = BasicAuthenticator<StdRng>;
+pub type MockAuthenticator = BasicAuthenticator<ChaCha20Rng>;
 
 // MOCK FUNGIBLE FAUCET
 // ================================================================================================
@@ -64,14 +64,14 @@ impl MockFungibleFaucet {
 struct MockAccount {
     account: Account,
     seed: Option<Word>,
-    authenticator: Option<BasicAuthenticator<StdRng>>,
+    authenticator: Option<BasicAuthenticator<ChaCha20Rng>>,
 }
 
 impl MockAccount {
     pub fn new(
         account: Account,
         seed: Option<Word>,
-        authenticator: Option<BasicAuthenticator<StdRng>>,
+        authenticator: Option<BasicAuthenticator<ChaCha20Rng>>,
     ) -> Self {
         MockAccount { account, seed, authenticator }
     }
@@ -89,7 +89,7 @@ impl MockAccount {
         self.seed.as_ref()
     }
 
-    pub fn authenticator(&self) -> &Option<BasicAuthenticator<StdRng>> {
+    pub fn authenticator(&self) -> &Option<BasicAuthenticator<ChaCha20Rng>> {
         &self.authenticator
     }
 }
@@ -300,7 +300,7 @@ impl MockChain {
     // ================================================================================================
 
     pub fn add_new_wallet(&mut self, auth_method: Auth, assets: Vec<Asset>) -> Account {
-        let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
+        let account_builder = AccountBuilder::new(ChaCha20Rng::from_seed(Default::default()))
             .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ZERO)
             .add_assets(assets);
@@ -308,7 +308,7 @@ impl MockChain {
     }
 
     pub fn add_existing_wallet(&mut self, auth_method: Auth, assets: Vec<Asset>) -> Account {
-        let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
+        let account_builder = AccountBuilder::new(ChaCha20Rng::from_seed(Default::default()))
             .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ONE)
             .add_assets(assets);
@@ -330,7 +330,7 @@ impl MockChain {
 
         let faucet_metadata = StorageSlot::Value(metadata);
 
-        let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
+        let account_builder = AccountBuilder::new(ChaCha20Rng::from_seed(Default::default()))
             .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ZERO)
             .account_type(AccountType::FungibleFaucet)
@@ -356,7 +356,7 @@ impl MockChain {
 
         let faucet_metadata = StorageSlot::Value(metadata);
 
-        let account_builder = AccountBuilder::new(ChaCha20Rng::from_entropy())
+        let account_builder = AccountBuilder::new(ChaCha20Rng::from_seed(Default::default()))
             .default_code(TransactionKernel::testing_assembler())
             .nonce(Felt::ONE)
             .account_type(AccountType::FungibleFaucet)
@@ -373,14 +373,14 @@ impl MockChain {
     ) -> Account {
         let (account, seed, authenticator) = match auth_method {
             Auth::BasicAuth => {
-                let mut rng = StdRng::from_entropy();
+                let mut rng = ChaCha20Rng::from_seed(Default::default());
 
                 let (acc, seed, auth) = account_builder.build_with_auth(&mut rng).unwrap();
 
-                let authenticator = BasicAuthenticator::<StdRng>::new(&[(
-                    auth.public_key().into(),
-                    AuthSecretKey::RpoFalcon512(auth),
-                )]);
+                let authenticator = BasicAuthenticator::<ChaCha20Rng>::new_with_rng(
+                    &[(auth.public_key().into(), AuthSecretKey::RpoFalcon512(auth))],
+                    rng,
+                );
 
                 (acc, seed, Some(authenticator))
             },

--- a/miden-tx/src/testing/tx_context/builder.rs
+++ b/miden-tx/src/testing/tx_context/builder.rs
@@ -1,7 +1,7 @@
 // TRANSACTION CONTEXT BUILDER
 // ================================================================================================
 
-use std::{collections::BTreeMap, vec::Vec};
+use alloc::{collections::BTreeMap, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{

--- a/miden-tx/src/testing/tx_context/mod.rs
+++ b/miden-tx/src/testing/tx_context/mod.rs
@@ -1,5 +1,4 @@
-use alloc::{rc::Rc, vec::Vec};
-use std::sync::Arc;
+use alloc::{rc::Rc, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{

--- a/objects/src/testing/account_code.rs
+++ b/objects/src/testing/account_code.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use assembly::{ast::Module, Assembler, Library, LibraryPath};
 


### PR DESCRIPTION
Since the `testing` feature flag is additive in the sense that it just adds code, it should be OK to add it directly to the `no-std` make target to detect potential problems in that code.