### PR TITLE
Followup: Refactored storage from `Smt` to `sequential hash`

### DIFF
--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -17,7 +17,10 @@ pub enum TransactionKernelError {
         got: Digest,
         data: Option<Vec<Felt>>,
     },
-    InvalidStorageSlotIndex(u64, u64),
+    InvalidStorageSlotIndex {
+        max: u64,
+        actual: u64,
+    },
     MalformedAccountId(AccountError),
     MalformedAsset(AssetError),
     MalformedAssetOnAccountVaultUpdate(AssetError),
@@ -49,8 +52,8 @@ impl fmt::Display for TransactionKernelError {
                     expected, got, data
                 )
             },
-            TransactionKernelError::InvalidStorageSlotIndex(index, num_storage_slots) => {
-                write!(f, "Storage slot index: {index} is invalid, must be smaller than the number of account storage slots: {num_storage_slots}")
+            TransactionKernelError::InvalidStorageSlotIndex { max, actual } => {
+                write!(f, "Storage slot index: {actual} is invalid, must be smaller than the number of account storage slots: {max}")
             },
             TransactionKernelError::MalformedAccountId(err) => {
                 write!( f, "Account id data extracted from the stack by the event handler is not well formed {err}")

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -437,7 +437,7 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
             .get_mem_value(process.ctx(), NUM_ACCT_STORAGE_SLOTS_PTR)
             .ok_or(TransactionKernelError::MissingMemoryValue(NUM_ACCT_STORAGE_SLOTS_PTR))?;
 
-        Ok(num_storage_slots_word[3].as_int())
+        Ok(num_storage_slots_word[0].as_int())
     }
 }
 

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -228,17 +228,14 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         // get slot index from the stack and make sure it is valid
         let slot_index = process.get_stack_item(0);
 
-        let num_storage_slots_word = process
-            .get_mem_value(process.ctx(), NUM_ACCT_STORAGE_SLOTS_PTR)
-            .ok_or(TransactionKernelError::MissingMemoryValue(NUM_ACCT_STORAGE_SLOTS_PTR))?;
-
-        let num_storage_slot = num_storage_slots_word[0].as_int();
+        // get number of storage slots initialised by the account
+        let num_storage_slot = Self::get_num_storage_slots(process)?;
 
         if slot_index.as_int() >= num_storage_slot {
-            return Err(TransactionKernelError::InvalidStorageSlotIndex(
-                slot_index.as_int(),
-                num_storage_slot,
-            ));
+            return Err(TransactionKernelError::InvalidStorageSlotIndex {
+                max: num_storage_slot,
+                actual: slot_index.as_int(),
+            });
         }
 
         // get the value to which the slot is being updated
@@ -277,17 +274,14 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         // get slot index from the stack and make sure it is valid
         let slot_index = process.get_stack_item(0);
 
-        let num_storage_slots_word = process
-            .get_mem_value(process.ctx(), NUM_ACCT_STORAGE_SLOTS_PTR)
-            .ok_or(TransactionKernelError::MissingMemoryValue(NUM_ACCT_STORAGE_SLOTS_PTR))?;
-
-        let num_storage_slot = num_storage_slots_word[0].as_int();
+        // get number of storage slots initialised by the account
+        let num_storage_slot = Self::get_num_storage_slots(process)?;
 
         if slot_index.as_int() >= num_storage_slot {
-            return Err(TransactionKernelError::InvalidStorageSlotIndex(
-                slot_index.as_int(),
-                num_storage_slot,
-            ));
+            return Err(TransactionKernelError::InvalidStorageSlotIndex {
+                max: num_storage_slot,
+                actual: slot_index.as_int(),
+            });
         }
 
         // get the KEY to which the slot is being updated
@@ -431,6 +425,19 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         } else {
             Ok(process.get_mem_value(process.ctx(), note_address).map(NoteId::from))
         }
+    }
+
+    /// Returns the number of storage slots initialised for the current account.
+    ///
+    /// # Errors
+    /// Returns an error if the memory location supposed to contain the account storage slot number
+    /// has not been initialised.
+    fn get_num_storage_slots<S: ProcessState>(process: &S) -> Result<u64, TransactionKernelError> {
+        let num_storage_slots_word = process
+            .get_mem_value(process.ctx(), NUM_ACCT_STORAGE_SLOTS_PTR)
+            .ok_or(TransactionKernelError::MissingMemoryValue(NUM_ACCT_STORAGE_SLOTS_PTR))?;
+
+        Ok(num_storage_slots_word[3].as_int())
     }
 }
 

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -40,7 +40,7 @@ pub enum AccountError {
     SeedDigestTooFewTrailingZeros { expected: u32, actual: u32 },
     StorageSlotNotMap(u8),
     StorageSlotNotValue(u8),
-    StorageIndexOutOfBounds(u8, u8),
+    StorageIndexOutOfBounds { max: u8, actual: u8 },
     StorageTooManySlots(u64),
 }
 


### PR DESCRIPTION
This is a followup PR adding the requested changes after the merge of this PR: #811 

Additions:
- Helper function `get_num_storage_slots` added in `TransactionHost`
- Added `max` and `actual` to `StorageIndexOutOfBounds` and `InvalidStorageSlotIndex` errors