### PR TITLE
Moved `MAX_NUM_FOREIGN_ACCOUNTS` into `miden-objects`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [BREAKING] `send_asset` procedure was removed from the basic wallet (#829).
 - [BREAKING] Updated limits, introduced additional limits (#889).
 - Introduced `AccountDelta` maximum size limit of 32 KiB (#889).
+- [BREAKING] Moved `MAX_NUM_FOREIGN_ACCOUNTS` into `miden-objects` (#904).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/miden-lib/src/transaction/memory.rs
+++ b/miden-lib/src/transaction/memory.rs
@@ -164,9 +164,6 @@ pub const KERNEL_PROCEDURES_PTR: MemoryAddress = 401;
 // ACCOUNT DATA
 // ------------------------------------------------------------------------------------------------
 
-/// Maximum number of the foreign accounts that can be loaded.
-pub const MAX_NUM_FOREIGN_ACCOUNTS: u8 = 64;
-
 /// The size of the memory segment allocated to core account data (excluding new code commitment)
 pub const ACCT_DATA_MEM_SIZE: MemSize = 4;
 

--- a/objects/src/constants.rs
+++ b/objects/src/constants.rs
@@ -28,6 +28,9 @@ pub const MAX_TX_EXECUTION_CYCLES: u32 = 1 << 30;
 /// The minimum number of VM cycles a transaction needs to execute.
 pub const MIN_TX_EXECUTION_CYCLES: u32 = 1 << 12;
 
+/// Maximum number of the foreign accounts that can be loaded.
+pub const MAX_NUM_FOREIGN_ACCOUNTS: u8 = 64;
+
 // TRANSACTION BATCH
 // ================================================================================================
 


### PR DESCRIPTION
We decided to move this constant into `miden-base` during review: https://github.com/0xPolygonMiden/miden-node/pull/506#discussion_r1782126954