### PR TITLE
feat: Add account codes to witness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+- Added account codes to `TransactionWitness` (#946).
 - Changed `RemoteTransactionProver` to lazily connect on prove (#937).
 - [BREAKING] Made `TransactionMastForest` and `BasicAuthenticator` be `Send`, `Sync`; made scripts lazily initialize (#939).
 - Added `RemoteTransactionProver` struct to `miden-tx-prover` (#921).

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -99,16 +99,6 @@ impl TransactionExecutor {
         self
     }
 
-    // STATE MUTATORS
-    // --------------------------------------------------------------------------------------------
-
-    /// Loads the provided code into the internal MAST forest store and adds the commitment of the
-    /// provided code to the commitments set.
-    pub fn add_account_code(&mut self, code: &AccountCode) {
-        // store the commitment of the foreign account code in the set
-        self.account_codes.insert(code.commitment(), code.clone());
-    }
-
     // TRANSACTION EXECUTION
     // --------------------------------------------------------------------------------------------
 
@@ -235,10 +225,10 @@ fn build_executed_transaction(
     Ok(ExecutedTransaction::new(
         tx_inputs,
         tx_outputs,
+        account_codes,
         account_delta,
         tx_args,
         advice_witness,
         tx_progress.into(),
-        account_codes,
     ))
 }

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -141,8 +141,8 @@ impl TransactionExecutor {
         // load note script MAST into the MAST store
         self.mast_store.load_transaction_code(&tx_inputs, &tx_args);
 
-        for (_, code) in &self.account_codes {
-            self.mast_store.load_account_code(&code);
+        for code in self.account_codes.values() {
+            self.mast_store.load_account_code(code);
         }
 
         let mut host = TransactionHost::new(
@@ -150,7 +150,7 @@ impl TransactionExecutor {
             advice_recorder,
             self.mast_store.clone(),
             self.authenticator.clone(),
-            self.account_codes.iter().map(|(comm, _)| *comm).collect(),
+            self.account_codes.keys().map(|code_comm| *code_comm).collect(),
         )
         .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
 
@@ -168,7 +168,7 @@ impl TransactionExecutor {
             .account_codes
             .iter()
             .filter_map(|(comm, code)| {
-                tx_args.advice_inputs().mapped_values(&comm).and(Some(code.clone()))
+                tx_args.advice_inputs().mapped_values(comm).and(Some(code.clone()))
             })
             .collect();
 

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -38,9 +38,6 @@ pub struct TransactionExecutor {
     authenticator: Option<Arc<dyn TransactionAuthenticator>>,
     /// Holds the code commitments of all accounts loaded into this transaction executor via the
     /// [Self::load_account_code()] method.
-    ///
-    /// These commitments are used to create the account procedure index map during transaction
-    /// execution.
     account_codes: BTreeMap<Digest, AccountCode>,
     exec_options: ExecutionOptions,
 }
@@ -97,6 +94,19 @@ impl TransactionExecutor {
     pub fn with_tracing(mut self) -> Self {
         self.exec_options = self.exec_options.with_tracing();
         self
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Loads the provided code into the internal MAST forest store and adds the commitment of the
+    /// provided code to the commitments set.
+    pub fn load_account_code(&mut self, code: &AccountCode) {
+        // load the code mast forest to the mast store
+        self.mast_store.load_account_code(code);
+
+        // store the commitment of the foreign account code in the set
+        self.account_codes.insert(code.commitment(), code.clone());
     }
 
     // TRANSACTION EXECUTION

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -150,7 +150,7 @@ impl TransactionExecutor {
             advice_recorder,
             self.mast_store.clone(),
             self.authenticator.clone(),
-            self.account_codes.keys().map(|code_comm| *code_comm).collect(),
+            self.account_codes.keys().copied().collect(),
         )
         .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
 

--- a/objects/src/accounts/code/mod.rs
+++ b/objects/src/accounts/code/mod.rs
@@ -213,6 +213,18 @@ impl PartialEq for AccountCode {
     }
 }
 
+impl Ord for AccountCode {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.commitment.cmp(&other.commitment)
+    }
+}
+
+impl PartialOrd for AccountCode {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl Eq for AccountCode {}
 
 // SERIALIZATION

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -6,6 +6,7 @@ use super::{
     InputNotes, NoteId, OutputNotes, TransactionArgs, TransactionId, TransactionInputs,
     TransactionOutputs, TransactionWitness,
 };
+use crate::accounts::AccountCode;
 
 // EXECUTED TRANSACTION
 // ================================================================================================
@@ -29,6 +30,7 @@ pub struct ExecutedTransaction {
     tx_args: TransactionArgs,
     advice_witness: AdviceInputs,
     tx_measurements: TransactionMeasurements,
+    account_codes: Vec<AccountCode>,
 }
 
 impl ExecutedTransaction {
@@ -46,6 +48,7 @@ impl ExecutedTransaction {
         tx_args: TransactionArgs,
         advice_witness: AdviceInputs,
         tx_measurements: TransactionMeasurements,
+        account_codes: Vec<AccountCode>,
     ) -> Self {
         // make sure account IDs are consistent across transaction inputs and outputs
         assert_eq!(tx_inputs.account().id(), tx_outputs.account.id());
@@ -58,6 +61,7 @@ impl ExecutedTransaction {
             tx_args,
             advice_witness,
             tx_measurements,
+            account_codes,
         }
     }
 
@@ -131,6 +135,7 @@ impl ExecutedTransaction {
             tx_inputs: self.tx_inputs,
             tx_args: self.tx_args,
             advice_witness: self.advice_witness,
+            account_codes: self.account_codes,
         };
         (self.account_delta, self.tx_outputs, tx_witness, self.tx_measurements)
     }

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -26,11 +26,11 @@ pub struct ExecutedTransaction {
     id: OnceCell<TransactionId>,
     tx_inputs: TransactionInputs,
     tx_outputs: TransactionOutputs,
+    account_codes: Vec<AccountCode>,
     account_delta: AccountDelta,
     tx_args: TransactionArgs,
     advice_witness: AdviceInputs,
     tx_measurements: TransactionMeasurements,
-    account_codes: Vec<AccountCode>,
 }
 
 impl ExecutedTransaction {
@@ -44,11 +44,11 @@ impl ExecutedTransaction {
     pub fn new(
         tx_inputs: TransactionInputs,
         tx_outputs: TransactionOutputs,
+        account_codes: Vec<AccountCode>,
         account_delta: AccountDelta,
         tx_args: TransactionArgs,
         advice_witness: AdviceInputs,
         tx_measurements: TransactionMeasurements,
-        account_codes: Vec<AccountCode>,
     ) -> Self {
         // make sure account IDs are consistent across transaction inputs and outputs
         assert_eq!(tx_inputs.account().id(), tx_outputs.account.id());
@@ -57,11 +57,11 @@ impl ExecutedTransaction {
             id: OnceCell::new(),
             tx_inputs,
             tx_outputs,
+            account_codes,
             account_delta,
             tx_args,
             advice_witness,
             tx_measurements,
-            account_codes,
         }
     }
 

--- a/objects/src/transaction/tx_witness.rs
+++ b/objects/src/transaction/tx_witness.rs
@@ -1,7 +1,10 @@
+use alloc::vec::Vec;
+
 use vm_core::utils::{ByteReader, Deserializable, Serializable};
 use vm_processor::DeserializationError;
 
 use super::{AdviceInputs, TransactionArgs, TransactionInputs};
+use crate::accounts::AccountCode;
 
 // TRANSACTION WITNESS
 // ================================================================================================
@@ -21,13 +24,15 @@ use super::{AdviceInputs, TransactionArgs, TransactionInputs};
 ///   executing the transaction program.
 ///
 /// TODO: currently, the advice witness contains redundant and irrelevant data (e.g., tx inputs
-/// and tx outputs). we should optimize it to contain only the minimum data required for
-/// executing/proving the transaction.
+/// and tx outputs; account codes and a subset of that data in advice inputs).
+/// We should optimize it to contain only the minimum data required for executing/proving the
+/// transaction.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionWitness {
     pub tx_inputs: TransactionInputs,
     pub tx_args: TransactionArgs,
     pub advice_witness: AdviceInputs,
+    pub account_codes: Vec<AccountCode>,
 }
 
 // SERIALIZATION
@@ -38,6 +43,7 @@ impl Serializable for TransactionWitness {
         self.tx_inputs.write_into(target);
         self.tx_args.write_into(target);
         self.advice_witness.write_into(target);
+        self.account_codes.write_into(target);
     }
 }
 
@@ -46,6 +52,12 @@ impl Deserializable for TransactionWitness {
         let tx_inputs = TransactionInputs::read_from(source)?;
         let tx_args = TransactionArgs::read_from(source)?;
         let advice_witness = AdviceInputs::read_from(source)?;
-        Ok(Self { tx_inputs, tx_args, advice_witness })
+        let account_codes = <Vec<AccountCode>>::read_from(source)?;
+        Ok(Self {
+            tx_inputs,
+            tx_args,
+            advice_witness,
+            account_codes,
+        })
     }
 }


### PR DESCRIPTION
Transaction provers need foreign account codes to be loaded but there is no way to load them from a witness (ie, in the `TransactionProver` trait)