### PR TITLE
Implement account code loading into transaction executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [BREAKING] Auto-generate `KERNEL_ERRORS` list from the transaction kernel's MASM files and rework error constant names (#906).
 - Implement `Serializable` for `FungibleAsset` (#907).
 - [BREAKING] Changed type of `EMPTY_STORAGE_MAP_ROOT` constant to `RpoDigst`, which references constant from `miden-crypto` (#916).
+- Added `TransactionExecutor::load_account_code()` method to support foreign procedure invocation (#936).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/miden-tx/src/executor/mast_store.rs
+++ b/miden-tx/src/executor/mast_store.rs
@@ -3,7 +3,10 @@ use core::cell::RefCell;
 
 use miden_lib::{transaction::TransactionKernel, MidenLib, StdLibrary};
 use miden_objects::{
-    accounts::AccountCode, assembly::mast::MastForest, transaction::{TransactionArgs, TransactionInputs}, Digest
+    accounts::AccountCode,
+    assembly::mast::MastForest,
+    transaction::{TransactionArgs, TransactionInputs},
+    Digest,
 };
 use vm_processor::MastForestStore;
 

--- a/miden-tx/src/executor/mast_store.rs
+++ b/miden-tx/src/executor/mast_store.rs
@@ -3,9 +3,7 @@ use core::cell::RefCell;
 
 use miden_lib::{transaction::TransactionKernel, MidenLib, StdLibrary};
 use miden_objects::{
-    assembly::mast::MastForest,
-    transaction::{TransactionArgs, TransactionInputs},
-    Digest,
+    accounts::AccountCode, assembly::mast::MastForest, transaction::{TransactionArgs, TransactionInputs}, Digest
 };
 use vm_processor::MastForestStore;
 
@@ -50,6 +48,11 @@ impl TransactionMastStore {
         store
     }
 
+    /// Loads the provided account code into this store.
+    pub fn load_account_code(&self, code: &AccountCode) {
+        self.insert(code.mast().clone());
+    }
+
     /// Loads code required for executing a transaction with the specified inputs and args into
     /// this store.
     ///
@@ -59,7 +62,7 @@ impl TransactionMastStore {
     /// - Transaction script (if any) from the specified [TransactionArgs].
     pub fn load_transaction_code(&self, tx_inputs: &TransactionInputs, tx_args: &TransactionArgs) {
         // load account code
-        self.insert(tx_inputs.account().code().mast().clone());
+        self.load_account_code(tx_inputs.account().code());
 
         // load note script MAST into the MAST store
         for note in tx_inputs.input_notes() {

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    accounts::AccountId,
+    accounts::{AccountCode, AccountId},
     notes::NoteId,
     transaction::{ExecutedTransaction, TransactionArgs, TransactionInputs},
     vm::StackOutputs,
@@ -95,6 +95,17 @@ impl TransactionExecutor {
     pub fn with_tracing(mut self) -> Self {
         self.exec_options = self.exec_options.with_tracing();
         self
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Loads the provided code into the internal MAST store and associates the procedures of the
+    /// account code with the specified account ID.
+    pub fn load_account_code(&mut self, _account_id: AccountId, code: &AccountCode) {
+        // TODO: account_id is not used yet, but it could be used to build a procedure map for the
+        // loaded accounts
+        self.mast_store.load_account_code(code);
     }
 
     // TRANSACTION EXECUTION


### PR DESCRIPTION
This PR adds `TransactionExecutor::load_account_code()` method. It is meant to address some issues brought up in https://github.com/0xPolygonMiden/miden-base/issues/934. Specifically, it'll let the users of the executor to load foreign account code into the executor. It'll also enable associating a given set of procedures with a given account ID - and this will allow us to avoid modifying `TransactionArgs` as described in https://github.com/0xPolygonMiden/miden-base/issues/934#issuecomment-2438231043.

I made `TransactionExecutor::load_account_code()` take a mutable reference to `self` - @igamigo, will that be an issue for the client?