### PR TITLE
Use `thiserror` in `miden-lib` and `miden-tx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added Format Guidebook to the `miden-lib` crate (#987).
 - Added conversion from `Account` to `AccountDelta` for initial account state representation as delta (#983).
 - [BREAKING] Added `miden::note::get_script_hash` procedure (#995).
+- [BREAKING] Refactor error messages in `miden-lib` and `miden-tx` and use `thiserror` 2.0 (#1005).
 
 ## 0.6.2 (2024-11-20)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "miden-verifier",
  "rand",
  "rand_chacha",
+ "thiserror 2.0.3",
  "winter-maybe-async",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "miden-processor",
  "miden-stdlib",
  "regex",
+ "thiserror 2.0.3",
  "walkdir",
 ]
 

--- a/miden-lib/Cargo.toml
+++ b/miden-lib/Cargo.toml
@@ -25,6 +25,7 @@ with-debug-info = ["miden-stdlib/with-debug-info"]
 [dependencies]
 miden-objects = { workspace = true }
 miden-stdlib = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 miden-objects = { workspace = true, features = ["testing"] }

--- a/miden-lib/src/transaction/errors.rs
+++ b/miden-lib/src/transaction/errors.rs
@@ -1,168 +1,88 @@
-use alloc::{string::String, vec::Vec};
-use core::fmt;
+use alloc::{boxed::Box, vec::Vec};
+use core::error::Error;
 
-use miden_objects::{
-    notes::NoteMetadata, AccountDeltaError, AccountError, AssetError, Digest, Felt, NoteError,
-};
+use miden_objects::{notes::NoteMetadata, AccountDeltaError, AssetError, Digest, Felt, NoteError};
+use thiserror::Error;
 
 // TRANSACTION KERNEL ERROR
 // ================================================================================================
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TransactionKernelError {
-    AccountDeltaError(AccountDeltaError),
-    FailedToAddAssetToNote(NoteError),
-    InvalidNoteInputs {
-        expected: Digest,
-        got: Digest,
-        data: Option<Vec<Felt>>,
+    #[error("failed to add asset to account delta")]
+    AccountDeltaAddAssetFailed(#[source] AccountDeltaError),
+    #[error("failed to remove asset to account delta")]
+    AccountDeltaRemoveAssetFailed(#[source] AccountDeltaError),
+    #[error("failed to add asset to note")]
+    FailedToAddAssetToNote(#[source] NoteError),
+    #[error("note input data has hash {actual} but expected hash {expected}")]
+    InvalidNoteInputs { expected: Digest, actual: Digest },
+    #[error("storage slot index {actual} is invalid, must be smaller than the number of account storage slots {max}")]
+    InvalidStorageSlotIndex { max: u64, actual: u64 },
+    #[error("asset data extracted from the stack by event handler `{handler}` is not well formed")]
+    MalformedAssetInEventHandler {
+        handler: &'static str,
+        source: AssetError,
     },
-    InvalidStorageSlotIndex {
-        max: u64,
-        actual: u64,
+    #[error(
+        "note inputs data extracted from the advice map by the event handler is not well formed"
+    )]
+    MalformedNoteInputs(#[source] NoteError),
+    #[error("note metadata created by the event handler is not well formed")]
+    MalformedNoteMetadata(#[source] NoteError),
+    #[error("note script data `{data:?}` extracted from the advice map by the event handler is not well formed")]
+    MalformedNoteScript {
+        data: Vec<Felt>,
+        // This is always a DeserializationError, but we can't import it directly here without
+        // adding dependencies, so we make it a trait object instead.
+        source: Box<dyn Error + Send + Sync + 'static>,
     },
-    MalformedAccountId(AccountError),
-    MalformedAsset(AssetError),
-    MalformedAssetOnAccountVaultUpdate(AssetError),
-    MalformedNoteInputs(NoteError),
-    MalformedNoteMetadata(NoteError),
-    MalformedNoteScript(Vec<Felt>),
-    MalformedNoteType(NoteError),
+    #[error("recipient data `{0:?}` in the advice provider is not well formed")]
     MalformedRecipientData(Vec<Felt>),
-    MalformedTag(Felt),
-    MissingNote(String),
-    MissingNoteDetails(NoteMetadata, Digest),
+    #[error("cannot add asset to note with index {0}, note does not exist in the advice provider")]
+    MissingNote(u64),
+    #[error("public note with metadata {0:?} and recipient digest {1} is missing details in the advice provider")]
+    PublicNoteMissingDetails(NoteMetadata, Digest),
+    #[error("public note has incomplete inputs in the advice provider")]
     MissingNoteInputs,
-    MissingStorageSlotValue(u8, String),
-    TooFewElementsForNoteInputs,
+    #[error("note input data in advice provider contains fewer elements ({actual}) than specified ({specified}) by its inputs length")]
+    TooFewElementsForNoteInputs { specified: u64, actual: u64 },
+    #[error("account procedure with procedure root {0} is not in the advice provider")]
     UnknownAccountProcedure(Digest),
+    #[error("code commitment {0} is not in the advice provider")]
     UnknownCodeCommitment(Digest),
-    MissingMemoryValue(u32),
+    #[error("account storage slots number is missing in memory at address {0}")]
+    AccountStorageSlotsNumMissing(u32),
 }
-
-impl fmt::Display for TransactionKernelError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TransactionKernelError::FailedToAddAssetToNote(err) => {
-                write!(f, "Failed to add asset to note: {err}")
-            },
-            TransactionKernelError::InvalidNoteInputs { expected, got, data } => {
-                write!(
-                    f,
-                    "The note input data does not match its hash, expected: {} got: {} data {:?}",
-                    expected, got, data
-                )
-            },
-            TransactionKernelError::InvalidStorageSlotIndex { max, actual } => {
-                write!(f, "Storage slot index: {actual} is invalid, must be smaller than the number of account storage slots: {max}")
-            },
-            TransactionKernelError::MalformedAccountId(err) => {
-                write!( f, "Account id data extracted from the stack by the event handler is not well formed {err}")
-            },
-            TransactionKernelError::MalformedAsset(err) => {
-                write!(f, "Asset data extracted from the stack by the event handler is not well formed {err}")
-            },
-            TransactionKernelError::MalformedAssetOnAccountVaultUpdate(err) => {
-                write!(f, "Malformed asset during account vault update: {err}")
-            },
-            TransactionKernelError::MalformedNoteInputs(err) => {
-                write!( f, "Note inputs data extracted from the advice map by the event handler is not well formed {err}")
-            },
-            TransactionKernelError::MalformedNoteMetadata(err) => {
-                write!(f, "Note metadata created by the event handler is not well formed {err}")
-            },
-            TransactionKernelError::MalformedNoteScript(data) => {
-                write!( f, "Note script data extracted from the advice map by the event handler is not well formed {data:?}")
-            },
-            TransactionKernelError::MalformedNoteType(err) => {
-                write!( f, "Note type data extracted from the stack by the event handler is not well formed {err}")
-            },
-            TransactionKernelError::MalformedRecipientData(data) => {
-                write!(f, "Recipient data in the advice provider is not well formed {data:?}")
-            },
-            TransactionKernelError::MalformedTag(tag) => {
-                write!( f, "Tag data extracted from the stack by the event handler is not well formed {tag}")
-            },
-            TransactionKernelError::MissingNote(note_idx) => {
-                write!(f, "Cannot add asset to note with index {note_idx}, note does not exist in the advice provider")
-            },
-            TransactionKernelError::MissingNoteDetails(metadata, recipient) => {
-                write!( f, "Public note missing the details in the advice provider. metadata: {metadata:?}, recipient: {recipient:?}")
-            },
-            TransactionKernelError::MissingNoteInputs => {
-                write!(f, "Public note missing or incomplete inputs in the advice provider")
-            },
-            TransactionKernelError::MissingStorageSlotValue(index, err) => {
-                write!(f, "Value for storage slot {index} could not be found: {err}")
-            },
-            TransactionKernelError::TooFewElementsForNoteInputs => {
-                write!(
-                    f,
-                    "Note input data in advice provider contains fewer elements than specified by its inputs length"
-                )
-            },
-            TransactionKernelError::UnknownAccountProcedure(proc_root) => {
-                write!(f, "Account procedure with root {proc_root} is not in the advice provider")
-            },
-            TransactionKernelError::UnknownCodeCommitment(code_commitment) => {
-                write!(f, "Code commitment {code_commitment} is not in the advice provider")
-            },
-            TransactionKernelError::AccountDeltaError(error) => {
-                write!(f, "Account delta error: {error}")
-            },
-            TransactionKernelError::MissingMemoryValue(location) => {
-                write!(f, "Value missing in memory at location: {location}")
-            },
-        }
-    }
-}
-
-impl core::error::Error for TransactionKernelError {}
 
 // TRANSACTION EVENT PARSING ERROR
 // ================================================================================================
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TransactionEventParsingError {
+    #[error("event id {0} is not a valid transaction kernel event")]
     InvalidTransactionEvent(u32),
+    #[error("event id {0} is not a transaction kernel event")]
     NotTransactionEvent(u32),
 }
-
-impl fmt::Display for TransactionEventParsingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidTransactionEvent(event_id) => {
-                write!(f, "event {event_id} is not a valid transaction kernel event")
-            },
-            Self::NotTransactionEvent(event_id) => {
-                write!(f, "event {event_id} is not a transaction kernel event")
-            },
-        }
-    }
-}
-
-impl core::error::Error for TransactionEventParsingError {}
 
 // TRANSACTION TRACE PARSING ERROR
 // ================================================================================================
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TransactionTraceParsingError {
-    InvalidTransactionTrace(u32),
-    NotTransactionTrace(u32),
+    #[error("trace id {0} is an unknown transaction kernel trace")]
+    UnknownTransactionTrace(u32),
 }
 
-impl fmt::Display for TransactionTraceParsingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidTransactionTrace(trace_id) => {
-                write!(f, "trace {trace_id} is invalid")
-            },
-            Self::NotTransactionTrace(trace_id) => {
-                write!(f, "trace {trace_id} is not a transaction kernel trace")
-            },
-        }
+#[cfg(test)]
+mod error_assertions {
+    use super::*;
+
+    /// Asserts at compile time that the passed error has Send + Sync + 'static bounds.
+    fn _assert_error_is_send_sync_static<E: core::error::Error + Send + Sync + 'static>(_: E) {}
+
+    fn _assert_transaction_kernel_error_bounds(err: TransactionKernelError) {
+        _assert_error_is_send_sync_static(err);
     }
 }
-
-impl core::error::Error for TransactionTraceParsingError {}

--- a/miden-lib/src/transaction/events.rs
+++ b/miden-lib/src/transaction/events.rs
@@ -146,7 +146,7 @@ impl TryFrom<u32> for TransactionTrace {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         if value >> 16 != EVENT_ID_PREFIX {
-            return Err(TransactionTraceParsingError::NotTransactionTrace(value));
+            return Err(TransactionTraceParsingError::UnknownTransactionTrace(value));
         }
 
         match value {
@@ -160,7 +160,7 @@ impl TryFrom<u32> for TransactionTrace {
             0x2_0007 => Ok(TransactionTrace::TxScriptProcessingEnd),
             0x2_0008 => Ok(TransactionTrace::EpilogueStart),
             0x2_0009 => Ok(TransactionTrace::EpilogueEnd),
-            _ => Err(TransactionTraceParsingError::InvalidTransactionTrace(value)),
+            _ => Err(TransactionTraceParsingError::UnknownTransactionTrace(value)),
         }
     }
 }

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -31,6 +31,7 @@ miden-prover = { workspace = true }
 miden-verifier = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { version = "0.3", default-features = false, optional = true }
+thiserror = { workspace = true }
 vm-processor = { workspace = true }
 winter-maybe-async = { version = "0.10" }
 

--- a/miden-tx/src/auth/tx_authenticator.rs
+++ b/miden-tx/src/auth/tx_authenticator.rs
@@ -96,8 +96,8 @@ impl<R: Rng> TransactionAuthenticator for BasicAuthenticator<R> {
                     get_falcon_signature(falcon_key, message, &mut *rng)
                 },
             },
-            None => Err(AuthenticationError::UnknownKey(format!(
-                "Public key {} is not contained in the authenticator's keys",
+            None => Err(AuthenticationError::UnknownPublicKey(format!(
+                "public key {} is not contained in the authenticator's keys",
                 Digest::from(pub_key)
             ))),
         }
@@ -115,7 +115,7 @@ impl TransactionAuthenticator for () {
         _account_delta: &AccountDelta,
     ) -> Result<Vec<Felt>, AuthenticationError> {
         Err(AuthenticationError::RejectedSignature(
-            "Default authenticator cannot provide signatures".to_string(),
+            "default authenticator cannot provide signatures".to_string(),
         ))
     }
 }

--- a/miden-tx/src/executor/mod.rs
+++ b/miden-tx/src/executor/mod.rs
@@ -166,7 +166,7 @@ impl TransactionExecutor {
             &mut host,
             self.exec_options,
         )
-        .map_err(TransactionExecutorError::ExecuteTransactionProgramFailed)?;
+        .map_err(TransactionExecutorError::TransactionProgramExecutionFailed)?;
 
         // Attempt to retrieve used account codes based on the advice map
         let account_codes = self
@@ -208,7 +208,7 @@ fn build_executed_transaction(
 
     let tx_outputs =
         TransactionKernel::from_transaction_parts(&stack_outputs, &map.into(), output_notes)
-            .map_err(TransactionExecutorError::InvalidTransactionOutput)?;
+            .map_err(TransactionExecutorError::TransactionOutputConstructionFailed)?;
 
     let final_account = &tx_outputs.account;
 

--- a/miden-tx/src/host/account_procs.rs
+++ b/miden-tx/src/host/account_procs.rs
@@ -78,7 +78,7 @@ fn build_account_procedure_map(
     // get the account procedures from the advice_map
     let proc_data = adv_provider.get_mapped_values(&code_commitment).ok_or_else(|| {
         TransactionHostError::AccountProcedureIndexMapError(
-            "Failed to read account procedure data from the advice provider".to_string(),
+            "failed to read account procedure data from the advice provider".to_string(),
         )
     })?;
 
@@ -89,14 +89,14 @@ fn build_account_procedure_map(
     // check that there are procedures in the account code
     if proc_data.is_empty() {
         return Err(TransactionHostError::AccountProcedureIndexMapError(
-            "The account code does not contain any procedures.".to_string(),
+            "account code does not contain any procedures.".to_string(),
         ));
     }
 
     // check that procedure data have a correct length
     if proc_data.len() % AccountProcedureInfo::NUM_ELEMENTS_PER_PROC != 0 {
         return Err(TransactionHostError::AccountProcedureIndexMapError(
-            "The account procedure data has invalid length.".to_string(),
+            "account procedure data has invalid length.".to_string(),
         ));
     }
 
@@ -106,7 +106,7 @@ fn build_account_procedure_map(
     // check that the account code does not contain too many procedures
     if num_procs > AccountCode::MAX_NUM_PROCEDURES {
         return Err(TransactionHostError::AccountProcedureIndexMapError(
-            "The account code contains too many procedures.".to_string(),
+            "account code contains too many procedures.".to_string(),
         ));
     }
 
@@ -116,12 +116,8 @@ fn build_account_procedure_map(
         let proc_info_array: [Felt; AccountProcedureInfo::NUM_ELEMENTS_PER_PROC] =
             proc_info.try_into().expect("Failed conversion into procedure info array.");
 
-        let procedure = AccountProcedureInfo::try_from(proc_info_array).map_err(|e| {
-            TransactionHostError::AccountProcedureIndexMapError(format!(
-                "Failed to create AccountProcedureInfo: {:?}",
-                e
-            ))
-        })?;
+        let procedure = AccountProcedureInfo::try_from(proc_info_array)
+            .map_err(TransactionHostError::AccountProcedureInfoCreationFailed)?;
 
         let proc_idx = u8::try_from(proc_idx).expect("Invalid procedure index.");
 

--- a/miden-tx/src/prover/mod.rs
+++ b/miden-tx/src/prover/mod.rs
@@ -128,7 +128,7 @@ impl TransactionProver for LocalTransactionProver {
         let (_, map, _) = advice_provider.into_parts();
         let tx_outputs =
             TransactionKernel::from_transaction_parts(&stack_outputs, &map.into(), output_notes)
-                .map_err(TransactionProverError::InvalidTransactionOutput)?;
+                .map_err(TransactionProverError::TransactionOutputConstructionFailed)?;
 
         // erase private note information (convert private full notes to just headers)
         let output_notes: Vec<_> = tx_outputs.output_notes.iter().map(OutputNote::shrink).collect();
@@ -150,7 +150,7 @@ impl TransactionProver for LocalTransactionProver {
                     let mut account = account.clone();
                     account
                         .apply_delta(&account_delta)
-                        .map_err(TransactionProverError::InvalidAccountDelta)?;
+                        .map_err(TransactionProverError::AccountDeltaApplyFailed)?;
 
                     AccountUpdateDetails::New(account)
                 } else {
@@ -162,6 +162,6 @@ impl TransactionProver for LocalTransactionProver {
             false => builder,
         };
 
-        builder.build().map_err(TransactionProverError::ProvenTransactionError)
+        builder.build().map_err(TransactionProverError::ProvenTransactionBuildFailed)
     }
 }

--- a/miden-tx/src/verifier/mod.rs
+++ b/miden-tx/src/verifier/mod.rs
@@ -55,10 +55,10 @@ impl TransactionVerifier {
 
         // check security level
         if proof_security_level < self.proof_security_level {
-            return Err(TransactionVerifierError::InsufficientProofSecurityLevel(
-                proof_security_level,
-                self.proof_security_level,
-            ));
+            return Err(TransactionVerifierError::InsufficientProofSecurityLevel {
+                actual: proof_security_level,
+                expected_minimum: self.proof_security_level,
+            });
         }
 
         Ok(())

--- a/miden-tx/tests/integration/main.rs
+++ b/miden-tx/tests/integration/main.rs
@@ -25,7 +25,7 @@ use vm_processor::utils::Deserializable;
 macro_rules! assert_transaction_executor_error {
     ($execution_result:expr, $expected_err_code:expr) => {
         match $execution_result {
-            Err(miden_tx::TransactionExecutorError::ExecuteTransactionProgramFailed(
+            Err(miden_tx::TransactionExecutorError::TransactionProgramExecutionFailed(
                 miden_prover::ExecutionError::FailedAssertion { clk: _, err_code, err_msg: _ }
             )) => {
                 assert!(


### PR DESCRIPTION
Use `thiserror` in `miden-lib` and `miden-tx` and refactor some error messages to provide better errors and be in line with the guidelines discussed in #966 and #972.

Some `InternalError(String)` variants where replaced with a `Custom { error_msg: Box<str>, source: Option<Box<dyn Error + Send + Sync + 'static>> }` variant which allows implementors of traits like `DataStore` and `TransactionAuthenticator` to produce errors that are in line with our source-over-display approach. This is a small breaking change for the client cc @igamigo.

Some errors couldn't be made source errors because the latest miden-vm where errors implement `core::error::Error` in no-std is not yet published, so I've added them as a TODO here and added a note in #981.

closes #972