### PR TITLE
Revisit `Account::initialize_from_components` and add `AccountBuilder::build_existing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Changes
 
 - [BREAKING] Better error display when queues are full in the prover service (#967).
+- [BREAKING] Remove `AccountBuilder::build_testing` and make `Account::initialize_from_components` private (#969).
 
 ## 0.6.1 (2024-11-08)
 
 ### Features
 
 - [BREAKING] Added CLI for the transaction prover services both the workers and the proxy (#955).
-- [BREAKING] Remove `AccountBuilder::build_testing` and make `Account::initialize_from_components` private (#969).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - [BREAKING] Added CLI for the transaction prover services both the workers and the proxy (#955).
+- [BREAKING] Remove `AccountBuilder::build_testing` and make `Account::initialize_from_components` private (#969).
 
 ### Fixes
 

--- a/bin/bench-tx/src/utils.rs
+++ b/bin/bench-tx/src/utils.rs
@@ -4,17 +4,18 @@ use std::sync::Arc;
 
 use miden_lib::accounts::{auth::RpoFalcon512, wallets::BasicWallet};
 use miden_objects::{
-    accounts::{Account, AccountId, AuthSecretKey},
-    assets::{Asset, AssetVault},
+    accounts::{Account, AccountBuilder, AccountStorageMode, AccountType, AuthSecretKey},
+    assets::Asset,
     crypto::dsa::rpo_falcon512::{PublicKey, SecretKey},
     transaction::TransactionMeasurements,
-    Felt, Word,
+    Word,
 };
 use miden_tx::auth::{BasicAuthenticator, TransactionAuthenticator};
 use rand::rngs::StdRng;
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde::Serialize;
 use serde_json::{from_str, to_string_pretty, Value};
+use vm_processor::ONE;
 
 use super::{read_to_string, write, Benchmark, Path};
 
@@ -23,7 +24,6 @@ use super::{read_to_string, write, Benchmark, Path};
 
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u64 = 0x200000000000001f; // 2305843009213693983
 pub const ACCOUNT_ID_SENDER: u64 = 0x800000000000001f; // 9223372036854775839
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN: u64 = 0x900000000000003f; // 10376293541461622847
 
 pub const DEFAULT_AUTH_SCRIPT: &str = "
     begin
@@ -62,22 +62,23 @@ impl From<TransactionMeasurements> for MeasurementsPrinter {
 // ================================================================================================
 
 pub fn get_account_with_basic_authenticated_wallet(
-    account_id: AccountId,
+    init_seed: [u8; 32],
+    account_type: AccountType,
+    storage_mode: AccountStorageMode,
     public_key: Word,
     assets: Option<Asset>,
 ) -> Account {
-    let (account_code, account_storage) = Account::initialize_from_components(
-        account_id.account_type(),
-        &[BasicWallet.into(), RpoFalcon512::new(PublicKey::new(public_key)).into()],
-    )
-    .unwrap();
-
-    let account_vault = match assets {
-        Some(asset) => AssetVault::new(&[asset]).unwrap(),
-        None => AssetVault::new(&[]).unwrap(),
-    };
-
-    Account::from_parts(account_id, account_vault, account_storage, account_code, Felt::new(1))
+    AccountBuilder::new()
+        .init_seed(init_seed)
+        .nonce(ONE)
+        .account_type(account_type)
+        .storage_mode(storage_mode)
+        .with_assets(assets)
+        .with_component(BasicWallet)
+        .with_component(RpoFalcon512::new(PublicKey::new(public_key)))
+        .build_testing()
+        .unwrap()
+        .0
 }
 
 pub fn get_new_pk_and_authenticator() -> (Word, Arc<dyn TransactionAuthenticator>) {

--- a/bin/bench-tx/src/utils.rs
+++ b/bin/bench-tx/src/utils.rs
@@ -15,7 +15,6 @@ use rand::rngs::StdRng;
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde::Serialize;
 use serde_json::{from_str, to_string_pretty, Value};
-use vm_processor::ONE;
 
 use super::{read_to_string, write, Benchmark, Path};
 
@@ -70,15 +69,13 @@ pub fn get_account_with_basic_authenticated_wallet(
 ) -> Account {
     AccountBuilder::new()
         .init_seed(init_seed)
-        .nonce(ONE)
         .account_type(account_type)
         .storage_mode(storage_mode)
         .with_assets(assets)
         .with_component(BasicWallet)
         .with_component(RpoFalcon512::new(PublicKey::new(public_key)))
-        .build_testing()
+        .build_existing()
         .unwrap()
-        .0
 }
 
 pub fn get_new_pk_and_authenticator() -> (Word, Arc<dyn TransactionAuthenticator>) {

--- a/miden-tx/src/testing/mock_chain/mod.rs
+++ b/miden-tx/src/testing/mock_chain/mod.rs
@@ -7,7 +7,8 @@ use miden_lib::{
 };
 use miden_objects::{
     accounts::{
-        delta::AccountUpdateDetails, Account, AccountBuilder, AccountComponent, AccountDelta, AccountId, AccountType, AuthSecretKey
+        delta::AccountUpdateDetails, Account, AccountBuilder, AccountComponent, AccountDelta,
+        AccountId, AccountType, AuthSecretKey,
     },
     assets::{Asset, FungibleAsset, TokenSymbol},
     block::{compute_tx_hash, Block, BlockAccountUpdate, BlockNoteIndex, BlockNoteTree, NoteBatch},
@@ -376,9 +377,8 @@ impl MockChain {
 
     /// Adds a new wallet with the specified authentication method and assets.
     pub fn add_new_wallet(&mut self, auth_method: Auth) -> Account {
-        let account_builder = AccountBuilder::new()
-            .init_seed(self.rng.gen())
-            .with_component(BasicWallet);
+        let account_builder =
+            AccountBuilder::new().init_seed(self.rng.gen()).with_component(BasicWallet);
 
         self.add_from_account_builder(auth_method, account_builder, AccountState::New)
     }

--- a/miden-tx/src/testing/mock_chain/mod.rs
+++ b/miden-tx/src/testing/mock_chain/mod.rs
@@ -7,8 +7,7 @@ use miden_lib::{
 };
 use miden_objects::{
     accounts::{
-        delta::AccountUpdateDetails, Account, AccountBuilder, AccountDelta, AccountId, AccountType,
-        AuthSecretKey,
+        delta::AccountUpdateDetails, Account, AccountBuilder, AccountComponent, AccountDelta, AccountId, AccountType, AuthSecretKey
     },
     assets::{Asset, FungibleAsset, TokenSymbol},
     block::{compute_tx_hash, Block, BlockAccountUpdate, BlockNoteIndex, BlockNoteTree, NoteBatch},
@@ -22,7 +21,7 @@ use miden_objects::{
         ChainMmr, ExecutedTransaction, InputNote, InputNotes, OutputNote, ToInputNoteCommitments,
         TransactionId, TransactionInputs, TransactionScript,
     },
-    AccountError, BlockHeader, FieldElement, NoteError, ACCOUNT_TREE_DEPTH,
+    AccountError, BlockHeader, NoteError, ACCOUNT_TREE_DEPTH,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -270,7 +269,7 @@ impl MockChain {
     pub fn with_accounts(accounts: &[Account]) -> Self {
         let mut chain = MockChain::default();
         for acc in accounts {
-            chain.add_account(acc.clone());
+            chain.add_pending_account(acc.clone());
             chain.available_accounts.insert(
                 acc.id(),
                 MockAccount {
@@ -324,7 +323,7 @@ impl MockChain {
 
     /// Adds a public [Note] to the pending objects.
     /// A block has to be created to finalize the new entity.
-    pub fn add_note(&mut self, note: Note) {
+    pub fn add_pending_note(&mut self, note: Note) {
         self.pending_objects.output_note_batches.push(vec![OutputNote::Full(note)]);
     }
 
@@ -361,7 +360,7 @@ impl MockChain {
             )?
         };
 
-        self.add_note(note.clone());
+        self.add_pending_note(note.clone());
 
         Ok(note)
     }
@@ -379,20 +378,19 @@ impl MockChain {
     pub fn add_new_wallet(&mut self, auth_method: Auth) -> Account {
         let account_builder = AccountBuilder::new()
             .init_seed(self.rng.gen())
-            .nonce(Felt::ZERO)
             .with_component(BasicWallet);
 
-        self.add_from_account_builder(auth_method, account_builder)
+        self.add_from_account_builder(auth_method, account_builder, AccountState::New)
     }
 
     /// Adds an existing wallet (nonce == 1) with the specified authentication method and assets.
     pub fn add_existing_wallet(&mut self, auth_method: Auth, assets: Vec<Asset>) -> Account {
         let account_builder = AccountBuilder::new()
             .init_seed(self.rng.gen())
-            .nonce(Felt::ONE)
             .with_component(BasicWallet)
             .with_assets(assets);
-        self.add_from_account_builder(auth_method, account_builder)
+
+        self.add_from_account_builder(auth_method, account_builder, AccountState::Exists)
     }
 
     /// Adds a new faucet with the specified authentication method and metadata.
@@ -404,7 +402,6 @@ impl MockChain {
     ) -> MockFungibleFaucet {
         let account_builder = AccountBuilder::new()
             .init_seed(self.rng.gen())
-            .nonce(Felt::ZERO)
             .account_type(AccountType::FungibleFaucet)
             .with_component(
                 BasicFungibleFaucet::new(
@@ -415,7 +412,11 @@ impl MockChain {
                 .unwrap(),
             );
 
-        MockFungibleFaucet(self.add_from_account_builder(auth_method, account_builder))
+        MockFungibleFaucet(self.add_from_account_builder(
+            auth_method,
+            account_builder,
+            AccountState::New,
+        ))
     }
 
     /// Adds an existing (nonce == 1) faucet with the specified authentication method and metadata.
@@ -426,7 +427,7 @@ impl MockChain {
         max_supply: u64,
         total_issuance: Option<u64>,
     ) -> MockFungibleFaucet {
-        let account_builder = AccountBuilder::new()
+        let mut account_builder = AccountBuilder::new()
             .with_component(
                 BasicFungibleFaucet::new(
                     TokenSymbol::new(token_symbol).unwrap(),
@@ -435,33 +436,17 @@ impl MockChain {
                 )
                 .unwrap(),
             )
-            .nonce(Felt::ONE)
             .init_seed(self.rng.gen())
             .account_type(AccountType::FungibleFaucet);
 
-        let (mut account, seed, authenticator) = match auth_method {
-            Auth::BasicAuth => {
-                let mut rng = ChaCha20Rng::from_seed(Default::default());
-                let sec_key = SecretKey::with_rng(&mut rng);
-                let pub_key = sec_key.public_key();
-
-                let (acc, seed) = account_builder
-                    .with_component(RpoFalcon512::new(pub_key))
-                    .build_testing()
-                    .unwrap();
-
-                let authenticator = BasicAuthenticator::<ChaCha20Rng>::new_with_rng(
-                    &[(pub_key.into(), AuthSecretKey::RpoFalcon512(sec_key))],
-                    rng,
-                );
-
-                (acc, seed, Some(authenticator))
+        let authenticator = match Self::build_authentication_component(auth_method) {
+            Some((auth_component, authenticator)) => {
+                account_builder = account_builder.with_component(auth_component);
+                Some(authenticator)
             },
-            Auth::NoAuth => {
-                let (account, seed) = account_builder.build_testing().unwrap();
-                (account, seed, None)
-            },
+            None => None,
         };
+        let mut account = account_builder.build_existing().unwrap();
 
         // The faucet's reserved slot is initialized to an empty word by default.
         // If total_issuance is set, overwrite it.
@@ -473,59 +458,75 @@ impl MockChain {
         }
 
         self.available_accounts
-            .insert(account.id(), MockAccount::new(account.clone(), seed, authenticator));
+            .insert(account.id(), MockAccount::new(account.clone(), None, authenticator));
 
         MockFungibleFaucet(account)
     }
 
-    /// Adds a new `Account` from an `AccountBuilder` to the list of pending objects.
-    /// A block has to be created to finalize the new entity.
-    pub fn add_from_account_builder(
+    /// Adds the [`AccountComponent`] corresponding to `auth_method` to the account in the builder
+    /// and builds a new or existing account depending on `account_state`.
+    ///
+    /// This account is added to the available accounts and are immediately available without having
+    /// to seal a block.
+    fn add_from_account_builder(
         &mut self,
         auth_method: Auth,
-        account_builder: AccountBuilder,
+        mut account_builder: AccountBuilder,
+        account_state: AccountState,
     ) -> Account {
-        let (account, seed, authenticator) = match auth_method {
-            Auth::BasicAuth => {
-                let mut rng = ChaCha20Rng::from_seed(Default::default());
-                let sec_key = SecretKey::with_rng(&mut rng);
-                let pub_key = sec_key.public_key();
-
-                let (acc, seed) = account_builder
-                    .with_component(RpoFalcon512::new(pub_key))
-                    .build_testing()
-                    .unwrap();
-
-                let authenticator = BasicAuthenticator::<ChaCha20Rng>::new_with_rng(
-                    &[(pub_key.into(), AuthSecretKey::RpoFalcon512(sec_key))],
-                    rng,
-                );
-
-                (acc, seed, Some(authenticator))
+        let authenticator = match Self::build_authentication_component(auth_method) {
+            Some((auth_component, authenticator)) => {
+                account_builder = account_builder.with_component(auth_component);
+                Some(authenticator)
             },
-            Auth::NoAuth => {
-                let (account, seed) = account_builder.build_testing().unwrap();
-                (account, seed, None)
-            },
+            None => None,
+        };
+
+        let (account, seed) = if let AccountState::New = account_state {
+            account_builder.build().map(|(account, seed)| (account, Some(seed))).unwrap()
+        } else {
+            account_builder.build_existing().map(|account| (account, None)).unwrap()
         };
 
         self.available_accounts
             .insert(account.id(), MockAccount::new(account.clone(), seed, authenticator));
-
-        self.add_account(account.clone());
 
         account
     }
 
     /// Adds a new `Account` to the list of pending objects.
     /// A block has to be created to finalize the new entity.
-    pub fn add_account(&mut self, account: Account) {
+    pub fn add_pending_account(&mut self, account: Account) {
         self.pending_objects.updated_accounts.push(BlockAccountUpdate::new(
             account.id(),
             account.hash(),
             AccountUpdateDetails::New(account),
             vec![],
         ));
+    }
+
+    /// Convert `auth_method` into its corresponding authentication [`AccountComponent`] and a
+    /// [`BasicAuthenticator`] or `None` when [`Auth::NoAuth`] is passed.
+    fn build_authentication_component(
+        auth_method: Auth,
+    ) -> Option<(AccountComponent, BasicAuthenticator<ChaCha20Rng>)> {
+        match auth_method {
+            Auth::BasicAuth => {
+                let mut rng = ChaCha20Rng::from_seed(Default::default());
+                let sec_key = SecretKey::with_rng(&mut rng);
+                let pub_key = sec_key.public_key();
+
+                let component = RpoFalcon512::new(pub_key).into();
+
+                let authenticator = BasicAuthenticator::<ChaCha20Rng>::new_with_rng(
+                    &[(pub_key.into(), AuthSecretKey::RpoFalcon512(sec_key))],
+                    rng,
+                );
+
+                Some((component, authenticator))
+            },
+            Auth::NoAuth => None,
+        }
     }
 
     /// Initializes a [TransactionContextBuilder].
@@ -765,6 +766,16 @@ impl MockChain {
     pub fn accounts(&self) -> &SimpleSmt<ACCOUNT_TREE_DEPTH> {
         &self.accounts
     }
+}
+
+// HELPER TYPES
+// ================================================================================================
+
+/// Helper type for increased readability at call-sites. Indicates whether to build a new (nonce =
+/// ZERO) or existing account (nonce = ONE).
+enum AccountState {
+    New,
+    Exists,
 }
 
 // HELPER FUNCTIONS

--- a/miden-tx/src/testing/tx_context/builder.rs
+++ b/miden-tx/src/testing/tx_context/builder.rs
@@ -600,7 +600,7 @@ impl TransactionContextBuilder {
 
                 let mut mock_chain = MockChain::default();
                 for i in self.input_notes {
-                    mock_chain.add_note(i);
+                    mock_chain.add_pending_note(i);
                 }
 
                 mock_chain.seal_block(None);

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -255,7 +255,7 @@ fn test_get_item() {
 
 #[test]
 fn test_get_map_item() {
-    let (account, _) = AccountBuilder::new()
+    let account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
@@ -264,8 +264,7 @@ fn test_get_map_item() {
             )
             .unwrap(),
         )
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     let tx_context = TransactionContextBuilder::new(account).build();
@@ -403,7 +402,7 @@ fn test_set_map_item() {
         [Felt::new(9_u64), Felt::new(10_u64), Felt::new(11_u64), Felt::new(12_u64)],
     );
 
-    let (account, _) = AccountBuilder::new()
+    let account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
@@ -412,8 +411,7 @@ fn test_set_map_item() {
             )
             .unwrap(),
         )
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     let tx_context = TransactionContextBuilder::new(account).build();
@@ -553,12 +551,11 @@ fn test_account_component_storage_offset() {
     .unwrap()
     .with_supported_type(AccountType::RegularAccountUpdatableCode);
 
-    let (mut account, _) = AccountBuilder::new()
+    let mut account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(component1)
         .with_component(component2)
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     // Assert that the storage offset and size have been set correctly.

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -406,9 +406,10 @@ pub fn test_prologue_create_account() {
             .unwrap()
             .with_supported_type(AccountType::RegularAccountUpdatableCode),
         )
-        .build_testing()
+        .build()
         .unwrap();
-    let tx_context = TransactionContextBuilder::new(account).account_seed(seed).build();
+
+    let tx_context = TransactionContextBuilder::new(account).account_seed(Some(seed)).build();
 
     let code = "
     use.kernel::prologue
@@ -535,7 +536,7 @@ pub fn test_prologue_create_account_invalid_seed() {
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .account_type(AccountType::RegularAccountUpdatableCode)
         .with_component(BasicWallet)
-        .build_testing()
+        .build()
         .unwrap();
 
     let code = "
@@ -552,7 +553,7 @@ pub fn test_prologue_create_account_invalid_seed() {
         AdviceInputs::default().with_map([(Digest::from(account_seed_key), vec![ZERO; 4])]);
 
     let tx_context = TransactionContextBuilder::new(acct)
-        .account_seed(account_seed)
+        .account_seed(Some(account_seed))
         .advice_inputs(adv_inputs)
         .build();
     let process = tx_context.execute_code(code);

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -658,7 +658,7 @@ fn test_load_foreign_account_basic() {
     // GET ITEM
     // --------------------------------------------------------------------------------------------
     let storage_slot = AccountStorage::mock_item_0().slot;
-    let (foreign_account, _) = AccountBuilder::new()
+    let foreign_account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
@@ -667,8 +667,7 @@ fn test_load_foreign_account_basic() {
             )
             .unwrap(),
         )
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     // TODO: Temporary fix: Build a native account that has the same code commitment as the foreign
@@ -741,7 +740,7 @@ fn test_load_foreign_account_basic() {
     // GET MAP ITEM
     // --------------------------------------------------------------------------------------------
     let storage_slot = AccountStorage::mock_item_2().slot;
-    let (foreign_account, _) = AccountBuilder::new()
+    let foreign_account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
@@ -750,8 +749,7 @@ fn test_load_foreign_account_basic() {
             )
             .unwrap(),
         )
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     let foreign_account_id = foreign_account.id();
@@ -835,7 +833,7 @@ fn test_load_foreign_account_basic() {
 #[test]
 fn test_load_foreign_account_twice() {
     let storage_slot = AccountStorage::mock_item_0().slot;
-    let (foreign_account, _) = AccountBuilder::new()
+    let foreign_account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
@@ -844,8 +842,7 @@ fn test_load_foreign_account_twice() {
             )
             .unwrap(),
         )
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     let foreign_account_id = foreign_account.id();

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -122,7 +122,7 @@ fn transaction_executor_witness() {
 #[test]
 fn executed_transaction_account_delta_new() {
     let account_assets = AssetVault::mock().assets().collect::<Vec<Asset>>();
-    let (account, _) = AccountBuilder::new()
+    let account = AccountBuilder::new()
         .init_seed(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
@@ -132,8 +132,7 @@ fn executed_transaction_account_delta_new() {
             .unwrap(),
         )
         .with_assets(account_assets)
-        .nonce(ONE)
-        .build_testing()
+        .build_existing()
         .unwrap();
 
     let mut tx_context = TransactionContextBuilder::new(account)

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -5,8 +5,8 @@ mod wallet;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    accounts::{account_id::testing::ACCOUNT_ID_SENDER, Account, AccountId},
-    assets::{Asset, AssetVault, FungibleAsset},
+    accounts::{account_id::testing::ACCOUNT_ID_SENDER, AccountId},
+    assets::FungibleAsset,
     crypto::utils::Serializable,
     notes::{Note, NoteAssets, NoteInputs, NoteMetadata, NoteRecipient, NoteScript, NoteType},
     transaction::{ExecutedTransaction, ProvenTransaction},
@@ -61,43 +61,6 @@ pub fn prove_and_verify_transaction(
     let verifier = TransactionVerifier::new(miden_objects::MIN_PROOF_SECURITY_LEVEL);
 
     verifier.verify(proven_transaction)
-}
-
-#[cfg(test)]
-pub fn get_account_with_basic_authenticated_wallet(
-    account_id: AccountId,
-    public_key: Word,
-    assets: Option<Asset>,
-) -> Account {
-    use miden_lib::accounts::auth::RpoFalcon512;
-    use miden_objects::{
-        accounts::{AccountComponent, StorageMap, StorageSlot},
-        crypto::dsa::rpo_falcon512::PublicKey,
-        testing::account_component::BASIC_WALLET_CODE,
-    };
-    let assembler = TransactionKernel::assembler().with_debug_mode(true);
-
-    // This component supports all types of accounts for testing purposes.
-    let wallet_component = AccountComponent::compile(
-        BASIC_WALLET_CODE,
-        assembler.clone(),
-        vec![StorageSlot::Value(Word::default()), StorageSlot::Map(StorageMap::default())],
-    )
-    .unwrap()
-    .with_supports_all_types();
-
-    let (account_code, account_storage) = Account::initialize_from_components(
-        account_id.account_type(),
-        &[RpoFalcon512::new(PublicKey::new(public_key)).into(), wallet_component],
-    )
-    .unwrap();
-
-    let account_vault = match assets {
-        Some(asset) => AssetVault::new(&[asset]).unwrap(),
-        None => AssetVault::new(&[]).unwrap(),
-    };
-
-    Account::from_parts(account_id, account_vault, account_storage, account_code, Felt::new(1))
 }
 
 #[cfg(test)]

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -166,7 +166,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
 
     let note = get_note_with_fungible_asset_and_script(fungible_asset, note_script);
 
-    mock_chain.add_note(note.clone());
+    mock_chain.add_pending_note(note.clone());
     mock_chain.seal_block(None);
 
     // CONSTRUCT AND EXECUTE TX (Success)

--- a/miden-tx/tests/integration/scripts/swap.rs
+++ b/miden-tx/tests/integration/scripts/swap.rs
@@ -84,7 +84,7 @@ fn prove_consume_swap_note() {
     // --------------------------------------------------------------------------------------------
 
     let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![requested_asset]);
-    mock_chain.add_note(note.clone());
+    mock_chain.add_pending_note(note.clone());
     mock_chain.seal_block(None);
 
     let consume_swap_note_tx = mock_chain

--- a/objects/src/accounts/builder/mod.rs
+++ b/objects/src/accounts/builder/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 ///
 /// This will build a valid new account with these properties:
 /// - An empty [`AssetVault`].
-/// - The nonce set to [`ZERO`].
+/// - The nonce set to [`Felt::ZERO`].
 /// - A seed which results in an [`AccountId`] valid for the configured account type and storage
 ///   mode.
 ///
@@ -182,7 +182,8 @@ impl AccountBuilder {
 impl AccountBuilder {
     /// Adds all the assets to the account's [`AssetVault`]. This method is optional.
     ///
-    /// Must only be called when nonce is non-[`ZERO`] since new accounts must have an empty vault.
+    /// Must only be called when nonce is non-[`Felt::ZERO`] since new accounts must have an empty
+    /// vault.
     pub fn with_assets<I: IntoIterator<Item = Asset>>(mut self, assets: I) -> Self {
         self.assets.extend(assets);
         self

--- a/objects/src/accounts/builder/mod.rs
+++ b/objects/src/accounts/builder/mod.rs
@@ -182,8 +182,8 @@ impl AccountBuilder {
 impl AccountBuilder {
     /// Adds all the assets to the account's [`AssetVault`]. This method is optional.
     ///
-    /// Must only be called when nonce is non-[`Felt::ZERO`] since new accounts must have an empty
-    /// vault.
+    /// Must only be used when using [`Self::build_existing`] instead of [`Self::build`] since new
+    /// accounts must have an empty vault.
     pub fn with_assets<I: IntoIterator<Item = Asset>>(mut self, assets: I) -> Self {
         self.assets.extend(assets);
         self

--- a/objects/src/accounts/builder/mod.rs
+++ b/objects/src/accounts/builder/mod.rs
@@ -1,5 +1,6 @@
 use alloc::{boxed::Box, vec::Vec};
 
+use vm_core::FieldElement;
 use vm_processor::Digest;
 
 use crate::{
@@ -104,14 +105,6 @@ impl AccountBuilder {
         #[cfg(all(not(feature = "testing"), not(test)))]
         let vault = AssetVault::default();
 
-        #[cfg(any(feature = "testing", test))]
-        if self.nonce == ZERO && !vault.is_empty() {
-            return Err(AccountError::BuildError(
-                "account asset vault must be empty on new accounts".into(),
-                None,
-            ));
-        }
-
         let (code, storage) =
             Account::initialize_from_components(self.account_type, &self.components).map_err(
                 |err| {
@@ -167,6 +160,14 @@ impl AccountBuilder {
     pub fn build(self) -> Result<(Account, Word), AccountError> {
         let (init_seed, vault, code, storage) = self.build_inner()?;
 
+        #[cfg(any(feature = "testing", test))]
+        if !vault.is_empty() {
+            return Err(AccountError::BuildError(
+                "account asset vault must be empty on new accounts".into(),
+                None,
+            ));
+        }
+
         let (account_id, seed) =
             self.grind_account_id(init_seed, code.commitment(), storage.commitment())?;
 
@@ -181,14 +182,6 @@ impl AccountBuilder {
 
 #[cfg(any(feature = "testing", test))]
 impl AccountBuilder {
-    /// Sets the nonce of the account. This method is optional.
-    ///
-    /// If unset, the nonce will default to [`ZERO`].
-    pub fn nonce(mut self, nonce: Felt) -> Self {
-        self.nonce = nonce;
-        self
-    }
-
     /// Adds all the assets to the account's [`AssetVault`]. This method is optional.
     ///
     /// Must only be called when nonce is non-[`ZERO`] since new accounts must have an empty vault.
@@ -197,33 +190,24 @@ impl AccountBuilder {
         self
     }
 
-    /// The build method optimized for testing scenarios. The only difference between this method
-    /// and the [`Self::build`] method is that when building existing accounts, this function
-    /// returns `None` for the seed, skips the grinding of an account id and constructs one
-    /// instead. Hence it is always preferable to use this method in testing code.
+    /// Builds the account as an existing account, that is, with the nonce set to [`Felt::ONE`].
+    ///
+    /// The [`AccountId`] is constructed by slightly modifying `init_seed[0..8]` to be a valid ID.
     ///
     /// For possible errors, see the documentation of [`Self::build`].
-    pub fn build_testing(self) -> Result<(Account, Option<Word>), AccountError> {
+    pub fn build_existing(mut self) -> Result<Account, AccountError> {
+        // Set nonce to one so that the asset-vault-empty-on-new-account check does not trigger.
+        self.nonce = Felt::ONE;
+
         let (init_seed, vault, code, storage) = self.build_inner()?;
 
-        let (account_id, seed) = if self.nonce == ZERO {
-            let (account_id, seed) =
-                self.grind_account_id(init_seed, code.commitment(), storage.commitment())?;
-
-            (account_id, Some(seed))
-        } else {
+        let account_id = {
             let bytes = <[u8; 8]>::try_from(&init_seed[0..8])
                 .expect("we should have sliced exactly 8 bytes off");
-
-            let account_id =
-                AccountId::new_with_type_and_mode(bytes, self.account_type, self.storage_mode);
-
-            (account_id, None)
+            AccountId::new_with_type_and_mode(bytes, self.account_type, self.storage_mode)
         };
 
-        let account = Account::from_parts(account_id, vault, storage, code, self.nonce);
-
-        Ok((account, seed))
+        Ok(Account::from_parts(account_id, vault, storage, code, Felt::ONE))
     }
 }
 

--- a/objects/src/accounts/builder/mod.rs
+++ b/objects/src/accounts/builder/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         AccountType,
     },
     assets::{Asset, AssetVault},
-    AccountError, Felt, Word, ZERO,
+    AccountError, Felt, Word,
 };
 
 /// A convenient builder for an [`Account`] allowing for safe construction of an account by
@@ -35,7 +35,6 @@ use crate::{
 /// - Set assets which will be placed in the account's vault.
 #[derive(Debug, Clone)]
 pub struct AccountBuilder {
-    nonce: Felt,
     #[cfg(any(feature = "testing", test))]
     assets: Vec<Asset>,
     components: Vec<AccountComponent>,
@@ -48,7 +47,6 @@ impl AccountBuilder {
     /// Creates a new builder for a single account.
     pub fn new() -> Self {
         Self {
-            nonce: ZERO,
             #[cfg(any(feature = "testing", test))]
             assets: vec![],
             components: vec![],
@@ -174,7 +172,7 @@ impl AccountBuilder {
         debug_assert_eq!(account_id.account_type(), self.account_type);
         debug_assert_eq!(account_id.storage_mode(), self.storage_mode);
 
-        let account = Account::from_parts(account_id, vault, storage, code, self.nonce);
+        let account = Account::from_parts(account_id, vault, storage, code, Felt::ZERO);
 
         Ok((account, seed))
     }
@@ -195,10 +193,7 @@ impl AccountBuilder {
     /// The [`AccountId`] is constructed by slightly modifying `init_seed[0..8]` to be a valid ID.
     ///
     /// For possible errors, see the documentation of [`Self::build`].
-    pub fn build_existing(mut self) -> Result<Account, AccountError> {
-        // Set nonce to one so that the asset-vault-empty-on-new-account check does not trigger.
-        self.nonce = Felt::ONE;
-
+    pub fn build_existing(self) -> Result<Account, AccountError> {
         let (init_seed, vault, code, storage) = self.build_inner()?;
 
         let account_id = {

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -140,7 +140,7 @@ impl Account {
     /// - Two or more libraries export a procedure with the same MAST root.
     /// - The number of [`StorageSlot`]s of all components exceeds 255.
     /// - [`MastForest::merge`](vm_processor::MastForest::merge) fails on all libraries.
-    pub fn initialize_from_components(
+    pub(super) fn initialize_from_components(
         account_type: AccountType,
         components: &[AccountComponent],
     ) -> Result<(AccountCode, AccountStorage), AccountError> {


### PR DESCRIPTION
## Changes

- Remove `AccountBuilder::build_testing` and add `AccountBuilder::build_existing`. This means we have a clear separation now between `AccountBuilder::build` which builds a new account and is available generally and `AccountBuilder::build_existing` which builds an existing account and is available only under `testing`.
- Make `Account::initialize_from_components` private and replace usages with `AccountBuilder`. It turns out that we don't need to build accounts with a specific `AccountId` anywhere in tests so those occurrences were changed to generate a new one instead.
- The `nonce` field in the `AccountBuilder` was no longer needed so I removed it. The nonce is set in `build` and `build_existing` directly.
- The methods on `MockChain` to add new accounts were all adding the build accounts to `MockChain::available_accounts` and some methods also to `MockChain::pending_objects` which seemed unnecessary. I'm not 100% sure whether this is fine though.

closes #949

Builds on top of #871 and should be merged after that one but is otherwise ready for review.