### PR TITLE
feat: Validate Account Delta size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `AccountStorageHeader` (#876).
 - Implemented generation of transaction kernel procedure hashes in build.rs (#887).
 - [BREAKING] `send_asset` procedure was removed from the basic wallet (#829).
+- Introduced `AccountDelta` maximum size limit of 32 KiB (#889).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b6c60823a563c66b87e2e6f68f4215667b14b03bc443000852d4b05c4f7d69"
+checksum = "825fc5d2e4c951f45da54da2d0d23071918d966133f85dbc219694e0b9a1e141"
 dependencies = [
  "blake3",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.20"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
@@ -190,18 +190,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -656,9 +656,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a69f8362ca496a79c88cf8e5b9b349bf9c6ed49fa867d0548e670afc1f3fca5"
+checksum = "f3b6c60823a563c66b87e2e6f68f4215667b14b03bc443000852d4b05c4f7d69"
 dependencies = [
  "blake3",
  "cc",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "62871f2d65009c0256aed1b9cfeeb8ac272833c404e13d53d400cd0dad7a2ac0"
 dependencies = [
  "bitflags",
 ]
@@ -1659,18 +1659,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -1836,15 +1836,15 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -2145,9 +2145,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "c52ac009d615e79296318c1bcce2d422aaca15ad08515e344feeda07df67a587"
 dependencies = [
  "memchr",
 ]
@@ -2245,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d71ec2c97685c7e7460a30e27f955d26b8426e7c2db0ddb55a6e0537141f53"
+checksum = "961e81e9388877a25db1c034ba38253de2055f569633ae6a665d857a0556391b"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62871f2d65009c0256aed1b9cfeeb8ac272833c404e13d53d400cd0dad7a2ac0"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags",
 ]
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -2145,9 +2145,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52ac009d615e79296318c1bcce2d422aaca15ad08515e344feeda07df67a587"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004f85bb051ce986ec0b9a2bd90aaf81b83e3c67464becfdf7db31f14c1019ba"
+checksum = "5b0e685b3b872d82e58a86519294a814b7bc7a4d3cd2c93570a7d80c0c5a1aba"
 dependencies = [
  "winter-utils",
 ]

--- a/objects/src/accounts/account_id.rs
+++ b/objects/src/accounts/account_id.rs
@@ -421,6 +421,10 @@ impl Serializable for AccountId {
     fn write_into<W: miden_crypto::utils::ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
 }
 
 impl Deserializable for AccountId {

--- a/objects/src/accounts/code/mod.rs
+++ b/objects/src/accounts/code/mod.rs
@@ -223,6 +223,22 @@ impl Serializable for AccountCode {
         target.write_u8((self.procedures.len() - 1) as u8);
         target.write_many(self.procedures());
     }
+
+    fn get_size_hint(&self) -> usize {
+        // TODO: Replace with proper calculation.
+        let mut mast_forest_target = Vec::new();
+        self.mast.write_into(&mut mast_forest_target);
+
+        // Size of the serialized procedures length.
+        let u8_size = 0u8.get_size_hint();
+        let mut size = u8_size + mast_forest_target.len();
+
+        for procedure in self.procedures() {
+            size += procedure.get_size_hint();
+        }
+
+        size
+    }
 }
 
 impl Deserializable for AccountCode {

--- a/objects/src/accounts/code/procedure.rs
+++ b/objects/src/accounts/code/procedure.rs
@@ -82,6 +82,10 @@ impl Serializable for AccountProcedureInfo {
         target.write(self.mast_root());
         target.write_u16(self.storage_offset());
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.mast_root.get_size_hint() + self.storage_offset.get_size_hint()
+    }
 }
 
 impl Deserializable for AccountProcedureInfo {

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -6,7 +6,7 @@ use super::{
     Account, ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Serializable,
     Word, ZERO,
 };
-use crate::AccountDeltaError;
+use crate::{AccountDeltaError, ACCOUNT_DELTA_MAX_SIZE};
 
 mod storage;
 pub use storage::{AccountStorageDelta, StorageMapDelta};
@@ -52,8 +52,11 @@ impl AccountDelta {
     /// Returns new [AccountDelta] instantiated from the provided components.
     ///
     /// # Errors
-    /// Returns an error if storage or vault were updated, but the nonce was either not updated
+    ///
+    /// - Returns an error if storage or vault were updated, but the nonce was either not updated
     /// or set to 0.
+    /// - Returns an error if the serialized size of the delta exceeds the maximum allowed
+    ///   size.
     pub fn new(
         storage: AccountStorageDelta,
         vault: AccountVaultDelta,
@@ -62,7 +65,11 @@ impl AccountDelta {
         // nonce must be updated if either account storage or vault were updated
         validate_nonce(nonce, &storage, &vault)?;
 
-        Ok(Self { storage, vault, nonce })
+        let account_delta = Self { storage, vault, nonce };
+
+        account_delta.validate_max_size()?;
+
+        Ok(account_delta)
     }
 
     /// Merge another [AccountDelta] into this one.
@@ -106,6 +113,18 @@ impl AccountDelta {
     /// Converts this storage delta into individual delta components.
     pub fn into_parts(self) -> (AccountStorageDelta, AccountVaultDelta, Option<Felt>) {
         (self.storage, self.vault, self.nonce)
+    }
+
+    // VALIDATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Validates that the delta's size does not exceed the maximum allowed size.
+    fn validate_max_size(&self) -> Result<(), AccountDeltaError> {
+        if self.get_size_hint() > ACCOUNT_DELTA_MAX_SIZE as usize {
+            Err(AccountDeltaError::SizeLimitExceeded)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -269,13 +288,16 @@ pub(super) fn usize_encoded_len(value: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::utils::Serializable;
+    use alloc::collections::BTreeMap;
+
+    use vm_core::{utils::Serializable, Felt};
+    use vm_processor::Digest;
 
     use super::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
     use crate::{
-        accounts::{AccountId, AccountType, StorageMapDelta},
+        accounts::{delta::WORD_SERIALIZED_SIZE, AccountId, AccountType, StorageMapDelta},
         assets::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
-        ONE, ZERO,
+        AccountDeltaError, ACCOUNT_DELTA_MAX_SIZE, ONE, ZERO,
     };
 
     #[test]
@@ -337,5 +359,43 @@ mod tests {
 
         let account_delta = AccountDelta::new(storage_delta, vault_delta, Some(ONE)).unwrap();
         assert_eq!(account_delta.to_bytes().len(), account_delta.get_size_hint());
+    }
+
+    #[test]
+    fn account_delta_size_limit() {
+        // A small delta does not exceed the limit.
+        let storage_delta = AccountStorageDelta::from_iters(
+            [1, 2, 3, 4],
+            [(2, [ONE, ONE, ONE, ONE]), (3, [ONE, ONE, ZERO, ONE])],
+            [],
+        );
+        AccountDelta::new(storage_delta, AccountVaultDelta::default(), Some(ONE)).unwrap();
+
+        let mut map = BTreeMap::new();
+        // The number of entries in the map required to exceed the limit.
+        let required_entries = ACCOUNT_DELTA_MAX_SIZE / (2 * WORD_SERIALIZED_SIZE as u16);
+        for _ in 0..required_entries {
+            map.insert(
+                Digest::new([
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                ]),
+                [
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                ],
+            );
+        }
+        let storage_delta = StorageMapDelta::new(map);
+
+        // A delta that exceeds the limit returns an error.
+        let storage_delta = AccountStorageDelta::from_iters([], [], [(4, storage_delta)]);
+        let err =
+            AccountDelta::new(storage_delta, AccountVaultDelta::default(), Some(ONE)).unwrap_err();
+        assert!(matches!(err, AccountDeltaError::SizeLimitExceeded));
     }
 }

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -173,12 +173,7 @@ impl Serializable for AccountDelta {
     }
 
     fn get_size_hint(&self) -> usize {
-        self.storage.get_size_hint() + self.vault.get_size_hint() +
-        // Uncomment once winter-math has been updated so that the felt size does not return 0.
-        // self.nonce.get_size_hint()
-        // An option's tag is serialized as a bool which is always 1 byte.
-        1
-        + self.nonce.map(|_nonce| 8).unwrap_or(0)
+        self.storage.get_size_hint() + self.vault.get_size_hint() + self.nonce.get_size_hint()
     }
 }
 

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -285,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn account_delta_size_hint() {
+    fn account_update_details_size_hint() {
         // AccountDelta
 
         let storage_delta = AccountStorageDelta::default();

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -17,13 +17,13 @@ pub use vault::{
 };
 
 /// The serialized size of a [`Felt`] which is serialized as a [`u64`].
-const FELT_SERIALIZED_SIZE: usize = std::mem::size_of::<u64>();
+const FELT_SERIALIZED_SIZE: usize = core::mem::size_of::<u64>();
 /// The serialized size of a [`Word`].
 const WORD_SERIALIZED_SIZE: usize = FELT_SERIALIZED_SIZE * WORD_SIZE;
 /// The serialized size of a [`u8`].
-const U8_SERIALIZED_SIZE: usize = std::mem::size_of::<u8>();
+const U8_SERIALIZED_SIZE: usize = core::mem::size_of::<u8>();
 /// The serialized size of a [`u64`].
-const U64_SERIALIZED_SIZE: usize = std::mem::size_of::<u64>();
+const U64_SERIALIZED_SIZE: usize = core::mem::size_of::<u64>();
 /// The serialized size of a [`Digest`].
 /// This is a copy of `miden_crypto::hash::rescue::DIGEST_BYTES`.
 const DIGEST_SERIALIZED_SIZE: usize = 32;

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -53,10 +53,9 @@ impl AccountDelta {
     ///
     /// # Errors
     ///
-    /// - Returns an error if storage or vault were updated, but the nonce was either not updated
-    /// or set to 0.
-    /// - Returns an error if the serialized size of the delta exceeds the maximum allowed
-    ///   size.
+    /// - Returns an error if storage or vault were updated, but the nonce was either not updated or
+    ///   set to 0.
+    /// - Returns an error if the serialized size of the delta exceeds the maximum allowed size.
     pub fn new(
         storage: AccountStorageDelta,
         vault: AccountVaultDelta,

--- a/objects/src/accounts/delta/storage.rs
+++ b/objects/src/accounts/delta/storage.rs
@@ -5,7 +5,6 @@ use alloc::{
 };
 
 use miden_crypto::EMPTY_WORD;
-use vm_core::{WORD_SIZE, ZERO};
 
 use super::{
     AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,

--- a/objects/src/accounts/delta/storage.rs
+++ b/objects/src/accounts/delta/storage.rs
@@ -145,13 +145,13 @@ impl Serializable for AccountStorageDelta {
 
     fn get_size_hint(&self) -> usize {
         let u8_size = 0u8.get_size_hint();
-        let word_size = [ZERO; WORD_SIZE].get_size_hint();
+        let word_size = EMPTY_WORD.get_size_hint();
 
         let mut storage_map_delta_size = 0;
-        for (_slot, storage_map_delta) in self.maps.iter() {
+        for (slot, storage_map_delta) in self.maps.iter() {
             // The serialized size of each entry is the combination of slot (key) and the delta
             // (value).
-            storage_map_delta_size += u8_size + storage_map_delta.get_size_hint();
+            storage_map_delta_size += slot.get_size_hint() + storage_map_delta.get_size_hint();
         }
 
         // Length Prefixes
@@ -265,7 +265,7 @@ impl Serializable for StorageMapDelta {
     }
 
     fn get_size_hint(&self) -> usize {
-        let word_size = [ZERO; WORD_SIZE].get_size_hint();
+        let word_size = EMPTY_WORD.get_size_hint();
 
         let cleared_keys_count = self.cleared_keys().count();
         let updated_entries_count = self.updated_entries().count();

--- a/objects/src/accounts/delta/storage.rs
+++ b/objects/src/accounts/delta/storage.rs
@@ -5,6 +5,7 @@ use alloc::{
 };
 
 use miden_crypto::EMPTY_WORD;
+use vm_core::{WORD_SIZE, ZERO};
 
 use super::{
     AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
@@ -144,9 +145,7 @@ impl Serializable for AccountStorageDelta {
 
     fn get_size_hint(&self) -> usize {
         let u8_size = 0u8.get_size_hint();
-        // Uncomment once winter-math has been updated so that this does not return 0.
-        // let word_size = [ZERO; WORD_SIZE].get_size_hint();
-        let word_size = 32;
+        let word_size = [ZERO; WORD_SIZE].get_size_hint();
 
         let mut storage_map_delta_size = 0;
         for (_slot, storage_map_delta) in self.maps.iter() {
@@ -266,9 +265,7 @@ impl Serializable for StorageMapDelta {
     }
 
     fn get_size_hint(&self) -> usize {
-        // Uncomment once winter-math has been updated so that this does not return 0.
-        // let word_size = [ZERO; WORD_SIZE].get_size_hint();
-        let word_size = 32;
+        let word_size = [ZERO; WORD_SIZE].get_size_hint();
 
         let cleared_keys_count = self.cleared_keys().count();
         let updated_entries_count = self.updated_entries().count();

--- a/objects/src/accounts/delta/storage.rs
+++ b/objects/src/accounts/delta/storage.rs
@@ -10,7 +10,12 @@ use super::{
     AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     Word,
 };
-use crate::Digest;
+use crate::{
+    accounts::delta::{
+        usize_encoded_len, DIGEST_SERIALIZED_SIZE, U8_SERIALIZED_SIZE, WORD_SERIALIZED_SIZE,
+    },
+    Digest,
+};
 
 // ACCOUNT STORAGE DELTA
 // ================================================================================================
@@ -95,6 +100,19 @@ impl AccountStorageDelta {
 
         Ok(())
     }
+
+    /// Returns an iterator of all the cleared storage slots.
+    fn cleared_slots(&self) -> impl Iterator<Item = u8> + '_ {
+        self.values
+            .iter()
+            .filter(|&(_, value)| (value == &EMPTY_WORD))
+            .map(|(slot, _)| *slot)
+    }
+
+    /// Returns an iterator of all the updated storage slots.
+    fn updated_slots(&self) -> impl Iterator<Item = (&u8, &Word)> + '_ {
+        self.values.iter().filter(|&(_, value)| value != &EMPTY_WORD)
+    }
 }
 
 #[cfg(any(feature = "testing", test))]
@@ -116,14 +134,8 @@ impl AccountStorageDelta {
 
 impl Serializable for AccountStorageDelta {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let cleared: Vec<u8> = self
-            .values
-            .iter()
-            .filter(|&(_, value)| (value == &EMPTY_WORD))
-            .map(|(slot, _)| *slot)
-            .collect();
-        let updated: Vec<_> =
-            self.values.iter().filter(|&(_, value)| value != &EMPTY_WORD).collect();
+        let cleared: Vec<u8> = self.cleared_slots().collect();
+        let updated: Vec<(&u8, &Word)> = self.updated_slots().collect();
 
         target.write_u8(cleared.len() as u8);
         target.write_many(cleared.iter());
@@ -133,6 +145,24 @@ impl Serializable for AccountStorageDelta {
 
         target.write_u8(self.maps.len() as u8);
         target.write_many(self.maps.iter());
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let mut storage_map_delta_size = 0;
+        for (_slot, storage_map_delta) in self.maps.iter() {
+            // The serialized size of each entry is the combination of slot (key) and the delta
+            // (value).
+            storage_map_delta_size += U8_SERIALIZED_SIZE + storage_map_delta.get_size_hint();
+        }
+
+        // Length Prefixes
+        U8_SERIALIZED_SIZE * 3 +
+        // Cleared Slots
+        self.cleared_slots().count() * U8_SERIALIZED_SIZE +
+        // Updated Slots
+        self.updated_slots().count() * (U8_SERIALIZED_SIZE + WORD_SERIALIZED_SIZE) +
+        // Storage Map Delta
+        storage_map_delta_size
     }
 }
 
@@ -195,6 +225,16 @@ impl StorageMapDelta {
         // Aggregate the changes into a map such that `other` overwrites self.
         self.0.extend(other.0);
     }
+
+    /// Returns an iterator of all the cleared keys in the storage map.
+    fn cleared_keys(&self) -> impl Iterator<Item = &Digest> + '_ {
+        self.0.iter().filter(|&(_, value)| value == &EMPTY_WORD).map(|(key, _)| key)
+    }
+
+    /// Returns an iterator of all the updated entries in the storage map.
+    fn updated_entries(&self) -> impl Iterator<Item = (&Digest, &Word)> + '_ {
+        self.0.iter().filter(|&(_, value)| value != &EMPTY_WORD)
+    }
 }
 
 #[cfg(any(feature = "testing", test))]
@@ -215,20 +255,27 @@ impl StorageMapDelta {
 
 impl Serializable for StorageMapDelta {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let cleared: Vec<&Digest> = self
-            .0
-            .iter()
-            .filter(|&(_, value)| value == &EMPTY_WORD)
-            .map(|(key, _)| key)
-            .collect();
-
-        let updated: Vec<_> = self.0.iter().filter(|&(_, value)| value != &EMPTY_WORD).collect();
+        let cleared: Vec<&Digest> = self.cleared_keys().collect();
+        let updated: Vec<(&Digest, &Word)> = self.updated_entries().collect();
 
         target.write_usize(cleared.len());
         target.write_many(cleared.iter());
 
         target.write_usize(updated.len());
         target.write_many(updated.iter());
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let cleared_keys_count = self.cleared_keys().count();
+        let updated_entries_count = self.updated_entries().count();
+
+        // Cleared Keys
+        usize_encoded_len(cleared_keys_count) +
+        cleared_keys_count * DIGEST_SERIALIZED_SIZE +
+
+        // Updated Entries
+        usize_encoded_len(updated_entries_count) +
+        updated_entries_count * (DIGEST_SERIALIZED_SIZE + WORD_SERIALIZED_SIZE)
     }
 }
 

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -251,6 +251,14 @@ impl Serializable for Account {
         code.write_into(target);
         nonce.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.id.get_size_hint()
+            + self.vault.get_size_hint()
+            + self.storage.get_size_hint()
+            + self.code.get_size_hint()
+            + self.nonce.get_size_hint()
+    }
 }
 
 impl Deserializable for Account {

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -205,12 +205,12 @@ mod log {
 
     /// Given a [Digest] returns its hex representation.
     pub fn digest_hex(digest: Digest) -> String {
-        to_hex(&digest.as_bytes()).expect("hex formatting failed")
+        to_hex(&digest.as_bytes())
     }
 
     /// Given a [Word] returns its hex representation.
     pub fn word_hex(word: Word) -> String {
-        to_hex(FieldElement::elements_as_bytes(&word)).expect("hex formatting failed")
+        to_hex(FieldElement::elements_as_bytes(&word))
     }
 
     impl Log {

--- a/objects/src/accounts/seed.rs
+++ b/objects/src/accounts/seed.rs
@@ -205,7 +205,7 @@ mod log {
 
     /// Given a [Digest] returns its hex representation.
     pub fn digest_hex(digest: Digest) -> String {
-        to_hex(&digest.as_bytes())
+        to_hex(digest.as_bytes())
     }
 
     /// Given a [Word] returns its hex representation.

--- a/objects/src/accounts/storage/map.rs
+++ b/objects/src/accounts/storage/map.rs
@@ -128,6 +128,10 @@ impl Serializable for StorageMap {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.map.write_into(target)
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.map.get_size_hint()
+    }
 }
 
 impl Deserializable for StorageMap {

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -234,6 +234,18 @@ impl Serializable for AccountStorage {
         target.write_u8(self.slots().len() as u8);
         target.write_many(self.slots());
     }
+
+    fn get_size_hint(&self) -> usize {
+        // Size of the serialized slot length.
+        let u8_size = 0u8.get_size_hint();
+        let mut size = u8_size;
+
+        for slot in self.slots() {
+            size += slot.get_size_hint();
+        }
+
+        size
+    }
 }
 
 impl Deserializable for AccountStorage {

--- a/objects/src/accounts/storage/slot/mod.rs
+++ b/objects/src/accounts/storage/slot/mod.rs
@@ -85,6 +85,17 @@ impl Serializable for StorageSlot {
             Self::Map(map) => target.write(map),
         }
     }
+
+    fn get_size_hint(&self) -> usize {
+        let mut size = self.slot_type().get_size_hint();
+
+        size += match self {
+            StorageSlot::Value(word) => word.get_size_hint(),
+            StorageSlot::Map(storage_map) => storage_map.get_size_hint(),
+        };
+
+        size
+    }
 }
 
 impl Deserializable for StorageSlot {

--- a/objects/src/accounts/storage/slot/type.rs
+++ b/objects/src/accounts/storage/slot/type.rs
@@ -52,6 +52,11 @@ impl Serializable for StorageSlotType {
             Self::Map => target.write_u8(1),
         }
     }
+
+    fn get_size_hint(&self) -> usize {
+        // The serialized size of a slot type.
+        0u8.get_size_hint()
+    }
 }
 
 impl Deserializable for StorageSlotType {

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -1,6 +1,8 @@
 use alloc::string::ToString;
 use core::fmt;
 
+use vm_core::FieldElement;
+
 use super::{
     is_not_a_non_fungible_asset, parse_word, AccountId, AccountType, Asset, AssetError, Felt, Word,
     ZERO,
@@ -23,6 +25,11 @@ impl FungibleAsset {
     // --------------------------------------------------------------------------------------------
     /// Specifies a maximum amount value for fungible assets which can be at most a 63-bit value.
     pub const MAX_AMOUNT: u64 = (1_u64 << 63) - 1;
+
+    /// The serialized size of a [`FungibleAsset`] in bytes.
+    ///
+    /// Currently an account id (felt) plus an amount (u64).
+    pub const SERIALIZED_SIZE: usize = Felt::ELEMENT_BYTES + core::mem::size_of::<u64>();
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -195,6 +195,10 @@ impl Serializable for NonFungibleAsset {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write(self.0)
     }
+
+    fn get_size_hint(&self) -> usize {
+        Self::SERIALIZED_SIZE
+    }
 }
 
 impl Deserializable for NonFungibleAsset {

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -1,6 +1,8 @@
 use alloc::{string::ToString, vec::Vec};
 use core::fmt;
 
+use vm_core::{FieldElement, WORD_SIZE};
+
 use super::{
     parse_word, AccountId, AccountType, Asset, AssetError, Felt, Hasher, Word,
     ACCOUNT_ISFAUCET_MASK,
@@ -41,6 +43,14 @@ impl Ord for NonFungibleAsset {
 }
 
 impl NonFungibleAsset {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// The serialized size of a [`NonFungibleAsset`] in bytes.
+    ///
+    /// Currently represented as a word.
+    pub const SERIALIZED_SIZE: usize = Felt::ELEMENT_BYTES * WORD_SIZE;
+
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 

--- a/objects/src/assets/vault.rs
+++ b/objects/src/assets/vault.rs
@@ -266,6 +266,22 @@ impl Serializable for AssetVault {
         target.write_u32(assets.len() as u32);
         target.write_many(&assets);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let mut size = 0;
+        let mut count: usize = 0;
+
+        for asset in self.assets() {
+            size += asset.get_size_hint();
+            count += 1;
+        }
+
+        // TODO: See TODO above.
+        assert!(count <= u32::MAX as usize, "too many assets in the vault");
+        size += (count as u32).get_size_hint();
+
+        size
+    }
 }
 
 impl Deserializable for AssetVault {

--- a/objects/src/constants.rs
+++ b/objects/src/constants.rs
@@ -1,6 +1,9 @@
 /// Depth of the account database tree.
 pub const ACCOUNT_TREE_DEPTH: u8 = 64;
 
+/// The maximum allowed size of an account delta is 32 KiB.
+pub const ACCOUNT_DELTA_MAX_SIZE: u16 = 2u16.pow(15);
+
 /// The maximum number of assets that can be stored in a single note.
 pub const MAX_ASSETS_PER_NOTE: usize = 256;
 

--- a/objects/src/constants.rs
+++ b/objects/src/constants.rs
@@ -1,8 +1,8 @@
 /// Depth of the account database tree.
 pub const ACCOUNT_TREE_DEPTH: u8 = 64;
 
-/// The maximum allowed size of an account delta is 32 KiB.
-pub const ACCOUNT_DELTA_MAX_SIZE: u16 = 2u16.pow(15);
+/// The maximum allowed size of an account update is 32 KiB.
+pub const ACCOUNT_UPDATE_MAX_SIZE: u16 = 2u16.pow(15);
 
 /// The maximum number of assets that can be stored in a single note.
 pub const MAX_ASSETS_PER_NOTE: usize = 256;

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -68,6 +68,7 @@ pub enum AccountDeltaError {
     IncompatibleAccountUpdates(AccountUpdateDetails, AccountUpdateDetails),
     InconsistentNonceUpdate(String),
     NotAFungibleFaucetId(AccountId),
+    SizeLimitExceeded,
 }
 
 #[cfg(feature = "std")]

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::{
     accounts::{delta::AccountUpdateDetails, AccountType},
     notes::NoteType,
+    ACCOUNT_UPDATE_MAX_SIZE,
 };
 
 // ACCOUNT ERROR
@@ -68,7 +69,6 @@ pub enum AccountDeltaError {
     IncompatibleAccountUpdates(AccountUpdateDetails, AccountUpdateDetails),
     InconsistentNonceUpdate(String),
     NotAFungibleFaucetId(AccountId),
-    SizeLimitExceeded,
 }
 
 #[cfg(feature = "std")]
@@ -304,6 +304,7 @@ pub enum ProvenTransactionError {
     NewOnChainAccountRequiresFullDetails(AccountId),
     ExistingOnChainAccountRequiresDeltaDetails(AccountId),
     OutputNotesError(TransactionOutputError),
+    AccountUpdateSizeLimitExceeded(AccountId, usize),
 }
 
 impl fmt::Display for ProvenTransactionError {
@@ -338,6 +339,9 @@ impl fmt::Display for ProvenTransactionError {
             },
             ProvenTransactionError::ExistingOnChainAccountRequiresDeltaDetails(account_id) => {
                 write!(f, "Existing on-chain account {account_id} should only provide deltas")
+            },
+            ProvenTransactionError::AccountUpdateSizeLimitExceeded(account_id, size) => {
+                write!(f, "Update on account {account_id} of size {size} exceeds the allowed limit of {ACCOUNT_UPDATE_MAX_SIZE}")
             },
         }
     }

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -503,10 +503,9 @@ impl Deserializable for InputNoteCommitment {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use alloc::collections::BTreeMap;
 
-    use vm_core::{utils::Serializable, Felt, EMPTY_WORD, ONE, ZERO};
-    use vm_processor::Digest;
+    use winter_rand_utils::rand_array;
 
     use super::ProvenTransaction;
     use crate::{
@@ -516,7 +515,8 @@ mod tests {
             AccountVaultDelta, StorageMapDelta,
         },
         transaction::TxAccountUpdate,
-        ProvenTransactionError, ACCOUNT_UPDATE_MAX_SIZE,
+        utils::Serializable,
+        Digest, Felt, ProvenTransactionError, ACCOUNT_UPDATE_MAX_SIZE, EMPTY_WORD, ONE, ZERO,
     };
 
     fn check_if_sync<T: Sync>() {}
@@ -565,20 +565,7 @@ mod tests {
         // 32 bytes in size.
         let required_entries = ACCOUNT_UPDATE_MAX_SIZE / (2 * 32);
         for _ in 0..required_entries {
-            map.insert(
-                Digest::new([
-                    Felt::new(rand::random()),
-                    Felt::new(rand::random()),
-                    Felt::new(rand::random()),
-                    Felt::new(rand::random()),
-                ]),
-                [
-                    Felt::new(rand::random()),
-                    Felt::new(rand::random()),
-                    Felt::new(rand::random()),
-                    Felt::new(rand::random()),
-                ],
-            );
+            map.insert(Digest::new(rand_array()), rand_array());
         }
         let storage_delta = StorageMapDelta::new(map);
 

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -10,7 +10,7 @@ use crate::{
         AccountId, Digest, InputNotes, Nullifier, OutputNote, OutputNotes, TransactionId,
     },
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    ProvenTransactionError,
+    ProvenTransactionError, ACCOUNT_UPDATE_MAX_SIZE,
 };
 
 // PROVEN TRANSACTION
@@ -93,6 +93,8 @@ impl ProvenTransaction {
 
     fn validate(self) -> Result<Self, ProvenTransactionError> {
         if self.account_id().is_public() {
+            self.account_update.validate()?;
+
             let is_new_account = self.account_update.init_state_hash() == Digest::default();
             match self.account_update.details() {
                 AccountUpdateDetails::Private => {
@@ -365,6 +367,21 @@ impl TxAccountUpdate {
     pub fn is_private(&self) -> bool {
         self.details.is_private()
     }
+
+    /// Validates the following properties of the account update:
+    ///
+    /// - The size of the serialized account update does not exceed [`ACCOUNT_UPDATE_MAX_SIZE`].
+    pub fn validate(&self) -> Result<(), ProvenTransactionError> {
+        let account_update_size = self.details().get_size_hint();
+        if account_update_size > ACCOUNT_UPDATE_MAX_SIZE as usize {
+            Err(ProvenTransactionError::AccountUpdateSizeLimitExceeded(
+                self.account_id(),
+                account_update_size,
+            ))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl Serializable for TxAccountUpdate {
@@ -486,7 +503,21 @@ impl Deserializable for InputNoteCommitment {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use vm_core::{utils::Serializable, Felt, EMPTY_WORD, ONE, ZERO};
+    use vm_processor::Digest;
+
     use super::ProvenTransaction;
+    use crate::{
+        accounts::{
+            account_id::testing::ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
+            delta::AccountUpdateDetails, AccountDelta, AccountId, AccountStorageDelta,
+            AccountVaultDelta, StorageMapDelta,
+        },
+        transaction::TxAccountUpdate,
+        ProvenTransactionError, ACCOUNT_UPDATE_MAX_SIZE,
+    };
 
     fn check_if_sync<T: Sync>() {}
     fn check_if_send<T: Send>() {}
@@ -503,5 +534,72 @@ mod tests {
     #[test]
     fn test_proven_transaction_is_send() {
         check_if_send::<ProvenTransaction>();
+    }
+
+    #[test]
+    fn account_update_size_limit_not_exceeded() {
+        // A small delta does not exceed the limit.
+        let storage_delta = AccountStorageDelta::from_iters(
+            [1, 2, 3, 4],
+            [(2, [ONE, ONE, ONE, ONE]), (3, [ONE, ONE, ZERO, ONE])],
+            [],
+        );
+        let delta =
+            AccountDelta::new(storage_delta, AccountVaultDelta::default(), Some(ONE)).unwrap();
+        let details = AccountUpdateDetails::Delta(delta);
+        TxAccountUpdate::new(
+            AccountId::new_unchecked(Felt::new(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN)),
+            Digest::new(EMPTY_WORD),
+            Digest::new(EMPTY_WORD),
+            details,
+        )
+        .validate()
+        .unwrap();
+    }
+
+    #[test]
+    fn account_update_size_limit_exceeded() {
+        let mut map = BTreeMap::new();
+        // The number of entries in the map required to exceed the limit.
+        // We divide by each entry's size which consists of a key (digest) and a value (word), both
+        // 32 bytes in size.
+        let required_entries = ACCOUNT_UPDATE_MAX_SIZE / (2 * 32);
+        for _ in 0..required_entries {
+            map.insert(
+                Digest::new([
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                ]),
+                [
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                    Felt::new(rand::random()),
+                ],
+            );
+        }
+        let storage_delta = StorageMapDelta::new(map);
+
+        // A delta that exceeds the limit returns an error.
+        let storage_delta = AccountStorageDelta::from_iters([], [], [(4, storage_delta)]);
+        let delta =
+            AccountDelta::new(storage_delta, AccountVaultDelta::default(), Some(ONE)).unwrap();
+        let details = AccountUpdateDetails::Delta(delta);
+        let details_size = details.get_size_hint();
+
+        let err = TxAccountUpdate::new(
+            AccountId::new_unchecked(Felt::new(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN)),
+            Digest::new(EMPTY_WORD),
+            Digest::new(EMPTY_WORD),
+            details,
+        )
+        .validate()
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ProvenTransactionError::AccountUpdateSizeLimitExceeded(_, size) if size == details_size)
+        );
     }
 }


### PR DESCRIPTION
Implements a validation function to check that the serialized size of an `AccountDelta` does not exceed a defined limit.

fixes #830

The general approach was to implement `get_size_hint` on the `AccountDelta` and any type that it depended on, as reasonably possible (see below) and then check that size against the defined limit.

Fixes compilation of the crate under the `log` feature (file `seed.rs`), which was broken and prevented my IDE from using IntelliSense on the code I was working on, so I fixed it. The `async` feature however also fails to compile and is explicitly included from the checks it seems, but I don't understand why just yet.

None of the types that implement `Serializable` defined in `winter-utils` implement `get_size_hint`, which means all the primitive types. So calling `0u8.get_size_hint()` returns the default of `0`. So this meant that I had to define the serialized size of such types myself as constants (`u64`, `Felt`, `Word`, `Digest`, ...). This is not that great, since this can easily go out of sync with the serialization code. A better option is to PR this to `winter-utils`. The very best option, in my opinion, would be code generation of serialized code anyway, which is a bigger task though. From prior experience, hand-written serialization code tends to be error-prone, even more so if it must be synced with a function like `get_size_hint`.

A function from `winter-utils` that calculates the encoded length of a `usize` (which is serialized in a variable length encoding, `vint64`) was copied over, since that function is not public. This has the same problem as the other copied constants, namely the potential to go out of sync, although realisticially, the format is unlikely to change.

I don't see any alternatives for the overall task than using the serialize size and calculating it in the way done here. Serializing the type to get its size gets around the custom size implementation, but is too wasteful. Using the in-memory size is also worse since it would mean defining another specification for calculating it, while the serialization format already needs to be specified so a node can be reimplemented (e.g. in other languages). At least, if I understand correctly, this delta must be enforced by all nodes in the same way, otherwise the network would fork.

I assume that adding the validation step in the `AccountDelta` constructor is sufficient for the issue, but let me know if I should add anything additional in this PR.