### PR TITLE
feat: implement `count` method for (non)fungible asset deltas

### DIFF
--- a/objects/src/accounts/delta/vault.rs
+++ b/objects/src/accounts/delta/vault.rs
@@ -234,7 +234,7 @@ impl FungibleAssetDelta {
     }
 
     /// Returns the number of fungible assets affected in the delta.
-    pub fn count(&self) -> usize {
+    pub fn num_assets(&self) -> usize {
         self.0.len()
     }
 
@@ -376,7 +376,7 @@ impl NonFungibleAssetDelta {
     }
 
     /// Returns the number of non-fungible assets affected in the delta.
-    pub fn count(&self) -> usize {
+    pub fn num_assets(&self) -> usize {
         self.0.len()
     }
 

--- a/objects/src/accounts/delta/vault.rs
+++ b/objects/src/accounts/delta/vault.rs
@@ -233,6 +233,11 @@ impl FungibleAssetDelta {
         self.add_delta(asset.faucet_id(), -amount)
     }
 
+    /// Returns the number of fungible assets affected in the delta.
+    pub fn count(&self) -> usize {
+        self.0.len()
+    }
+
     /// Returns true if this vault delta contains no updates.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -368,6 +373,11 @@ impl NonFungibleAssetDelta {
     /// Returns an error if the delta already contains the asset removal.
     pub fn remove(&mut self, asset: NonFungibleAsset) -> Result<(), AccountDeltaError> {
         self.apply_action(asset, NonFungibleDeltaAction::Remove)
+    }
+
+    /// Returns the number of non-fungible assets affected in the delta.
+    pub fn count(&self) -> usize {
+        self.0.len()
     }
 
     /// Returns true if this vault delta contains no updates.


### PR DESCRIPTION
This is needed for getting asset delta count without iteration over all of them.