### PR TITLE
feat: health check in worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Added health check endpoints to the prover service (#1006).
 - Implemented serialization for `AccountHeader` (#996).
 - Updated Pingora crates to 0.4 and added polling time to the configuration file (#997).
 - Added support for `miden-tx-prover` proxy to update workers on a running proxy (#989).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "toml",
  "tonic",
  "tonic-build",
+ "tonic-health",
  "tonic-web",
  "tonic-web-wasm-client",
  "tracing",
@@ -3906,6 +3907,19 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/bin/tx-prover/Cargo.toml
+++ b/bin/tx-prover/Cargo.toml
@@ -54,6 +54,7 @@ serde_qs = { version = "0.13" }
 tokio = { version = "1.38", optional = true, features = ["full"] }
 tokio-stream = { version = "0.1", optional = true, features = [ "net" ]}
 toml = { version = "0.8" }
+tonic-health = { version = "0.12" }
 tonic-web = { version = "0.12", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["fmt",  "json",  "env-filter"], optional = true }

--- a/bin/tx-prover/README.md
+++ b/bin/tx-prover/README.md
@@ -59,6 +59,8 @@ max_queue_items = 10
 max_retries_per_request = 1
 # Maximum amount of requests that a given IP address can make per second
 max_req_per_sec = 5
+# Interval to check the health of the workers
+health_check_interval_secs = 1
 
 [[workers]]
 host = "0.0.0.0"
@@ -101,6 +103,12 @@ miden-tx-prover remove-workers 158.12.12.3:8080 122.122.6.6:50051
 This changes will be persisted to the configuration file.
 
 Note that, in order to update the workers, the proxy must be running in the same computer as the command is being executed because it will check if the client address is localhost to avoid any security issues.
+
+### Health check
+
+The worker service implements the [gRPC Health Check](https://grpc.io/docs/guides/health-checking/) standard, and includes the methods described in this [official proto file](https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto).
+
+The proxy service uses this health check to determine if a worker is available to receive requests. If a worker is not available, it will be removed from the set of workers that the proxy can use to send requests, and will persist this change in the configuration file.
 
 ## Logging
 

--- a/bin/tx-prover/src/commands/mod.rs
+++ b/bin/tx-prover/src/commands/mod.rs
@@ -41,6 +41,8 @@ pub struct ProxyConfig {
     pub max_req_per_sec: isize,
     /// Time in milliseconds to poll available workers.
     pub available_workers_polling_time_ms: u64,
+    /// Health check interval in seconds.
+    pub health_check_interval_secs: u64,
 }
 
 impl Default for ProxyConfig {
@@ -55,6 +57,7 @@ impl Default for ProxyConfig {
             max_retries_per_request: 1,
             max_req_per_sec: 5,
             available_workers_polling_time_ms: 20,
+            health_check_interval_secs: 1,
         }
     }
 }
@@ -100,6 +103,17 @@ impl ProxyConfig {
 
         Ok(())
     }
+
+    /// Updates the workers in the configuration
+    ///
+    /// This method will persist the new workers list to the configuration file.
+    pub(crate) fn update_workers(workers: Vec<WorkerConfig>) -> Result<(), String> {
+        let mut proxy_config = Self::load_config_from_file().unwrap();
+
+        proxy_config.workers = workers;
+
+        proxy_config.save_to_config_file()
+    }
 }
 
 /// Configuration for a worker
@@ -137,7 +151,7 @@ pub enum Command {
     /// values. The file will be named as defined in the
     /// [miden_tx_prover::PROVER_SERVICE_CONFIG_FILE_NAME] constant.
     Init(Init),
-    /// Starts the workers defined in the config file.
+    /// Starts the workers with the configuration defined in the command.
     StartWorker(StartWorker),
     /// Starts the proxy defined in the config file.
     StartProxy(StartProxy),

--- a/bin/tx-prover/src/commands/update_workers.rs
+++ b/bin/tx-prover/src/commands/update_workers.rs
@@ -57,10 +57,8 @@ impl UpdateWorkers {
     /// - If the request fails.
     /// - If the status code is not successful.
     /// - If the X-Worker-Count header is missing.
-    pub fn execute(&self) -> Result<(), String> {
+    pub async fn execute(&self) -> Result<(), String> {
         // Define a runtime
-        let rt = tokio::runtime::Runtime::new()
-            .map_err(|e| format!("Failed to create runtime: {:?}", e))?;
 
         let query_params = serde_qs::to_string(&self).map_err(|err| err.to_string())?;
 
@@ -79,7 +77,7 @@ impl UpdateWorkers {
             .map_err(|err| err.to_string())?;
 
         // Make the request
-        let response = rt.block_on(client.get(url).send()).map_err(|err| err.to_string())?;
+        let response = client.get(url).send().await.map_err(|err| err.to_string())?;
 
         // Check status code
         if !response.status().is_success() {

--- a/bin/tx-prover/src/commands/worker.rs
+++ b/bin/tx-prover/src/commands/worker.rs
@@ -47,7 +47,6 @@ impl StartWorker {
         tonic::transport::Server::builder()
             .accept_http1(true)
             .add_service(tonic_web::enable(rpc.api_service))
-            // Add the health service to the server
             .add_service(health_service)
             .serve_with_incoming(TcpListenerStream::new(rpc.listener))
             .await

--- a/bin/tx-prover/src/commands/worker.rs
+++ b/bin/tx-prover/src/commands/worker.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
+use miden_tx_prover::generated::api_server::ApiServer;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
+use tonic_health::server::health_reporter;
 use tracing::info;
 
 use crate::api::RpcListener;
@@ -22,6 +24,10 @@ impl StartWorker {
     /// This method receives the host and port from the CLI and starts a worker on that address.
     /// In case that one of the parameters is not provided, it will default to `0.0.0.0` for the
     /// host and `50051` for the port.
+    ///
+    /// The worker includes a health reporter that will mark the service as serving, following the
+    /// [gRPC health checking protocol](
+    /// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto).
     pub async fn execute(&self) -> Result<(), String> {
         let worker_addr = format!("{}:{}", self.host, self.port);
         let rpc =
@@ -32,9 +38,17 @@ impl StartWorker {
             rpc.listener.local_addr().map_err(|err| err.to_string())?
         );
 
+        // Create a health reporter
+        let (mut health_reporter, health_service) = health_reporter();
+
+        // Mark the service as serving
+        health_reporter.set_serving::<ApiServer<RpcListener>>().await;
+
         tonic::transport::Server::builder()
             .accept_http1(true)
             .add_service(tonic_web::enable(rpc.api_service))
+            // Add the health service to the server
+            .add_service(health_service)
             .serve_with_incoming(TcpListenerStream::new(rpc.listener))
             .await
             .map_err(|err| err.to_string())?;

--- a/bin/tx-prover/src/main.rs
+++ b/bin/tx-prover/src/main.rs
@@ -5,7 +5,8 @@ mod utils;
 use commands::Cli;
 use utils::setup_tracing;
 
-fn main() -> Result<(), String> {
+#[tokio::main]
+async fn main() -> Result<(), String> {
     use clap::Parser;
 
     setup_tracing();
@@ -14,7 +15,7 @@ fn main() -> Result<(), String> {
     let cli = Cli::parse();
 
     // execute cli action
-    cli.execute()
+    cli.execute().await
 }
 
 // TESTS

--- a/bin/tx-prover/src/proxy/worker.rs
+++ b/bin/tx-prover/src/proxy/worker.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+
+use pingora::lb::Backend;
+use tonic::transport::Channel;
+use tonic_health::pb::{
+    health_check_response::ServingStatus, health_client::HealthClient, HealthCheckRequest,
+};
+use tracing::error;
+
+use crate::{commands::WorkerConfig, utils::create_health_check_client};
+
+// WORKER
+// ================================================================================================
+
+/// A worker used for processing of requests.
+///
+/// A worker consists of a backend service (defined by worker address), a flag indicating wheter
+/// the worker is currently available to process new requests, and a gRPC health check client.
+#[derive(Debug, Clone)]
+pub struct Worker {
+    backend: Backend,
+    health_check_client: HealthClient<Channel>,
+    is_available: bool,
+}
+
+impl Worker {
+    pub async fn new(
+        worker: Backend,
+        connection_timeout: Duration,
+        total_timeout: Duration,
+    ) -> Result<Self, String> {
+        let health_check_client =
+            create_health_check_client(worker.addr.to_string(), connection_timeout, total_timeout)
+                .await?;
+
+        Ok(Self {
+            backend: worker,
+            is_available: true,
+            health_check_client,
+        })
+    }
+
+    pub fn address(&self) -> String {
+        self.backend.addr.to_string()
+    }
+
+    pub async fn is_healthy(&mut self) -> bool {
+        match self
+            .health_check_client
+            .check(HealthCheckRequest { service: "".to_string() })
+            .await
+        {
+            Ok(response) => response.into_inner().status() == ServingStatus::Serving,
+            Err(err) => {
+                error!("Failed to check worker health ({}): {}", self.address(), err);
+                false
+            },
+        }
+    }
+
+    pub fn is_available(&self) -> bool {
+        self.is_available
+    }
+
+    pub fn set_availability(&mut self, is_available: bool) {
+        self.is_available = is_available;
+    }
+}
+
+impl PartialEq for Worker {
+    fn eq(&self, other: &Self) -> bool {
+        self.backend == other.backend
+    }
+}
+
+impl TryInto<WorkerConfig> for &Worker {
+    type Error = String;
+
+    fn try_into(self) -> std::result::Result<WorkerConfig, String> {
+        self.backend
+            .as_inet()
+            .ok_or_else(|| "Failed to get worker address".to_string())
+            .map(|worker_addr| WorkerConfig::new(&worker_addr.ip().to_string(), worker_addr.port()))
+    }
+}


### PR DESCRIPTION
This PR adds:
- Health Check endpoints to the remote prover using the `tonic-health` crate, which adds the required endpoints without the need of defining the methods in a `.proto` file.
- Add a background service in the Proxy that periodically checks the health of each worker and removes the ones that are not working.