### PR TITLE
fix: export expiration block number procedures

### DIFF
--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -1082,6 +1082,9 @@ end
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
 export.update_expiration_delta
+    # drop the procedure's hash
+    dropw
+
     exec.tx::update_expiration_delta
 end
 
@@ -1093,6 +1096,9 @@ end
 #! Where:
 #! - block_height_delta is the stored expiration time delta (1 to 0xFFFF).
 export.get_expiration_delta
+    # drop the procedure's hash
+    dropw
+
     exec.tx::get_expiration_delta
 end
 

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -1076,7 +1076,7 @@ end
 #! The input block height delta is added to the reference block in order to output an upper limit
 #! up until which the transaction will be considered valid (not expired).
 #!
-#! Inputs: [block_height_delta, ...]
+#! Inputs: [KERNEL_PROCEDURE_HASH, block_height_delta, ...]
 #! Output: [...]
 #!
 #! Where:
@@ -1091,7 +1091,7 @@ end
 #! Gets the transaction expiration delta.
 #!
 #! Inputs: [...]
-#! Output: [block_height_delta, ...]
+#! Output: [KERNEL_PROCEDURE_HASH, block_height_delta, ...]
 #!
 #! Where:
 #! - block_height_delta is the stored expiration time delta (1 to 0xFFFF).

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -1081,11 +1081,11 @@ end
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-export.update_expiration_delta
+export.update_expiration_block_num
     # drop the procedure's hash
     dropw
 
-    exec.tx::update_expiration_delta
+    exec.tx::update_expiration_block_num
 end
 
 #! Gets the transaction expiration delta.

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -67,8 +67,8 @@ proc.authenticate_account_origin
 end
 
 #! Verifies that the procedure to be invoked against the foreign account is part of its code.
-#! TODO: it is a temporary solution. This and other `*_foreign` procedures should be removed after 
-#! the refactoring of the `DYN` operation (see miden-vm/#1091) and the fix of the CALLER operation. 
+#! TODO: it is a temporary solution. This and other `*_foreign` procedures should be removed after
+#! the refactoring of the `DYN` operation (see miden-vm/#1091) and the fix of the CALLER operation.
 #!
 #! Stack: [FOREIGN_PROC_ROOT]
 #! Output: [storage_offset, storage_size, ...]
@@ -230,7 +230,7 @@ end
 #!
 #! Where:
 #! - KERNEL_PROCEDURE_HASH is the hash of this procedure.
-#! - FOREIGN_PROC_ROOT is the hash of the foreign procedure which called this procedure. 
+#! - FOREIGN_PROC_ROOT is the hash of the foreign procedure which called this procedure.
 #! - index is the index of the item to get.
 #! - VALUE is the value of the item.
 #!
@@ -356,7 +356,7 @@ end
 #! Panics if:
 #! - the index is out of bounds (>255).
 #! - the requested storage slot type is not map
-export.get_account_map_item_foreign    
+export.get_account_map_item_foreign
     # drop the procedure's hash
     dropw
     # => [FOREIGN_PROC_ROOT, index, KEY, pad(6)]
@@ -976,10 +976,10 @@ end
 #! - account_nonce is the nonce of the foreign account.
 #! - VAULT_ROOT is the commitment of the foreign account's vault.
 #! - STORAGE_ROOT is the commitment of the foreign account's storage.
-#! - STORAGE_SLOT_DATA is the data contained in the storage slot which is constructed as follows: 
+#! - STORAGE_SLOT_DATA is the data contained in the storage slot which is constructed as follows:
 #!   [SLOT_VALUE, slot_type, 0, 0, 0]
 #! - CODE_ROOT is the commitment of the foreign account's code.
-#! - ACCOUNT_PROCEDURE_DATA is the information about account procedure which is constructed as 
+#! - ACCOUNT_PROCEDURE_DATA is the information about account procedure which is constructed as
 #!   follows: [PROCEDURE_MAST_ROOT, storage_offset, 0, 0, 0]
 #!
 #! Panics if:
@@ -1014,7 +1014,7 @@ export.start_foreign_context
         # AS => [[foreign_account_id, 0, 0, account_nonce], VAULT_ROOT, STORAGE_ROOT, CODE_ROOT]
 
         # store the id and nonce of the foreign account to the memory
-        dropw adv_loadw 
+        dropw adv_loadw
         exec.memory::set_acct_id_and_nonce dropw
         # OS => []
         # AS => [VAULT_ROOT, STORAGE_ROOT, CODE_ROOT]
@@ -1024,7 +1024,7 @@ export.start_foreign_context
         # OS => []
         # AS => [STORAGE_ROOT, CODE_ROOT]
 
-        # move the storage root and the code root to the operand stack 
+        # move the storage root and the code root to the operand stack
         adv_loadw padw adv_loadw
         # OS => [CODE_ROOT, STORAGE_ROOT]
         # AS => []
@@ -1050,7 +1050,7 @@ export.start_foreign_context
         # AS => []
     end
 
-    # make sure that the state of the loaded foreign account corresponds to this commitment in the 
+    # make sure that the state of the loaded foreign account corresponds to this commitment in the
     # account database
     exec.account::validate_current_foreign_account
     # => []
@@ -1081,8 +1081,8 @@ end
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-export.update_expiration_block_num
-    exec.tx::update_expiration_block_num
+export.update_expiration_delta
+    exec.tx::update_expiration_delta
 end
 
 #! Gets the transaction expiration delta.

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -21,6 +21,9 @@ const.EXPIRY_UPPER_LIMIT=0xFFFF+1
 # The note type must be PUBLIC, unless the high bits are `0b11`. (See the table below.)
 const.ALL_NOTE_TYPES_ALLOWED=3 # 0b11
 
+# Max U32 value, used for initializing the expiration block number
+const.MAX_BLOCK_NUM=0xFFFFFFFF
+
 # ERRORS
 # =================================================================================================
 
@@ -227,8 +230,17 @@ end
 #! Where:
 #! - block_height_delta is the stored expiration time delta (1 to 0xFFFF).
 export.get_expiration_delta
-    exec.memory::get_expiration_block_num exec.get_block_number
-    sub
+    exec.memory::get_expiration_block_num
+    # => [stored_expiration_block_num]
+
+    dup eq.MAX_BLOCK_NUM
+    if.true
+        # The delta was not set
+        drop push.0
+    else
+        # Calculate the delta
+        exec.get_block_number sub
+    end
 end
 
 

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -196,7 +196,7 @@ end
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-export.update_expiration_delta
+export.update_expiration_block_num
     # Ensure block_height_delta is between 1 and 0xFFFF (inclusive)
     dup neq.0 assert.err=ERR_TX_INVALID_EXPIRATION_DELTA
     dup push.EXPIRY_UPPER_LIMIT lt assert.err=ERR_TX_INVALID_EXPIRATION_DELTA

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -80,7 +80,7 @@ const.NOTE_AFTER_CREATED_EVENT=131084
 const.NOTE_BEFORE_ADD_ASSET_EVENT=131085
 # Event emitted after an ASSET is added to a note
 const.NOTE_AFTER_ADD_ASSET_EVENT=131086
- 
+
 #! Returns the block hash of the reference block to memory.
 #!
 #! Stack: []
@@ -189,14 +189,14 @@ end
 #!
 #! The input block_height_delta is added to the block reference number in order to output an upper
 #! limit at which the transaction will be considered valid (not expired).
-#! This value can be later decreased, but not increased. 
+#! This value can be later decreased, but not increased.
 #!
 #! Inputs: [block_height_delta, ...]
 #! Output: [...]
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-export.update_expiration_block_num
+export.update_expiration_delta
     # Ensure block_height_delta is between 1 and 0xFFFF (inclusive)
     dup neq.0 assert.err=ERR_TX_INVALID_EXPIRATION_DELTA
     dup push.EXPIRY_UPPER_LIMIT lt assert.err=ERR_TX_INVALID_EXPIRATION_DELTA
@@ -206,16 +206,16 @@ export.update_expiration_block_num
     # => [absolute_expiration_num]
 
     # Load the current stored delta from memory
-    dup exec.memory::get_expiration_block_num  
+    dup exec.memory::get_expiration_block_num
     # => [stored_expiration_block_num, absolute_expiration_num, absolute_expiration_num]
 
     # Check if block_height_delta is greater
     u32lt
     if.true
         # Set new expiration delta
-        exec.memory::set_expiration_block_num 
+        exec.memory::set_expiration_block_num
     else
-        drop                           
+        drop
     end
 end
 

--- a/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -40,7 +40,7 @@ const.GET_BLOCK_HASH_OFFSET=28
 const.GET_BLOCK_NUMBER_OFFSET=29
 const.START_FOREIGN_CONTEXT_OFFSET=30
 const.END_FOREIGN_CONTEXT_OFFSET=31
-const.UPDATE_EXPIRATION_DELTA_OFFSET=32
+const.UPDATE_EXPIRATION_BLOCK_NUM_OFFSET=32
 const.GET_EXPIRATION_DELTA_OFFSET=33
 
 # ACCESSORS
@@ -262,7 +262,7 @@ export.get_block_number_offset
     push.GET_BLOCK_NUMBER_OFFSET
 end
 
-#! Returns an offset of the `update_expiration_delta` kernel procedure.
+#! Returns an offset of the `update_expiration_block_num` kernel procedure.
 #!
 #! Stack: []
 #! Output: [proc_offset]
@@ -270,8 +270,8 @@ end
 #! Where:
 #! - proc_offset is the offset of the `set_tx_expiration_delta` kernel procedure required to get the
 #! address where this procedure is stored.
-export.update_expiration_delta_offset
-    push.UPDATE_EXPIRATION_DELTA_OFFSET
+export.update_expiration_block_num_offset
+    push.UPDATE_EXPIRATION_BLOCK_NUM_OFFSET
 end
 
 #! Returns an offset of the `get_expiration_delta` kernel procedure.

--- a/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -1,7 +1,7 @@
 # OFFSET CONSTANTS
 # -------------------------------------------------------------------------------------------------
 
-# Current account 
+# Current account
 const.ACCOUNT_VAULT_ADD_ASSET_OFFSET=0
 const.ACCOUNT_VAULT_GET_BALANCE_OFFSET=1
 const.ACCOUNT_VAULT_HAS_NON_FUNGIBLE_ASSET_OFFSET=2
@@ -40,7 +40,7 @@ const.GET_BLOCK_HASH_OFFSET=28
 const.GET_BLOCK_NUMBER_OFFSET=29
 const.START_FOREIGN_CONTEXT_OFFSET=30
 const.END_FOREIGN_CONTEXT_OFFSET=31
-const.UPDATE_EXPIRATION_BLOCK_NUM_OFFSET=32
+const.UPDATE_EXPIRATION_DELTA_OFFSET=32
 const.GET_EXPIRATION_DELTA_OFFSET=33
 
 # ACCESSORS
@@ -52,7 +52,7 @@ const.GET_EXPIRATION_DELTA_OFFSET=33
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_id` kernel procedure required to get the address 
+#! - proc_offset is the offset of the `get_account_id` kernel procedure required to get the address
 #! where this procedure is stored.
 export.get_account_id_offset
     push.GET_ACCOUNT_ID_OFFSET
@@ -64,7 +64,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_nonce` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_account_nonce` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_account_nonce_offset
     push.GET_ACCOUNT_NONCE_OFFSET
@@ -76,7 +76,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_initial_account_hash` kernel procedure required to get 
+#! - proc_offset is the offset of the `get_initial_account_hash` kernel procedure required to get
 #! the address where this procedure is stored.
 export.get_initial_account_hash_offset
     push.GET_INITIAL_ACCOUNT_HASH_OFFSET
@@ -88,7 +88,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_current_account_hash` kernel procedure required to get 
+#! - proc_offset is the offset of the `get_current_account_hash` kernel procedure required to get
 #! the address where this procedure is stored.
 export.get_current_account_hash_offset
     push.GET_CURRENT_ACCOUNT_HASH_OFFSET
@@ -100,7 +100,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `incr_account_nonce` kernel procedure required to get the 
+#! - proc_offset is the offset of the `incr_account_nonce` kernel procedure required to get the
 #! address where this procedure is stored.
 export.incr_account_nonce_offset
     push.INCR_ACCOUNT_NONCE_OFFSET
@@ -109,10 +109,10 @@ end
 #! Returns an offset of the `get_account_item` kernel procedure.
 #!
 #! Stack: []
-#! Output: [proc_offset] 
+#! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_item` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_account_item` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_account_item_offset
     push.GET_ACCOUNT_ITEM_OFFSET
@@ -124,7 +124,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `set_account_item` kernel procedure required to get the 
+#! - proc_offset is the offset of the `set_account_item` kernel procedure required to get the
 #! address where this procedure is stored.
 export.set_account_item_offset
     push.SET_ACCOUNT_ITEM_OFFSET
@@ -136,7 +136,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_map_item` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_account_map_item` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_account_map_item_offset
     push.GET_ACCOUNT_MAP_ITEM_OFFSET
@@ -148,7 +148,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `set_account_map_item` kernel procedure required to get the 
+#! - proc_offset is the offset of the `set_account_map_item` kernel procedure required to get the
 #! address where this procedure is stored.
 export.set_account_map_item_offset
     push.SET_ACCOUNT_MAP_ITEM_OFFSET
@@ -160,7 +160,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `set_account_code` kernel procedure required to get the 
+#! - proc_offset is the offset of the `set_account_code` kernel procedure required to get the
 #! address where this procedure is stored.
 export.set_account_code_offset
     push.SET_ACCOUNT_CODE_OFFSET
@@ -172,7 +172,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_vault_get_balance` kernel procedure required to get 
+#! - proc_offset is the offset of the `account_vault_get_balance` kernel procedure required to get
 #! the address where this procedure is stored.
 export.account_vault_get_balance_offset
     push.ACCOUNT_VAULT_GET_BALANCE_OFFSET
@@ -184,7 +184,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_vault_has_non_fungible_asset` kernel procedure 
+#! - proc_offset is the offset of the `account_vault_has_non_fungible_asset` kernel procedure
 #! required to get the address where this procedure is stored.
 export.account_vault_has_non_fungible_asset_offset
     push.ACCOUNT_VAULT_HAS_NON_FUNGIBLE_ASSET_OFFSET
@@ -208,7 +208,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_vault_remove_asset` kernel procedure required to get 
+#! - proc_offset is the offset of the `account_vault_remove_asset` kernel procedure required to get
 #! the address where this procedure is stored.
 export.account_vault_remove_asset_offset
     push.ACCOUNT_VAULT_REMOVE_ASSET_OFFSET
@@ -220,7 +220,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_note_assets_info` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_note_assets_info` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_note_assets_info_offset
     push.GET_NOTE_ASSETS_INFO_OFFSET
@@ -232,7 +232,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_note_inputs_hash` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_note_inputs_hash` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_note_inputs_hash_offset
     push.GET_NOTE_INPUTS_HASH_OFFSET
@@ -256,22 +256,22 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_block_number` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_block_number` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_block_number_offset
     push.GET_BLOCK_NUMBER_OFFSET
 end
 
-#! Returns an offset of the `update_expiration_block_num` kernel procedure.
+#! Returns an offset of the `update_expiration_delta` kernel procedure.
 #!
 #! Stack: []
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `set_tx_expiration_delta` kernel procedure required to get the 
+#! - proc_offset is the offset of the `set_tx_expiration_delta` kernel procedure required to get the
 #! address where this procedure is stored.
-export.update_expiration_block_num_offset
-    push.UPDATE_EXPIRATION_BLOCK_NUM_OFFSET
+export.update_expiration_delta_offset
+    push.UPDATE_EXPIRATION_DELTA_OFFSET
 end
 
 #! Returns an offset of the `get_expiration_delta` kernel procedure.
@@ -280,7 +280,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `set_tx_expiration_delta` kernel procedure required to get the 
+#! - proc_offset is the offset of the `set_tx_expiration_delta` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_expiration_block_delta_offset
     push.GET_EXPIRATION_DELTA_OFFSET
@@ -292,7 +292,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_block_hash` kernel procedure required to get the address 
+#! - proc_offset is the offset of the `get_block_hash` kernel procedure required to get the address
 #! where this procedure is stored.
 export.get_block_hash_offset
     push.GET_BLOCK_HASH_OFFSET
@@ -304,7 +304,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_input_notes_commitment` kernel procedure required to get 
+#! - proc_offset is the offset of the `get_input_notes_commitment` kernel procedure required to get
 #! the address where this procedure is stored.
 export.get_input_notes_commitment_offset
     push.GET_INPUT_NOTES_COMMITMENT_OFFSET
@@ -316,7 +316,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_output_notes_hash` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_output_notes_hash` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_output_notes_hash_offset
     push.GET_OUTPUT_NOTES_HASH_OFFSET
@@ -328,7 +328,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `create_note` kernel procedure required to get the address 
+#! - proc_offset is the offset of the `create_note` kernel procedure required to get the address
 #! where this procedure is stored.
 export.create_note_offset
     push.CREATE_NOTE_OFFSET
@@ -340,7 +340,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `add_asset_to_note` kernel procedure required to get the 
+#! - proc_offset is the offset of the `add_asset_to_note` kernel procedure required to get the
 #! address where this procedure is stored.
 export.add_asset_to_note_offset
     push.ADD_ASSET_TO_NOTE_OFFSET
@@ -352,7 +352,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_vault_commitment` kernel procedure required to 
+#! - proc_offset is the offset of the `get_account_vault_commitment` kernel procedure required to
 #! get the address where this procedure is stored.
 export.get_account_vault_commitment_offset
     push.GET_ACCOUNT_VAULT_COMMITMENT_OFFSET
@@ -364,7 +364,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `mint_asset` kernel procedure required to get the address 
+#! - proc_offset is the offset of the `mint_asset` kernel procedure required to get the address
 #! where this procedure is stored.
 export.mint_asset_offset
     push.MINT_ASSET_OFFSET
@@ -376,7 +376,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `burn_asset` kernel procedure required to get the address 
+#! - proc_offset is the offset of the `burn_asset` kernel procedure required to get the address
 #! where this procedure is stored.
 export.burn_asset_offset
     push.BURN_ASSET_OFFSET
@@ -400,7 +400,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_note_serial_number` kernel procedure required to get the 
+#! - proc_offset is the offset of the `get_note_serial_number` kernel procedure required to get the
 #! address where this procedure is stored.
 export.get_note_serial_number_offset
     push.GET_NOTE_SERIAL_NUMBER_OFFSET
@@ -412,7 +412,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `start_foreign_context` kernel procedure required to get the 
+#! - proc_offset is the offset of the `start_foreign_context` kernel procedure required to get the
 #! address where this procedure is stored.
 export.start_foreign_context_offset
     push.START_FOREIGN_CONTEXT_OFFSET
@@ -424,7 +424,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `end_foreign_context` kernel procedure required to get the 
+#! - proc_offset is the offset of the `end_foreign_context` kernel procedure required to get the
 #! address where this procedure is stored.
 export.end_foreign_context_offset
     push.END_FOREIGN_CONTEXT_OFFSET
@@ -436,7 +436,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_item_foreign` kernel procedure required to get 
+#! - proc_offset is the offset of the `get_account_item_foreign` kernel procedure required to get
 #! the address where this procedure is stored.
 export.get_account_item_foreign_offset
     push.GET_ACCOUNT_ITEM_FOREIGN_OFFSET
@@ -448,7 +448,7 @@ end
 #! Output: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `get_account_map_item_foreign` kernel procedure required to 
+#! - proc_offset is the offset of the `get_account_map_item_foreign` kernel procedure required to
 #! get the address where this procedure is stored.
 export.get_account_map_item_foreign_offset
     push.GET_ACCOUNT_MAP_ITEM_FOREIGN_OFFSET

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -213,3 +213,19 @@ export.update_expiration_block_num
     # clear the stack
     dropw dropw dropw dropw
 end
+
+export.get_expiration_block_delta
+    # pad the stack
+    padw padw padw push.0.0.0
+    # => [PAD(15)]
+
+    exec.kernel_proc_offsets::get_expiration_block_delta_offset
+    # => [offset, PAD(15)]
+
+    syscall.exec_kernel_proc
+    # => [expiration_delta, PAD(15)]
+
+    # clear the stack
+    swapdw dropw dropw swapw dropw movdn.3 drop drop drop
+    # => [expiration_delta]
+end

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -211,5 +211,5 @@ export.update_expiration_delta
     syscall.exec_kernel_proc
 
     # clear the stack
-    drop drop dropw dropw dropw
+    dropw dropw dropw dropw
 end

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -200,6 +200,17 @@ export.execute_foreign_procedure
     # => [<values returned from the foreign procedure>]
 end
 
+#! Updates the transaction expiration block number.
+#!
+#! The input block_height_delta is added to the block reference number in order to output an upper
+#! limit at which the transaction will be considered valid (not expired).
+#! This value can be later decreased, but not increased.
+#!
+#! Inputs: [block_height_delta, ...]
+#! Output: [...]
+#!
+#! Where:
+#! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
 export.update_expiration_block_num
     exec.kernel_proc_offsets::update_expiration_block_num_offset
     # => [offset, expiration_delta, ...]
@@ -214,6 +225,13 @@ export.update_expiration_block_num
     dropw dropw dropw dropw
 end
 
+#! Gets the transaction expiration delta.
+#!
+#! Inputs: [...]
+#! Output: [block_height_delta, ...]
+#!
+#! Where:
+#! - block_height_delta is the stored expiration time delta (1 to 0xFFFF).
 export.get_expiration_block_delta
     # pad the stack
     padw padw padw push.0.0.0

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -200,11 +200,15 @@ export.execute_foreign_procedure
     # => [<values returned from the foreign procedure>]
 end
 
-#! Updates the transaction expiration block delta.
+#! Updates the transaction expiration delta.
 #!
-#! The input block_height_delta is added to the block reference number in order to determine an upper
-#! limit at which the transaction will be considered valid (not expired).
-#! This value can be later decreased, but not increased.
+#! The transaction expiration delta specifies how close to the transaction's reference block the
+#! transaction must be included into the chain. For example, if the transaction's reference block
+#! is 100 and transaction expiration delta is 10, the transaction can be included into the chain
+#! by block 110. If this does not happen, the transaction is considered expired and cannot be
+#! included into the chain.
+#!
+#! Once set, transaction expiration delta can be decreased, but not increased.
 #!
 #! Inputs: [block_height_delta, ...]
 #! Output: [...]
@@ -225,7 +229,7 @@ export.update_expiration_block_delta
     dropw dropw dropw dropw
 end
 
-#! Gets the transaction expiration delta.
+#! Returns the transaction expiration delta, or 0 if the delta has not been set.
 #!
 #! Inputs: [...]
 #! Output: [block_height_delta, ...]

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -200,8 +200,8 @@ export.execute_foreign_procedure
     # => [<values returned from the foreign procedure>]
 end
 
-export.update_expiration_delta
-    exec.kernel_proc_offsets::update_expiration_delta_offset
+export.update_expiration_block_num
+    exec.kernel_proc_offsets::update_expiration_block_num_offset
     # => [offset, expiration_delta, ...]
 
     # pad the stack

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -200,8 +200,8 @@ export.execute_foreign_procedure
     # => [<values returned from the foreign procedure>]
 end
 
-export.update_expiration_block_num
-    exec.kernel_proc_offsets::update_expiration_block_num_offset
+export.update_expiration_delta
+    exec.kernel_proc_offsets::update_expiration_delta_offset
     # => [offset, expiration_delta, ...]
 
     # pad the stack

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -67,7 +67,7 @@ export.get_input_notes_commitment
 
     # clean the stack
     swapdw dropw dropw swapw dropw
-    # => [INPUT_NOTES_COMMITMENT]    
+    # => [INPUT_NOTES_COMMITMENT]
 end
 
 #! Returns the output notes hash. This is computed as a sequential hash of (note_id, note_metadata)
@@ -90,7 +90,7 @@ export.get_output_notes_hash
 
     # clean the stack
     swapdw dropw dropw swapw dropw
-    # => [COM]        
+    # => [COM]
 end
 
 #! Creates a new note and returns the index of the note.
@@ -105,8 +105,8 @@ end
 #! RECIPIENT is the recipient of the note.
 #! note_idx is the index of the crated note.
 export.create_note
-    # pad the stack before the syscall to prevent accidental modification of the deeper stack 
-    # elements 
+    # pad the stack before the syscall to prevent accidental modification of the deeper stack
+    # elements
     padw padw swapdw movup.8 drop
     # => [tag, aux, note_type, execution_hint, RECIPIENT, PAD(7)]
 
@@ -116,7 +116,7 @@ export.create_note
     syscall.exec_kernel_proc
     # => [note_idx, PAD(15)]
 
-    # remove excess PADs from the stack 
+    # remove excess PADs from the stack
     swapdw dropw dropw movdn.7 dropw drop drop drop
     # => [note_idx]
 end
@@ -132,15 +132,15 @@ export.add_asset_to_note
     movup.4 exec.kernel_proc_offsets::add_asset_to_note_offset
     # => [offset, note_idx, ASSET]
 
-    # pad the stack before the syscall to prevent accidental modification of the deeper stack 
-    # elements 
+    # pad the stack before the syscall to prevent accidental modification of the deeper stack
+    # elements
     push.0.0 movdn.7 movdn.7 padw padw swapdw
     # => [offset, note_idx, ASSET, PAD(10)]
 
     syscall.exec_kernel_proc
     # => [note_idx, ASSET, PAD(11)]
 
-    # remove excess PADs from the stack 
+    # remove excess PADs from the stack
     swapdw dropw dropw swapw movdn.7 drop drop drop movdn.4
     # => [ASSET, note_idx]
 end
@@ -163,13 +163,13 @@ end
 
 #! Executes the provided procedure against the foreign account.
 #!
-#! WARNING: the procedure to be invoked can not have more than 12 inputs and it can not return more 
-#! than 12 elements back. Otherwise exceeding elements will not be provided to the procedure and 
+#! WARNING: the procedure to be invoked can not have more than 12 inputs and it can not return more
+#! than 12 elements back. Otherwise exceeding elements will not be provided to the procedure and
 #! will not be returned from it.
 #!
 #! Inputs:  [foreign_account_id, FOREIGN_PROC_ROOT, <foreign account inputs>, pad(n), ...]
 #! Outputs: [<values returned from the foreign procedure>]
-#! 
+#!
 #! Where:
 #! - pad(n) is the exact number of pads needed to set the number of procedure inputs to 16 at the moment of the foreign procedure execution
 #!   (n = 16 - WORD_SIZE - foreign_inputs_len)
@@ -195,7 +195,21 @@ export.execute_foreign_procedure
     # reset the current account data offset to the native offset (2048)
     exec.kernel_proc_offsets::end_foreign_context_offset
     # => [offset, <values returned from the foreign procedure>]
-    
+
     syscall.exec_kernel_proc
     # => [<values returned from the foreign procedure>]
+end
+
+export.update_expiration_block_num
+    exec.kernel_proc_offsets::update_expiration_block_num_offset
+    # => [offset, expiration_delta, ...]
+
+    # pad the stack
+    push.0 movdn.2 push.0 movdn.2 padw swapw padw padw swapdw
+    # => [offset, expiration_delta, PAD(14)]
+
+    syscall.exec_kernel_proc
+
+    # clear the stack
+    drop drop dropw dropw dropw
 end

--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -200,9 +200,9 @@ export.execute_foreign_procedure
     # => [<values returned from the foreign procedure>]
 end
 
-#! Updates the transaction expiration block number.
+#! Updates the transaction expiration block delta.
 #!
-#! The input block_height_delta is added to the block reference number in order to output an upper
+#! The input block_height_delta is added to the block reference number in order to determine an upper
 #! limit at which the transaction will be considered valid (not expired).
 #! This value can be later decreased, but not increased.
 #!
@@ -211,7 +211,7 @@ end
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-export.update_expiration_block_num
+export.update_expiration_block_delta
     exec.kernel_proc_offsets::update_expiration_block_num_offset
     # => [offset, expiration_delta, ...]
 

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -50,7 +50,7 @@ pub fn create_basic_fungible_faucet(
         export.::miden::contracts::faucets::basic_fungible::distribute
         export.::miden::contracts::faucets::basic_fungible::burn
         export.::miden::contracts::auth::basic::{auth_scheme_procedure}
-    "
+        "
     );
 
     let assembler = TransactionKernel::assembler();

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -47,7 +47,7 @@ pub fn create_basic_wallet(
         export.::miden::contracts::wallets::basic::create_note
         export.::miden::contracts::wallets::basic::move_asset_to_note
         export.::miden::contracts::auth::basic::{auth_scheme_procedure}
-    "
+        "
     );
 
     let assembler = TransactionKernel::assembler();

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -71,7 +71,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 34] = [
     digest!(0xa96c44785874ca90, 0x7534ee3618355b2a, 0x5e45a034f624dd88, 0x5542ff311c8340b7),
     // end_foreign_context
     digest!(0x3770db711ce9aaf1, 0xb6f3c929151a5d52, 0x3ed145ec5dbee85f, 0xf979d975d7951bf6),
-    // update_expiration_block_num
+    // update_expiration_delta
     digest!(0xb5b796c8143e57de, 0x43d6914fb889f3ba, 0xf65308f85c7c73b7, 0xe86bfcaccebe6b49),
     // get_expiration_delta
     digest!(0x2d93af519fa32359, 0x14275beadcb2ab9c, 0x68f9336f45c32c86, 0x75ee8ba0f3c11c83),

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -71,8 +71,8 @@ pub const KERNEL0_PROCEDURES: [Digest; 34] = [
     digest!(0xa96c44785874ca90, 0x7534ee3618355b2a, 0x5e45a034f624dd88, 0x5542ff311c8340b7),
     // end_foreign_context
     digest!(0x3770db711ce9aaf1, 0xb6f3c929151a5d52, 0x3ed145ec5dbee85f, 0xf979d975d7951bf6),
-    // update_expiration_delta
-    digest!(0xb5b796c8143e57de, 0x43d6914fb889f3ba, 0xf65308f85c7c73b7, 0xe86bfcaccebe6b49),
+    // update_expiration_block_num
+    digest!(0x268af21ef3c89bcc, 0x4142290b918c7df8, 0x4d220ca00ecb6ec2, 0xa36b719508d30cb2),
     // get_expiration_delta
-    digest!(0x2d93af519fa32359, 0x14275beadcb2ab9c, 0x68f9336f45c32c86, 0x75ee8ba0f3c11c83),
+    digest!(0x4f8ba89ed03ed171, 0x847f80cf50f96733, 0xf41141e83cb42597, 0x6f21b93bdafe7270),
 ];

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -74,5 +74,5 @@ pub const KERNEL0_PROCEDURES: [Digest; 34] = [
     // update_expiration_block_num
     digest!(0x268af21ef3c89bcc, 0x4142290b918c7df8, 0x4d220ca00ecb6ec2, 0xa36b719508d30cb2),
     // get_expiration_delta
-    digest!(0x4f8ba89ed03ed171, 0x847f80cf50f96733, 0xf41141e83cb42597, 0x6f21b93bdafe7270),
+    digest!(0xc315b9b152b64c75, 0x4eb3b30ec94a0887, 0xa8bb394f6805a266, 0xa05857dac130cf87),
 ];

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -208,9 +208,9 @@ fn test_block_expiration_height_monotonically_decreases() {
         begin
             exec.prologue::prepare_transaction
             push.{value_1}
-            exec.tx::update_expiration_block_num
+            exec.tx::update_expiration_delta
             push.{value_2}
-            exec.tx::update_expiration_block_num
+            exec.tx::update_expiration_delta
 
             push.{min_value} exec.tx::get_expiration_delta assert_eq
 
@@ -243,7 +243,7 @@ fn test_invalid_expiration_deltas() {
 
         begin
             push.{value_1}
-            exec.tx::update_expiration_block_num
+            exec.tx::update_expiration_delta
         end
         ";
 

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -208,9 +208,9 @@ fn test_block_expiration_height_monotonically_decreases() {
         begin
             exec.prologue::prepare_transaction
             push.{value_1}
-            exec.tx::update_expiration_delta
+            exec.tx::update_expiration_block_num
             push.{value_2}
-            exec.tx::update_expiration_delta
+            exec.tx::update_expiration_block_num
 
             push.{min_value} exec.tx::get_expiration_delta assert_eq
 
@@ -243,7 +243,7 @@ fn test_invalid_expiration_deltas() {
 
         begin
             push.{value_1}
-            exec.tx::update_expiration_delta
+            exec.tx::update_expiration_block_num
         end
         ";
 

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -262,9 +262,13 @@ fn test_no_expiration_delta_set() {
     let code_template = "
     use.kernel::prologue
     use.kernel::epilogue
+    use.kernel::tx
 
     begin
         exec.prologue::prepare_transaction
+
+        exec.tx::get_expiration_delta assertz
+
         exec.epilogue::finalize_transaction
     end
     ";


### PR DESCRIPTION
Exposes procedures to get and set the expiration block number so that they can be used by the client