### PR TITLE
Add error messages to `miden-objects` errors and implement `core::error::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [BREAKING] Better error display when queues are full in the prover service (#967).
 - [BREAKING] Remove `AccountBuilder::build_testing` and make `Account::initialize_from_components` private (#969).
+- [BREAKING] Add error messages to errors and implement `core::error::Error` (#974).
 
 ## 0.6.1 (2024-11-08)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "rand",
  "rstest",
  "tempfile",
+ "thiserror 2.0.3",
  "winter-rand-utils",
 ]
 
@@ -2069,7 +2070,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.68",
  "unicode-width 0.1.14",
 ]
 
@@ -2801,7 +2802,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2888,7 +2889,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2900,7 +2901,7 @@ dependencies = [
  "logos",
  "miette",
  "prost-types",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2979,7 +2980,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3383,7 +3384,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "url",
  "uuid",
@@ -3771,7 +3772,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -3783,6 +3793,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4066,7 +4087,7 @@ dependencies = [
  "httparse",
  "js-sys",
  "pin-project",
- "thiserror",
+ "thiserror 1.0.68",
  "tonic",
  "tower-service",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1918,7 @@ dependencies = [
 name = "miden-objects"
 version = "0.7.0"
 dependencies = [
+ "assert_matches",
  "criterion",
  "getrandom",
  "log",
@@ -1985,6 +1992,7 @@ dependencies = [
 name = "miden-tx"
 version = "0.7.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "miden-assembly",
  "miden-lib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size",
  "textwrap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
@@ -2802,7 +2802,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2889,7 +2889,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2901,7 +2901,7 @@ dependencies = [
  "logos",
  "miette",
  "prost-types",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2980,7 +2980,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3384,7 +3384,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "time",
  "url",
  "uuid",
@@ -3772,7 +3772,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4087,7 +4087,7 @@ dependencies = [
  "httparse",
  "js-sys",
  "pin-project",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tonic",
  "tower-service",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ lto = true
 
 [workspace.dependencies]
 assembly = { package = "miden-assembly", version = "0.11", default-features = false }
+assert_matches = { version = "1.5.0", default-features = false }
 miden-crypto = { version = "0.12", default-features = false }
 miden-lib = { path = "miden-lib", version = "0.7", default-features = false }
 miden-objects = { path = "objects", version = "0.7", default-features = false }
@@ -41,7 +42,6 @@ miden-stdlib = { version = "0.11", default-features = false }
 miden-tx = { path = "miden-tx", version = "0.7", default-features = false }
 miden-verifier = { version = "0.11", default-features = false }
 rand = { version = "0.8", default-features = false }
+thiserror = { version = "2", default-features = false }
 vm-core = { package = "miden-core", version = "0.11", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.11", default-features = false }
-assert_matches = { version = "1.5.0", default-features = false }
-thiserror = { version = "2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ miden-verifier = { version = "0.11", default-features = false }
 rand = { version = "0.8", default-features = false }
 vm-core = { package = "miden-core", version = "0.11", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.11", default-features = false }
+assert_matches = { version = "1.5.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ rand = { version = "0.8", default-features = false }
 vm-core = { package = "miden-core", version = "0.11", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.11", default-features = false }
 assert_matches = { version = "1.5.0", default-features = false }
+thiserror = { version = "2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ lto = true
 
 [workspace.dependencies]
 assembly = { package = "miden-assembly", version = "0.11", default-features = false }
-assert_matches = { version = "1.5.0", default-features = false }
+assert_matches = { version = "1.5", default-features = false }
 miden-crypto = { version = "0.12", default-features = false }
 miden-lib = { path = "miden-lib", version = "0.7", default-features = false }
 miden-objects = { path = "objects", version = "0.7", default-features = false }
@@ -42,6 +42,6 @@ miden-stdlib = { version = "0.11", default-features = false }
 miden-tx = { path = "miden-tx", version = "0.7", default-features = false }
 miden-verifier = { version = "0.11", default-features = false }
 rand = { version = "0.8", default-features = false }
-thiserror = { version = "2", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 vm-core = { package = "miden-core", version = "0.11", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.11", default-features = false }

--- a/bin/tx-prover/src/lib.rs
+++ b/bin/tx-prover/src/lib.rs
@@ -39,3 +39,5 @@ impl std::fmt::Display for RemoteTransactionProverError {
         }
     }
 }
+
+impl core::error::Error for RemoteTransactionProverError {}

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -51,8 +51,8 @@ pub fn create_basic_wallet(
     account_storage_mode: AccountStorageMode,
 ) -> Result<(Account, Word), AccountError> {
     if matches!(account_type, AccountType::FungibleFaucet | AccountType::NonFungibleFaucet) {
-        return Err(AccountError::AccountIdInvalidFieldElement(
-            "Basic wallet accounts cannot have a faucet account type".to_string(),
+        return Err(AccountError::AssumptionViolated(
+            "basic wallet accounts cannot have a faucet account type".to_string(),
         ));
     }
 

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -117,8 +117,7 @@ impl fmt::Display for TransactionKernelError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionKernelError {}
+impl core::error::Error for TransactionKernelError {}
 
 // TRANSACTION EVENT PARSING ERROR
 // ================================================================================================
@@ -142,8 +141,7 @@ impl fmt::Display for TransactionEventParsingError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionEventParsingError {}
+impl core::error::Error for TransactionEventParsingError {}
 
 // TRANSACTION TRACE PARSING ERROR
 // ================================================================================================
@@ -167,5 +165,4 @@ impl fmt::Display for TransactionTraceParsingError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionTraceParsingError {}
+impl core::error::Error for TransactionTraceParsingError {}

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -8,7 +8,7 @@ use miden_objects::{
 // TRANSACTION KERNEL ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum TransactionKernelError {
     AccountDeltaError(AccountDeltaError),
     FailedToAddAssetToNote(NoteError),
@@ -123,7 +123,7 @@ impl std::error::Error for TransactionKernelError {}
 // TRANSACTION EVENT PARSING ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum TransactionEventParsingError {
     InvalidTransactionEvent(u32),
     NotTransactionEvent(u32),
@@ -148,7 +148,7 @@ impl std::error::Error for TransactionEventParsingError {}
 // TRANSACTION TRACE PARSING ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum TransactionTraceParsingError {
     InvalidTransactionTrace(u32),
     NotTransactionTrace(u32),

--- a/miden-lib/src/transaction/mod.rs
+++ b/miden-lib/src/transaction/mod.rs
@@ -272,18 +272,18 @@ impl TransactionKernel {
         let final_account_data: &[Word] = group_slice_elements(
             adv_map
                 .get(&final_acct_hash)
-                .ok_or(TransactionOutputError::FinalAccountDataNotFound)?,
+                .ok_or(TransactionOutputError::FinalAccountHashMissingInAdviceMap)?,
         );
         let account = parse_final_account_header(final_account_data)
-            .map_err(TransactionOutputError::FinalAccountHeaderDataInvalid)?;
+            .map_err(TransactionOutputError::FinalAccountHeaderParseFailure)?;
 
         // validate output notes
         let output_notes = OutputNotes::new(output_notes)?;
         if output_notes_hash != output_notes.commitment() {
-            return Err(TransactionOutputError::OutputNotesCommitmentInconsistent(
-                output_notes_hash,
-                output_notes.commitment(),
-            ));
+            return Err(TransactionOutputError::OutputNotesCommitmentInconsistent {
+                actual: output_notes.commitment(),
+                expected: output_notes_hash,
+            });
         }
 
         Ok(TransactionOutputs {

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -27,7 +27,10 @@ pub const EXPIRATION_BLOCK_ELEMENT_IDX: usize = 8;
 /// Returns a tuple of account ID, vault root, storage commitment, code commitment, and nonce.
 pub fn parse_final_account_header(elements: &[Word]) -> Result<AccountHeader, AccountError> {
     if elements.len() != ACCT_DATA_MEM_SIZE {
-        return Err(AccountError::HeaderDataIncorrectLength(elements.len(), ACCT_DATA_MEM_SIZE));
+        return Err(AccountError::HeaderDataIncorrectLength {
+            actual: elements.len(),
+            expected: ACCT_DATA_MEM_SIZE,
+        });
     }
 
     let id = AccountId::try_from(elements[ACCT_ID_AND_NONCE_OFFSET as usize][ACCT_ID_IDX])?;

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -36,5 +36,6 @@ winter-maybe-async = { version = "0.10" }
 
 [dev-dependencies]
 assembly = { workspace = true }
+assert_matches = { workspace = true }
 miden-tx = { path = ".", features = ["testing"] }
 rand_chacha = { version = "0.3", default-features = false }

--- a/miden-tx/src/errors/mod.rs
+++ b/miden-tx/src/errors/mod.rs
@@ -33,8 +33,7 @@ impl fmt::Display for TransactionExecutorError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionExecutorError {}
+impl core::error::Error for TransactionExecutorError {}
 
 // TRANSACTION PROVER ERROR
 // ================================================================================================
@@ -74,8 +73,7 @@ impl Display for TransactionProverError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionProverError {}
+impl core::error::Error for TransactionProverError {}
 
 // TRANSACTION VERIFIER ERROR
 // ================================================================================================
@@ -92,8 +90,7 @@ impl fmt::Display for TransactionVerifierError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionVerifierError {}
+impl core::error::Error for TransactionVerifierError {}
 
 // TRANSACTION HOST ERROR
 // ================================================================================================
@@ -109,8 +106,7 @@ impl fmt::Display for TransactionHostError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TransactionHostError {}
+impl core::error::Error for TransactionHostError {}
 
 // DATA STORE ERROR
 // ================================================================================================
@@ -131,8 +127,7 @@ impl fmt::Display for DataStoreError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DataStoreError {}
+impl core::error::Error for DataStoreError {}
 
 // AUTHENTICATION ERROR
 // ================================================================================================
@@ -158,5 +153,4 @@ impl fmt::Display for AuthenticationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AuthenticationError {}
+impl core::error::Error for AuthenticationError {}

--- a/miden-tx/src/errors/mod.rs
+++ b/miden-tx/src/errors/mod.rs
@@ -11,7 +11,7 @@ use vm_processor::ExecutionError;
 // TRANSACTION EXECUTOR ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionExecutorError {
     ExecuteTransactionProgramFailed(ExecutionError),
     FetchTransactionInputsFailed(DataStoreError),
@@ -39,7 +39,7 @@ impl std::error::Error for TransactionExecutorError {}
 // TRANSACTION PROVER ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionProverError {
     InternalError(String),
     InvalidAccountDelta(AccountError),
@@ -80,7 +80,7 @@ impl std::error::Error for TransactionProverError {}
 // TRANSACTION VERIFIER ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionVerifierError {
     TransactionVerificationFailed(VerificationError),
     InsufficientProofSecurityLevel(u32, u32),
@@ -98,7 +98,7 @@ impl std::error::Error for TransactionVerifierError {}
 // TRANSACTION HOST ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionHostError {
     AccountProcedureIndexMapError(String),
 }
@@ -115,7 +115,7 @@ impl std::error::Error for TransactionHostError {}
 // DATA STORE ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum DataStoreError {
     AccountNotFound(AccountId),
     BlockNotFound(u32),
@@ -137,7 +137,7 @@ impl std::error::Error for DataStoreError {}
 // AUTHENTICATION ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum AuthenticationError {
     InternalError(String),
     RejectedSignature(String),

--- a/miden-tx/src/tests/kernel_tests/test_asset_vault.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset_vault.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use miden_lib::{
     errors::tx_kernel_errors::{
         ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW,
@@ -366,10 +367,10 @@ fn test_remove_inexisting_non_fungible_asset_fails() {
     let nonfungible = NonFungibleAsset::new(&non_fungible_asset_details).unwrap();
     let non_existent_non_fungible_asset = Asset::NonFungible(nonfungible);
 
-    assert_eq!(
-        account_vault.remove_asset(non_existent_non_fungible_asset),
-        Err(AssetVaultError::NonFungibleAssetNotFound(nonfungible)),
-        "Asset must not be in the vault before the test",
+    assert_matches!(
+        account_vault.remove_asset(non_existent_non_fungible_asset).unwrap_err(),
+        AssetVaultError::NonFungibleAssetNotFound(err_asset) if err_asset == nonfungible,
+        "asset must not be in the vault before the test",
     );
 
     let code = format!(
@@ -389,10 +390,10 @@ fn test_remove_inexisting_non_fungible_asset_fails() {
     let process = tx_context.execute_code(&code);
 
     assert_execution_error!(process, ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND);
-    assert_eq!(
-        account_vault.remove_asset(non_existent_non_fungible_asset),
-        Err(AssetVaultError::NonFungibleAssetNotFound(nonfungible)),
-        "Asset should not be in the vault after the test",
+    assert_matches!(
+        account_vault.remove_asset(non_existent_non_fungible_asset).unwrap_err(),
+        AssetVaultError::NonFungibleAssetNotFound(err_asset) if err_asset == nonfungible,
+        "asset should not be in the vault after the test",
     );
 }
 

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -189,9 +189,12 @@ fn executed_transaction_account_delta_new() {
 
     let note_types = [NoteType::Private; 3];
 
-    assert_eq!(tag1.validate(NoteType::Private), Ok(tag1));
-    assert_eq!(tag2.validate(NoteType::Private), Ok(tag2));
-    assert_eq!(tag3.validate(NoteType::Private), Ok(tag3));
+    tag1.validate(NoteType::Private)
+        .expect("note tag 1 should support private notes");
+    tag2.validate(NoteType::Private)
+        .expect("note tag 2 should support private notes");
+    tag3.validate(NoteType::Private)
+        .expect("note tag 3 should support private notes");
 
     let execution_hint_1 = Felt::from(NoteExecutionHint::always());
     let execution_hint_2 = Felt::from(NoteExecutionHint::none());
@@ -466,7 +469,7 @@ fn test_send_note_proc() {
     let aux = Felt::new(27);
     let note_type = NoteType::Private;
 
-    assert_eq!(tag.validate(note_type), Ok(tag));
+    tag.validate(note_type).expect("note tag should support private notes");
 
     // prepare the asset vector to be removed for each test variant
     let assets_matrix = vec![
@@ -627,9 +630,9 @@ fn executed_transaction_output_notes() {
     let note_type2 = NoteType::Public;
     let note_type3 = NoteType::Public;
 
-    assert_eq!(tag1.validate(note_type1), Ok(tag1));
-    assert_eq!(tag2.validate(note_type2), Ok(tag2));
-    assert_eq!(tag3.validate(note_type3), Ok(tag3));
+    tag1.validate(note_type1).expect("note tag 1 should support private notes");
+    tag2.validate(note_type2).expect("note tag 2 should support public notes");
+    tag3.validate(note_type3).expect("note tag 3 should support public notes");
 
     // In this test we create 3 notes. Note 1 is private, Note 2 is public and Note 3 is public
     // without assets.

--- a/miden-tx/tests/integration/scripts/faucet.rs
+++ b/miden-tx/tests/integration/scripts/faucet.rs
@@ -35,7 +35,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     let note_type = NoteType::Private;
     let amount = Felt::new(100);
 
-    assert_eq!(tag.validate(note_type), Ok(tag));
+    tag.validate(note_type).expect("note tag should support private notes");
 
     let tx_script_code = format!(
         "

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -34,6 +34,7 @@ rand = { workspace = true, optional = true }
 vm-core = { workspace = true }
 vm-processor = { workspace = true }
 winter-rand-utils = { version = "0.10", optional = true }
+thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -43,3 +43,4 @@ criterion = { version = "0.5", default-features = false, features = ["html_repor
 miden-objects = { path = ".", features = ["testing"] }
 rstest = { version = "0.23" }
 tempfile = { version = "3.14" }
+assert_matches = { workspace = true }

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -31,17 +31,17 @@ log = { version = "0.4", optional = true }
 miden-crypto = { workspace = true }
 miden-verifier = { workspace = true }
 rand = { workspace = true, optional = true }
+thiserror = { workspace = true }
 vm-core = { workspace = true }
 vm-processor = { workspace = true }
 winter-rand-utils = { version = "0.10", optional = true }
-thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
 miden-objects = { path = ".", features = ["testing"] }
 rstest = { version = "0.23" }
 tempfile = { version = "3.14" }
-assert_matches = { workspace = true }

--- a/objects/src/accounts/code/mod.rs
+++ b/objects/src/accounts/code/mod.rs
@@ -75,7 +75,7 @@ impl AccountCode {
     ) -> Result<Self, AccountError> {
         let (merged_mast_forest, _) =
             MastForest::merge(components.iter().map(|component| component.mast_forest()))
-                .map_err(|err| AccountError::AccountCodeMergeError(err.to_string()))?;
+                .map_err(|err| AccountError::AccountComponentMergeError(err.to_string()))?;
 
         let mut procedures = Vec::new();
         let mut proc_root_set = BTreeSet::new();
@@ -94,7 +94,7 @@ impl AccountCode {
                     // procedures where the offset has already been inserted would cause that
                     // procedure of the earlier component to write to the wrong slot.
                     if !proc_root_set.insert(proc_mast_root) {
-                        return Err(AccountError::AccountCodeMergeError(format!(
+                        return Err(AccountError::AccountComponentMergeError(format!(
                             "procedure with MAST root {proc_mast_root} is present in multiple account components"
                         )));
                     }
@@ -123,10 +123,7 @@ impl AccountCode {
         if procedures.is_empty() {
             return Err(AccountError::AccountCodeNoProcedures);
         } else if procedures.len() > Self::MAX_NUM_PROCEDURES {
-            return Err(AccountError::AccountCodeTooManyProcedures {
-                max: Self::MAX_NUM_PROCEDURES,
-                actual: procedures.len(),
-            });
+            return Err(AccountError::AccountCodeTooManyProcedures(procedures.len()));
         }
 
         Ok(Self {
@@ -367,6 +364,6 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(err, AccountError::StorageOffsetOutOfBounds { actual: 256, .. }))
+        assert!(matches!(err, AccountError::StorageOffsetPlusSizeOutOfBounds(256)))
     }
 }

--- a/objects/src/accounts/component/mod.rs
+++ b/objects/src/accounts/component/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
+use alloc::{collections::BTreeSet, vec::Vec};
 
 use assembly::{Assembler, Compile, Library};
 use vm_processor::MastForest;
@@ -78,7 +78,7 @@ impl AccountComponent {
     ) -> Result<Self, AccountError> {
         let library = assembler
             .assemble_library([source_code])
-            .map_err(|report| AccountError::AccountCodeAssemblyError(report.to_string()))?;
+            .map_err(AccountError::AccountComponentAssemblyError)?;
 
         Self::new(library, storage_slots)
     }

--- a/objects/src/accounts/delta/mod.rs
+++ b/objects/src/accounts/delta/mod.rs
@@ -57,7 +57,7 @@ impl AccountDelta {
         match (&mut self.nonce, other.nonce) {
             (Some(old), Some(new)) if new.as_int() <= old.as_int() => {
                 return Err(AccountDeltaError::InconsistentNonceUpdate(format!(
-                    "New nonce {new} is not larger than the old nonce {old}"
+                    "new nonce {new} is not larger than the old nonce {old}"
                 )))
             },
             // Incoming nonce takes precedence.
@@ -123,11 +123,11 @@ impl AccountUpdateDetails {
                 AccountUpdateDetails::Private
             },
             (AccountUpdateDetails::New(mut account), AccountUpdateDetails::Delta(delta)) => {
-                account.apply_delta(&delta).map_err(|_| {
-                    AccountDeltaError::IncompatibleAccountUpdates(
-                        AccountUpdateDetails::New(account.clone()),
-                        AccountUpdateDetails::Delta(delta),
-                    )
+                account.apply_delta(&delta).map_err(|err| {
+                    AccountDeltaError::AccountDeltaApplicationFailed {
+                        account_id: account.id(),
+                        source: err,
+                    }
                 })?;
 
                 AccountUpdateDetails::New(account)
@@ -137,11 +137,23 @@ impl AccountUpdateDetails {
                 AccountUpdateDetails::Delta(delta)
             },
             (left, right) => {
-                return Err(AccountDeltaError::IncompatibleAccountUpdates(left, right))
+                return Err(AccountDeltaError::IncompatibleAccountUpdates {
+                    left_update_type: left.as_tag_str(),
+                    right_update_type: right.as_tag_str(),
+                })
             },
         };
 
         Ok(merged_update)
+    }
+
+    /// Returns the tag of the [`AccountUpdateDetails`] as a string for inclusion in error messages.
+    pub(crate) const fn as_tag_str(&self) -> &'static str {
+        match self {
+            AccountUpdateDetails::Private => "private",
+            AccountUpdateDetails::New(_) => "new",
+            AccountUpdateDetails::Delta(_) => "delta",
+        }
     }
 }
 

--- a/objects/src/accounts/delta/storage.rs
+++ b/objects/src/accounts/delta/storage.rs
@@ -89,7 +89,7 @@ impl AccountStorageDelta {
     fn validate(&self) -> Result<(), AccountDeltaError> {
         for slot in self.maps.keys() {
             if self.values.contains_key(slot) {
-                return Err(AccountDeltaError::DuplicateStorageItemUpdate(*slot as usize));
+                return Err(AccountDeltaError::StorageSlotUsedAsDifferentTypes(*slot));
             }
         }
 

--- a/objects/src/accounts/delta/vault.rs
+++ b/objects/src/accounts/delta/vault.rs
@@ -252,8 +252,8 @@ impl FungibleAssetDelta {
                 let new = old.checked_add(delta).ok_or(
                     AccountDeltaError::FungibleAssetDeltaOverflow {
                         faucet_id,
-                        this: old,
-                        other: delta,
+                        current: old,
+                        delta,
                     },
                 )?;
 

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -643,6 +643,6 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(err, AccountError::AccountCodeMergeError(_)))
+        assert!(matches!(err, AccountError::AccountComponentMergeError(_)))
     }
 }

--- a/objects/src/accounts/storage/header.rs
+++ b/objects/src/accounts/storage/header.rs
@@ -51,8 +51,8 @@ impl AccountStorageHeader {
     /// - If the index is out of bounds.
     pub fn slot(&self, index: usize) -> Result<&(StorageSlotType, Word), AccountError> {
         self.slots.get(index).ok_or(AccountError::StorageIndexOutOfBounds {
-            max: self.slots.len() as u8,
-            actual: index as u8,
+            slots_len: self.slots.len() as u8,
+            index: index as u8,
         })
     }
 }

--- a/objects/src/accounts/storage/mod.rs
+++ b/objects/src/accounts/storage/mod.rs
@@ -116,8 +116,8 @@ impl AccountStorage {
         self.slots
             .get(index as usize)
             .ok_or(AccountError::StorageIndexOutOfBounds {
-                max: self.slots.len() as u8,
-                actual: index,
+                slots_len: self.slots.len() as u8,
+                index,
             })
             .map(|slot| slot.value().into())
     }
@@ -129,8 +129,8 @@ impl AccountStorage {
     /// - If the [StorageSlot] is not [StorageSlotType::Map]
     pub fn get_map_item(&self, index: u8, key: Word) -> Result<Word, AccountError> {
         match self.slots.get(index as usize).ok_or(AccountError::StorageIndexOutOfBounds {
-            max: self.slots.len() as u8,
-            actual: index,
+            slots_len: self.slots.len() as u8,
+            index,
         })? {
             StorageSlot::Map(ref map) => Ok(map.get_value(&Digest::from(key))),
             _ => Err(AccountError::StorageSlotNotMap(index)),
@@ -159,7 +159,7 @@ impl AccountStorage {
             let storage_slot = self
                 .slots
                 .get_mut(idx as usize)
-                .ok_or(AccountError::StorageIndexOutOfBounds { max: len, actual: idx })?;
+                .ok_or(AccountError::StorageIndexOutOfBounds { slots_len: len, index: idx })?;
 
             let storage_map = match storage_slot {
                 StorageSlot::Map(map) => map,
@@ -191,8 +191,8 @@ impl AccountStorage {
 
         if index as usize >= num_slots {
             return Err(AccountError::StorageIndexOutOfBounds {
-                max: self.slots.len() as u8,
-                actual: index,
+                slots_len: self.slots.len() as u8,
+                index,
             });
         }
 
@@ -227,8 +227,8 @@ impl AccountStorage {
 
         if index as usize >= num_slots {
             return Err(AccountError::StorageIndexOutOfBounds {
-                max: self.slots.len() as u8,
-                actual: index,
+                slots_len: self.slots.len() as u8,
+                index,
             });
         }
 

--- a/objects/src/assets/token_symbol.rs
+++ b/objects/src/assets/token_symbol.rs
@@ -1,4 +1,4 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
 
 use super::{AssetError, Felt};
 
@@ -39,7 +39,11 @@ impl TryFrom<Felt> for TokenSymbol {
     fn try_from(felt: Felt) -> Result<Self, Self::Error> {
         // Check if the felt value is within the valid range
         if felt.as_int() >= TokenSymbol::MAX_ENCODED_VALUE {
-            return Err(AssetError::TokenSymbolError("Encoded value is too large".to_string()));
+            return Err(AssetError::TokenSymbolError(format!(
+                "token symbol value {} cannot exceed {}",
+                felt.as_int(),
+                TokenSymbol::MAX_ENCODED_VALUE
+            )));
         }
         Ok(TokenSymbol(felt))
     }
@@ -51,13 +55,15 @@ impl TryFrom<Felt> for TokenSymbol {
 // characters , e.g., A = 0, ...
 fn encode_symbol_to_felt(s: &str) -> Result<Felt, AssetError> {
     if s.is_empty() || s.len() > TokenSymbol::MAX_SYMBOL_LENGTH {
-        return Err(AssetError::TokenSymbolError(
-            "Token symbol must be between 1 and 6 characters long.".to_string(),
-        ));
+        return Err(AssetError::TokenSymbolError(format!(
+            "token symbol of length {} is not between 1 and 6 characters long",
+            s.len()
+        )));
     } else if s.chars().any(|c| !c.is_ascii_uppercase()) {
-        return Err(AssetError::TokenSymbolError(
-            "Token Symbol contains characters that are not ASCII upper case".to_string(),
-        ));
+        return Err(AssetError::TokenSymbolError(format!(
+            "token symbol {} contains characters that are not uppercase ASCII",
+            s
+        )));
     }
 
     let mut encoded_value = 0;

--- a/objects/src/assets/vault.rs
+++ b/objects/src/assets/vault.rs
@@ -50,11 +50,7 @@ impl AssetVault {
     }
 
     /// Returns true if the specified non-fungible asset is stored in this vault.
-    pub fn has_non_fungible_asset(&self, asset: Asset) -> Result<bool, AssetVaultError> {
-        if asset.is_fungible() {
-            return Err(AssetVaultError::NotANonFungibleAsset(asset));
-        }
-
+    pub fn has_non_fungible_asset(&self, asset: NonFungibleAsset) -> Result<bool, AssetVaultError> {
         // check if the asset is stored in the vault
         match self.asset_tree.get_value(&asset.vault_key().into()) {
             asset if asset == Smt::EMPTY_VALUE => Ok(false),
@@ -140,7 +136,7 @@ impl AssetVault {
         })
     }
 
-    /// Add the specified fungible asset to the vault.  If the vault already contains an asset
+    /// Add the specified fungible asset to the vault. If the vault already contains an asset
     /// issued by the same faucet, the amounts are added together.
     ///
     /// # Errors

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -57,7 +57,8 @@ pub enum AccountError {
     FungibleFaucetMaxSupplyTooLarge { actual: u64, max: u64 },
     #[error("account header data has length {actual} but it must be of length {expected}")]
     HeaderDataIncorrectLength { actual: usize, expected: usize },
-    // TODO: Make #[source] and remove from msg once HexParseError implements Error trait in no-std.
+    // TODO: Make #[source] and remove from msg once HexParseError implements Error trait in
+    // no-std.
     #[error("failed to parse hex string into account id: {0}")]
     AccountIdHexParseError(HexParseError),
     #[error("`{0}` is not a valid account storage mode")]

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -216,9 +216,8 @@ pub enum NoteError {
     NetworkExecutionRequiresPublicNote(NoteType),
     #[error("failed to assemble note script:\n{}", PrintDiagnostic::new(.0))]
     NoteScriptAssemblyError(Report),
-    /// TODO: Turn into #[source] once it implements Error.
-    #[error("failed to deserialize note script: {0}")]
-    NoteScriptDeserializationError(DeserializationError),
+    #[error("failed to deserialize note script")]
+    NoteScriptDeserializationError(#[source] DeserializationError),
     #[error("public use case requires a public note but note is of type {0:?}")]
     PublicUseCaseRequiresPublicNote(NoteType),
     #[error("note contains {0} assets which exceeds the maximum of {max}", max = NoteAssets::MAX_NUM_ASSETS)]

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -176,7 +176,7 @@ pub enum AssetVaultError {
 // NOTE ERROR
 // ================================================================================================
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum NoteError {
     DuplicateFungibleAsset(AccountId),
     DuplicateNonFungibleAsset(NonFungibleAsset),
@@ -388,46 +388,20 @@ impl std::error::Error for ProvenTransactionError {}
 // BLOCK VALIDATION ERROR
 // ================================================================================================
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum BlockError {
+    #[error("duplicate note with id {0} in the block")]
     DuplicateNoteFound(NoteId),
+    #[error("too many accounts updated in the block (max: {MAX_ACCOUNTS_PER_BLOCK}, actual: {0})")]
     TooManyAccountUpdates(usize),
+    #[error("too many notes in the batch (max: {MAX_OUTPUT_NOTES_PER_BATCH}, actual: {0})")]
     TooManyNotesInBatch(usize),
+    #[error("too many notes in the block (max: {MAX_OUTPUT_NOTES_PER_BLOCK}, actual: {0})")]
     TooManyNotesInBlock(usize),
+    #[error("too many nullifiers in the block (max: {MAX_INPUT_NOTES_PER_BLOCK}, actual: {0})")]
     TooManyNullifiersInBlock(usize),
+    #[error(
+        "too many transaction batches in the block (max: {MAX_BATCHES_PER_BLOCK}, actual: {0})"
+    )]
     TooManyTransactionBatches(usize),
 }
-
-impl fmt::Display for BlockError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BlockError::DuplicateNoteFound(id) => {
-                write!(f, "Duplicate note {id} found in the block")
-            },
-            BlockError::TooManyAccountUpdates(actual) => {
-                write!(f, "Too many accounts updated in a block. Max: {MAX_ACCOUNTS_PER_BLOCK}, actual: {actual}")
-            },
-            BlockError::TooManyNotesInBatch(actual) => {
-                write!(f, "Too many notes in a batch. Max: {MAX_OUTPUT_NOTES_PER_BATCH}, actual: {actual}")
-            },
-            BlockError::TooManyNotesInBlock(actual) => {
-                write!(f, "Too many notes in a block. Max: {MAX_OUTPUT_NOTES_PER_BLOCK}, actual: {actual}")
-            },
-            BlockError::TooManyNullifiersInBlock(actual) => {
-                write!(
-                    f,
-                    "Too many nullifiers in a block. Max: {MAX_INPUT_NOTES_PER_BLOCK}, actual: {actual}"
-                )
-            },
-            BlockError::TooManyTransactionBatches(actual) => {
-                write!(
-                    f,
-                    "Too many transaction batches. Max: {MAX_BATCHES_PER_BLOCK}, actual: {actual}"
-                )
-            },
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for BlockError {}

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -87,8 +87,7 @@ impl fmt::Display for AccountError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AccountError {}
+impl core::error::Error for AccountError {}
 
 // ACCOUNT DELTA ERROR
 // ================================================================================================
@@ -165,8 +164,9 @@ pub enum AssetError {
 pub enum AssetVaultError {
     #[error("adding fungible asset amounts would exceed maximum allowed amount")]
     AddFungibleAssetBalanceError(#[source] AssetError),
-    #[error("provided assets contain duplicates")]
-    DuplicateAsset(#[source] MerkleError),
+    // TODO: Make #[source] and remove from msg once MerkleError implements Error trait in no-std.
+    #[error("provided assets contain duplicates: {0}")]
+    DuplicateAsset(MerkleError),
     #[error("non fungible asset {0} already exists in the vault")]
     DuplicateNonFungibleAsset(NonFungibleAsset),
     #[error("fungible asset {0} does not exist in the vault")]

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -20,7 +20,7 @@ use crate::{
 // ACCOUNT ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum AccountError {
     AccountCodeAssemblyError(String), // TODO: use Report
     AccountCodeMergeError(String),    // TODO: use MastForestError once it implements Clone
@@ -91,7 +91,7 @@ impl std::error::Error for AccountError {}
 // ACCOUNT DELTA ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum AccountDeltaError {
     DuplicateStorageItemUpdate(usize),
     DuplicateNonFungibleVaultUpdate(NonFungibleAsset),
@@ -117,7 +117,7 @@ impl fmt::Display for AccountDeltaError {
 // ASSET ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum AssetError {
     AmountTooBig(u64),
     AssetAmountNotSufficient(u64, u64),
@@ -145,7 +145,7 @@ impl std::error::Error for AssetError {}
 // ASSET VAULT ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum AssetVaultError {
     AddFungibleAssetBalanceError(AssetError),
     DuplicateAsset(MerkleError),
@@ -169,7 +169,7 @@ impl std::error::Error for AssetVaultError {}
 // NOTE ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum NoteError {
     DuplicateFungibleAsset(AccountId),
     DuplicateNonFungibleAsset(NonFungibleAsset),
@@ -227,7 +227,7 @@ impl std::error::Error for NoteError {}
 // CHAIN MMR ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum ChainMmrError {
     BlockNumTooBig { chain_length: usize, block_num: u32 },
     DuplicateBlock { block_num: u32 },
@@ -260,7 +260,7 @@ impl std::error::Error for ChainMmrError {}
 // TRANSACTION SCRIPT ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionScriptError {
     AssemblyError(String), // TODO: change to Report
 }
@@ -277,7 +277,7 @@ impl std::error::Error for TransactionScriptError {}
 // TRANSACTION INPUT ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionInputError {
     AccountSeedNotProvidedForNewAccount,
     AccountSeedProvidedForExistingAccount,
@@ -303,7 +303,7 @@ impl std::error::Error for TransactionInputError {}
 // TRANSACTION OUTPUT ERROR
 // ===============================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TransactionOutputError {
     DuplicateOutputNote(NoteId),
     FinalAccountDataNotFound,
@@ -327,7 +327,7 @@ impl std::error::Error for TransactionOutputError {}
 // PROVEN TRANSACTION ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum ProvenTransactionError {
     AccountFinalHashMismatch(Digest, Digest),
     AccountIdMismatch(AccountId, AccountId),
@@ -387,7 +387,7 @@ impl std::error::Error for ProvenTransactionError {}
 // BLOCK VALIDATION ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum BlockError {
     DuplicateNoteFound(NoteId),
     TooManyAccountUpdates(usize),

--- a/objects/src/notes/assets.rs
+++ b/objects/src/notes/assets.rs
@@ -40,7 +40,7 @@ impl NoteAssets {
     /// - There are duplicate assets in the list.
     pub fn new(assets: Vec<Asset>) -> Result<Self, NoteError> {
         if assets.len() > Self::MAX_NUM_ASSETS {
-            return Err(NoteError::too_many_assets(assets.len()));
+            return Err(NoteError::TooManyAssets(assets.len()));
         }
 
         // make sure all provided assets are unique
@@ -49,8 +49,8 @@ impl NoteAssets {
             // asset in the list, and if so return an error
             if assets[..i].iter().any(|a| a.is_same(asset)) {
                 return Err(match asset {
-                    Asset::Fungible(a) => NoteError::duplicate_fungible_asset(a.faucet_id()),
-                    Asset::NonFungible(a) => NoteError::duplicate_non_fungible_asset(*a),
+                    Asset::Fungible(asset) => NoteError::DuplicateFungibleAsset(asset.faucet_id()),
+                    Asset::NonFungible(asset) => NoteError::DuplicateNonFungibleAsset(*asset),
                 });
             }
         }
@@ -127,18 +127,18 @@ impl NoteAssets {
                     // the provided asset to it
                     let new_asset = f_own_asset
                         .add(asset.unwrap_fungible())
-                        .map_err(NoteError::InvalidAssetData)?;
+                        .map_err(NoteError::AddFungibleAssetBalanceError)?;
                     *own_asset = Asset::Fungible(new_asset);
                 },
                 Asset::NonFungible(nf_asset) => {
-                    return Err(NoteError::duplicate_non_fungible_asset(*nf_asset));
+                    return Err(NoteError::DuplicateNonFungibleAsset(*nf_asset));
                 },
             }
         } else {
             // if the asset is not in the list, add it to the list
             self.assets.push(asset);
             if self.assets.len() > Self::MAX_NUM_ASSETS {
-                return Err(NoteError::too_many_assets(self.assets.len()));
+                return Err(NoteError::TooManyAssets(self.assets.len()));
             }
         }
 

--- a/objects/src/notes/execution_hint.rs
+++ b/objects/src/notes/execution_hint.rs
@@ -99,7 +99,7 @@ impl NoteExecutionHint {
 
                 Ok(hint)
             },
-            _ => Err(NoteError::InvalidNoteExecutionHintTag(tag)),
+            _ => Err(NoteError::NoteExecutionHintTagOutOfRange(tag)),
         }
     }
 

--- a/objects/src/notes/inputs.rs
+++ b/objects/src/notes/inputs.rs
@@ -33,7 +33,7 @@ impl NoteInputs {
     /// Returns an error if the number of provided inputs is greater than 128.
     pub fn new(values: Vec<Felt>) -> Result<Self, NoteError> {
         if values.len() > MAX_INPUTS_PER_NOTE {
-            return Err(NoteError::too_many_inputs(values.len()));
+            return Err(NoteError::TooManyInputs(values.len()));
         }
 
         Ok(pad_and_build(values))

--- a/objects/src/notes/location.rs
+++ b/objects/src/notes/location.rs
@@ -49,9 +49,10 @@ impl NoteInclusionProof {
     ) -> Result<Self, NoteError> {
         const HIGHEST_INDEX: usize = MAX_BATCHES_PER_BLOCK * MAX_OUTPUT_NOTES_PER_BATCH - 1;
         if node_index_in_block as usize > HIGHEST_INDEX {
-            return Err(NoteError::InvalidLocationIndex(format!(
-                "Node index ({node_index_in_block}) is out of bounds (0..={HIGHEST_INDEX})."
-            )));
+            return Err(NoteError::NoteLocationIndexOutOfBounds {
+                node_index_in_block,
+                highest_index: HIGHEST_INDEX,
+            });
         }
         let location = NoteLocation { block_num, node_index_in_block };
 

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -107,7 +107,7 @@ impl TryFrom<Word> for NoteMetadata {
     type Error = NoteError;
 
     fn try_from(elements: Word) -> Result<Self, Self::Error> {
-        let sender = elements[1].try_into().map_err(NoteError::InvalidNoteSender)?;
+        let sender = elements[1].try_into().map_err(NoteError::NoteSenderInvalidAccountId)?;
         let (note_type, note_execution_hint) = unmerge_type_and_hint(elements[2].into())?;
         let tag: u64 = elements[0].into();
         let tag: u32 =

--- a/objects/src/notes/note_tag.rs
+++ b/objects/src/notes/note_tag.rs
@@ -65,6 +65,13 @@ pub enum NoteExecutionMode {
 pub struct NoteTag(u32);
 
 impl NoteTag {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// The exponent of the maximum allowed use case id. In other words, 2^exponent is the maximum
+    /// allowed use case id.
+    pub(crate) const MAX_USE_CASE_ID_EXPONENT: u8 = 14;
+
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
@@ -127,7 +134,7 @@ impl NoteTag {
         execution: NoteExecutionMode,
     ) -> Result<Self, NoteError> {
         if (use_case_id >> 14) != 0 {
-            return Err(NoteError::InvalidNoteTagUseCase(use_case_id));
+            return Err(NoteError::NoteTagUseCaseTooLarge(use_case_id));
         }
 
         let execution_bits = match execution {
@@ -150,10 +157,10 @@ impl NoteTag {
     ///
     /// # Errors
     ///
-    /// - If `use_case_id` is larger than or equal to $2^{14}$.
+    /// - If `use_case_id` is larger than or equal to 2^14.
     pub fn for_local_use_case(use_case_id: u16, payload: u16) -> Result<Self, NoteError> {
-        if (use_case_id >> 14) != 0 {
-            return Err(NoteError::InvalidNoteTagUseCase(use_case_id));
+        if (use_case_id >> NoteTag::MAX_USE_CASE_ID_EXPONENT) != 0 {
+            return Err(NoteError::NoteTagUseCaseTooLarge(use_case_id));
         }
 
         let execution_bits = LOCAL_EXECUTION_WITH_ALL_NOTE_TYPES_ALLOWED;
@@ -464,11 +471,11 @@ mod tests {
 
         assert_matches!(
           NoteTag::for_public_use_case(1 << 15, 0b0, NoteExecutionMode::Local).unwrap_err(),
-          NoteError::InvalidNoteTagUseCase(use_case) if use_case == 1 << 15
+          NoteError::NoteTagUseCaseTooLarge(use_case) if use_case == 1 << 15
         );
         assert_matches!(
           NoteTag::for_public_use_case(1 << 14, 0b0, NoteExecutionMode::Local).unwrap_err(),
-          NoteError::InvalidNoteTagUseCase(use_case) if use_case == 1 << 14
+          NoteError::NoteTagUseCaseTooLarge(use_case) if use_case == 1 << 14
         );
     }
 
@@ -495,11 +502,11 @@ mod tests {
 
         assert_matches!(
           NoteTag::for_local_use_case(1 << 15, 0b0).unwrap_err(),
-          NoteError::InvalidNoteTagUseCase(use_case) if use_case == 1 << 15
+          NoteError::NoteTagUseCaseTooLarge(use_case) if use_case == 1 << 15
         );
         assert_matches!(
           NoteTag::for_local_use_case(1 << 14, 0b0).unwrap_err(),
-          NoteError::InvalidNoteTagUseCase(use_case) if use_case == 1 << 14
+          NoteError::NoteTagUseCaseTooLarge(use_case) if use_case == 1 << 14
         );
     }
 

--- a/objects/src/notes/note_type.rs
+++ b/objects/src/notes/note_type.rs
@@ -20,7 +20,7 @@ pub enum NoteType {
     /// Notes with this type have only their hash published to the network.
     Private = PRIVATE,
 
-    /// Notes with type are shared with the network encrypted.
+    /// Notes with this type are shared with the network encrypted.
     Encrypted = ENCRYPTED,
 
     /// Notes with this type are fully shared with the network.
@@ -47,7 +47,7 @@ impl TryFrom<u8> for NoteType {
             PRIVATE => Ok(NoteType::Private),
             ENCRYPTED => Ok(NoteType::Encrypted),
             PUBLIC => Ok(NoteType::Public),
-            _ => Err(NoteError::InvalidNoteTypeValue(value.into())),
+            _ => Err(NoteError::InvalidNoteType(value.into())),
         }
     }
 }
@@ -72,7 +72,7 @@ impl TryFrom<u64> for NoteType {
     type Error = NoteError;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        let value: u8 = value.try_into().map_err(|_| NoteError::InvalidNoteTypeValue(value))?;
+        let value: u8 = value.try_into().map_err(|_| NoteError::InvalidNoteType(value))?;
         value.try_into()
     }
 }

--- a/objects/src/notes/script.rs
+++ b/objects/src/notes/script.rs
@@ -1,4 +1,4 @@
-use alloc::{string::ToString, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::fmt::Display;
 
 use assembly::{Assembler, Compile};
@@ -47,7 +47,7 @@ impl NoteScript {
     pub fn compile(source_code: impl Compile, assembler: Assembler) -> Result<Self, NoteError> {
         let program = assembler
             .assemble_program(source_code)
-            .map_err(|report| NoteError::NoteScriptAssemblyError(report.to_string()))?;
+            .map_err(NoteError::NoteScriptAssemblyError)?;
         Ok(Self::new(program))
     }
 

--- a/objects/src/testing/account_component.rs
+++ b/objects/src/testing/account_component.rs
@@ -1,4 +1,4 @@
-use alloc::{string::ToString, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 
 use assembly::{ast::Module, Assembler, Library, LibraryPath};
 
@@ -43,11 +43,11 @@ impl AccountMockComponent {
                 MOCK_ACCOUNT_CODE,
                 &source_manager,
             )
-            .map_err(|report| AccountError::AccountCodeAssemblyError(report.to_string()))?;
+            .map_err(AccountError::AccountComponentAssemblyError)?;
 
         let library = assembler
             .assemble_library(&[*module])
-            .map_err(|report| AccountError::AccountCodeAssemblyError(report.to_string()))?;
+            .map_err(AccountError::AccountComponentAssemblyError)?;
 
         Ok(Self { library, storage_slots })
     }

--- a/objects/src/testing/assets.rs
+++ b/objects/src/testing/assets.rs
@@ -29,7 +29,7 @@ pub struct FungibleAssetBuilder {
 impl<T: Rng> NonFungibleAssetDetailsBuilder<T> {
     pub fn new(faucet_id: AccountId, rng: T) -> Result<Self, AssetError> {
         if !matches!(faucet_id.account_type(), AccountType::NonFungibleFaucet) {
-            return Err(AssetError::NotANonFungibleFaucetId(faucet_id));
+            return Err(AssetError::NonFungibleFaucetIdTypeMismatch(faucet_id));
         }
 
         Ok(Self { faucet_id, rng })
@@ -65,7 +65,7 @@ impl FungibleAssetBuilder {
     pub fn new(faucet_id: AccountId) -> Result<Self, AssetError> {
         let account_type = faucet_id.account_type();
         if !matches!(account_type, AccountType::FungibleFaucet) {
-            return Err(AssetError::NotAFungibleFaucetId(faucet_id, account_type));
+            return Err(AssetError::FungibleFaucetIdTypeMismatch(faucet_id));
         }
 
         Ok(Self { faucet_id, amount: Self::DEFAULT_AMOUNT })
@@ -73,7 +73,7 @@ impl FungibleAssetBuilder {
 
     pub fn amount(&mut self, amount: u64) -> Result<&mut Self, AssetError> {
         if amount > FungibleAsset::MAX_AMOUNT {
-            return Err(AssetError::AmountTooBig(amount));
+            return Err(AssetError::FungibleAssetAmountTooBig(amount));
         }
 
         self.amount = amount;

--- a/objects/src/transaction/outputs.rs
+++ b/objects/src/transaction/outputs.rs
@@ -41,7 +41,7 @@ impl OutputNotes {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The total number of notes is greater than 1024.
+    /// - The total number of notes is greater than [`MAX_OUTPUT_NOTES_PER_TX`].
     /// - The vector of notes contains duplicates.
     pub fn new(notes: Vec<OutputNote>) -> Result<Self, TransactionOutputError> {
         if notes.len() > MAX_OUTPUT_NOTES_PER_TX {

--- a/objects/src/transaction/proven_tx.rs
+++ b/objects/src/transaction/proven_tx.rs
@@ -119,16 +119,16 @@ impl ProvenTransaction {
                         );
                     }
                     if account.id() != self.account_id() {
-                        return Err(ProvenTransactionError::AccountIdMismatch(
-                            self.account_id(),
-                            account.id(),
-                        ));
+                        return Err(ProvenTransactionError::AccountIdMismatch {
+                            tx_account_id: self.account_id(),
+                            details_account_id: account.id(),
+                        });
                     }
                     if account.hash() != self.account_update.final_state_hash() {
-                        return Err(ProvenTransactionError::AccountFinalHashMismatch(
-                            self.account_update.final_state_hash(),
-                            account.hash(),
-                        ));
+                        return Err(ProvenTransactionError::AccountFinalHashMismatch {
+                            tx_final_hash: self.account_update.final_state_hash(),
+                            details_hash: account.hash(),
+                        });
                     }
                 },
                 AccountUpdateDetails::Delta(_) => {
@@ -391,10 +391,10 @@ impl TxAccountUpdate {
     pub fn validate(&self) -> Result<(), ProvenTransactionError> {
         let account_update_size = self.details().get_size_hint();
         if account_update_size > ACCOUNT_UPDATE_MAX_SIZE as usize {
-            Err(ProvenTransactionError::AccountUpdateSizeLimitExceeded(
-                self.account_id(),
-                account_update_size,
-            ))
+            Err(ProvenTransactionError::AccountUpdateSizeLimitExceeded {
+                account_id: self.account_id(),
+                update_size: account_update_size,
+            })
         } else {
             Ok(())
         }
@@ -603,7 +603,7 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(err, ProvenTransactionError::AccountUpdateSizeLimitExceeded(_, size) if size == details_size)
+            matches!(err, ProvenTransactionError::AccountUpdateSizeLimitExceeded { update_size, .. } if update_size == details_size)
         );
     }
 }

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, string::ToString, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 use core::ops::Deref;
 
 use assembly::{Assembler, Compile};
@@ -214,7 +214,7 @@ impl TransactionScript {
     ) -> Result<Self, TransactionScriptError> {
         let program = assembler
             .assemble_program(source_code)
-            .map_err(|report| TransactionScriptError::AssemblyError(report.to_string()))?;
+            .map_err(TransactionScriptError::AssemblyError)?;
         Ok(Self::new(program, inputs))
     }
 


### PR DESCRIPTION
Refactor errors according to the guidelines in #966 in `miden-objects` and some small error-related changes in other crates.

Part of #972. To close that issue, another PR needs to be made to update the remaining errors in miden-tx. I would split it in two parts in case there is feedback on these errors and I have to adjust some things.

