### PR TITLE
fix: typos in documentation files

### DIFF
--- a/miden-lib/asm/miden/tx.masm
+++ b/miden-lib/asm/miden/tx.masm
@@ -103,7 +103,7 @@ end
 #! note_type is the storage type of the note
 #! execution_hint is the note's execution hint
 #! RECIPIENT is the recipient of the note.
-#! note_idx is the index of the crated note.
+#! note_idx is the index of the created note.
 export.create_note
     # pad the stack before the syscall to prevent accidental modification of the deeper stack
     # elements


### PR DESCRIPTION
Corrected "crated" to "created".