### PR TITLE
Implement `Serializable` for `FungibleAsset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [BREAKING] Moved `MAX_NUM_FOREIGN_ACCOUNTS` into `miden-objects` (#904).
 - Implemented `storage_size`, updated storage bounds (#886).
 - [BREAKING] Auto-generate `KERNEL_ERRORS` list from the transaction kernel's MASM files and rework error constant names (#906).
+- Implement `Serializable` for `FungibleAsset` (#907).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -1,11 +1,14 @@
 use alloc::string::ToString;
 use core::fmt;
 
-use vm_core::FieldElement;
+use vm_core::{
+    utils::{ByteReader, ByteWriter, Deserializable, Serializable},
+    FieldElement,
+};
+use vm_processor::DeserializationError;
 
 use super::{
-    is_not_a_non_fungible_asset, parse_word, AccountId, AccountType, Asset, AssetError, Felt, Word,
-    ZERO,
+    is_not_a_non_fungible_asset, AccountId, AccountType, Asset, AssetError, Felt, Word, ZERO,
 };
 
 // FUNGIBLE ASSET
@@ -145,16 +148,6 @@ impl From<FungibleAsset> for Word {
     }
 }
 
-impl From<FungibleAsset> for [u8; 32] {
-    fn from(asset: FungibleAsset) -> Self {
-        let mut result = [0_u8; 32];
-        let id_bytes: [u8; 8] = asset.faucet_id.into();
-        result[..8].copy_from_slice(&asset.amount.to_le_bytes());
-        result[24..].copy_from_slice(&id_bytes);
-        result
-    }
-}
-
 impl From<FungibleAsset> for Asset {
     fn from(asset: FungibleAsset) -> Self {
         Asset::Fungible(asset)
@@ -175,17 +168,44 @@ impl TryFrom<Word> for FungibleAsset {
     }
 }
 
-impl TryFrom<[u8; 32]> for FungibleAsset {
-    type Error = AssetError;
-
-    fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
-        let word = parse_word(value)?;
-        Self::try_from(word)
-    }
-}
-
 impl fmt::Display for FungibleAsset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for FungibleAsset {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // All assets should serialize their faucet ID at the first position to allow them to be
+        // easily distinguishable during deserialization.
+        target.write(self.faucet_id);
+        target.write(self.amount);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.faucet_id.get_size_hint() + self.amount.get_size_hint()
+    }
+}
+
+impl Deserializable for FungibleAsset {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let faucet_id: AccountId = source.read()?;
+        FungibleAsset::deserialize_with_account_id(faucet_id, source)
+    }
+}
+
+impl FungibleAsset {
+    /// Deserializes a [`FungibleAsset`] from an [`AccountId`] and the remaining data from the given
+    /// `source`.
+    pub(super) fn deserialize_with_account_id<R: ByteReader>(
+        faucet_id: AccountId,
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
+        let amount: u64 = source.read()?;
+        FungibleAsset::new(faucet_id, amount)
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -1,5 +1,3 @@
-use alloc::string::ToString;
-
 use super::{
     accounts::{AccountId, AccountType, ACCOUNT_ISFAUCET_MASK},
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
@@ -70,12 +68,6 @@ pub enum Asset {
 }
 
 impl Asset {
-    // CONSTANTS
-    // --------------------------------------------------------------------------------------------
-
-    /// The serialized size of an [`Asset`] in bytes.
-    pub const SERIALIZED_SIZE: usize = 32;
-
     /// Creates a new [Asset] without checking its validity.
     pub(crate) fn new_unchecked(value: Word) -> Asset {
         if is_not_a_non_fungible_asset(value) {
@@ -152,21 +144,6 @@ impl From<&Asset> for Word {
     }
 }
 
-impl From<Asset> for [u8; Asset::SERIALIZED_SIZE] {
-    fn from(asset: Asset) -> Self {
-        match asset {
-            Asset::Fungible(asset) => asset.into(),
-            Asset::NonFungible(asset) => asset.into(),
-        }
-    }
-}
-
-impl From<&Asset> for [u8; Asset::SERIALIZED_SIZE] {
-    fn from(value: &Asset) -> Self {
-        (*value).into()
-    }
-}
-
 impl TryFrom<&Word> for Asset {
     type Error = AssetError;
 
@@ -187,63 +164,50 @@ impl TryFrom<Word> for Asset {
     }
 }
 
-impl TryFrom<[u8; Asset::SERIALIZED_SIZE]> for Asset {
-    type Error = AssetError;
-
-    fn try_from(value: [u8; Asset::SERIALIZED_SIZE]) -> Result<Self, Self::Error> {
-        parse_word(value)?.try_into()
-    }
-}
-
-impl TryFrom<&[u8; Asset::SERIALIZED_SIZE]> for Asset {
-    type Error = AssetError;
-
-    fn try_from(value: &[u8; Asset::SERIALIZED_SIZE]) -> Result<Self, Self::Error> {
-        (*value).try_into()
-    }
-}
-
 // SERIALIZATION
 // ================================================================================================
 
 impl Serializable for Asset {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let data: [u8; Asset::SERIALIZED_SIZE] = self.into();
-        target.write_bytes(&data);
+        match self {
+            Asset::Fungible(fungible_asset) => fungible_asset.write_into(target),
+            Asset::NonFungible(non_fungible_asset) => non_fungible_asset.write_into(target),
+        }
     }
 
     fn get_size_hint(&self) -> usize {
-        Asset::SERIALIZED_SIZE
+        match self {
+            Asset::Fungible(fungible_asset) => fungible_asset.get_size_hint(),
+            Asset::NonFungible(non_fungible_asset) => non_fungible_asset.get_size_hint(),
+        }
     }
 }
 
 impl Deserializable for Asset {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let data_vec = source.read_vec(Asset::SERIALIZED_SIZE)?;
-        let data_array: [u8; Asset::SERIALIZED_SIZE] =
-            data_vec.try_into().expect("Vec must be of size 32");
+        // Both asset types have their faucet ID as the first element, so we can use it to inspect
+        // what type of asset it is.
+        let account_id: AccountId = source.read()?;
+        let account_type = account_id.account_type();
 
-        let asset = Asset::try_from(&data_array)
-            .map_err(|error| DeserializationError::InvalidValue(format!("{error}")))?;
-        Ok(asset)
+        match account_type {
+            AccountType::FungibleFaucet => {
+              FungibleAsset::deserialize_with_account_id(account_id, source).map(Asset::from)
+            },
+            AccountType::NonFungibleFaucet => {
+                NonFungibleAsset::deserialize_with_account_id(account_id, source).map(Asset::from)
+            },
+            other_type => {
+                 Err(DeserializationError::InvalidValue(format!(
+                    "failed to deserialize asset: expected an account ID of type faucet, found {other_type:?}"
+                )))
+            },
+        }
     }
 }
 
 // HELPER FUNCTIONS
 // ================================================================================================
-
-fn parse_word(bytes: [u8; Asset::SERIALIZED_SIZE]) -> Result<Word, AssetError> {
-    Ok([
-        parse_felt(&bytes[..8])?,
-        parse_felt(&bytes[8..16])?,
-        parse_felt(&bytes[16..24])?,
-        parse_felt(&bytes[24..])?,
-    ])
-}
-
-fn parse_felt(bytes: &[u8]) -> Result<Felt, AssetError> {
-    Felt::try_from(bytes).map_err(|err| AssetError::InvalidFieldElement(err.to_string()))
-}
 
 /// Returns `true` if asset in [Word] is not a non-fungible asset.
 ///
@@ -260,6 +224,7 @@ fn is_not_a_non_fungible_asset(asset: Word) -> bool {
 
 #[cfg(test)]
 mod tests {
+
     use miden_crypto::{
         utils::{Deserializable, Serializable},
         Word,


### PR DESCRIPTION
Implements `Serializable` for `FungibleAsset`.

I reconsidered whether it would make sense to
- forward the `Serializable` implementation from `Asset` to `FungibleAsset`, but `Asset` has a dedicated byte conversion implementation (`impl From<Asset> for [u8; Asset::SERIALIZED_SIZE]`) which makes more sense to keep using since it means that serialization is only defined in one place.
- forward the serialization and size hint implementation from `FungibleAssetDelta` to `FungibleAsset` but this is a special case. In the delta implementation we serialize the asset as 16 bytes whereas elsewhere it is serialized as 32 bytes.

The `Serializable` implementation reuses the 32-byte asset format even though it could be made more compact at 16 bytes (omitting the zeroes).

I guess the argument for keeping all assets at one word for now is that there is no need for a discriminant in the serialization format for `Asset` since assets are already designed to be distinguishable by their structure plus it is much easier to handle assets in the VM when they are all the same length. Such a discriminant would only cost 1 byte per asset though and the saving per fungible asset would be 15 bytes, so it seems worthwhile to think about that optimization for use cases outside the VM like network transmission of objects containing assets. As far as I can tell we could come up with different formats for assets within the VM (e.g. one word for its easy handling) and outside the VM (e.g. with discriminant and space-optimized for storage or transmission purposes). 

Wouldn't it already be possible to make assets distinguishable by their first or second byte such that no discriminant was needed and we could still store fungible assets as 16 bytes? For instance, the serialized format for a fungible asset could be: `[amount, faucet_id]` instead of `[amount, 0, 0, faucet_id]`. Assets are thus always _at least_ 2 Felts long. So to distinguish assets we could always inspect the second Felt and determine the asset's type from the faucet's type. This could use up to 50% less space (if only fungible assets are used) but it might also be a premature optimization.
I might easily be missing some context though, just wanted to raise this point I found interesting :)

This is also somewhat interesting in the context of #140 which might lead to a rework of the asset format. If we determine that the `amount` of a fungible asset suffices to be 64-192 bits, meaning we can keep them at one word, and we have to go to two words for non fungible assets, that space saving per fungible asset would go up even further.