### PR TITLE
fix: WASM build for libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ name = "miden-objects"
 version = "0.6.0"
 dependencies = [
  "criterion",
+ "getrandom",
  "log",
  "miden-assembly",
  "miden-core",

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ build: ## By default we should build in release mode
 
 .PHONY: build-no-std
 build-no-std: ## Build without the standard library
-	cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx --exclude miden-tx-prover --exclude miden-prover-proxy
+	cargo build --no-default-features --target wasm32-unknown-unknown --workspace --lib
 
 
 .PHONY: build-no-std-testing

--- a/bin/tx-prover/Cargo.toml
+++ b/bin/tx-prover/Cargo.toml
@@ -37,6 +37,11 @@ getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 tonic = { version = "0.12", default-features = false, features = ["prost", "codegen", "transport"] }
+once_cell = "1.19.0"
+pingora = { version = "0.3", features = [ "lb" ] }
+pingora-core = "0.3"
+pingora-proxy = "0.3"
+pingora-limits = "0.3"
 
 [dependencies]
 async-trait = "0.1"
@@ -44,11 +49,6 @@ axum = {version = "0.7", optional = true }
 miden-lib = { workspace = true, default-features = false }
 miden-objects = { workspace = true, default-features = false }
 miden-tx = { workspace = true, default-features = false }
-once_cell = "1.19.0"
-pingora = { version = "0.3", features = [ "lb" ] }
-pingora-core = "0.3"
-pingora-proxy = "0.3"
-pingora-limits = "0.3"
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 rand = "0.8"
 tokio = { version = "1.38", optional = true, features = ["full"] }

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -35,6 +35,9 @@ vm-core = { workspace = true }
 vm-processor = { workspace = true }
 winter-rand-utils = { version = "0.9", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
 miden-objects = { path = ".", features = ["testing"] }


### PR DESCRIPTION
As part of the prover proxy we added dependencies that the binary use, but we don't want to import when using `RemoteTransactionProver` (this should probably be separated some other way). We have a check for no-std builds, but it was not reached because the crate was excluded, so I changed the check to reach all crates, but only attempt to compile libraries and not binaries.