### PR TITLE
Add ability to load libraries into TX executor and prover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [BREAKING] Migrated to v0.11 version of Miden VM (#929).
 - [BREAKING] Introduce a new way to build `Account`s from `AccountComponent`s (#941).
 - Added `total_cycles` and `trace_length` to the `TransactionMeasurements` (#953).
+- Added ability to load libraries into `TransactionExecutor` and `LocalTransactionProver` (#954).
 
 ## 0.5.1 (2024-08-28) - `miden-objects` crate only
 

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -37,6 +37,7 @@ winter-maybe-async = { version = "0.10" }
 [dev-dependencies]
 miden-tx = { path = ".", features = ["testing"] }
 rand_chacha = { version = "0.3", default-features = false }
+assembly = { workspace = true }
 
 [build-dependencies]
 assembly = { workspace = true }

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -3,6 +3,7 @@ use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
     accounts::{AccountCode, AccountId},
+    assembly::Library,
     notes::NoteId,
     transaction::{ExecutedTransaction, TransactionArgs, TransactionInputs},
     vm::StackOutputs,
@@ -99,14 +100,22 @@ impl TransactionExecutor {
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Loads the provided code into the internal MAST forest store and adds the commitment of the
-    /// provided code to the commitments set.
+    /// Loads the provided account code into the internal MAST forest store and adds the commitment
+    /// of the provided code to the commitments set.
     pub fn load_account_code(&mut self, code: &AccountCode) {
         // load the code mast forest to the mast store
         self.mast_store.load_account_code(code);
 
         // store the commitment of the foreign account code in the set
         self.account_codes.insert(code.clone());
+    }
+
+    /// Loads the provided library code into the internal MAST forest store.
+    ///
+    /// TODO: this is a work-around to support accounts which were complied with user-defined
+    /// libraries. Once Miden Assembler supports library vendoring, this should go away.
+    pub fn load_library(&mut self, library: &Library) {
+        self.mast_store.insert(library.mast_forest().clone());
     }
 
     // TRANSACTION EXECUTION

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -5,6 +5,7 @@ use alloc::{sync::Arc, vec::Vec};
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
     accounts::delta::AccountUpdateDetails,
+    assembly::Library,
     transaction::{OutputNote, ProvenTransaction, ProvenTransactionBuilder, TransactionWitness},
 };
 use miden_prover::prove;
@@ -47,14 +48,20 @@ pub struct LocalTransactionProver {
 }
 
 impl LocalTransactionProver {
-    // CONSTRUCTOR
-    // --------------------------------------------------------------------------------------------
     /// Creates a new [LocalTransactionProver] instance.
     pub fn new(proof_options: ProvingOptions) -> Self {
         Self {
             mast_store: Arc::new(TransactionMastStore::new()),
             proof_options,
         }
+    }
+
+    /// Loads the provided library code into the internal MAST forest store.
+    ///
+    /// TODO: this is a work-around to support accounts which were complied with user-defined
+    /// libraries. Once Miden Assembler supports library vendoring, this should go away.
+    pub fn load_library(&mut self, library: &Library) {
+        self.mast_store.insert(library.mast_forest().clone());
     }
 }
 


### PR DESCRIPTION
This PR adds two small methods to let users load custom libraries into `TransactionExecutor` and `LocalTransactionProver`. This is a temporary workaround which is needed to let users use user-defined libraries in account code. As mentioned in the comments, once we have support for library vendoring in the assembler, these methods can be removed.

cc @plafer and @bitwalker to highlight one use-case were we need library vendoring.