### PR TITLE
Make tx measurements public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added `RemoteTransactionProver` struct to `miden-tx-prover` (#921).
 - [BREAKING] Migrated to v0.11 version of Miden VM (#929).
 - [BREAKING] Introduce a new way to build `Account`s from `AccountComponent`s (#941).
+- Added `total_cycles` and `trace_length` to the `TransactionMeasurements` (#953).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/objects/src/transaction/executed_tx.rs
+++ b/objects/src/transaction/executed_tx.rs
@@ -124,6 +124,12 @@ impl ExecutedTransaction {
         &self.advice_witness
     }
 
+    /// Returns a reference to the transaction measurements which are the cycle counts for
+    /// each stage.
+    pub fn measurements(&self) -> &TransactionMeasurements {
+        &self.tx_measurements
+    }
+
     // CONVERSIONS
     // --------------------------------------------------------------------------------------------
 
@@ -167,4 +173,18 @@ pub struct TransactionMeasurements {
     pub note_execution: Vec<(NoteId, usize)>,
     pub tx_script_processing: usize,
     pub epilogue: usize,
+}
+
+impl TransactionMeasurements {
+    /// Returns the total number of cycles spent executing the transaction.
+    pub fn total_cycles(&self) -> usize {
+        self.prologue + self.notes_processing + self.tx_script_processing + self.epilogue
+    }
+
+    /// Returns the trace length of the transaction which is the next power of 2 of the total cycles
+    /// spent executing the transaction.
+    pub fn trace_length(&self) -> usize {
+        let total_cycles = self.total_cycles();
+        total_cycles.next_power_of_two()
+    }
 }


### PR DESCRIPTION
This PR adds two new methods to the `TransactionMeasurements` struct. 

- total()
- trace_length()

I also added a function to expose `tx_measurements` from the `TransactionExecutor` directly.