### PR TITLE
refactor: migrate to `miden-crypto` v0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added conversion from `Account` to `AccountDelta` for initial account state representation as delta (#983).
 - [BREAKING] Added `miden::note::get_script_hash` procedure (#995).
 - [BREAKING] Refactor error messages in `miden-lib` and `miden-tx` and use `thiserror` 2.0 (#1005).
+- Migrated to `miden-crypto` v0.13 (#1025).
 
 ## 0.6.2 (2024-11-20)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arc-swap"
@@ -229,10 +229,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "itoa",
  "matchit",
@@ -247,7 +247,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -262,7 +262,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -427,9 +427,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -444,9 +444,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "num-traits",
 ]
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.18",
@@ -507,13 +507,13 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.3",
+ "clap_lex 0.7.4",
  "strsim 0.11.1",
 ]
 
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
@@ -621,7 +621,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.21",
+ "clap 4.5.23",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -648,18 +648,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -676,18 +676,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "figment"
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1066,7 +1066,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap 2.7.0",
  "slab",
  "tokio",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1185,7 +1185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1196,7 +1196,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1215,9 +1215,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1239,15 +1239,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1264,7 +1264,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1278,7 +1278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1293,9 +1293,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1599,9 +1599,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
@@ -1665,18 +1665,18 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6aa86787fd2da255f97a4425799c8d1fd39951f5798a1192fc1b956581f605"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3303189202bb8a052bcd93d66b6c03e6fe70d9c7c47c0ea5e974955e54c876"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
 dependencies = [
  "beef",
  "fnv",
@@ -1684,15 +1684,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.5",
- "rustc_version 0.4.1",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774a1c225576486e4fdf40b74646f672c542ca3608160d348749693ae9d456e6"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
 dependencies = [
  "logos-codegen",
 ]
@@ -1758,11 +1757,10 @@ dependencies = [
 [[package]]
 name = "miden-air"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00ea451d1547978817a37c1904ff34f4a24de2c23f9b77b282a0bc570ac3f1"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "miden-core",
- "miden-thiserror",
+ "thiserror 2.0.8",
  "winter-air",
  "winter-prover",
 ]
@@ -1770,17 +1768,16 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58925d5ab3d625b8e828267a64dd555b1fe37cd5a1d89d09224920d3255de5a9"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
  "miden-core",
  "miden-miette",
- "miden-thiserror",
  "rustc_version 0.4.1",
  "smallvec",
+ "thiserror 2.0.8",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -1802,8 +1799,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba2f0ffd0362c91c0eedba391a3c17a8047389e15020ec95b0d7e840375bf03"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "lock_api",
  "loom",
@@ -1811,19 +1807,19 @@ dependencies = [
  "miden-crypto",
  "miden-formatting",
  "miden-miette",
- "miden-thiserror",
  "num-derive",
  "num-traits",
  "parking_lot",
+ "thiserror 2.0.8",
  "winter-math",
  "winter-utils",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50a68deed96cde1f51eb623f75828e320f699e0d798f11592f8958ba8b512c3"
+checksum = "a74af93a5640786def85a08a1fc25e02d8681ed0449ffb4898f4832a5fa08958"
 dependencies = [
  "blake3",
  "cc",
@@ -1833,6 +1829,7 @@ dependencies = [
  "rand",
  "rand_core",
  "sha3",
+ "thiserror 2.0.8",
  "winter-crypto",
  "winter-math",
  "winter-utils",
@@ -1856,15 +1853,15 @@ dependencies = [
  "miden-processor",
  "miden-stdlib",
  "regex",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-miette"
-version = "7.1.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c532250422d933f15b148fb81e4522a5d649c178ab420d0d596c86228da35570"
+checksum = "eef536978f24a179d94fa2a41e4f92b28e7d8aab14b8d23df28ad2a3d7098b20"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -1873,7 +1870,6 @@ dependencies = [
  "indenter",
  "lazy_static",
  "miden-miette-derive",
- "miden-thiserror",
  "owo-colors",
  "regex",
  "rustc_version 0.2.3",
@@ -1887,15 +1883,16 @@ dependencies = [
  "syn 2.0.90",
  "terminal_size 0.3.0",
  "textwrap",
+ "thiserror 2.0.8",
  "trybuild",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "miden-miette-derive"
-version = "7.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc759f0a2947acae217a2f32f722105cacc57d17d5f93bc16362142943a4edd"
+checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1919,18 +1916,18 @@ dependencies = [
  "rand",
  "rstest",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
  "winter-rand-utils",
 ]
 
 [[package]]
 name = "miden-processor"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1a756be679bfe2bdb209b9f4f12b4b59e8cac7c9f884ad90535b32bbd75923"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "miden-air",
  "miden-core",
+ "thiserror 2.0.8",
  "tracing",
  "winter-prover",
 ]
@@ -1938,43 +1935,21 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6c2fc7ed9831493e1c18fb9d15a4b780ec624e9192f494ad3900c19bfe5b17"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "miden-air",
  "miden-processor",
  "tracing",
- "winter-maybe-async",
+ "winter-maybe-async 0.11.0",
  "winter-prover",
 ]
 
 [[package]]
 name = "miden-stdlib"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09948fda011d044273d1bbc56669da410ee3167f96bf1ad9885c946cfbed5757"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "miden-assembly",
-]
-
-[[package]]
-name = "miden-thiserror"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183ff8de338956ecfde3a38573241eb7a6f3d44d73866c210e5629c07fa00253"
-dependencies = [
- "miden-thiserror-impl",
-]
-
-[[package]]
-name = "miden-thiserror-impl"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee4176a0f2e7d29d2a8ee7e60b6deb14ce67a20e94c3e2c7275cdb8804e1862"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -1992,8 +1967,8 @@ dependencies = [
  "miden-verifier",
  "rand",
  "rand_chacha",
- "thiserror 2.0.3",
- "winter-maybe-async",
+ "thiserror 2.0.8",
+ "winter-maybe-async 0.10.1",
 ]
 
 [[package]]
@@ -2002,7 +1977,7 @@ version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
- "clap 4.5.21",
+ "clap 4.5.23",
  "figment",
  "getrandom",
  "miden-lib",
@@ -2031,17 +2006,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "winter-maybe-async",
+ "winter-maybe-async 0.10.1",
 ]
 
 [[package]]
 name = "miden-verifier"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636b2eab9dc0a9fdd6d30d9ece3cf276b012e9ecbccd934d4c0befa07c84cfd0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#21da03da2d31ae49b9b5d9ac2e7c552c20ed1447"
 dependencies = [
  "miden-air",
  "miden-core",
+ "thiserror 2.0.8",
  "tracing",
  "winter-verifier",
 ]
@@ -2085,9 +2060,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -2455,7 +2430,7 @@ dependencies = [
  "blake2",
  "bytes",
  "hex",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "httpdate",
  "indexmap 1.9.3",
@@ -2495,7 +2470,7 @@ dependencies = [
  "flate2",
  "futures",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "httpdate",
  "libc",
@@ -2541,7 +2516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcb3f62d852da015e76ced56e93e6d52941679a9825281c90f2897841129e59d"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "pingora-error",
  "pingora-http",
@@ -2557,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70202f126056f366549afc804741e12dd9f419cfc79a0063ab15653007a0f4c6"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
  "pingora-error",
 ]
 
@@ -2590,7 +2565,7 @@ dependencies = [
  "derivative",
  "fnv",
  "futures",
- "http 1.1.0",
+ "http 1.2.0",
  "log",
  "pingora-core",
  "pingora-error",
@@ -2639,7 +2614,7 @@ dependencies = [
  "clap 3.2.25",
  "futures",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "log",
  "once_cell",
  "pingora-cache",
@@ -2779,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2789,11 +2764,10 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "bytes",
  "heck 0.5.0",
  "itertools 0.13.0",
  "log",
@@ -2810,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -2823,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7535b02f0e5efe3e1dbfcb428be152226ed0c66cad9541f2274c8ba8d4cd40"
+checksum = "20ae544fca2892fd4b7e9ff26cba1090cedf1d4d95c2aded1af15d2f93f270b8"
 dependencies = [
  "logos",
  "miette",
@@ -2836,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
  "prost",
 ]
@@ -2937,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3019,7 +2993,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3128,20 +3102,20 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.24",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3237,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3256,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "semver-parser"
@@ -3268,18 +3242,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3677,11 +3651,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -3697,9 +3671,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3796,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3820,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3877,10 +3851,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -3930,7 +3904,7 @@ checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project",
@@ -3952,7 +3926,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "httparse",
@@ -3989,14 +3963,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4011,7 +3985,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -4311,9 +4285,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4322,13 +4296,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -4337,9 +4310,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4350,9 +4323,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4360,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4373,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
@@ -4392,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4664,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c92f0d9a736cb744b0a3e267fafd50d27d6625be3681f55a2b7650ddbf3a2ce"
+checksum = "3a8fdb702503625f54dcaf9222aa2c7a0b2e868b3eb84b90d1837d68034bf999"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -4677,9 +4650,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcae1ada055aa10554910ecffc106cb116a19dba11ac91390ef982f94adb9c5"
+checksum = "67c57748fd2da77742be601f03eda639ff6046879738fd1faae86e80018263cb"
 dependencies = [
  "blake3",
  "sha3",
@@ -4689,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff88657560100f34fb83882a0adf33fb7caee235deb83193d0d251ddb28ed9c9"
+checksum = "3f9f999bc248c6254138b627035cb6d2c319580eb37dadcab6672298dbf00e41"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -4700,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82479f94efc0b5374a93e2074ba46ef404384fb1ea6e35a847febec53096509b"
+checksum = "6020c17839fa107ce4a7cc178e407ebbc24adfac1980f4fa2111198e052700ab"
 dependencies = [
  "winter-utils",
 ]
@@ -4718,25 +4691,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "winter-prover"
-version = "0.10.3"
+name = "winter-maybe-async"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab5e02d53d5df7903ebf3e1f4ba44b918267876bfd37eade046d9a669f4e9fb"
+checksum = "91ce144fde121b98523bb8a6c15a311773e1d534d33c1cb47f5580bba9cff8e7"
+dependencies = [
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "winter-prover"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c2f3cf80955f084fd614c86883195331116b6c96dc88532d43d6836bd7adee"
 dependencies = [
  "tracing",
  "winter-air",
  "winter-crypto",
  "winter-fri",
  "winter-math",
- "winter-maybe-async",
+ "winter-maybe-async 0.11.0",
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-rand-utils"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7616d11fcc26552dada45c803a884ac97c253218835b83a2c63e1c2a988639"
+checksum = "226e4c455f6eb72f64ac6eeb7642df25e21ff2280a4f6b09db75392ad6b390ef"
 dependencies = [
  "rand",
  "winter-utils",
@@ -4744,18 +4727,18 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f948e71ffd482aa13d0ec3349047f81ecdb89f3b3287577973dcbf092a25fb4"
+checksum = "1507ef312ea5569d54c2c7446a18b82143eb2a2e21f5c3ec7cfbe8200c03bd7c"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "winter-verifier"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517c31712cceaafc3c7dcc9311f7d5d306b34e208bc72664c691056fd863f7b8"
+checksum = "56d949eab6c26328733477ec56ca054fdc69c0c1b8267fa03d8b618ffe2193c4"
 dependencies = [
  "winter-air",
  "winter-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,16 +32,17 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", version = "0.11", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 assert_matches = { version = "1.5", default-features = false }
-miden-crypto = { version = "0.12", default-features = false }
+miden-crypto = { version = "0.13", default-features = false }
 miden-lib = { path = "miden-lib", version = "0.7", default-features = false }
 miden-objects = { path = "objects", version = "0.7", default-features = false }
-miden-prover = { version = "0.11", default-features = false }
-miden-stdlib = { version = "0.11", default-features = false }
+miden-prover = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 miden-tx = { path = "miden-tx", version = "0.7", default-features = false }
-miden-verifier = { version = "0.11", default-features = false }
+miden-verifier = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 rand = { version = "0.8", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-vm-core = { package = "miden-core", version = "0.11", default-features = false }
-vm-processor = { package = "miden-processor", version = "0.11", default-features = false }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -8,19 +8,19 @@ use miden_objects::{digest, Digest};
 /// Hashes of all dynamically executed procedures from the kernel 0.
 pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // account_vault_add_asset
-    digest!("0xc69b608da541fea9a41322359cc049cac55f816858f530005e333d0b54f2f284"),
+    digest!("0x3aa1700be525d8fe711c53a7b963327b4f0474198795059f73bef5f95fc15c76"),
     // account_vault_get_balance
-    digest!("0x37c528cbc741f6c9d81602bcb435185f471eec705a59a36704ef3632960607e8"),
+    digest!("0x873a4e8a1ea6fdc5f6a77d3f5738cc019e169b6a994fc94c91e408ebbb92991b"),
     // account_vault_has_non_fungible_asset
-    digest!("0x7144f9ac1df4c4c90b770891e1665d25a819ea026227a7d143ab89b89991bc14"),
+    digest!("0xa85ddaa4996222fe64d8e4d8c47672dac666c2771078309ec8505f8ed23f1523"),
     // account_vault_remove_asset
-    digest!("0xba1814cd33cbd3504803d8d11c075775f0cb4a2fb959bf15214ad9ce708db3e5"),
+    digest!("0xebcbe3c46e81a5b9d5bf66be02dcbe3b6487d8d16f594d8892a458bb141d9250"),
     // get_account_id
     digest!("0x595d4386e0d4ce6a62ef2c946ef476ba62d1dcf248b200b26fd4f0d51d065711"),
     // get_account_item
     digest!("0x1a73504fc477eb17c9c9fcedd97ba4f397c9827c562aff1822a2fd08f8e9da18"),
     // get_account_map_item
-    digest!("0x2b3ad4c92f7cbce843eae3ef56e061317b41a46116cdc7bdd9da1b5318228523"),
+    digest!("0x63480b0458945bdd8d3b3ec18d0ee0363e1c013c5c1a83a7a43ec67a082a2934"),
     // get_account_nonce
     digest!("0x7456aa74a3bddeacfbcf02eb04130b8aea0772b5b15f0aeb49f91b1269d16bf7"),
     // get_account_vault_commitment
@@ -36,13 +36,13 @@ pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // set_account_item
     digest!("0x079a2b36c1799f49981e06509826921bdc6ae49eb1536979bbdc0d7b6ad32de7"),
     // set_account_map_item
-    digest!("0x02befd8e777bacc5f4c3b14267b7e5558c9557d82970e74612c5aa6d7febf9c2"),
+    digest!("0xaf9eb3c1ab938d1438015b58e3ff8200e36ac73ef38e2fd012e27b93f40fba82"),
     // burn_asset
-    digest!("0x5b3bcc39db744de02b0111a43191c09c7cafbf138fac5913d959290225f061aa"),
+    digest!("0x5d4c05286edace36e344ccec27bd025164d7d0772e51f6412637156213e8977a"),
     // get_fungible_faucet_total_issuance
     digest!("0x0ba11e1765fac99dd615e32f4035773fad1093f14bd2ed7c98fa5470a60b7e19"),
     // mint_asset
-    digest!("0xc1e42d63f41e1b5f8b550e01b0ad69de5b264fe7214d036ca09927998eb8e422"),
+    digest!("0x42d26c735dd7d6ced0cb5049b5305cdb4436fde8bf6a33d3554b621d408dbd2f"),
     // add_asset_to_note
     digest!("0x9728db11ce1e4aa6420f53bfd8002289d3aa5b18dae9039d3c3ee2b2541ecbeb"),
     // create_note
@@ -66,7 +66,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // get_block_number
     digest!("0x17da2a77b878820854bfff2b5f9eb969a4e2e76a998f97f4967b2b1a7696437c"),
     // start_foreign_context
-    digest!("0xb4d7a4c18ccc26fc22522cde28a950ebe34097937d02307964460f6217d11842"),
+    digest!("0xc96760389579d62941b144de8ba9a947b517c8caaee09987c0f10ea02bc02709"),
     // end_foreign_context
     digest!("0x132b50feca8ecec10937c740640c59733e643e89c1d8304cf4523120e27a0428"),
     // update_expiration_block_num

--- a/miden-tx/Cargo.toml
+++ b/miden-tx/Cargo.toml
@@ -17,7 +17,7 @@ name = "miden-tx"
 path = "tests/integration/main.rs"
 
 [features]
-async = ["winter-maybe-async/async"]
+async = ["winter-maybe-async/async", "miden-prover/async"]
 concurrent = ["miden-lib/concurrent", "miden-objects/concurrent", "miden-prover/concurrent", "std"]
 default = ["std"]
 std = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]

--- a/miden-tx/src/host/account_procs.rs
+++ b/miden-tx/src/host/account_procs.rs
@@ -42,10 +42,7 @@ impl AccountProcedureIndexMap {
     /// # Errors
     /// Returns an error if the procedure at the top of the operand stack is not present in this
     /// map.
-    pub fn get_proc_index(
-        &self,
-        process: &impl ProcessState,
-    ) -> Result<u8, TransactionKernelError> {
+    pub fn get_proc_index(&self, process: &ProcessState) -> Result<u8, TransactionKernelError> {
         // get current account code commitment
         let code_commitment = {
             let curr_data_ptr = process

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -21,8 +21,8 @@ use miden_objects::{
     Digest, Hasher,
 };
 use vm_processor::{
-    AdviceExtractor, AdviceInjector, AdviceProvider, AdviceSource, ContextId, ExecutionError, Felt,
-    Host, HostResponse, MastForest, MastForestStore, ProcessState,
+    AdviceProvider, AdviceSource, ContextId, ExecutionError, Felt, Host, MastForest,
+    MastForestStore, ProcessState,
 };
 
 mod account_delta_tracker;
@@ -156,9 +156,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// `output_notes` field of this [TransactionHost].
     ///
     /// Expected stack state: `[NOTE_METADATA, RECIPIENT, ...]`
-    fn on_note_after_created<S: ProcessState>(
+    fn on_note_after_created(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let stack = process.get_stack_state();
         // # => [NOTE_METADATA]
@@ -177,9 +177,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// Adds an asset at the top of the [OutputNoteBuilder] identified by the note pointer.
     ///
     /// Expected stack state: [ASSET, note_ptr, ...]
-    fn on_note_before_add_asset<S: ProcessState>(
+    fn on_note_before_add_asset(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let stack = process.get_stack_state();
         //# => [ASSET, note_ptr, num_of_assets, note_idx]
@@ -208,9 +208,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// Loads the index of the procedure root onto the advice stack.
     ///
     /// Expected stack state: [PROC_ROOT, ...]
-    fn on_account_push_procedure_index<S: ProcessState>(
+    fn on_account_push_procedure_index(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let proc_idx = self.acct_procedure_index_map.get_proc_index(process)?;
         self.adv_provider
@@ -222,9 +222,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// Extracts the nonce increment from the process state and adds it to the nonce delta tracker.
     ///
     /// Expected stack state: [nonce_delta, ...]
-    pub fn on_account_before_increment_nonce<S: ProcessState>(
+    pub fn on_account_before_increment_nonce(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let value = process.get_stack_item(0);
         self.account_delta.increment_nonce(value);
@@ -238,9 +238,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// records the latest value of this storage slot.
     ///
     /// Expected stack state: [slot_index, NEW_SLOT_VALUE, CURRENT_SLOT_VALUE, ...]
-    pub fn on_account_storage_after_set_item<S: ProcessState>(
+    pub fn on_account_storage_after_set_item(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         // get slot index from the stack and make sure it is valid
         let slot_index = process.get_stack_item(0);
@@ -284,9 +284,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// records the latest values of this storage map.
     ///
     /// Expected stack state: [slot_index, NEW_MAP_KEY, NEW_MAP_VALUE, ...]
-    pub fn on_account_storage_after_set_map_item<S: ProcessState>(
+    pub fn on_account_storage_after_set_map_item(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         // get slot index from the stack and make sure it is valid
         let slot_index = process.get_stack_item(0);
@@ -334,9 +334,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// updates the appropriate fungible or non-fungible asset map.
     ///
     /// Expected stack state: [ASSET, ...]
-    pub fn on_account_vault_after_add_asset<S: ProcessState>(
+    pub fn on_account_vault_after_add_asset(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let asset: Asset = process.get_stack_word(0).try_into().map_err(|source| {
             TransactionKernelError::MalformedAssetInEventHandler {
@@ -356,9 +356,9 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// and updates the appropriate fungible or non-fungible asset map.
     ///
     /// Expected stack state: [ASSET, ...]
-    pub fn on_account_vault_after_remove_asset<S: ProcessState>(
+    pub fn on_account_vault_after_remove_asset(
         &mut self,
-        process: &S,
+        process: &ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let asset: Asset = process.get_stack_word(0).try_into().map_err(|source| {
             TransactionKernelError::MalformedAssetInEventHandler {
@@ -382,10 +382,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// This signature is created during transaction execution and stored for use as advice map
     /// inputs in the proving host. If not already present in the advice map, it is requested from
     /// the host's authenticator.
-    pub fn on_signature_requested<S: ProcessState>(
-        &mut self,
-        process: &S,
-    ) -> Result<HostResponse, ExecutionError> {
+    pub fn on_signature_requested(&mut self, process: &ProcessState) -> Result<(), ExecutionError> {
         let pub_key = process.get_stack_word(0);
         let msg = process.get_stack_word(1);
         let signature_key = Hasher::merge(&[pub_key.into(), msg.into()]);
@@ -417,7 +414,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
             self.adv_provider.push_stack(AdviceSource::Value(r))?;
         }
 
-        Ok(HostResponse::None)
+        Ok(())
     }
 
     // HELPER FUNCTIONS
@@ -429,7 +426,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// # Errors
     /// Returns an error if the address of the currently executing input note is invalid (e.g.,
     /// greater than `u32::MAX`).
-    fn get_current_note_id<S: ProcessState>(process: &S) -> Result<Option<NoteId>, ExecutionError> {
+    fn get_current_note_id(process: &ProcessState) -> Result<Option<NoteId>, ExecutionError> {
         // get the word where note address is stored
         let note_address_word = process.get_mem_value(process.ctx(), CURRENT_INPUT_NOTE_PTR);
         // get the note address in `Felt` from or return `None` if the address hasn't been accessed
@@ -455,7 +452,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
     /// # Errors
     /// Returns an error if the memory location supposed to contain the account storage slot number
     /// has not been initialized.
-    fn get_num_storage_slots<S: ProcessState>(process: &S) -> Result<u64, TransactionKernelError> {
+    fn get_num_storage_slots(process: &ProcessState) -> Result<u64, TransactionKernelError> {
         let num_storage_slots_word = process
             .get_mem_value(process.ctx(), NATIVE_NUM_ACCT_STORAGE_SLOTS_PTR)
             .ok_or(TransactionKernelError::AccountStorageSlotsNumMissing(
@@ -470,91 +467,74 @@ impl<A: AdviceProvider> TransactionHost<A> {
 // ================================================================================================
 
 impl<A: AdviceProvider> Host for TransactionHost<A> {
-    fn get_advice<S: ProcessState>(
-        &mut self,
-        process: &S,
-        extractor: AdviceExtractor,
-    ) -> Result<HostResponse, ExecutionError> {
-        self.adv_provider.get_advice(process, &extractor)
+    type AdviceProvider = A;
+
+    fn advice_provider(&self) -> &Self::AdviceProvider {
+        &self.adv_provider
     }
 
-    fn set_advice<S: ProcessState>(
-        &mut self,
-        process: &S,
-        injector: AdviceInjector,
-    ) -> Result<HostResponse, ExecutionError> {
-        match injector {
-            AdviceInjector::SigToStack { .. } => self.on_signature_requested(process),
-            injector => self.adv_provider.set_advice(process, &injector),
-        }
+    fn advice_provider_mut(&mut self) -> &mut Self::AdviceProvider {
+        &mut self.adv_provider
     }
 
     fn get_mast_forest(&self, node_digest: &Digest) -> Option<Arc<MastForest>> {
         self.mast_store.get(node_digest)
     }
 
-    fn on_event<S: ProcessState>(
-        &mut self,
-        process: &S,
-        event_id: u32,
-    ) -> Result<HostResponse, ExecutionError> {
+    fn on_event(&mut self, process: ProcessState, event_id: u32) -> Result<(), ExecutionError> {
         let event = TransactionEvent::try_from(event_id)
-            .map_err(|err| ExecutionError::EventError(err.to_string()))?;
+            .map_err(|err| ExecutionError::EventError(err.into()))?;
 
         if process.ctx() != ContextId::root() {
-            return Err(ExecutionError::EventError(format!(
-                "{event} event can only be emitted from the root context"
-            )));
+            return Err(ExecutionError::EventError(
+                format!("{event} event can only be emitted from the root context").into(),
+            ));
         }
 
         match event {
             TransactionEvent::AccountVaultBeforeAddAsset => Ok(()),
             TransactionEvent::AccountVaultAfterAddAsset => {
-                self.on_account_vault_after_add_asset(process)
+                self.on_account_vault_after_add_asset(&process)
             },
 
             TransactionEvent::AccountVaultBeforeRemoveAsset => Ok(()),
             TransactionEvent::AccountVaultAfterRemoveAsset => {
-                self.on_account_vault_after_remove_asset(process)
+                self.on_account_vault_after_remove_asset(&process)
             },
 
             TransactionEvent::AccountStorageBeforeSetItem => Ok(()),
             TransactionEvent::AccountStorageAfterSetItem => {
-                self.on_account_storage_after_set_item(process)
+                self.on_account_storage_after_set_item(&process)
             },
 
             TransactionEvent::AccountStorageBeforeSetMapItem => Ok(()),
             TransactionEvent::AccountStorageAfterSetMapItem => {
-                self.on_account_storage_after_set_map_item(process)
+                self.on_account_storage_after_set_map_item(&process)
             },
 
             TransactionEvent::AccountBeforeIncrementNonce => {
-                self.on_account_before_increment_nonce(process)
+                self.on_account_before_increment_nonce(&process)
             },
             TransactionEvent::AccountAfterIncrementNonce => Ok(()),
 
             TransactionEvent::AccountPushProcedureIndex => {
-                self.on_account_push_procedure_index(process)
+                self.on_account_push_procedure_index(&process)
             },
 
             TransactionEvent::NoteBeforeCreated => Ok(()),
-            TransactionEvent::NoteAfterCreated => self.on_note_after_created(process),
+            TransactionEvent::NoteAfterCreated => self.on_note_after_created(&process),
 
-            TransactionEvent::NoteBeforeAddAsset => self.on_note_before_add_asset(process),
+            TransactionEvent::NoteBeforeAddAsset => self.on_note_before_add_asset(&process),
             TransactionEvent::NoteAfterAddAsset => Ok(()),
         }
-        .map_err(|err| ExecutionError::EventError(err.to_string()))?;
+        .map_err(|err| ExecutionError::EventError(err.into()))?;
 
-        Ok(HostResponse::None)
+        Ok(())
     }
 
-    fn on_trace<S: ProcessState>(
-        &mut self,
-        process: &S,
-        trace_id: u32,
-    ) -> Result<HostResponse, ExecutionError> {
+    fn on_trace(&mut self, process: ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
         let event = TransactionTrace::try_from(trace_id)
-            .map_err(|err| ExecutionError::EventError(err.to_string()))?;
+            .map_err(|err| ExecutionError::EventError(err.into()))?;
 
         use TransactionTrace::*;
         match event {
@@ -563,7 +543,7 @@ impl<A: AdviceProvider> Host for TransactionHost<A> {
             NotesProcessingStart => self.tx_progress.start_notes_processing(process.clk()),
             NotesProcessingEnd => self.tx_progress.end_notes_processing(process.clk()),
             NoteExecutionStart => {
-                let note_id = Self::get_current_note_id(process)?.expect(
+                let note_id = Self::get_current_note_id(&process)?.expect(
                     "Note execution interval measurement is incorrect: check the placement of the start and the end of the interval",
                 );
                 self.tx_progress.start_note_execution(process.clk(), note_id);
@@ -575,10 +555,10 @@ impl<A: AdviceProvider> Host for TransactionHost<A> {
             EpilogueEnd => self.tx_progress.end_epilogue(process.clk()),
         }
 
-        Ok(HostResponse::None)
+        Ok(())
     }
 
-    fn on_assert_failed<S: ProcessState>(&mut self, process: &S, err_code: u32) -> ExecutionError {
+    fn on_assert_failed(&mut self, process: ProcessState, err_code: u32) -> ExecutionError {
         let err_msg = self
             .error_messages
             .get(&err_code)

--- a/miden-tx/src/testing/executor.rs
+++ b/miden-tx/src/testing/executor.rs
@@ -35,18 +35,15 @@ impl<H: Host> CodeExecutor<H> {
     }
 
     /// Compiles and runs the desired code in the host and returns the [Process] state
-    pub fn run(self, code: &str) -> Result<Process<H>, ExecutionError> {
+    pub fn run(self, code: &str) -> Result<Process, ExecutionError> {
         let program = TransactionKernel::testing_assembler().assemble_program(code).unwrap();
         self.execute_program(program)
     }
 
-    pub fn execute_program(self, program: Program) -> Result<Process<H>, ExecutionError> {
-        let mut process = Process::new_debug(
-            program.kernel().clone(),
-            self.stack_inputs.unwrap_or_default(),
-            self.host,
-        );
-        process.execute(&program)?;
+    pub fn execute_program(mut self, program: Program) -> Result<Process, ExecutionError> {
+        let mut process =
+            Process::new_debug(program.kernel().clone(), self.stack_inputs.unwrap_or_default());
+        process.execute(&program, &mut self.host)?;
 
         Ok(process)
     }
@@ -60,7 +57,7 @@ where
         let mut host = DefaultHost::new(adv_provider);
 
         let test_lib = TransactionKernel::kernel_as_library();
-        host.load_mast_forest(test_lib.mast_forest().clone());
+        host.load_mast_forest(test_lib.mast_forest().clone()).unwrap();
 
         CodeExecutor::new(host)
     }

--- a/miden-tx/src/testing/tx_context/builder.rs
+++ b/miden-tx/src/testing/tx_context/builder.rs
@@ -26,11 +26,12 @@ use miden_objects::{
         storage::prepare_assets,
     },
     transaction::{OutputNote, TransactionArgs, TransactionInputs, TransactionScript},
+    vm::AdviceMap,
     FieldElement,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{AdviceInputs, AdviceMap, Felt, Word};
+use vm_processor::{AdviceInputs, Felt, Word};
 
 use super::TransactionContext;
 use crate::{auth::BasicAuthenticator, testing::MockChain};

--- a/miden-tx/src/testing/tx_context/mod.rs
+++ b/miden-tx/src/testing/tx_context/mod.rs
@@ -51,7 +51,7 @@ impl TransactionContext {
     ///
     /// # Errors
     /// Returns an error if the assembly of execution of the provided code fails.
-    pub fn execute_code(&self, code: &str) -> Result<Process<MockHost>, ExecutionError> {
+    pub fn execute_code(&self, code: &str) -> Result<Process, ExecutionError> {
         let (stack_inputs, mut advice_inputs) = TransactionKernel::prepare_inputs(
             &self.tx_inputs,
             &self.tx_args,

--- a/miden-tx/src/tests/kernel_tests/mod.rs
+++ b/miden-tx/src/tests/kernel_tests/mod.rs
@@ -10,7 +10,7 @@ use miden_objects::{
     vm::StackInputs,
     Felt, Hasher, Word, ONE, ZERO,
 };
-use vm_processor::{ContextId, Host, Process, ProcessState};
+use vm_processor::{ContextId, Process, ProcessState};
 
 mod test_account;
 mod test_asset;
@@ -44,12 +44,12 @@ macro_rules! assert_execution_error {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-pub fn read_root_mem_value<H: Host>(process: &Process<H>, addr: u32) -> Word {
-    process.get_mem_value(ContextId::root(), addr).unwrap()
+pub fn read_root_mem_value(process: &Process, addr: u32) -> Word {
+    ProcessState::from(process).get_mem_value(ContextId::root(), addr).unwrap()
 }
 
-pub fn try_read_root_mem_value<H: Host>(process: &Process<H>, addr: u32) -> Option<Word> {
-    process.get_mem_value(ContextId::root(), addr)
+pub fn try_read_root_mem_value(process: &Process, addr: u32) -> Option<Word> {
+    ProcessState::from(process).get_mem_value(ContextId::root(), addr)
 }
 
 pub fn output_notes_data_procedure(notes: &[Note]) -> String {

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -295,25 +295,26 @@ fn test_get_map_item() {
             map_key = prepare_word(&key),
         );
         let process = tx_context.execute_code(&code).unwrap();
+        let state = ProcessState::from(&process);
 
         assert_eq!(
             value,
-            process.get_stack_word(0),
+            state.get_stack_word(0),
             "get_map_item result doesn't match the expected value",
         );
         assert_eq!(
             Word::default(),
-            process.get_stack_word(1),
+            state.get_stack_word(1),
             "The rest of the stack must be cleared",
         );
         assert_eq!(
             Word::default(),
-            process.get_stack_word(2),
+            state.get_stack_word(2),
             "The rest of the stack must be cleared",
         );
         assert_eq!(
             Word::default(),
-            process.get_stack_word(3),
+            state.get_stack_word(3),
             "The rest of the stack must be cleared",
         );
     }
@@ -350,16 +351,17 @@ fn test_get_storage_slot_type() {
         );
 
         let process = tx_context.execute_code(&code).unwrap();
+        let state = ProcessState::from(&process);
 
         let storage_slot_type = storage_item.slot.slot_type();
 
-        assert_eq!(storage_slot_type, process.get_stack_item(0).try_into().unwrap());
-        assert_eq!(process.get_stack_item(1), ZERO, "the rest of the stack is empty");
-        assert_eq!(process.get_stack_item(2), ZERO, "the rest of the stack is empty");
-        assert_eq!(process.get_stack_item(3), ZERO, "the rest of the stack is empty");
-        assert_eq!(Word::default(), process.get_stack_word(1), "the rest of the stack is empty");
-        assert_eq!(Word::default(), process.get_stack_word(2), "the rest of the stack is empty");
-        assert_eq!(Word::default(), process.get_stack_word(3), "the rest of the stack is empty");
+        assert_eq!(storage_slot_type, state.get_stack_item(0).try_into().unwrap());
+        assert_eq!(state.get_stack_item(1), ZERO, "the rest of the stack is empty");
+        assert_eq!(state.get_stack_item(2), ZERO, "the rest of the stack is empty");
+        assert_eq!(state.get_stack_item(3), ZERO, "the rest of the stack is empty");
+        assert_eq!(Word::default(), state.get_stack_word(1), "the rest of the stack is empty");
+        assert_eq!(Word::default(), state.get_stack_word(2), "the rest of the stack is empty");
+        assert_eq!(Word::default(), state.get_stack_word(3), "the rest of the stack is empty");
     }
 }
 
@@ -452,18 +454,19 @@ fn test_set_map_item() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
+    let state = ProcessState::from(&process);
 
     let mut new_storage_map = AccountStorage::mock_map();
     new_storage_map.insert(new_key, new_value);
 
     assert_eq!(
         new_storage_map.root(),
-        Digest::from(process.get_stack_word(0)),
+        Digest::from(state.get_stack_word(0)),
         "get_item must return the new updated value",
     );
     assert_eq!(
         storage_item.slot.value(),
-        process.get_stack_word(1),
+        state.get_stack_word(1),
         "The original value stored in the map doesn't match the expected value",
     );
 }

--- a/miden-tx/src/tests/kernel_tests/test_asset.rs
+++ b/miden-tx/src/tests/kernel_tests/test_asset.rs
@@ -41,9 +41,10 @@ fn test_create_fungible_asset_succeeds() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
+    let state = ProcessState::from(&process);
 
     assert_eq!(
-        process.get_stack_word(0),
+        state.get_stack_word(0),
         Word::from([
             Felt::new(FUNGIBLE_ASSET_AMOUNT),
             Felt::new(0),
@@ -84,8 +85,9 @@ fn test_create_non_fungible_asset_succeeds() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
+    let state = ProcessState::from(&process);
 
-    assert_eq!(process.get_stack_word(0), Word::from(non_fungible_asset));
+    assert_eq!(state.get_stack_word(0), Word::from(non_fungible_asset));
 }
 
 #[test]
@@ -116,5 +118,6 @@ fn test_validate_non_fungible_asset() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
-    assert_eq!(process.get_stack_word(0), encoded);
+    let state = ProcessState::from(&process);
+    assert_eq!(state.get_stack_word(0), encoded);
 }

--- a/miden-tx/src/tests/kernel_tests/test_epilogue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_epilogue.rs
@@ -241,11 +241,12 @@ fn test_block_expiration_height_monotonically_decreases() {
             .replace("{min_value}", &v2.min(v1).to_string());
 
         let process = tx_context.execute_code(code).unwrap();
+        let state = ProcessState::from(&process);
 
         // Expiry block should be set to transaction's block + the stored expiration delta
         // (which can only decrease, not increase)
         let expected_expiry = v1.min(v2) + tx_context.tx_inputs().block_header().block_num() as u64;
-        assert_eq!(process.get_stack_item(8).as_int(), expected_expiry);
+        assert_eq!(state.get_stack_item(8).as_int(), expected_expiry);
     }
 }
 
@@ -292,8 +293,10 @@ fn test_no_expiration_delta_set() {
     end
     ";
     let process = tx_context.execute_code(code_template).unwrap();
+    let state = ProcessState::from(&process);
+
     // Default value should be equal to u32::max, set in the prologue
-    assert_eq!(process.get_stack_item(8).as_int() as u32, u32::MAX);
+    assert_eq!(state.get_stack_item(8).as_int() as u32, u32::MAX);
 }
 
 #[test]

--- a/miden-tx/src/tests/kernel_tests/test_faucet.rs
+++ b/miden-tx/src/tests/kernel_tests/test_faucet.rs
@@ -69,14 +69,14 @@ fn test_mint_fungible_asset_succeeds() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
+    let state = ProcessState::from(&process);
 
     let expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT;
     let faucet_reserved_slot_storage_location =
         FAUCET_STORAGE_DATA_SLOT as u32 + NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR;
 
-    let faucet_memory_value_word = process
-        .get_mem_value(process.ctx(), faucet_reserved_slot_storage_location)
-        .unwrap();
+    let faucet_memory_value_word =
+        state.get_mem_value(state.ctx(), faucet_reserved_slot_storage_location).unwrap();
 
     assert_eq!(faucet_memory_value_word[3].as_int(), expected_final_storage_amount);
 }
@@ -332,14 +332,14 @@ fn test_burn_fungible_asset_succeeds() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
+    let state = ProcessState::from(&process);
 
     let expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT;
     let faucet_reserved_slot_storage_location =
         FAUCET_STORAGE_DATA_SLOT as u32 + NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR;
 
-    let faucet_memory_value_word = process
-        .get_mem_value(process.ctx(), faucet_reserved_slot_storage_location)
-        .unwrap();
+    let faucet_memory_value_word =
+        state.get_mem_value(state.ctx(), faucet_reserved_slot_storage_location).unwrap();
 
     assert_eq!(faucet_memory_value_word[3].as_int(), expected_final_storage_amount);
 }

--- a/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -12,9 +12,7 @@ use vm_processor::{ProcessState, EMPTY_WORD, ONE};
 use super::{Felt, Process, ZERO};
 use crate::{
     assert_execution_error,
-    testing::{
-        utils::input_note_data_ptr, MockHost, TransactionContext, TransactionContextBuilder,
-    },
+    testing::{utils::input_note_data_ptr, TransactionContext, TransactionContextBuilder},
     tests::kernel_tests::read_root_mem_value,
 };
 
@@ -374,7 +372,7 @@ fn test_note_script_and_note_args() {
     assert_eq!(process.stack.get_word(1), note_args[1]);
 }
 
-fn note_setup_stack_assertions(process: &Process<MockHost>, inputs: &TransactionContext) {
+fn note_setup_stack_assertions(process: &Process, inputs: &TransactionContext) {
     let mut expected_stack = [ZERO; 16];
 
     // replace the top four elements with the tx script root
@@ -386,7 +384,7 @@ fn note_setup_stack_assertions(process: &Process<MockHost>, inputs: &Transaction
     assert_eq!(process.stack.trace_state(), expected_stack)
 }
 
-fn note_setup_memory_assertions(process: &Process<MockHost>) {
+fn note_setup_memory_assertions(process: &Process) {
     // assert that the correct pointer is stored in bookkeeping memory
     assert_eq!(
         read_root_mem_value(process, CURRENT_INPUT_NOTE_PTR)[0],
@@ -466,6 +464,7 @@ fn test_get_inputs_hash() {
     ";
 
     let process = tx_context.execute_code(code).unwrap();
+    let state = ProcessState::from(&process);
 
     let mut expected_5 = Hasher::hash_elements(&[
         Felt::new(1),
@@ -515,7 +514,7 @@ fn test_get_inputs_hash() {
     expected_stack.extend_from_slice(&expected_8);
     expected_stack.extend_from_slice(&expected_5);
 
-    assert_eq!(process.get_stack_state()[0..16], expected_stack);
+    assert_eq!(state.get_stack_state()[0..16], expected_stack);
 }
 
 #[test]

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -46,9 +46,7 @@ use vm_processor::{AdviceInputs, ONE};
 use super::{Felt, Process, Word, ZERO};
 use crate::{
     assert_execution_error,
-    testing::{
-        utils::input_note_data_ptr, MockHost, TransactionContext, TransactionContextBuilder,
-    },
+    testing::{utils::input_note_data_ptr, TransactionContext, TransactionContextBuilder},
     tests::kernel_tests::read_root_mem_value,
 };
 
@@ -105,7 +103,7 @@ fn test_transaction_prologue() {
     input_notes_memory_assertions(&process, &tx_context, &note_args);
 }
 
-fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &TransactionContext) {
+fn global_input_memory_assertions(process: &Process, inputs: &TransactionContext) {
     assert_eq!(
         read_root_mem_value(process, BLK_HASH_PTR),
         inputs.tx_inputs().block_header().hash().as_elements(),
@@ -143,7 +141,7 @@ fn global_input_memory_assertions(process: &Process<MockHost>, inputs: &Transact
     );
 }
 
-fn block_data_memory_assertions(process: &Process<MockHost>, inputs: &TransactionContext) {
+fn block_data_memory_assertions(process: &Process, inputs: &TransactionContext) {
     assert_eq!(
         read_root_mem_value(process, BLK_HASH_PTR),
         inputs.tx_inputs().block_header().hash().as_elements(),
@@ -217,7 +215,7 @@ fn block_data_memory_assertions(process: &Process<MockHost>, inputs: &Transactio
     );
 }
 
-fn chain_mmr_memory_assertions(process: &Process<MockHost>, prepared_tx: &TransactionContext) {
+fn chain_mmr_memory_assertions(process: &Process, prepared_tx: &TransactionContext) {
     // update the chain MMR to point to the block against which this transaction is being executed
     let mut chain_mmr = prepared_tx.tx_inputs().block_chain().clone();
     chain_mmr.add_block(*prepared_tx.tx_inputs().block_header(), true);
@@ -237,7 +235,7 @@ fn chain_mmr_memory_assertions(process: &Process<MockHost>, prepared_tx: &Transa
     }
 }
 
-fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &TransactionContext) {
+fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext) {
     assert_eq!(
         read_root_mem_value(process, NATIVE_ACCT_ID_AND_NONCE_PTR),
         [inputs.account().id().into(), ZERO, ZERO, inputs.account().nonce()],
@@ -314,7 +312,7 @@ fn account_data_memory_assertions(process: &Process<MockHost>, inputs: &Transact
 }
 
 fn input_notes_memory_assertions(
-    process: &Process<MockHost>,
+    process: &Process,
     inputs: &TransactionContext,
     note_args: &[[Felt; 4]],
 ) {
@@ -606,6 +604,6 @@ fn test_get_blk_timestamp() {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn read_note_element(process: &Process<MockHost>, note_idx: u32, offset: MemoryOffset) -> Word {
+fn read_note_element(process: &Process, note_idx: u32, offset: MemoryOffset) -> Word {
     read_root_mem_value(process, input_note_data_ptr(note_idx) + offset)
 }

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -40,12 +40,12 @@ use miden_objects::{
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::AdviceInputs;
+use vm_processor::{AdviceInputs, ProcessState};
 
-use super::{Felt, Process, ProcessState, Word, ONE, ZERO};
+use super::{Felt, Process, Word, ONE, ZERO};
 use crate::{
     assert_execution_error,
-    testing::{MockChain, MockHost, TransactionContextBuilder},
+    testing::{MockChain, TransactionContextBuilder},
     tests::kernel_tests::{read_root_mem_value, try_read_root_mem_value},
     TransactionExecutor,
 };
@@ -332,6 +332,7 @@ fn test_get_output_notes_commitment() {
     );
 
     let process = tx_context.execute_code(&code).unwrap();
+    let state = ProcessState::from(&process);
 
     assert_eq!(
         read_root_mem_value(&process, NUM_OUTPUT_NOTES_PTR),
@@ -357,7 +358,7 @@ fn test_get_output_notes_commitment() {
         "Validate the output note 1 metadata",
     );
 
-    assert_eq!(process.get_stack_word(0), *expected_output_notes_hash);
+    assert_eq!(state.get_stack_word(0), *expected_output_notes_hash);
 }
 
 #[test]
@@ -1083,7 +1084,7 @@ fn get_mock_fpi_adv_inputs(foreign_account: &Account, mock_chain: &MockChain) ->
     advice_inputs
 }
 
-fn foreign_account_data_memory_assertions(foreign_account: &Account, process: &Process<MockHost>) {
+fn foreign_account_data_memory_assertions(foreign_account: &Account, process: &Process) {
     let foreign_account_data_ptr = NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32;
 
     assert_eq!(

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -34,7 +34,7 @@ rand = { workspace = true, optional = true }
 thiserror = { workspace = true }
 vm-core = { workspace = true }
 vm-processor = { workspace = true }
-winter-rand-utils = { version = "0.10", optional = true }
+winter-rand-utils = { version = "0.11", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -172,6 +172,6 @@ pub mod utils {
 
 pub mod vm {
     pub use miden_verifier::ExecutionProof;
-    pub use vm_core::{Program, ProgramInfo};
-    pub use vm_processor::{AdviceInputs, AdviceMap, RowIndex, StackInputs, StackOutputs};
+    pub use vm_core::{AdviceMap, Program, ProgramInfo};
+    pub use vm_processor::{AdviceInputs, RowIndex, StackInputs, StackOutputs};
 }

--- a/objects/src/transaction/tx_args.rs
+++ b/objects/src/transaction/tx_args.rs
@@ -6,9 +6,9 @@ use miden_crypto::merkle::InnerNodeInfo;
 use vm_core::{
     mast::{MastForest, MastNodeId},
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},
-    Program,
+    AdviceMap, Program,
 };
-use vm_processor::{AdviceInputs, AdviceMap, DeserializationError};
+use vm_processor::{AdviceInputs, DeserializationError};
 
 use super::{Digest, Felt, Word};
 use crate::{
@@ -273,8 +273,10 @@ impl Deserializable for TransactionScript {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::utils::{Deserializable, Serializable};
-    use vm_processor::AdviceMap;
+    use vm_core::{
+        utils::{Deserializable, Serializable},
+        AdviceMap,
+    };
 
     use crate::transaction::TransactionArgs;
 


### PR DESCRIPTION
In order to use latest changes in `miden-crypto`, we need to migrate `miden-base`.