### PR TITLE
feat: Implement `maybe_async_trait` and use trait objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+- [BREAKING] Changed `TransactionExecutor` and `TransactionHost` to use trait objects (#897).
 - Implemented kernel procedure to set transaction expiration block delta (#897).
 - Created a proving service that receives `TransactionWitness` and returns the proof using gRPC (#881).
 - Made note scripts public (#880).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -309,9 +309,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -588,15 +588,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -605,15 +605,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -622,15 +622,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -640,9 +640,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -1373,7 +1373,7 @@ dependencies = [
  "miden-verifier",
  "rand",
  "rand_chacha",
- "winter-maybe-async 0.10.0",
+ "winter-maybe-async 0.10.1",
 ]
 
 [[package]]
@@ -1577,21 +1577,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -1661,18 +1658,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1690,12 +1687,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -3115,8 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.10.0"
-source = "git+https://github.com/lambdaclass/winterfell?branch=igamigo-maybe-async-trait-updated#7495f4b529aa17bb9b48a04bde0d9dda7825adad"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be43529f43f70306437d2c2c9f9e2b3a4d39b42e86702d8d7577f2357ea32fa6"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -134,12 +134,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f43644eed690f5374f1af436ecd6aea01cd201f6fbdf0178adaf6907afb2cec"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
- "axum-core 0.4.4",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6b8ba012a258d63c9adfa28b9ddcf66149da6f986c5b5452e629d5ee64bf00"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -297,9 +297,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cast"
@@ -309,9 +309,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "jobserver",
  "libc",
@@ -353,18 +353,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -714,7 +714,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -739,9 +739,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -825,9 +825,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-util",
@@ -903,7 +903,6 @@ dependencies = [
  "hyper 1.4.1",
  "pin-project-lite",
  "tokio",
- "tower 0.4.13",
  "tower-service",
 ]
 
@@ -925,12 +924,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1014,7 +1013,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1080,33 +1079,33 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1ceb190eb9bdeecdd8f1ad6a71d6d632a50905948771718741b5461fb01e13"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90be66cb7bd40cb5cc2e9cfaf2d1133b04a3d93b72344267715010a466e0915a"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
 dependencies = [
  "beef",
  "fnv",
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "syn",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45154231e8e96586b39494029e58f12f8ffcb5ecf80333a603a13aa205ea8cbd"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
 dependencies = [
  "logos-codegen",
 ]
@@ -1365,6 +1364,7 @@ dependencies = [
 name = "miden-tx"
 version = "0.6.0"
 dependencies = [
+ "async-trait",
  "miden-lib",
  "miden-objects",
  "miden-processor",
@@ -1380,7 +1380,7 @@ dependencies = [
 name = "miden-tx-prover"
 version = "0.6.0"
 dependencies = [
- "axum 0.7.6",
+ "axum 0.7.7",
  "miden-lib",
  "miden-objects",
  "miden-prover",
@@ -1586,9 +1586,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -1644,7 +1647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -1687,6 +1690,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -1885,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1905,14 +1914,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1926,13 +1935,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1943,9 +1952,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
@@ -2100,7 +2109,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2260,9 +2269,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2283,9 +2292,9 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2474,7 +2483,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3107,8 +3116,7 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77eafc7944188b941c90759b938b8377247ee6e440952a0a7c4dbde7edc4ecbb"
+source = "git+https://github.com/lambdaclass/winterfell?branch=igamigo-maybe-async-trait-updated#7495f4b529aa17bb9b48a04bde0d9dda7825adad"
 dependencies = [
  "quote",
  "syn",

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ALL_FEATURES_BUT_ASYNC=--features concurrent,testing
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo clippy --workspace --all-targets $(ALL_FEATURES_BUT_ASYNC) -- -D warnings
+	cargo clippy --workspace --all-targets $(ALL_FEATURES_BUT_ASYNC) -- -D warnings --allow clippy::arc_with_non_send_sync
 
 
 .PHONY: fix

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{read_to_string, write, File},
     io::Write,
     path::Path,
+    sync::Arc,
 };
 
 use miden_lib::{notes::create_p2id_note, transaction::TransactionKernel};
@@ -74,8 +75,8 @@ pub fn benchmark_default_tx() -> Result<TransactionMeasurements, String> {
         .map(|note| note.id())
         .collect::<Vec<_>>();
 
-    let executor: TransactionExecutor<_, ()> =
-        TransactionExecutor::new(tx_context.clone(), None).with_tracing();
+    let executor: TransactionExecutor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), None).with_tracing();
     let executed_transaction = executor
         .execute_transaction(account_id, block_ref, &note_ids, tx_context.tx_args().clone())
         .map_err(|e| e.to_string())?;
@@ -115,7 +116,8 @@ pub fn benchmark_p2id() -> Result<TransactionMeasurements, String> {
         .build();
 
     let executor =
-        TransactionExecutor::new(tx_context.clone(), Some(falcon_auth.clone())).with_tracing();
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(falcon_auth.clone()))
+            .with_tracing();
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context

--- a/bin/bench-tx/src/utils.rs
+++ b/bin/bench-tx/src/utils.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 pub use alloc::{collections::BTreeMap, string::String};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
@@ -10,7 +10,7 @@ use miden_objects::{
     transaction::TransactionMeasurements,
     Felt, Word,
 };
-use miden_tx::auth::BasicAuthenticator;
+use miden_tx::auth::{BasicAuthenticator, TransactionAuthenticator};
 use rand::rngs::StdRng;
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde::Serialize;
@@ -87,7 +87,7 @@ pub fn get_account_with_default_account_code(
     Account::from_parts(account_id, account_vault, account_storage, account_code, Felt::new(1))
 }
 
-pub fn get_new_pk_and_authenticator() -> (Word, Rc<BasicAuthenticator<StdRng>>) {
+pub fn get_new_pk_and_authenticator() -> (Word, Arc<dyn TransactionAuthenticator>) {
     let seed = [0_u8; 32];
     let mut rng = ChaCha20Rng::from_seed(seed);
 
@@ -97,7 +97,7 @@ pub fn get_new_pk_and_authenticator() -> (Word, Rc<BasicAuthenticator<StdRng>>) 
     let authenticator =
         BasicAuthenticator::<StdRng>::new(&[(pub_key, AuthSecretKey::RpoFalcon512(sec_key))]);
 
-    (pub_key, Rc::new(authenticator))
+    (pub_key, Arc::new(authenticator) as Arc<dyn TransactionAuthenticator>)
 }
 
 pub fn write_bench_results_to_json(

--- a/bin/tx-prover/src/server/generated/api.rs
+++ b/bin/tx-prover/src/server/generated/api.rs
@@ -14,7 +14,8 @@ pub struct ProveTransactionResponse {
 /// Generated client implementations.
 pub mod api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -45,7 +46,10 @@ pub mod api_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> ApiClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ApiClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -55,8 +59,9 @@ pub mod api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             ApiClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -94,14 +99,19 @@ pub mod api_client {
         pub async fn prove_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::ProveTransactionRequest>,
-        ) -> std::result::Result<tonic::Response<super::ProveTransactionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ProveTransactionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/api.Api/ProveTransaction");
             let mut req = request.into_request();
@@ -120,7 +130,10 @@ pub mod api_server {
         async fn prove_transaction(
             &self,
             request: tonic::Request<super::ProveTransactionRequest>,
-        ) -> std::result::Result<tonic::Response<super::ProveTransactionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ProveTransactionResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ApiServer<T: Api> {
@@ -145,7 +158,10 @@ pub mod api_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -201,18 +217,23 @@ pub mod api_server {
                 "/api.Api/ProveTransaction" => {
                     #[allow(non_camel_case_types)]
                     struct ProveTransactionSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api> tonic::server::UnaryService<super::ProveTransactionRequest>
-                        for ProveTransactionSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<super::ProveTransactionRequest>
+                    for ProveTransactionSvc<T> {
                         type Response = super::ProveTransactionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ProveTransactionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Api>::prove_transaction(&inner, request).await };
+                            let fut = async move {
+                                <T as Api>::prove_transaction(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -238,15 +259,19 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/bin/tx-prover/src/server/generated/api.rs
+++ b/bin/tx-prover/src/server/generated/api.rs
@@ -14,8 +14,7 @@ pub struct ProveTransactionResponse {
 /// Generated client implementations.
 pub mod api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct ApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -46,10 +45,7 @@ pub mod api_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> ApiClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> ApiClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -59,9 +55,8 @@ pub mod api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             ApiClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -99,19 +94,14 @@ pub mod api_client {
         pub async fn prove_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::ProveTransactionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ProveTransactionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ProveTransactionResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/api.Api/ProveTransaction");
             let mut req = request.into_request();
@@ -130,10 +120,7 @@ pub mod api_server {
         async fn prove_transaction(
             &self,
             request: tonic::Request<super::ProveTransactionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ProveTransactionResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ProveTransactionResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ApiServer<T: Api> {
@@ -158,10 +145,7 @@ pub mod api_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -217,23 +201,18 @@ pub mod api_server {
                 "/api.Api/ProveTransaction" => {
                     #[allow(non_camel_case_types)]
                     struct ProveTransactionSvc<T: Api>(pub Arc<T>);
-                    impl<
-                        T: Api,
-                    > tonic::server::UnaryService<super::ProveTransactionRequest>
-                    for ProveTransactionSvc<T> {
+                    impl<T: Api> tonic::server::UnaryService<super::ProveTransactionRequest>
+                        for ProveTransactionSvc<T>
+                    {
                         type Response = super::ProveTransactionResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ProveTransactionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Api>::prove_transaction(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as Api>::prove_transaction(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -259,19 +238,15 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                },
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -32,7 +32,7 @@ miden-verifier = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { version = "0.3", default-features = false, optional = true }
 vm-processor = { workspace = true }
-winter-maybe-async = { git = "https://github.com/lambdaclass/winterfell", branch = "igamigo-maybe-async-trait-updated" }
+winter-maybe-async = { version = "0.10" }
 
 [dev-dependencies]
 miden-tx = { path = ".", features = ["testing"] }

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -24,6 +24,7 @@ std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier
 testing = ["miden-objects/testing", "miden-lib/testing", "vm-processor/testing", "dep:rand_chacha"]
 
 [dependencies]
+async-trait = "0.1"
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miden-prover = { workspace = true }
@@ -31,7 +32,7 @@ miden-verifier = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { version = "0.3", default-features = false, optional = true }
 vm-processor = { workspace = true }
-winter-maybe-async = { version = "0.10" }
+winter-maybe-async = { git = "https://github.com/lambdaclass/winterfell", branch = "igamigo-maybe-async-trait-updated" }
 
 [dev-dependencies]
 miden-tx = { path = ".", features = ["testing"] }

--- a/miden-tx/src/executor/data_store.rs
+++ b/miden-tx/src/executor/data_store.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "async")]
+use alloc::boxed::Box;
+
 use miden_objects::{accounts::AccountId, notes::NoteId, transaction::TransactionInputs};
-use winter_maybe_async::maybe_async;
+use winter_maybe_async::*;
 
 use crate::DataStoreError;
 
@@ -8,6 +11,7 @@ use crate::DataStoreError;
 
 /// The [DataStore] trait defines the interface that transaction objects use to fetch data
 /// required for transaction execution.
+#[maybe_async_trait]
 pub trait DataStore {
     /// Returns account, chain, and input note data required to execute a transaction against
     /// the account with the specified ID and consuming the set of specified input notes.

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, rc::Rc, string::ToString, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, string::ToString, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::{
     memory::{CURRENT_INPUT_NOTE_PTR, NATIVE_NUM_ACCT_STORAGE_SLOTS_PTR},
@@ -39,16 +39,16 @@ use crate::{
 
 /// Transaction host is responsible for handling [Host] requests made by a transaction kernel.
 ///
-/// Transaction hosts are created on per-transaction basis. That is a transaction host is meant to
-/// support execution of a single transaction, and is discarded after the transaction finishes
+/// Transaction hosts are created on a per-transaction basis. That is, a transaction host is meant
+/// to support execution of a single transaction and is discarded after the transaction finishes
 /// execution.
-pub struct TransactionHost<A, T> {
+pub struct TransactionHost<A> {
     /// Advice provider which is used to provide non-deterministic inputs to the transaction
     /// runtime.
     adv_provider: A,
 
     /// MAST store which contains the code required to execute the transaction.
-    mast_store: Rc<TransactionMastStore>,
+    mast_store: Arc<TransactionMastStore>,
 
     /// Account state changes accumulated during transaction execution.
     ///
@@ -65,7 +65,7 @@ pub struct TransactionHost<A, T> {
 
     /// Serves signature generation requests from the transaction runtime for signatures which are
     /// not present in the `generated_signatures` field.
-    authenticator: Option<Rc<T>>,
+    authenticator: Option<Arc<dyn TransactionAuthenticator>>,
 
     /// Contains previously generated signatures (as a message |-> signature map) required for
     /// transaction execution.
@@ -85,13 +85,13 @@ pub struct TransactionHost<A, T> {
     error_messages: BTreeMap<u32, &'static str>,
 }
 
-impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
+impl<A: AdviceProvider> TransactionHost<A> {
     /// Returns a new [TransactionHost] instance with the provided [AdviceProvider].
     pub fn new(
         account: AccountHeader,
         adv_provider: A,
-        mast_store: Rc<TransactionMastStore>,
-        authenticator: Option<Rc<T>>,
+        mast_store: Arc<TransactionMastStore>,
+        authenticator: Option<Arc<dyn TransactionAuthenticator>>,
     ) -> Result<Self, TransactionHostError> {
         let proc_index_map =
             AccountProcedureIndexMap::new(account.code_commitment(), &adv_provider)?;
@@ -109,8 +109,8 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         })
     }
 
-    /// Consumes `self` and returns the advice provider, account vault delta, output notes and
-    /// signatures generated during the transaction execution.
+    /// Consumes `self` and returns the advice provider, account delta, output notes, generated
+    /// signatures, and transaction progress.
     pub fn into_parts(
         self,
     ) -> (
@@ -139,7 +139,7 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
     // EVENT HANDLERS
     // --------------------------------------------------------------------------------------------
 
-    /// Crates a new [OutputNoteBuilder] from the data on the operand stack and stores it into the
+    /// Creates a new [OutputNoteBuilder] from the data on the operand stack and stores it into the
     /// `output_notes` field of this [TransactionHost].
     ///
     /// Expected stack state: `[NOTE_METADATA, RECIPIENT, ...]`
@@ -228,7 +228,7 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         // get slot index from the stack and make sure it is valid
         let slot_index = process.get_stack_item(0);
 
-        // get number of storage slots initialised by the account
+        // get number of storage slots initialized by the account
         let num_storage_slot = Self::get_num_storage_slots(process)?;
 
         if slot_index.as_int() >= num_storage_slot {
@@ -274,7 +274,7 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         // get slot index from the stack and make sure it is valid
         let slot_index = process.get_stack_item(0);
 
-        // get number of storage slots initialised by the account
+        // get number of storage slots initialized by the account
         let num_storage_slot = Self::get_num_storage_slots(process)?;
 
         if slot_index.as_int() >= num_storage_slot {
@@ -376,9 +376,11 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
             let account_delta = self.account_delta.clone().into_delta();
 
             let signature: Vec<Felt> = match &self.authenticator {
-                None => Err(ExecutionError::FailedSignatureGeneration(
-                    "No authenticator assigned to transaction host",
-                )),
+                None => {
+                    return Err(ExecutionError::FailedSignatureGeneration(
+                        "No authenticator assigned to transaction host",
+                    ))
+                },
                 Some(authenticator) => {
                     authenticator.get_signature(pub_key, msg, &account_delta).map_err(|_| {
                         ExecutionError::FailedSignatureGeneration("Error generating signature")
@@ -427,11 +429,11 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
         }
     }
 
-    /// Returns the number of storage slots initialised for the current account.
+    /// Returns the number of storage slots initialized for the current account.
     ///
     /// # Errors
     /// Returns an error if the memory location supposed to contain the account storage slot number
-    /// has not been initialised.
+    /// has not been initialized.
     fn get_num_storage_slots<S: ProcessState>(process: &S) -> Result<u64, TransactionKernelError> {
         let num_storage_slots_word = process
             .get_mem_value(process.ctx(), NATIVE_NUM_ACCT_STORAGE_SLOTS_PTR)
@@ -444,7 +446,7 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> TransactionHost<A, T> {
 // HOST IMPLEMENTATION FOR TRANSACTION HOST
 // ================================================================================================
 
-impl<A: AdviceProvider, T: TransactionAuthenticator> Host for TransactionHost<A, T> {
+impl<A: AdviceProvider> Host for TransactionHost<A> {
     fn get_advice<S: ProcessState>(
         &mut self,
         process: &S,
@@ -538,8 +540,9 @@ impl<A: AdviceProvider, T: TransactionAuthenticator> Host for TransactionHost<A,
             NotesProcessingStart => self.tx_progress.start_notes_processing(process.clk()),
             NotesProcessingEnd => self.tx_progress.end_notes_processing(process.clk()),
             NoteExecutionStart => {
-                let note_id = Self::get_current_note_id(process)?
-                    .expect("Note execution interval measurement is incorrect: check the placement of the start and the end of the interval");
+                let note_id = Self::get_current_note_id(process)?.expect(
+                    "Note execution interval measurement is incorrect: check the placement of the start and the end of the interval",
+                );
                 self.tx_progress.start_note_execution(process.clk(), note_id);
             },
             NoteExecutionEnd => self.tx_progress.end_note_execution(process.clk()),

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{rc::Rc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
@@ -39,7 +39,7 @@ pub trait TransactionProver {
 ///
 /// Local Transaction Prover implements the [TransactionProver] trait.
 pub struct LocalTransactionProver {
-    mast_store: Rc<TransactionMastStore>,
+    mast_store: Arc<TransactionMastStore>,
     proof_options: ProvingOptions,
 }
 
@@ -49,7 +49,7 @@ impl LocalTransactionProver {
     /// Creates a new [LocalTransactionProver] instance.
     pub fn new(proof_options: ProvingOptions) -> Self {
         Self {
-            mast_store: Rc::new(TransactionMastStore::new()),
+            mast_store: Arc::new(TransactionMastStore::new()),
             proof_options,
         }
     }
@@ -58,7 +58,7 @@ impl LocalTransactionProver {
 impl Default for LocalTransactionProver {
     fn default() -> Self {
         Self {
-            mast_store: Rc::new(TransactionMastStore::new()),
+            mast_store: Arc::new(TransactionMastStore::new()),
             proof_options: Default::default(),
         }
     }
@@ -85,7 +85,7 @@ impl TransactionProver for LocalTransactionProver {
         // load the store with account/note/tx_script MASTs
         self.mast_store.load_transaction_code(&tx_inputs, &tx_args);
 
-        let mut host: TransactionHost<_, ()> =
+        let mut host: TransactionHost<_> =
             TransactionHost::new(account.into(), advice_provider, self.mast_store.clone(), None)
                 .map_err(TransactionProverError::TransactionHostCreationFailed)?;
         let (stack_outputs, proof) =

--- a/miden-tx/src/testing/tx_context/mod.rs
+++ b/miden-tx/src/testing/tx_context/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "async")]
+use alloc::boxed::Box;
 use alloc::{rc::Rc, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
@@ -8,7 +10,7 @@ use miden_objects::{
     transaction::{ExecutedTransaction, InputNote, InputNotes, TransactionArgs, TransactionInputs},
 };
 use vm_processor::{AdviceInputs, ExecutionError, Process};
-use winter_maybe_async::{maybe_async, maybe_await};
+use winter_maybe_async::*;
 
 use super::{
     executor::CodeExecutor,
@@ -16,7 +18,8 @@ use super::{
     MockHost,
 };
 use crate::{
-    DataStore, DataStoreError, TransactionExecutor, TransactionExecutorError, TransactionMastStore,
+    auth::TransactionAuthenticator, DataStore, DataStoreError, TransactionExecutor,
+    TransactionExecutorError, TransactionMastStore,
 };
 
 mod builder;
@@ -39,6 +42,7 @@ pub struct TransactionContext {
     authenticator: Option<MockAuthenticator>,
     assembler: Assembler,
 }
+
 impl TransactionContext {
     /// Executes arbitrary code within the context of a mocked transaction environment and returns
     /// the resulting [Process].
@@ -79,8 +83,10 @@ impl TransactionContext {
 
         let account_id = self.account().id();
         let block_num = mock_data_store.tx_inputs.block_header().block_num();
-        let tx_executor =
-            TransactionExecutor::new(mock_data_store, self.authenticator.map(Rc::new));
+        let authenticator = self
+            .authenticator
+            .map(|auth| Arc::new(auth) as Arc<dyn TransactionAuthenticator>);
+        let tx_executor = TransactionExecutor::new(Arc::new(mock_data_store), authenticator);
         let notes: Vec<NoteId> = self.tx_inputs.input_notes().into_iter().map(|n| n.id()).collect();
 
         maybe_await!(tx_executor.execute_transaction(account_id, block_num, &notes, self.tx_args))
@@ -115,6 +121,7 @@ impl TransactionContext {
     }
 }
 
+#[maybe_async_trait]
 impl DataStore for TransactionContext {
     #[maybe_async]
     fn get_transaction_inputs(

--- a/miden-tx/src/testing/tx_context/mod.rs
+++ b/miden-tx/src/testing/tx_context/mod.rs
@@ -121,6 +121,9 @@ impl TransactionContext {
     }
 }
 
+unsafe impl Send for TransactionContext {}
+unsafe impl Sync for TransactionContext {}
+
 #[maybe_async_trait]
 impl DataStore for TransactionContext {
     #[maybe_async]

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -1,4 +1,5 @@
-use alloc::{collections::BTreeMap, rc::Rc, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use std::sync::Arc;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
@@ -47,7 +48,7 @@ fn transaction_executor_witness() {
         .with_mock_notes_preserved()
         .build();
 
-    let executor: TransactionExecutor<_, ()> = TransactionExecutor::new(tx_context.clone(), None);
+    let executor = TransactionExecutor::new(Arc::new(tx_context.clone()), None);
 
     let account_id = tx_context.account().id();
 
@@ -75,10 +76,10 @@ fn transaction_executor_witness() {
     let mem_advice_provider: MemAdviceProvider = advice_inputs.into();
 
     // load account/note/tx_script MAST to the mast_store
-    let mast_store = Rc::new(TransactionMastStore::new());
+    let mast_store = Arc::new(TransactionMastStore::new());
     mast_store.load_transaction_code(tx_inputs, tx_args);
 
-    let mut host: TransactionHost<MemAdviceProvider, ()> =
+    let mut host: TransactionHost<MemAdviceProvider> =
         TransactionHost::new(tx_inputs.account().into(), mem_advice_provider, mast_store, None)
             .unwrap();
     let result = vm_processor::execute(
@@ -345,7 +346,7 @@ fn executed_transaction_account_delta() {
 fn test_empty_delta_nonce_update() {
     let tx_context = TransactionContextBuilder::with_standard_account(ONE).build();
 
-    let executor: TransactionExecutor<_, ()> = TransactionExecutor::new(tx_context.clone(), None);
+    let executor = TransactionExecutor::new(Arc::new(tx_context.clone()), None);
     let account_id = tx_context.tx_inputs().account().id();
 
     let tx_script_src = "
@@ -405,8 +406,8 @@ fn test_send_note_proc() {
         .with_mock_notes_preserved_with_account_vault_delta()
         .build();
 
-    let executor: TransactionExecutor<_, ()> =
-        TransactionExecutor::new(tx_context.clone(), None).with_debug_mode(true);
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), None).with_debug_mode(true);
     let account_id = tx_context.tx_inputs().account().id();
 
     // removed assets
@@ -551,8 +552,8 @@ fn executed_transaction_output_notes() {
         .with_mock_notes_preserved_with_account_vault_delta()
         .build();
 
-    let executor: TransactionExecutor<_, ()> =
-        TransactionExecutor::new(tx_context.clone(), None).with_debug_mode(true);
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), None).with_debug_mode(true);
     let account_id = tx_context.tx_inputs().account().id();
 
     // removed assets
@@ -786,7 +787,7 @@ fn prove_witness_and_verify() {
         .map(|note| note.id())
         .collect::<Vec<_>>();
 
-    let executor: TransactionExecutor<_, ()> = TransactionExecutor::new(tx_context.clone(), None);
+    let executor = TransactionExecutor::new(Arc::new(tx_context.clone()), None);
     let executed_transaction = executor
         .execute_transaction(account_id, block_ref, &note_ids, tx_context.tx_args().clone())
         .unwrap();
@@ -812,7 +813,7 @@ fn test_tx_script() {
     let tx_context = TransactionContextBuilder::with_standard_account(ONE)
         .with_mock_notes_preserved()
         .build();
-    let executor: TransactionExecutor<_, ()> = TransactionExecutor::new(tx_context.clone(), None);
+    let executor = TransactionExecutor::new(Arc::new(tx_context.clone()), None);
 
     let account_id = tx_context.tx_inputs().account().id();
 

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -1,5 +1,4 @@
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
-use std::sync::Arc;
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 mod scripts;
 mod wallet;
 
@@ -49,7 +51,7 @@ pub fn prove_and_verify_transaction(
 #[cfg(test)]
 pub fn get_new_pk_and_authenticator(
 ) -> (Word, std::sync::Arc<dyn miden_tx::auth::TransactionAuthenticator>) {
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     use miden_objects::accounts::AuthSecretKey;
     use miden_tx::auth::{BasicAuthenticator, TransactionAuthenticator};

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -48,11 +48,11 @@ pub fn prove_and_verify_transaction(
 
 #[cfg(test)]
 pub fn get_new_pk_and_authenticator(
-) -> (Word, std::rc::Rc<miden_tx::auth::BasicAuthenticator<rand::rngs::StdRng>>) {
-    use std::rc::Rc;
+) -> (Word, std::sync::Arc<dyn miden_tx::auth::TransactionAuthenticator>) {
+    use std::sync::Arc;
 
     use miden_objects::accounts::AuthSecretKey;
-    use miden_tx::auth::BasicAuthenticator;
+    use miden_tx::auth::{BasicAuthenticator, TransactionAuthenticator};
     use rand::rngs::StdRng;
 
     let seed = [0_u8; 32];
@@ -64,7 +64,7 @@ pub fn get_new_pk_and_authenticator(
     let authenticator =
         BasicAuthenticator::<StdRng>::new(&[(pub_key, AuthSecretKey::RpoFalcon512(sec_key))]);
 
-    (pub_key, Rc::new(authenticator))
+    (pub_key, Arc::new(authenticator) as Arc<dyn TransactionAuthenticator>)
 }
 
 #[cfg(test)]

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -1,5 +1,7 @@
 extern crate alloc;
 
+use std::sync::Arc;
+
 use miden_lib::transaction::{memory::FAUCET_STORAGE_DATA_SLOT, TransactionKernel};
 use miden_objects::{
     accounts::{
@@ -37,7 +39,8 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     // --------------------------------------------------------------------------------------------
     let tx_context = TransactionContextBuilder::new(faucet_account.clone()).build();
 
-    let executor = TransactionExecutor::new(tx_context.clone(), Some(falcon_auth.clone()));
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(falcon_auth.clone()));
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context
@@ -114,7 +117,8 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
     // --------------------------------------------------------------------------------------------
     let tx_context = TransactionContextBuilder::new(faucet_account.clone()).build();
 
-    let executor = TransactionExecutor::new(tx_context.clone(), Some(falcon_auth.clone()));
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(falcon_auth.clone()));
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context
@@ -200,7 +204,8 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
         .input_notes(vec![note.clone()])
         .build();
 
-    let executor = TransactionExecutor::new(tx_context.clone(), Some(falcon_auth.clone()));
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(falcon_auth.clone()));
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context

--- a/miden-tx/tests/integration/scripts/p2id.rs
+++ b/miden-tx/tests/integration/scripts/p2id.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use miden_lib::{notes::create_p2id_note, transaction::TransactionKernel};
 use miden_objects::{

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use miden_lib::notes::create_p2idr_note;
 use miden_objects::{

--- a/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/miden-tx/tests/integration/scripts/p2idr.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use miden_lib::notes::create_p2idr_note;
 use miden_objects::{
     accounts::{
@@ -98,7 +100,7 @@ fn p2idr_script() {
         .input_notes(vec![note_in_time.clone()])
         .build();
     let executor_1 =
-        TransactionExecutor::new(tx_context_1.clone(), Some(target_falcon_auth.clone()));
+        TransactionExecutor::new(Arc::new(tx_context_1.clone()), Some(target_falcon_auth.clone()));
 
     let block_ref_1 = tx_context_1.tx_inputs().block_header().block_num();
     let note_ids = tx_context_1.input_notes().iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -127,7 +129,7 @@ fn p2idr_script() {
         .input_notes(vec![note_in_time.clone()])
         .build();
     let executor_2 =
-        TransactionExecutor::new(tx_context_2.clone(), Some(sender_falcon_auth.clone()));
+        TransactionExecutor::new(Arc::new(tx_context_2.clone()), Some(sender_falcon_auth.clone()));
     let tx_script_sender = build_default_auth_script();
     let tx_args_sender = TransactionArgs::with_tx_script(tx_script_sender);
 
@@ -151,8 +153,10 @@ fn p2idr_script() {
     let tx_context_3 = TransactionContextBuilder::new(malicious_account.clone())
         .input_notes(vec![note_in_time.clone()])
         .build();
-    let executor_3 =
-        TransactionExecutor::new(tx_context_3.clone(), Some(malicious_falcon_auth.clone()));
+    let executor_3 = TransactionExecutor::new(
+        Arc::new(tx_context_3.clone()),
+        Some(malicious_falcon_auth.clone()),
+    );
 
     let tx_script_malicious = build_default_auth_script();
     let tx_args_malicious = TransactionArgs::with_tx_script(tx_script_malicious);
@@ -177,7 +181,8 @@ fn p2idr_script() {
     let tx_context_4 = TransactionContextBuilder::new(target_account.clone())
         .input_notes(vec![note_reclaimable.clone()])
         .build();
-    let executor_4 = TransactionExecutor::new(tx_context_4.clone(), Some(target_falcon_auth));
+    let executor_4 =
+        TransactionExecutor::new(Arc::new(tx_context_4.clone()), Some(target_falcon_auth));
 
     let block_ref_4 = tx_context_4.tx_inputs().block_header().block_num();
     let note_ids_4 = tx_context_4.input_notes().iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -207,7 +212,8 @@ fn p2idr_script() {
     let tx_context_5 = TransactionContextBuilder::new(sender_account.clone())
         .input_notes(vec![note_reclaimable.clone()])
         .build();
-    let executor_5 = TransactionExecutor::new(tx_context_5.clone(), Some(sender_falcon_auth));
+    let executor_5 =
+        TransactionExecutor::new(Arc::new(tx_context_5.clone()), Some(sender_falcon_auth));
 
     let block_ref_5 = tx_context_5.tx_inputs().block_header().block_num();
     let note_ids_5 = tx_context_5.input_notes().iter().map(|note| note.id()).collect::<Vec<_>>();
@@ -237,7 +243,8 @@ fn p2idr_script() {
         .input_notes(vec![note_reclaimable.clone()])
         .build();
 
-    let executor_6 = TransactionExecutor::new(tx_context_6.clone(), Some(malicious_falcon_auth));
+    let executor_6 =
+        TransactionExecutor::new(Arc::new(tx_context_6.clone()), Some(malicious_falcon_auth));
 
     let block_ref_6 = tx_context_6.tx_inputs().block_header().block_num();
     let note_ids_6 = tx_context_6.input_notes().iter().map(|note| note.id()).collect::<Vec<_>>();

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
 use miden_objects::{
     accounts::{
@@ -56,7 +58,8 @@ fn prove_receive_asset_via_wallet() {
         .input_notes(vec![note])
         .build();
 
-    let executor = TransactionExecutor::new(tx_context.clone(), Some(target_falcon_auth.clone()));
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(target_falcon_auth.clone()));
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context
@@ -111,7 +114,8 @@ fn prove_send_note_without_asset_via_wallet() {
     // --------------------------------------------------------------------------------------------
     let tx_context = TransactionContextBuilder::new(sender_account.clone()).build();
 
-    let executor = TransactionExecutor::new(tx_context.clone(), Some(sender_falcon_auth.clone()));
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(sender_falcon_auth.clone()));
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context
@@ -194,7 +198,8 @@ fn prove_send_note_with_asset_via_wallet() {
     // --------------------------------------------------------------------------------------------
     let tx_context = TransactionContextBuilder::new(sender_account.clone()).build();
 
-    let executor = TransactionExecutor::new(tx_context.clone(), Some(sender_falcon_auth.clone()));
+    let executor =
+        TransactionExecutor::new(Arc::new(tx_context.clone()), Some(sender_falcon_auth.clone()));
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use miden_lib::{accounts::wallets::create_basic_wallet, AuthScheme};
 use miden_objects::{


### PR DESCRIPTION
This PR implements trait objects for user-facing structs instead of relying on crates as explained [here](https://github.com/0xPolygonMiden/miden-client/issues/366#issuecomment-2336779921).

Additionally, in order to make traits object-safe, `maybe_async_trait` (which relies on `async_trait`) is implemented for the correspondent traits.