### PR TITLE
Remove `num_procs` from account procedure data

### DIFF
--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -112,6 +112,9 @@ const.ACCOUNT_TREE_DEPTH=64
 # The number of field elements it takes to store one account storage slot.
 const.ACCOUNT_STORAGE_SLOT_DATA_LENGTH=8
 
+# The number of field elements it takes to store one account procedure.
+const.ACCOUNT_PROCEDURE_DATA_LENGTH=8
+
 # EVENTS
 # =================================================================================================
 
@@ -796,14 +799,13 @@ end
 #! Inputs:
 #!   Operand stack: [CODE_COMMITMENT]
 #!   Advice map: {
-#!     CODE_COMMITMENT: [num_procs, [ACCOUNT_PROCEDURE_DATA]],
+#!     CODE_COMMITMENT: [[ACCOUNT_PROCEDURE_DATA]],
 #!   }
 #! Outputs:
 #!   Operand stack: []
 #! 
 #! Where:
 #! - CODE_COMMITMENT is the commitment of the current account's code.
-#! - num_procs is the number of foreign account's procedures.
 #! - ACCOUNT_PROCEDURE_DATA is the information about account procedure which is constructed as 
 #!   follows: [PROCEDURE_MAST_ROOT, storage_offset, storage_size, 0, 0]
 #!
@@ -812,12 +814,13 @@ end
 #! - the computed account code commitment does not match the provided account code commitment
 export.save_account_procedure_data
     # move procedure data from the advice map to the advice stack
-    adv.push_mapval push.15161 drop               # TODO: remove line, see miden-vm/#1122
+    adv.push_mapvaln push.15161 drop               # TODO: remove line, see miden-vm/#1122
     # OS => [CODE_COMMITMENT]
-    # AS => [num_procs, [ACCOUNT_PROCEDURE_DATA]]
+    # AS => [account_procedure_data_len, [ACCOUNT_PROCEDURE_DATA]]
 
-    # push the number of procedures onto the operand stack before storing it in memory
-    adv_push.1
+    # push the length of the account procedure data onto the operand stack and compute the number of 
+    # procedures from it 
+    adv_push.1 div.ACCOUNT_PROCEDURE_DATA_LENGTH
     # OS => [num_procs, CODE_COMMITMENT]
     # AS => [[ACCOUNT_PROCEDURE_DATA]]
 

--- a/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1069,6 +1069,8 @@ end
 #!      INPUT_NOTES_COMMITMENT => NOTE_DATA,
 #!      KERNEL_ROOT => KERNEL_HASHES
 #!      KERNEL_HASH => KERNEL_PROCEDURE_HASHES
+#!      ACCOUNT_CODE_COMMITMENT => [ACCOUNT_PROCEDURE_DATA]
+#!      ACCOUNT_STORAGE_COMMITMENT => [ACCOUNT_STORAGE_SLOT_DATA]
 #! }
 #! Output: []
 #!
@@ -1094,6 +1096,8 @@ end
 #! - ACCOUNT_VAULT_ROOT, account's vault root.
 #! - ACCOUNT_STORAGE_COMMITMENT, account's storage commitment.
 #! - ACCOUNT_CODE_COMMITMENT, account's code commitment.
+#! - ACCOUNT_PROCEDURE_DATA, vector of the account's procedure data.
+#! - ACCOUNT_STORAGE_SLOT_DATA, vector of the account's storage slot data.
 #! - number_of_input_notes, number of input notes.
 #! - TX_SCRIPT_ROOT, the transaction's script root.
 #! - MMR_PEAKS, is the MMR peak data, see process_chain_data

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -144,8 +144,8 @@ fn add_chain_mmr_to_advice_inputs(mmr: &ChainMmr, inputs: &mut AdviceInputs) {
 /// - If present, the Merkle nodes associated with the account storage maps.
 ///
 /// Inserts the following entries into the advice map:
-/// - The account storage commitment |-> length, storage slots and types vector.
-/// - The account code commitment |-> length and procedures vector.
+/// - The account storage commitment |-> storage slots and types vector.
+/// - The account code commitment |-> procedures vector.
 /// - The node |-> (key, value), for all leaf nodes of the asset vault SMT.
 /// - [account_id, 0, 0, 0] |-> account_seed, when account seed is provided.
 /// - If present, the Merkle leaves associated with the account storage maps.

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -183,7 +183,7 @@ fn add_account_to_advice_inputs(
     // --- account code -------------------------------------------------------
     let code = account.code();
 
-    // extend the advice map with the account code data and number of procedures
+    // extend the advice map with the account code data
     inputs.extend_map([(code.commitment(), code.as_elements())]);
 
     // --- account seed -------------------------------------------------------

--- a/miden-lib/src/transaction/inputs.rs
+++ b/miden-lib/src/transaction/inputs.rs
@@ -168,8 +168,7 @@ fn add_account_to_advice_inputs(
     }
 
     // extend advice map with storage commitment |-> length, storage slots and types vector
-    let storage_slots = storage.as_elements();
-    inputs.extend_map([(storage.commitment(), storage_slots)]);
+    inputs.extend_map([(storage.commitment(), storage.as_elements())]);
 
     // --- account vault ------------------------------------------------------
     let vault = account.vault();
@@ -185,9 +184,7 @@ fn add_account_to_advice_inputs(
     let code = account.code();
 
     // extend the advice map with the account code data and number of procedures
-    let mut procedures: Vec<Felt> = vec![(code.num_procedures() as u8).into()];
-    procedures.append(&mut code.as_elements());
-    inputs.extend_map([(code.commitment(), procedures)]);
+    inputs.extend_map([(code.commitment(), code.as_elements())]);
 
     // --- account seed -------------------------------------------------------
     if let Some(account_seed) = account_seed {

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -68,7 +68,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 34] = [
     // get_block_number
     digest!(0xd483c8edceb956d, 0xf9f8d62043fcf072, 0xb917fc68b6e01ad1, 0x3ef8d736e7331692),
     // start_foreign_context
-    digest!(0x5d64e0991481cb12, 0x4ea85139f6c7672d, 0xcbcb5b1b94536c73, 0xd61b2581bc5ec88),
+    digest!(0xa96c44785874ca90, 0x7534ee3618355b2a, 0x5e45a034f624dd88, 0x5542ff311c8340b7),
     // end_foreign_context
     digest!(0x3770db711ce9aaf1, 0xb6f3c929151a5d52, 0x3ed145ec5dbee85f, 0xf979d975d7951bf6),
     // update_expiration_block_num

--- a/miden-tx/src/host/account_procs.rs
+++ b/miden-tx/src/host/account_procs.rs
@@ -38,7 +38,15 @@ impl AccountProcedureIndexMap {
             ));
         }
 
-        let num_procs = proc_data[0].as_int() as usize;
+        // check that procedure data have a correct length
+        if proc_data.len() % AccountProcedureInfo::NUM_ELEMENTS_PER_PROC != 0 {
+            return Err(TransactionHostError::AccountProcedureIndexMapError(
+                "The account procedure data has invalid length.".to_string(),
+            ));
+        }
+
+        // One procedure requires 8 values to represent
+        let num_procs = proc_data.len() / AccountProcedureInfo::NUM_ELEMENTS_PER_PROC;
 
         // check that the account code does not contain too many procedures
         if num_procs > AccountCode::MAX_NUM_PROCEDURES {
@@ -47,17 +55,8 @@ impl AccountProcedureIndexMap {
             ));
         }
 
-        // check that the stored number of procedures matches the length of the procedures array
-        if num_procs * AccountProcedureInfo::NUM_ELEMENTS_PER_PROC != proc_data.len() - 1 {
-            return Err(TransactionHostError::AccountProcedureIndexMapError(
-                "Invalid number of procedures.".to_string(),
-            ));
-        }
-
-        // we skip proc_data[0] because it's the number of procedures
-        for (proc_idx, proc_info) in proc_data[1..]
-            .chunks_exact(AccountProcedureInfo::NUM_ELEMENTS_PER_PROC)
-            .enumerate()
+        for (proc_idx, proc_info) in
+            proc_data.chunks_exact(AccountProcedureInfo::NUM_ELEMENTS_PER_PROC).enumerate()
         {
             let proc_info_array: [Felt; AccountProcedureInfo::NUM_ELEMENTS_PER_PROC] =
                 proc_info.try_into().expect("Failed conversion into procedure info array.");

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -828,14 +828,7 @@ fn get_mock_advice_inputs(foreign_account: &Account, mock_chain: &MockChain) -> 
             // STORAGE_ROOT |-> [[STORAGE_SLOT_DATA]]
             (foreign_storage_root, foreign_account.storage().as_elements()),
             // CODE_ROOT |-> [num_procs, [ACCOUNT_PROCEDURE_DATA]]
-            (
-                foreign_code_root,
-                [
-                    vec![Felt::try_from(foreign_account.code().procedures().len()).unwrap()],
-                    foreign_account.code().as_elements(),
-                ]
-                .concat(),
-            ),
+            (foreign_code_root, foreign_account.code().as_elements()),
         ])
         .with_merkle_store(mock_chain.accounts().into())
 }


### PR DESCRIPTION
This small PR changes the value in the advice map corresponding to the account code commitment.

Similar to the account storage data, the number of procedures was removed from the data provided to the advice map. Now the number of account procedures is computed from the number of field elements used to represent the procedure data. 