### PR TITLE
feat: `RemoteTransactionProver` lazy connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+- Changed `RemoteTransactionProver` to lazily connect on prove (#937).
 - Added `RemoteTransactionProver` struct to `miden-tx-prover` (#921).
 - [BREAKING] Changed `TransactionProver` trait to be `maybe_async_trait` based on the `async` feature (#913).
 - [BREAKING] Changed `TransactionExecutor` and `TransactionHost` to use trait objects (#897).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,15 +34,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arrayref"
@@ -258,9 +258,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cast"
@@ -270,9 +270,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -961,15 +961,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "a00419de735aac21d53b0de5ce2c03bd3627277cf471300f27ebc89f7d828047"
 
 [[package]]
 name = "libredox"
@@ -1590,18 +1590,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1610,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -1637,9 +1637,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno",
@@ -2008,18 +2008,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "indexmap 2.6.0",
  "itoa",
@@ -2192,9 +2192,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2212,6 +2212,12 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
@@ -2269,18 +2275,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2318,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2639,15 +2645,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8923cde76a6329058a86f04d033f0945a2c6df8b94093512e4ab188b3e3a8950"
+checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
 dependencies = [
  "dissimilar",
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]
@@ -2814,9 +2821,9 @@ checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,8 @@ bench-tx: ## Run transaction benchmarks
 
 .PHONY: install-prover
 install-prover: ## Installs prover
+	cargo install --path bin/tx-prover --locked
+
+.PHONY: install-prover-testing
+install-prover-testing: ## Installs prover
 	cargo install --path bin/tx-prover --locked --features testing

--- a/Makefile
+++ b/Makefile
@@ -108,5 +108,5 @@ install-prover: ## Installs prover
 	cargo install --path bin/tx-prover --locked
 
 .PHONY: install-prover-testing
-install-prover-testing: ## Installs prover
+install-prover-testing: ## Installs prover intended for testing purposes
 	cargo install --path bin/tx-prover --locked --features testing

--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ bench-tx: ## Run transaction benchmarks
 
 .PHONY: install-prover
 install-prover: ## Installs prover
-	cargo install --path bin/tx-prover --locked
+	cargo install --path bin/tx-prover --locked --features testing

--- a/bin/tx-prover/src/lib.rs
+++ b/bin/tx-prover/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate alloc;
-use alloc::string::String;
 
 pub(crate) mod generated;
 
@@ -10,15 +9,3 @@ pub use prover::RemoteTransactionProver;
 
 /// Contains the protobuf definitions
 pub const PROTO_MESSAGES: &str = include_str!("../proto/api.proto");
-
-/// ERRORS
-/// ===============================================================================================
-
-#[derive(Debug)]
-pub enum RemoteTransactionProverError {
-    /// Indicates that the provided gRPC server endpoint is invalid.
-    InvalidEndpoint(String),
-
-    /// Indicates that the connection to the server failed.
-    ConnectionFailed(String),
-}

--- a/bin/tx-prover/src/lib.rs
+++ b/bin/tx-prover/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate alloc;
+use alloc::string::String;
 
 pub(crate) mod generated;
 
@@ -9,3 +10,28 @@ pub use prover::RemoteTransactionProver;
 
 /// Contains the protobuf definitions
 pub const PROTO_MESSAGES: &str = include_str!("../proto/api.proto");
+
+/// ERRORS
+/// ===============================================================================================
+
+#[derive(Debug)]
+pub enum RemoteTransactionProverError {
+    /// Indicates that the provided gRPC server endpoint is invalid.
+    InvalidEndpoint(String),
+
+    /// Indicates that the connection to the server failed.
+    ConnectionFailed(String),
+}
+
+impl std::fmt::Display for RemoteTransactionProverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RemoteTransactionProverError::InvalidEndpoint(endpoint) => {
+                write!(f, "Invalid endpoint: {}", endpoint)
+            },
+            RemoteTransactionProverError::ConnectionFailed(endpoint) => {
+                write!(f, "Failed to connect to transaction prover at: {}", endpoint)
+            },
+        }
+    }
+}

--- a/bin/tx-prover/src/prover.rs
+++ b/bin/tx-prover/src/prover.rs
@@ -1,4 +1,7 @@
-use alloc::{boxed::Box, string::ToString};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 
 use miden_objects::transaction::{ProvenTransaction, TransactionWitness};
 use miden_tx::{TransactionProver, TransactionProverError};
@@ -23,7 +26,7 @@ pub struct RemoteTransactionProver {
 impl RemoteTransactionProver {
     /// Creates a new [RemoteTransactionProver] with the specified gRPC server endpoint. The
     /// endpoint should be in the format `{protocol}://{hostname}:{port}`.
-    pub async fn new(endpoint: &str) -> Self {
+    pub fn new(endpoint: &str) -> Self {
         RemoteTransactionProver { endpoint: endpoint.to_string() }
     }
 }
@@ -37,7 +40,7 @@ impl TransactionProver for RemoteTransactionProver {
         use miden_objects::utils::Serializable;
         #[cfg(target_arch = "wasm32")]
         let mut client = {
-            let web_client = tonic_web_wasm_client::Client::new(self.endpoint);
+            let web_client = tonic_web_wasm_client::Client::new(self.endpoint.clone());
             ApiClient::new(web_client)
         };
 

--- a/bin/tx-prover/src/prover.rs
+++ b/bin/tx-prover/src/prover.rs
@@ -2,11 +2,12 @@ use alloc::{
     boxed::Box,
     string::{String, ToString},
 };
+use core::cell::RefCell;
 
 use miden_objects::transaction::{ProvenTransaction, TransactionWitness};
 use miden_tx::{TransactionProver, TransactionProverError};
 
-use crate::generated::api_client::ApiClient;
+use crate::{generated::api_client::ApiClient, RemoteTransactionProverError};
 
 // REMOTE TRANSACTION PROVER
 // ================================================================================================
@@ -20,6 +21,12 @@ use crate::generated::api_client::ApiClient;
 
 #[derive(Clone)]
 pub struct RemoteTransactionProver {
+    #[cfg(target_arch = "wasm32")]
+    client: RefCell<Option<ApiClient<tonic_web_wasm_client::Client>>>,
+
+    #[cfg(not(target_arch = "wasm32"))]
+    client: RefCell<Option<ApiClient<tonic::transport::Channel>>>,
+
     endpoint: String,
 }
 
@@ -27,7 +34,29 @@ impl RemoteTransactionProver {
     /// Creates a new [RemoteTransactionProver] with the specified gRPC server endpoint. The
     /// endpoint should be in the format `{protocol}://{hostname}:{port}`.
     pub fn new(endpoint: &str) -> Self {
-        RemoteTransactionProver { endpoint: endpoint.to_string() }
+        RemoteTransactionProver {
+            endpoint: endpoint.to_string(),
+            client: RefCell::new(None),
+        }
+    }
+
+    async fn connect(&self) -> Result<(), RemoteTransactionProverError> {
+        #[cfg(target_arch = "wasm32")]
+        let new_client = {
+            let web_client = tonic_web_wasm_client::Client::new(self.endpoint.clone());
+            ApiClient::new(web_client)
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let new_client = {
+            ApiClient::connect(self.endpoint.clone()).await.map_err(|_| {
+                RemoteTransactionProverError::ConnectionFailed(self.endpoint.to_string())
+            })?
+        };
+
+        self.client.replace(Some(new_client));
+
+        Ok(())
     }
 }
 
@@ -38,25 +67,29 @@ impl TransactionProver for RemoteTransactionProver {
         tx_witness: TransactionWitness,
     ) -> Result<ProvenTransaction, TransactionProverError> {
         use miden_objects::utils::Serializable;
-        #[cfg(target_arch = "wasm32")]
-        let mut client = {
-            let web_client = tonic_web_wasm_client::Client::new(self.endpoint.clone());
-            ApiClient::new(web_client)
+        let connected = {
+            let client = self.client.borrow();
+            client.is_some()
         };
 
-        #[cfg(not(target_arch = "wasm32"))]
-        let mut client = ApiClient::connect(self.endpoint.clone()).await.map_err(|_| {
-            TransactionProverError::InternalError(format!(
-                "Failed to connect to endpoint {}",
-                self.endpoint
-            ))
-        })?;
+        if !connected {
+            self.connect().await.map_err(|err| {
+                TransactionProverError::InternalError(format!(
+                    "Failed to connect to the remote prover: {}",
+                    err
+                ))
+            })?;
+        }
+
+        let mut client = self.client.borrow_mut();
 
         let request = tonic::Request::new(crate::generated::ProveTransactionRequest {
             transaction_witness: tx_witness.to_bytes(),
         });
 
         let response = client
+            .as_mut()
+            .expect("client should be connected")
             .prove_transaction(request)
             .await
             .map_err(|err| TransactionProverError::InternalError(err.to_string()))?;

--- a/bin/tx-prover/src/prover.rs
+++ b/bin/tx-prover/src/prover.rs
@@ -18,7 +18,6 @@ use crate::{generated::api_client::ApiClient, RemoteTransactionProverError};
 /// When compiled for the `wasm32-unknown-unknown` target, it uses the `tonic_web_wasm_client`
 /// transport. Otherwise, it uses the built-in `tonic::transport` for native platforms.
 /// The transport layer connection is established lazily when the first transaction is proven.
-
 #[derive(Clone)]
 pub struct RemoteTransactionProver {
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
closes #927

This PR changes the remote prover so that it connects on prove, this connection is not mantained and it's dropped at the end. 