### PR TITLE
feat: add `Send` to internal error

### DIFF
--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -145,7 +145,7 @@ pub enum AssetError {
         other_issuer: AccountId,
     },
     #[error("faucet account id in asset is invalid")]
-    InvalidFaucetAccountId(#[source] Box<dyn Error>),
+    InvalidFaucetAccountId(#[source] Box<dyn Error + Send>),
     #[error(
       "faucet id {0} of type {id_type:?} must be of type {expected_ty:?} for fungible assets",
       id_type = .0.account_type(),


### PR DESCRIPTION
When changing the base branches to `next` in the Miden Client (https://github.com/0xPolygonMiden/miden-client/pull/617), one of the errors is caused because an element of `AssetError` is not `Send`. By changing this line the error in the client is fixed (tested it locally).