### PR TITLE
fix: Add kernel root to `Block::mock()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "serde",

--- a/objects/src/block/header.rs
+++ b/objects/src/block/header.rs
@@ -265,7 +265,14 @@ mod tests {
     fn test_serde() {
         let chain_root: Word = rand_array();
         let note_root: Word = rand_array();
-        let header = BlockHeader::mock(0, Some(chain_root.into()), Some(note_root.into()), &[]);
+        let kernel_root: Word = rand_array();
+        let header = BlockHeader::mock(
+            0,
+            Some(chain_root.into()),
+            Some(note_root.into()),
+            &[],
+            kernel_root.into(),
+        );
         let serialized = header.to_bytes();
         let deserialized = BlockHeader::read_from_bytes(&serialized).unwrap();
 

--- a/objects/src/testing/block.rs
+++ b/objects/src/testing/block.rs
@@ -20,6 +20,7 @@ impl BlockHeader {
         chain_root: Option<Digest>,
         note_root: Option<Digest>,
         accounts: &[Account],
+        kernel_root: Digest,
     ) -> Self {
         let acct_db = SimpleSmt::<ACCOUNT_TREE_DEPTH>::with_leaves(
             accounts
@@ -38,48 +39,21 @@ impl BlockHeader {
         let account_root = acct_db.root();
 
         #[cfg(not(target_family = "wasm"))]
-        let (
-            prev_hash,
-            chain_root,
-            nullifier_root,
-            note_root,
-            tx_hash,
-            kernel_root,
-            proof_hash,
-            timestamp,
-        ) = {
+        let (prev_hash, chain_root, nullifier_root, note_root, tx_hash, proof_hash, timestamp) = {
             let prev_hash = rand_array::<Felt, 4>().into();
             let chain_root = chain_root.unwrap_or(rand_array::<Felt, 4>().into());
             let nullifier_root = rand_array::<Felt, 4>().into();
             let note_root = note_root.unwrap_or(rand_array::<Felt, 4>().into());
             let tx_hash = rand_array::<Felt, 4>().into();
-            let kernel_root = rand_array::<Felt, 4>().into();
             let proof_hash = rand_array::<Felt, 4>().into();
             let timestamp = rand_value();
 
-            (
-                prev_hash,
-                chain_root,
-                nullifier_root,
-                note_root,
-                tx_hash,
-                kernel_root,
-                proof_hash,
-                timestamp,
-            )
+            (prev_hash, chain_root, nullifier_root, note_root, tx_hash, proof_hash, timestamp)
         };
 
         #[cfg(target_family = "wasm")]
-        let (
-            prev_hash,
-            chain_root,
-            nullifier_root,
-            note_root,
-            tx_hash,
-            kernel_root,
-            proof_hash,
-            timestamp,
-        ) = Default::default();
+        let (prev_hash, chain_root, nullifier_root, note_root, tx_hash, proof_hash, timestamp) =
+            Default::default();
 
         BlockHeader::new(
             0,


### PR DESCRIPTION
To correctly mock functional blocks we'd need this. Tests that rely on mocked blocks on the client would fail otherwise.