### PR TITLE
feat: Expose prover features

### DIFF
--- a/bin/tx-prover/Cargo.toml
+++ b/bin/tx-prover/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [[bin]]
-name = "prover-service"
+name = "miden-tx-prover"
 path = "src/main.rs"
 required-features = ["std"]
 

--- a/bin/tx-prover/Cargo.toml
+++ b/bin/tx-prover/Cargo.toml
@@ -23,6 +23,8 @@ crate-type = ["lib"]
 async = ["miden-tx/async"]
 default = ["std"]
 std = ["miden-objects/std", "miden-tx/std", "dep:tokio", "dep:tonic-web", "dep:tokio-stream", "dep:axum",  "dep:tracing", "dep:tracing-subscriber", "tonic/transport"]
+testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing"]
+concurrent = ["miden-lib/concurrent", "miden-objects/concurrent", "miden-tx/concurrent", "std"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 tonic-web-wasm-client = { version = "0.6", default-features = false }

--- a/bin/tx-prover/README.md
+++ b/bin/tx-prover/README.md
@@ -53,6 +53,13 @@ PROVER_SERVICE_PORT=<your-port>
 RUST_LOG=<log-level>
 ```
 
+## Features
+
+For the service, the following features are available:
+
+- `testing`: This flag reduces the difficulty target of the account seed creation. If the client uses the `testing` flag, then the prover will not be able to prove transactions correctly without it.
+- `concurrent`: Enables transaction proving speedups.
+
 ### Using RemoteTransactionProver
 To use the `RemoteTransactionProver` struct, enable `async`. Additionally, when compiling for `wasm32-unknown-unknown`, disable default features.
 

--- a/bin/tx-prover/README.md
+++ b/bin/tx-prover/README.md
@@ -53,12 +53,17 @@ PROVER_SERVICE_PORT=<your-port>
 RUST_LOG=<log-level>
 ```
 
+
 ## Features
 
-For the service, the following features are available:
+Description of this crate's feature:
 
-- `testing`: This flag reduces the difficulty target of the account seed creation. If the client uses the `testing` flag, then the prover will not be able to prove transactions correctly without it.
-- `concurrent`: Enables transaction proving speedups.
+| Features     | Description                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------------|
+| `std`        | Enable usage of Rust's `std`, use `--no-default-features` for `no-std` support.                             |
+| `concurrent` | Enables concurrent code to speed up runtime execution.                                                      |
+| `async`      | Enables the `RemoteTransactionProver` struct, that implements an async version of `TransactionProver` trait.|
+| `testing`    | Enables testing utilities and reduces proof-of-work requirements to speed up tests' runtimes.               |
 
 ### Using RemoteTransactionProver
 To use the `RemoteTransactionProver` struct, enable `async`. Additionally, when compiling for `wasm32-unknown-unknown`, disable default features.


### PR DESCRIPTION
Exposes `testing` and `concurrent` on the prover service features instead of assuming they should be enabled or disabled.