### PR TITLE
build(lib): do not run build script based on changes to `kernel_v0.rs`

### DIFF
--- a/miden-lib/build.rs
+++ b/miden-lib/build.rs
@@ -42,7 +42,6 @@ const KERNEL_ERRORS_FILE: &str = "src/errors/tx_kernel_errors.rs";
 fn main() -> Result<()> {
     // re-build when the MASM code changes
     println!("cargo:rerun-if-changed={ASM_DIR}");
-    println!("cargo:rerun-if-changed={KERNEL_V0_RS_FILE}");
     println!("cargo:rerun-if-changed={KERNEL_ERRORS_FILE}");
     println!("cargo::rerun-if-env-changed=BUILD_KERNEL_ERRORS");
 

--- a/miden-lib/build.rs
+++ b/miden-lib/build.rs
@@ -42,7 +42,6 @@ const KERNEL_ERRORS_FILE: &str = "src/errors/tx_kernel_errors.rs";
 fn main() -> Result<()> {
     // re-build when the MASM code changes
     println!("cargo:rerun-if-changed={ASM_DIR}");
-    println!("cargo:rerun-if-changed={KERNEL_ERRORS_FILE}");
     println!("cargo::rerun-if-env-changed=BUILD_KERNEL_ERRORS");
 
     // Copies the MASM code to the build directory


### PR DESCRIPTION
https://github.com/0xPolygonMiden/miden-base/pull/887 added a build script that builds `kernel_v0.rs`, but the script runs on changes to the file itself. I suspect this was the reason for test times doubling after that PR as pointed out in https://github.com/0xPolygonMiden/miden-base/issues/903.

This PR simply removes this rerun check. I doubt this check is the correct behaviour either way, since if it reruns based on changes to the `kernel_v0.rs`, it means it reruns every time the file is generated - which means the build script is triggered between each invocation of `cargo nextest` as well.

I've tested this in my personal repo - the run is here: https://github.com/eightfilms/miden-base/actions/runs/12064550221/job/33641593187 and is based on this branch: https://github.com/eightfilms/miden-base/tree/refs/heads/kernel-build-once. There is no longer recompilation between the different test steps, which means we should expect to see CI times for the test step go back down to ~15 minutes from ~40 minutes (which is similar to the last [commit](https://github.com/0xPolygonMiden/miden-base/commit/15a3774030134cd3558514ba662f4ac45b4a31f9) prior to #887)