### PR TITLE
Introduce `AccountIdError` and make account ID byte representations consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Implemented `to_hex` for `AccountIdPrefix` and `epoch_block_num` for `BlockHeader` (#1039).
 - Introduce `AccountIdBuilder` to simplify `AccountId` generation in tests (#1045).
 - Introduced `AccountComponentTemplate` with TOML serialization and templating (#1015, #1027).
+- Introduce `AccountIdError` and make account ID byte representations (`u128`, `[u8; 15]`) consistent (#1055).
 
 ## 0.6.2 (2024-11-20)
 

--- a/bin/bench-tx/src/utils.rs
+++ b/bin/bench-tx/src/utils.rs
@@ -70,8 +70,7 @@ pub fn get_account_with_basic_authenticated_wallet(
     public_key: Word,
     assets: Option<Asset>,
 ) -> Account {
-    AccountBuilder::new()
-        .init_seed(init_seed)
+    AccountBuilder::new(init_seed)
         .account_type(account_type)
         .storage_mode(storage_mode)
         .with_assets(assets)

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -75,6 +75,9 @@ const.ERR_ACCOUNT_ID_UNKNOWN_VERSION=0x00020057
 # Epoch must be less than u16::MAX (0xffff).
 const.ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX=0x00020058
 
+# Unknown account storage mode in account ID.
+const.ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE=0x00020059
+
 # CONSTANTS
 # =================================================================================================
 
@@ -85,6 +88,18 @@ const.ACCOUNT_VERSION_MASK_U32=0x0f # 0b1111
 # Given the least significant 32 bits of an account ID's prefix, this mask defines the bits used
 # to determine the account type.
 const.ACCOUNT_ID_TYPE_MASK_U32=0x30 # 0b11_0000
+
+# Given the least significant 32 bits of an account ID's first felt, this mask defines the bits used
+# to determine the account storage mode.
+const.ACCOUNT_ID_STORAGE_MODE_MASK_U32=0xC0 # 0b1100_0000
+
+# Given the least significant 32 bits of an account ID's first felt with the storage mode mask
+# applied, this value defines the public storage mode.
+const.ACCOUNT_ID_STORAGE_MODE_PUBLIC_U32=0 # 0b0000_0000
+
+# Given the least significant 32 bits of an account ID's first felt with the storage mode mask
+# applied, this value defines the private storage mode.
+const.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32=0x80 # 0b1000_0000
 
 # Bit pattern for an account w/ immutable code, after the account type mask has been applied.
 const.REGULAR_ACCOUNT_IMMUTABLE_CODE=0 # 0b00_0000
@@ -344,7 +359,8 @@ export.is_id_eq
     # => [is_id_equal]
 end
 
-#! Validates an account ID.
+#! Validates an account ID. Note that this does not validate anything about the account type,
+#! since any bit pattern is a valid account type.
 #!
 #! Inputs:  [account_id_prefix, account_id_suffix]
 #! Outputs: []
@@ -354,15 +370,28 @@ end
 #!
 #! Panics if:
 #! - account_id_prefix does not contain version zero.
+#! - account_id_prefix does not contain either the public or private storage mode.
 #! - account_id_suffix contains an anchor epoch that is greater or equal to 2^16.
 #! - account_id_suffix does not have its lower 8 bits set to zero.
 export.validate_id
     # Validate version in prefix. For now only version 0 is supported.
     # ---------------------------------------------------------------------------------------------
 
-    exec.id_version
-    # => [id_version, account_id_suffix]
+    dup exec.id_version
+    # => [id_version, account_id_prefix, account_id_suffix]
     assertz.err=ERR_ACCOUNT_ID_UNKNOWN_VERSION
+    # => [account_id_prefix, account_id_suffix]
+
+    # Validate storage mode in prefix.
+    # ---------------------------------------------------------------------------------------------
+
+    u32split drop
+    # => [account_id_prefix_lo, account_id_suffix]
+    u32and.ACCOUNT_ID_STORAGE_MODE_MASK_U32 dup eq.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32
+    # => [is_private_storage_mode, id_storage_mode_masked, account_id_suffix]
+    swap eq.ACCOUNT_ID_STORAGE_MODE_PUBLIC_U32
+    # => [is_public_storage_mode, is_private_storage_mode, account_id_suffix]
+    or assert.err=ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE
     # => [account_id_suffix]
 
     # Validate anchor epoch is less than u16::MAX (0xffff) in suffix.

--- a/miden-lib/asm/kernels/transaction/lib/constants.masm
+++ b/miden-lib/asm/kernels/transaction/lib/constants.masm
@@ -22,14 +22,6 @@ const.NOTE_TREE_DEPTH=16
 # The maximum number of notes that can be created in a single transaction.
 const.MAX_OUTPUT_NOTES_PER_TX=1024
 
-# Specifies a modulus used to assess if an account seed digest has the required number of trailing
-# zeros for a regular account (2^23).
-const.REGULAR_ACCOUNT_SEED_DIGEST_MODULUS=8388608
-
-# Specifies a modulus used to assess if an account seed digest has the required number of trailing
-# zeros for a faucet account (2^31).
-const.FAUCET_ACCOUNT_SEED_DIGEST_MODULUS=2147483648
-
 # TYPES
 # =================================================================================================
 
@@ -116,32 +108,6 @@ end
 #! - max_num_output_notes is the max number of notes that can be created in a single transaction.
 export.get_max_num_output_notes
     push.MAX_OUTPUT_NOTES_PER_TX
-end
-
-#! Returns a modulus used to assess if an account seed digest has the required number of trailing
-#! zeros for a regular account (2^23).
-#!
-#! Inputs:  []
-#! Outputs: [REGULAR_ACCOUNT_SEED_DIGEST_MODULUS]
-#!
-#! Where:
-#! - REGULAR_ACCOUNT_SEED_DIGEST_MODULUS is a modulus used to assess if a seed digest has the
-#!   required number of trailing zeros for a regular account.
-export.get_regular_account_seed_digest_modulus
-    push.REGULAR_ACCOUNT_SEED_DIGEST_MODULUS
-end
-
-#! Returns a modulus used to assess if an account seed digest has the required number of trailing
-#! zeros for a faucet account (2^31).
-#!
-#! Inputs:  []
-#! Outputs: [FAUCET_ACCOUNT_SEED_DIGEST_MODULUS]
-#!
-#! Where:
-#! - FAUCET_ACCOUNT_SEED_DIGEST_MODULUS is a modulus used to assess if a seed digest has the
-#!   required number of trailing zeros for a faucet account.
-export.get_faucet_seed_digest_modulus
-    push.FAUCET_ACCOUNT_SEED_DIGEST_MODULUS
 end
 
 #! Returns the root of an empty Sparse Merkle Tree.

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -354,6 +354,8 @@ end
 
 #! Builds the stack into the NOTE_METADATA word, encoding the note type and execution hint into a 
 #! single element.
+#! Note that this procedure is only exported so it can be tested. It should not be called from
+#! non-test code.
 #!
 #! Inputs:  [tag, aux, note_type, execution_hint]
 #! Outputs: [NOTE_METADATA]
@@ -366,7 +368,6 @@ end
 #! - execution_hint is the hint which specifies when a note is ready to be consumed.
 #! - NOTE_METADATA is the metadata associated with a note.
 export.build_note_metadata
-    # This procedure is only exported so it can be tested.
 
     # Validate the note type.
     # --------------------------------------------------------------------------------------------

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -365,7 +365,9 @@ end
 #!   or off-chain).
 #! - execution_hint is the hint which specifies when a note is ready to be consumed.
 #! - NOTE_METADATA is the metadata associated with a note.
-proc.build_note_metadata
+export.build_note_metadata
+    # This procedure is only exported so it can be tested.
+
     # Validate the note type.
     # --------------------------------------------------------------------------------------------
 

--- a/miden-lib/build.rs
+++ b/miden-lib/build.rs
@@ -100,9 +100,6 @@ fn main() -> Result<()> {
 /// - {target_dir}/tx_kernel.masl               -> contains kernel library compiled from api.masm.
 /// - {target_dir}/tx_kernel.masb               -> contains the executable compiled from main.masm.
 /// - src/transaction/procedures/kernel_v0.rs   -> contains the kernel procedures table.
-///
-/// When the `testing` feature is enabled, the POW requirements for account ID generation are
-/// adjusted by modifying the corresponding constants in {source_dir}/lib/constants.masm file.
 fn compile_tx_kernel(source_dir: &Path, target_dir: &Path) -> Result<Assembler> {
     let assembler = build_assembler(None)?;
 

--- a/miden-lib/build.rs
+++ b/miden-lib/build.rs
@@ -2,8 +2,8 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     env,
     fmt::Write,
-    fs::{self, File},
-    io::{self, BufRead, BufReader},
+    fs::{self},
+    io::{self},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -106,31 +106,6 @@ fn main() -> Result<()> {
 fn compile_tx_kernel(source_dir: &Path, target_dir: &Path) -> Result<Assembler> {
     let assembler = build_assembler(None)?;
 
-    // if this build has the testing flag set, modify the code and reduce the cost of proof-of-work
-    match env::var("CARGO_FEATURE_TESTING") {
-        Ok(ref s) if s == "1" => {
-            let constants = source_dir.join("lib/constants.masm");
-            let patched = source_dir.join("lib/constants.masm.patched");
-
-            // scope for file handlers
-            {
-                let read = File::open(&constants).unwrap();
-                let mut write = File::create(&patched).unwrap();
-                let modified = BufReader::new(read).lines().map(decrease_pow);
-
-                for line in modified {
-                    io::Write::write_all(&mut write, line.unwrap().as_bytes()).unwrap();
-                    io::Write::write_all(&mut write, b"\n").unwrap();
-                }
-                io::Write::flush(&mut write).unwrap();
-            }
-
-            fs::remove_file(&constants).unwrap();
-            fs::rename(&patched, &constants).unwrap();
-        },
-        _ => (),
-    }
-
     // assemble the kernel library and write it to the "tx_kernel.masl" file
     let kernel_lib = KernelLibrary::from_dir(
         source_dir.join("api.masm"),
@@ -172,20 +147,6 @@ fn compile_tx_kernel(source_dir: &Path, target_dir: &Path) -> Result<Assembler> 
     }
 
     Ok(assembler)
-}
-
-fn decrease_pow(line: io::Result<String>) -> io::Result<String> {
-    let mut line = line?;
-    if line.starts_with("const.REGULAR_ACCOUNT_SEED_DIGEST_MODULUS") {
-        line.clear();
-        // 2**5
-        line.push_str("const.REGULAR_ACCOUNT_SEED_DIGEST_MODULUS=32 # reduced via build.rs");
-    } else if line.starts_with("const.FAUCET_ACCOUNT_SEED_DIGEST_MODULUS") {
-        line.clear();
-        // 2**6
-        line.push_str("const.FAUCET_ACCOUNT_SEED_DIGEST_MODULUS=64 # reduced via build.rs");
-    }
-    Ok(line)
 }
 
 /// Generates `kernel_v0.rs` file based on the kernel library

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -104,8 +104,7 @@ pub fn create_basic_fungible_faucet(
         AuthScheme::RpoFalcon512 { pub_key } => RpoFalcon512::new(pub_key),
     };
 
-    let (account, account_seed) = AccountBuilder::new()
-        .init_seed(init_seed)
+    let (account, account_seed) = AccountBuilder::new(init_seed)
         .anchor(id_anchor)
         .account_type(AccountType::FungibleFaucet)
         .storage_mode(account_storage_mode)

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -63,8 +63,7 @@ pub fn create_basic_wallet(
         AuthScheme::RpoFalcon512 { pub_key } => RpoFalcon512::new(pub_key),
     };
 
-    let (account, account_seed) = AccountBuilder::new()
-        .init_seed(init_seed)
+    let (account, account_seed) = AccountBuilder::new(init_seed)
         .anchor(id_anchor)
         .account_type(account_type)
         .storage_mode(account_storage_mode)

--- a/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/miden-lib/src/errors/tx_kernel_errors.rs
@@ -15,6 +15,7 @@ pub const ERR_ACCOUNT_CODE_COMMITMENT_MISMATCH: u32 = 0x0002000F;
 pub const ERR_ACCOUNT_CODE_IS_NOT_UPDATABLE: u32 = 0x00020006;
 pub const ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX: u32 = 0x00020058;
 pub const ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO: u32 = 0x00020005;
+pub const ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE: u32 = 0x00020059;
 pub const ERR_ACCOUNT_ID_UNKNOWN_VERSION: u32 = 0x00020057;
 pub const ERR_ACCOUNT_INVALID_STORAGE_OFFSET_FOR_SIZE: u32 = 0x00020013;
 pub const ERR_ACCOUNT_IS_NOT_NATIVE: u32 = 0x00020030;
@@ -114,12 +115,13 @@ pub const ERR_VAULT_NON_FUNGIBLE_ASSET_ALREADY_EXISTS: u32 = 0x0002001C;
 pub const ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND: u32 = 0x0002001F;
 pub const ERR_VAULT_REMOVE_FUNGIBLE_ASSET_FAILED_INITIAL_VALUE_INVALID: u32 = 0x0002001E;
 
-pub const TX_KERNEL_ERRORS: [(u32, &str); 89] = [
+pub const TX_KERNEL_ERRORS: [(u32, &str); 90] = [
     (ERR_ACCOUNT_ANCHOR_BLOCK_HASH_MUST_NOT_BE_EMPTY, "Anchor block hash must not be empty"),
     (ERR_ACCOUNT_CODE_COMMITMENT_MISMATCH, "Computed account code commitment does not match recorded account code commitment"),
     (ERR_ACCOUNT_CODE_IS_NOT_UPDATABLE, "Account code must be updatable for it to be possible to set new code"),
     (ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX, "Epoch must be less than u16::MAX (0xffff)."),
     (ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO, "Least significant byte of the account ID suffix must be zero."),
+    (ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE, "Unknown account storage mode in account ID."),
     (ERR_ACCOUNT_ID_UNKNOWN_VERSION, "Unknown version in account ID."),
     (ERR_ACCOUNT_INVALID_STORAGE_OFFSET_FOR_SIZE, "Storage offset is invalid for 0 storage size (should be 0)"),
     (ERR_ACCOUNT_IS_NOT_NATIVE, "The current account is not native"),

--- a/miden-lib/src/transaction/outputs.rs
+++ b/miden-lib/src/transaction/outputs.rs
@@ -37,7 +37,8 @@ pub fn parse_final_account_header(elements: &[Word]) -> Result<AccountHeader, Ac
     let id = AccountId::try_from([
         elements[ACCT_ID_AND_NONCE_OFFSET as usize][ACCT_ID_PREFIX_IDX],
         elements[ACCT_ID_AND_NONCE_OFFSET as usize][ACCT_ID_SUFFIX_IDX],
-    ])?;
+    ])
+    .map_err(AccountError::FinalAccountHeaderIdParsingFailed)?;
     let nonce = elements[ACCT_ID_AND_NONCE_OFFSET as usize][ACCT_NONCE_IDX];
     let vault_root = elements[ACCT_VAULT_ROOT_OFFSET as usize].into();
     let storage_commitment = elements[ACCT_STORAGE_COMMITMENT_OFFSET as usize].into();

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -8,7 +8,7 @@ use miden_objects::{digest, Digest};
 /// Hashes of all dynamically executed procedures from the kernel 0.
 pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // account_vault_add_asset
-    digest!("0x88b15f96c05351ecd320b136fb9f082535e1d493b9d6ddbf1851d49ee02db677"),
+    digest!("0x78d6a2544fcb8d8749165ece83cd72f73ffed433f39543f87090691f5c052838"),
     // account_vault_get_balance
     digest!("0xbe5819bf5aabf1a7c9d8ebfc330a7869f610ca4f86e3708265d8d361b5b82f14"),
     // account_vault_has_non_fungible_asset
@@ -38,13 +38,13 @@ pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // set_account_map_item
     digest!("0x02befd8e777bacc5f4c3b14267b7e5558c9557d82970e74612c5aa6d7febf9c2"),
     // burn_asset
-    digest!("0xd73206fcca792d525ca70c8ce3e241ce6fcad0fc5b2f308884f59f2814ee95b9"),
+    digest!("0x27f721dba5a5710e295ac9404e17a9497f2052bbbb73293cd0fe0ba1ad63bad6"),
     // get_fungible_faucet_total_issuance
     digest!("0xe56c3538757d5e2cee385028a5ba4e78eca3982698a4e6a3d5ddb17ea59fc13a"),
     // mint_asset
-    digest!("0x910b153409b5b6220a76e0b602a1745130d3b2148fc45ed9e1afaf892c4e1ec6"),
+    digest!("0x83521ee1aec0ffb09cfc65c47bb08aa5ad3924da42ab5a4bff9152d6534d4918"),
     // add_asset_to_note
-    digest!("0xf72141eb3e07bc175312b1db97b488d3d73820f36fd2fef67157b6193a21d873"),
+    digest!("0xf0ae3bde840b005661422bcf64d1700602aae19f5bcff038ed7fed95b384a42f"),
     // create_note
     digest!("0x1f4f867434fc2704a16a15edd783f3825b1b5d932e04412b46eee3c85adcf1d2"),
     // get_input_notes_commitment

--- a/miden-tx/src/testing/mock_chain/mod.rs
+++ b/miden-tx/src/testing/mock_chain/mod.rs
@@ -404,18 +404,15 @@ impl MockChain {
 
     /// Adds a new wallet with the specified authentication method and assets.
     pub fn add_new_wallet(&mut self, auth_method: Auth) -> Account {
-        let account_builder =
-            AccountBuilder::new().init_seed(self.rng.gen()).with_component(BasicWallet);
+        let account_builder = AccountBuilder::new(self.rng.gen()).with_component(BasicWallet);
 
         self.add_from_account_builder(auth_method, account_builder, AccountState::New)
     }
 
     /// Adds an existing wallet (nonce == 1) with the specified authentication method and assets.
     pub fn add_existing_wallet(&mut self, auth_method: Auth, assets: Vec<Asset>) -> Account {
-        let account_builder = AccountBuilder::new()
-            .init_seed(self.rng.gen())
-            .with_component(BasicWallet)
-            .with_assets(assets);
+        let account_builder =
+            Account::builder(self.rng.gen()).with_component(BasicWallet).with_assets(assets);
 
         self.add_from_account_builder(auth_method, account_builder, AccountState::Exists)
     }
@@ -427,8 +424,7 @@ impl MockChain {
         token_symbol: &str,
         max_supply: u64,
     ) -> MockFungibleFaucet {
-        let account_builder = AccountBuilder::new()
-            .init_seed(self.rng.gen())
+        let account_builder = AccountBuilder::new(self.rng.gen())
             .account_type(AccountType::FungibleFaucet)
             .with_component(
                 BasicFungibleFaucet::new(
@@ -454,7 +450,7 @@ impl MockChain {
         max_supply: u64,
         total_issuance: Option<u64>,
     ) -> MockFungibleFaucet {
-        let mut account_builder = AccountBuilder::new()
+        let mut account_builder = AccountBuilder::new(self.rng.gen())
             .with_component(
                 BasicFungibleFaucet::new(
                     TokenSymbol::new(token_symbol).unwrap(),
@@ -463,7 +459,6 @@ impl MockChain {
                 )
                 .unwrap(),
             )
-            .init_seed(self.rng.gen())
             .account_type(AccountType::FungibleFaucet);
 
         let authenticator = match auth_method.build_component() {

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -1,6 +1,13 @@
-use miden_lib::transaction::{
-    memory::{NATIVE_ACCT_CODE_COMMITMENT_PTR, NEW_CODE_ROOT_PTR},
-    TransactionKernel,
+use miden_lib::{
+    errors::tx_kernel_errors::{
+        ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX,
+        ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO, ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE,
+        ERR_ACCOUNT_ID_UNKNOWN_VERSION, TX_KERNEL_ERRORS,
+    },
+    transaction::{
+        memory::{NATIVE_ACCT_CODE_COMMITMENT_PTR, NEW_CODE_ROOT_PTR},
+        TransactionKernel,
+    },
 };
 use miden_objects::{
     accounts::{
@@ -22,7 +29,7 @@ use miden_objects::{
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{Digest, MemAdviceProvider, ProcessState};
+use vm_processor::{Digest, ExecutionError, MemAdviceProvider, ProcessState};
 
 use super::{Felt, StackInputs, Word, ONE, ZERO};
 use crate::{
@@ -163,6 +170,80 @@ pub fn test_account_type() {
 
         assert!(has_type, "missing test for type {:?}", expected_type);
     }
+}
+
+#[test]
+pub fn test_account_validate_id() -> anyhow::Result<()> {
+    let test_cases = [
+        (ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN, None),
+        (ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, None),
+        (ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, None),
+        (ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN, None),
+        (
+            // Set version to a non-zero value (10).
+            ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN | (0x0a << 64),
+            Some(ERR_ACCOUNT_ID_UNKNOWN_VERSION),
+        ),
+        (
+            // Set epoch to u16::MAX.
+            ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN | (0xffff << 48),
+            Some(ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX),
+        ),
+        (
+            // Set storage mode to an unknown value (0b01).
+            ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN | (0b01 << (64 + 6)),
+            Some(ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE),
+        ),
+        (
+            // Set lower 8 bits to a non-zero value (1).
+            ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN | 1,
+            Some(ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO),
+        ),
+    ];
+
+    let error_map = alloc::collections::BTreeMap::from(TX_KERNEL_ERRORS);
+    for (account_id, expected_error) in test_cases.iter() {
+        // Manually split the account ID into prefix and suffix since we can't use AccountId methods
+        // on invalid ids.
+        let prefix = Felt::try_from((account_id / (1u128 << 64)) as u64).unwrap();
+        let suffix = Felt::try_from((account_id % (1u128 << 64)) as u64).unwrap();
+
+        let code = "
+            use.kernel::account
+
+            begin
+                exec.account::validate_id
+            end
+            ";
+
+        let result = CodeExecutor::with_advice_provider(MemAdviceProvider::default())
+            .stack_inputs(StackInputs::new(vec![suffix, prefix]).unwrap())
+            .run(code);
+
+        match (result, expected_error) {
+            (Ok(_), None) => (),
+            (Ok(_), Some(err)) => {
+                anyhow::bail!("expected error {} but validation was successful", error_map[err])
+            },
+            (Err(ExecutionError::FailedAssertion { err_code, .. }), Some(err)) => {
+                if err_code != *err {
+                    anyhow::bail!(
+                        "actual error {err_code} ({}) did not match expected error {err} ({})",
+                        error_map[&err_code],
+                        error_map[err]
+                    );
+                }
+            },
+            (Err(err), None) => {
+                anyhow::bail!("validation is supposed to succeed but error occurred {}", err)
+            },
+            (Err(err), Some(_)) => {
+                anyhow::bail!("unexpected different error than expected {}", err)
+            },
+        }
+    }
+
+    Ok(())
 }
 
 #[test]

--- a/miden-tx/src/tests/kernel_tests/test_account.rs
+++ b/miden-tx/src/tests/kernel_tests/test_account.rs
@@ -323,8 +323,7 @@ fn test_get_item() {
 
 #[test]
 fn test_get_map_item() {
-    let account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
                 TransactionKernel::testing_assembler(),
@@ -470,8 +469,7 @@ fn test_set_map_item() {
         [Felt::new(9_u64), Felt::new(10_u64), Felt::new(11_u64), Felt::new(12_u64)],
     );
 
-    let account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
                 TransactionKernel::testing_assembler(),
@@ -619,8 +617,7 @@ fn test_account_component_storage_offset() {
     .unwrap()
     .with_supported_type(AccountType::RegularAccountUpdatableCode);
 
-    let mut account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let mut account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(component1)
         .with_component(component2)
         .build_existing()

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -603,8 +603,6 @@ pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> any
 }
 
 /// Tests that supplying an invalid seed causes account creation to fail.
-///
-/// TODO: Add variant of this test with incorrect block hash.
 #[test]
 pub fn create_account_invalid_seed() {
     let mut mock_chain = MockChain::new();

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -29,12 +29,15 @@ use miden_lib::{
 };
 use miden_objects::{
     accounts::{
-        Account, AccountBuilder, AccountIdAnchor, AccountProcedureInfo, AccountStorageMode,
-        AccountType, StorageSlot,
+        Account, AccountBuilder, AccountId, AccountIdAnchor, AccountIdVersion,
+        AccountProcedureInfo, AccountStorageMode, AccountType, StorageSlot,
     },
     testing::{
         account_component::AccountMockComponent,
-        storage::{generate_account_seed, AccountSeedType},
+        account_id::{
+            ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
+        },
+        constants::FUNGIBLE_FAUCET_INITIAL_BALANCE,
     },
     transaction::{TransactionArgs, TransactionScript},
     BlockHeader, GENESIS_BLOCK,
@@ -518,6 +521,36 @@ pub fn create_accounts_with_non_zero_anchor_block() -> anyhow::Result<()> {
     create_multiple_accounts_test(&mock_chain, &epoch1_block_header, AccountStorageMode::Public)
 }
 
+/// Takes an account with a placeholder ID and returns the same account but with its ID replaced.
+/// The ID is newly generated and anchored in the given block header.
+fn compute_valid_account_id(
+    account: Account,
+    anchor_block_header: &BlockHeader,
+) -> (Account, Word) {
+    let init_seed: [u8; 32] = [5; 32];
+    let seed = AccountId::compute_account_seed(
+        init_seed,
+        account.account_type(),
+        AccountStorageMode::Public,
+        AccountIdVersion::VERSION_0,
+        account.code().commitment(),
+        account.storage().commitment(),
+        anchor_block_header.hash(),
+    )
+    .unwrap();
+
+    let anchor = AccountIdAnchor::try_from(anchor_block_header).unwrap();
+    let account_id =
+        AccountId::new(seed, anchor, account.code().commitment(), account.storage().commitment())
+            .unwrap();
+
+    // Overwrite old ID with generated ID.
+    let (_, vault, storage, code, nonce) = account.into_parts();
+    let account = Account::from_parts(account_id, vault, storage, code, nonce);
+
+    (account, seed)
+}
+
 /// Tests that creating a fungible faucet account with a non-empty initial balance in its reserved
 /// slot fails.
 #[test]
@@ -527,11 +560,13 @@ pub fn create_account_fungible_faucet_invalid_initial_balance() -> anyhow::Resul
 
     let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
 
-    let (account, _, account_seed) = generate_account_seed(
-        AccountSeedType::FungibleFaucetInvalidInitialBalance,
-        &genesis_block_header,
+    let account = Account::mock_fungible_faucet(
+        ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
+        ZERO,
+        Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
         TransactionKernel::assembler().with_debug_mode(true),
     );
+    let (account, account_seed) = compute_valid_account_id(account, &genesis_block_header);
 
     let result = create_account_test(&mock_chain, account, account_seed);
 
@@ -549,11 +584,13 @@ pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> any
 
     let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
 
-    let (account, _, account_seed) = generate_account_seed(
-        AccountSeedType::NonFungibleFaucetInvalidReservedSlot,
-        &genesis_block_header,
+    let account = Account::mock_non_fungible_faucet(
+        ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
+        ZERO,
+        false,
         TransactionKernel::assembler().with_debug_mode(true),
     );
+    let (account, account_seed) = compute_valid_account_id(account, &genesis_block_header);
 
     let result = create_account_test(&mock_chain, account, account_seed);
 

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -449,10 +449,9 @@ pub fn create_multiple_accounts_test(
         AccountType::FungibleFaucet,
         AccountType::NonFungibleFaucet,
     ] {
-        let (account, seed) = AccountBuilder::new()
+        let (account, seed) = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
             .account_type(account_type)
             .storage_mode(storage_mode)
-            .init_seed(ChaCha20Rng::from_entropy().gen())
             .anchor(
                 AccountIdAnchor::try_from(anchor_block_header)
                     .context("block header to anchor conversion failed")?,
@@ -610,9 +609,8 @@ pub fn create_account_invalid_seed() {
 
     let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
 
-    let (account, seed) = AccountBuilder::new()
+    let (account, seed) = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .anchor(AccountIdAnchor::try_from(&genesis_block_header).unwrap())
-        .init_seed(ChaCha20Rng::from_entropy().gen())
         .account_type(AccountType::RegularAccountUpdatableCode)
         .with_component(BasicWallet)
         .build()

--- a/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -689,14 +689,12 @@ fn test_fpi_memory() {
     .unwrap()
     .with_supports_all_types();
 
-    let foreign_account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(foreign_account_component)
         .build_existing()
         .unwrap();
 
-    let native_account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let native_account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
                 TransactionKernel::testing_assembler(),
@@ -937,14 +935,12 @@ fn test_fpi_execute_foreign_procedure() {
     .unwrap()
     .with_supports_all_types();
 
-    let foreign_account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(foreign_account_component)
         .build_existing()
         .unwrap();
 
-    let native_account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let native_account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(TransactionKernel::testing_assembler(), vec![])
                 .unwrap(),

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -122,8 +122,7 @@ fn transaction_executor_witness() {
 #[test]
 fn executed_transaction_account_delta_new() {
     let account_assets = AssetVault::mock().assets().collect::<Vec<Asset>>();
-    let account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(
             AccountMockComponent::new_with_slots(
                 TransactionKernel::testing_assembler(),
@@ -982,8 +981,7 @@ fn transaction_executor_account_code_using_custom_library() {
             .with_supports_all_types();
 
     // Build an existing account with nonce 1.
-    let native_account = AccountBuilder::new()
-        .init_seed(ChaCha20Rng::from_entropy().gen())
+    let native_account = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .with_component(account_component)
         .build_existing()
         .unwrap();

--- a/objects/benches/account_seed.rs
+++ b/objects/benches/account_seed.rs
@@ -1,19 +1,33 @@
+use std::time::Duration;
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use miden_objects::{
     accounts::{AccountId, AccountIdVersion, AccountStorageMode, AccountType},
     Digest,
 };
+use rand::{Rng, SeedableRng};
 
+/// Running this benchmark with --no-default-features will use the single-threaded account seed
+/// computation.
+///
+/// Passing --features concurrent will use the multi-threaded account seed computation.
 fn grind_account_seed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("grind-seed");
+    // Increase measurement time (= target time) from the default 5s as suggested by criterion
+    // during a run.
+    group.measurement_time(Duration::from_secs(20));
+
     let init_seed = [
         1, 18, 222, 14, 56, 94, 222, 213, 12, 57, 86, 1, 22, 34, 187, 100, 210, 1, 18, 222, 14, 56,
         94, 43, 213, 12, 57, 86, 1, 22, 34, 187,
     ];
+    // Use an rng to ensure we're starting from different seeds for each iteration.
+    let mut rng = rand_xoshiro::Xoshiro256PlusPlus::from_seed(init_seed);
 
-    c.bench_function("Grind regular on-chain account seed", |bench| {
+    group.bench_function("Grind regular on-chain account seed", |bench| {
         bench.iter(|| {
             AccountId::compute_account_seed(
-                init_seed,
+                rng.gen(),
                 AccountType::RegularAccountImmutableCode,
                 AccountStorageMode::Public,
                 AccountIdVersion::VERSION_0,
@@ -24,10 +38,12 @@ fn grind_account_seed(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("Grind fungible faucet on-chain account seed", |bench| {
+    // Reinitialize the RNG.
+    let mut rng = rand_xoshiro::Xoshiro256PlusPlus::from_seed(init_seed);
+    group.bench_function("Grind fungible faucet on-chain account seed", |bench| {
         bench.iter(|| {
             AccountId::compute_account_seed(
-                init_seed,
+                rng.gen(),
                 AccountType::FungibleFaucet,
                 AccountStorageMode::Public,
                 AccountIdVersion::VERSION_0,
@@ -37,6 +53,8 @@ fn grind_account_seed(c: &mut Criterion) {
             )
         })
     });
+
+    group.finish();
 }
 
 criterion_group!(account_seed, grind_account_seed);

--- a/objects/src/accounts/account_id_anchor.rs
+++ b/objects/src/accounts/account_id_anchor.rs
@@ -1,4 +1,6 @@
-use crate::{block::block_epoch_from_number, AccountError, BlockHeader, Digest, EMPTY_WORD};
+use crate::{
+    block::block_epoch_from_number, errors::AccountIdError, BlockHeader, Digest, EMPTY_WORD,
+};
 
 // ACCOUNT ID ANCHOR
 // ================================================================================================
@@ -48,20 +50,18 @@ impl AccountIdAnchor {
     ///
     /// Returns an error if any of the anchor constraints are not met. See the [type
     /// documentation](AccountIdAnchor) for details.
-    pub fn new(anchor_block_number: u32, anchor_block_hash: Digest) -> Result<Self, AccountError> {
+    pub fn new(
+        anchor_block_number: u32,
+        anchor_block_hash: Digest,
+    ) -> Result<Self, AccountIdError> {
         if anchor_block_number & 0x0000_ffff != 0 {
-            return Err(AccountError::AssumptionViolated(format!(
-          "TODO: Make proper error: anchor block must be an epoch block, i.e. its block number must be a multiple of 2^{}",
-          BlockHeader::EPOCH_LENGTH_EXPONENT)));
+            return Err(AccountIdError::AnchorBlockMustBeEpochBlock);
         }
 
         let anchor_epoch = block_epoch_from_number(anchor_block_number);
 
         if anchor_epoch == u16::MAX {
-            return Err(AccountError::AssumptionViolated(format!(
-                "TODO: Make proper error: anchor epoch cannot be {}",
-                u16::MAX
-            )));
+            return Err(AccountIdError::AnchorEpochMustNotBeU16Max);
         }
 
         Ok(Self {
@@ -109,7 +109,7 @@ impl AccountIdAnchor {
 // ================================================================================================
 
 impl TryFrom<&BlockHeader> for AccountIdAnchor {
-    type Error = AccountError;
+    type Error = AccountIdError;
 
     /// Extracts the [`BlockHeader::block_num`] and [`BlockHeader::hash`] from the provided
     /// `block_header` and tries to convert it to an [`AccountIdAnchor`].

--- a/objects/src/accounts/account_id_prefix.rs
+++ b/objects/src/accounts/account_id_prefix.rs
@@ -11,7 +11,7 @@ use vm_processor::DeserializationError;
 use super::account_id;
 use crate::{
     accounts::{account_id::validate_prefix, AccountIdVersion, AccountStorageMode, AccountType},
-    AccountError,
+    errors::AccountIdError,
 };
 
 // ACCOUNT ID PREFIX
@@ -68,7 +68,7 @@ impl AccountIdPrefix {
     ///
     /// Returns an error if any of the ID constraints of the prefix are not met. See the
     /// [`AccountId`](crate::accounts::AccountId) type documentation for details.
-    pub fn new(prefix: Felt) -> Result<Self, AccountError> {
+    pub fn new(prefix: Felt) -> Result<Self, AccountIdError> {
         validate_prefix(prefix)?;
 
         Ok(AccountIdPrefix { prefix })
@@ -152,7 +152,7 @@ impl From<AccountIdPrefix> for u64 {
 // ================================================================================================
 
 impl TryFrom<[u8; 8]> for AccountIdPrefix {
-    type Error = AccountError;
+    type Error = AccountIdError;
 
     /// Tries to convert a byte array in little-endian order to an [`AccountIdPrefix`].
     ///
@@ -161,14 +161,14 @@ impl TryFrom<[u8; 8]> for AccountIdPrefix {
     /// Returns an error if any of the ID constraints of the prefix are not met. See the
     /// [`AccountId`](crate::accounts::AccountId) type documentation for details.
     fn try_from(value: [u8; 8]) -> Result<Self, Self::Error> {
-        let element =
-            Felt::try_from(&value[..8]).map_err(AccountError::AccountIdInvalidFieldElement)?;
+        let element = Felt::try_from(&value[..8])
+            .map_err(AccountIdError::AccountIdInvalidPrefixFieldElement)?;
         Self::new(element)
     }
 }
 
 impl TryFrom<u64> for AccountIdPrefix {
-    type Error = AccountError;
+    type Error = AccountIdError;
 
     /// Tries to convert a `u64` into an [`AccountIdPrefix`].
     ///
@@ -178,13 +178,13 @@ impl TryFrom<u64> for AccountIdPrefix {
     /// [`AccountId`](crate::accounts::AccountId) type documentation for details.
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         let element = Felt::try_from(value.to_le_bytes().as_slice())
-            .map_err(AccountError::AccountIdInvalidFieldElement)?;
+            .map_err(AccountIdError::AccountIdInvalidPrefixFieldElement)?;
         Self::new(element)
     }
 }
 
 impl TryFrom<Felt> for AccountIdPrefix {
-    type Error = AccountError;
+    type Error = AccountIdError;
 
     /// Returns an [`AccountIdPrefix`] instantiated with the provided field .
     ///
@@ -236,7 +236,7 @@ impl Deserializable for AccountIdPrefix {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         <[u8; 8]>::read_from(source)?
             .try_into()
-            .map_err(|err: AccountError| DeserializationError::InvalidValue(err.to_string()))
+            .map_err(|err: AccountIdError| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 

--- a/objects/src/accounts/account_id_prefix.rs
+++ b/objects/src/accounts/account_id_prefix.rs
@@ -137,7 +137,7 @@ impl From<AccountIdPrefix> for Felt {
 impl From<AccountIdPrefix> for [u8; 8] {
     fn from(id: AccountIdPrefix) -> Self {
         let mut result = [0_u8; 8];
-        result[..8].copy_from_slice(&id.prefix.as_int().to_le_bytes());
+        result[..8].copy_from_slice(&id.prefix.as_int().to_be_bytes());
         result
     }
 }
@@ -154,16 +154,19 @@ impl From<AccountIdPrefix> for u64 {
 impl TryFrom<[u8; 8]> for AccountIdPrefix {
     type Error = AccountIdError;
 
-    /// Tries to convert a byte array in little-endian order to an [`AccountIdPrefix`].
+    /// Tries to convert a byte array in big-endian order to an [`AccountIdPrefix`].
     ///
     /// # Errors
     ///
     /// Returns an error if any of the ID constraints of the prefix are not met. See the
     /// [`AccountId`](crate::accounts::AccountId) type documentation for details.
-    fn try_from(value: [u8; 8]) -> Result<Self, Self::Error> {
-        let element = Felt::try_from(&value[..8])
-            .map_err(AccountIdError::AccountIdInvalidPrefixFieldElement)?;
-        Self::new(element)
+    fn try_from(mut value: [u8; 8]) -> Result<Self, Self::Error> {
+        // Felt::try_from expects little-endian order.
+        value.reverse();
+
+        Felt::try_from(value.as_slice())
+            .map_err(AccountIdError::AccountIdInvalidPrefixFieldElement)
+            .and_then(Self::new)
     }
 }
 

--- a/objects/src/accounts/builder/mod.rs
+++ b/objects/src/accounts/builder/mod.rs
@@ -28,7 +28,6 @@ use crate::{
 ///
 /// The methods that are required to be called are:
 ///
-/// - [`AccountBuilder::init_seed`],
 /// - [`AccountBuilder::with_component`], which must be called at least once.
 /// - [`AccountBuilder::anchor`].
 ///
@@ -47,32 +46,25 @@ pub struct AccountBuilder {
     account_type: AccountType,
     storage_mode: AccountStorageMode,
     id_anchor: Option<AccountIdAnchor>,
-    init_seed: Option<[u8; 32]>,
+    init_seed: [u8; 32],
     id_version: AccountIdVersion,
 }
 
 impl AccountBuilder {
-    /// Creates a new builder for a single account.
-    pub fn new() -> Self {
+    /// Creates a new builder for an account and sets the initial seed from which the grinding
+    /// process for that account's [`AccountId`] will start. This initial seed should come from a
+    /// cryptographic random number generator.
+    pub fn new(init_seed: [u8; 32]) -> Self {
         Self {
             #[cfg(any(feature = "testing", test))]
             assets: vec![],
             components: vec![],
-            init_seed: None,
             id_anchor: None,
+            init_seed,
             account_type: AccountType::RegularAccountUpdatableCode,
             storage_mode: AccountStorageMode::Private,
             id_version: AccountIdVersion::VERSION_0,
         }
-    }
-
-    /// Sets the initial seed from which the grind for an [`AccountId`] will start. This initial
-    /// seed should come from a cryptographic random number generator.
-    ///
-    ///  This method **must** be called.
-    pub fn init_seed(mut self, init_seed: [u8; 32]) -> Self {
-        self.init_seed = Some(init_seed);
-        self
     }
 
     /// Sets the [`AccountIdAnchor`] used for the generation of the account ID.
@@ -109,14 +101,7 @@ impl AccountBuilder {
     }
 
     /// Builds the common parts of testing and non-testing code.
-    fn build_inner(
-        &self,
-    ) -> Result<([u8; 32], AssetVault, AccountCode, AccountStorage), AccountError> {
-        let init_seed = self.init_seed.ok_or(AccountError::BuildError(
-            "init_seed must be set on the account builder".into(),
-            None,
-        ))?;
-
+    fn build_inner(&self) -> Result<(AssetVault, AccountCode, AccountStorage), AccountError> {
         #[cfg(any(feature = "testing", test))]
         let vault = AssetVault::new(&self.assets).map_err(|err| {
             AccountError::BuildError(format!("asset vault failed to build: {err}"), None)
@@ -135,7 +120,7 @@ impl AccountBuilder {
                 },
             )?;
 
-        Ok((init_seed, vault, code, storage))
+        Ok((vault, code, storage))
     }
 
     /// Grinds a new [`AccountId`] using the `init_seed` as a starting point.
@@ -179,7 +164,7 @@ impl AccountBuilder {
     /// - If duplicate assets were added to the builder (only under the `testing` feature).
     /// - If the vault is not empty on new accounts (only under the `testing` feature).
     pub fn build(self) -> Result<(Account, Word), AccountError> {
-        let (init_seed, vault, code, storage) = self.build_inner()?;
+        let (vault, code, storage) = self.build_inner()?;
 
         let id_anchor = self
             .id_anchor
@@ -194,7 +179,7 @@ impl AccountBuilder {
         }
 
         let seed = self.grind_account_id(
-            init_seed,
+            self.init_seed,
             self.id_version,
             code.commitment(),
             storage.commitment(),
@@ -230,21 +215,15 @@ impl AccountBuilder {
     ///
     /// For possible errors, see the documentation of [`Self::build`].
     pub fn build_existing(self) -> Result<Account, AccountError> {
-        let (init_seed, vault, code, storage) = self.build_inner()?;
+        let (vault, code, storage) = self.build_inner()?;
 
         let account_id = {
-            let bytes = <[u8; 15]>::try_from(&init_seed[0..15])
+            let bytes = <[u8; 15]>::try_from(&self.init_seed[0..15])
                 .expect("we should have sliced exactly 15 bytes off");
             AccountId::dummy(bytes, self.account_type, self.storage_mode)
         };
 
         Ok(Account::from_parts(account_id, vault, storage, code, Felt::ONE))
-    }
-}
-
-impl Default for AccountBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -328,8 +307,7 @@ mod tests {
         let anchor_block_number = 1 << 16;
         let id_anchor = AccountIdAnchor::new(anchor_block_number, anchor_block_hash).unwrap();
 
-        let (account, seed) = Account::builder()
-            .init_seed([5; 32])
+        let (account, seed) = Account::builder([5; 32])
             .anchor(id_anchor)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .with_component(CustomComponent2 {
@@ -398,8 +376,7 @@ mod tests {
         let storage_slot0 = 25;
 
         let anchor = AccountIdAnchor::new_unchecked(5, Digest::default());
-        let build_error = Account::builder()
-            .init_seed([0xff; 32])
+        let build_error = Account::builder([0xff; 32])
             .anchor(anchor)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .with_assets(AssetVault::mock().assets())

--- a/objects/src/accounts/builder/mod.rs
+++ b/objects/src/accounts/builder/mod.rs
@@ -52,8 +52,9 @@ pub struct AccountBuilder {
 
 impl AccountBuilder {
     /// Creates a new builder for an account and sets the initial seed from which the grinding
-    /// process for that account's [`AccountId`] will start. This initial seed should come from a
-    /// cryptographic random number generator.
+    /// process for that account's [`AccountId`] will start.
+    ///
+    /// This initial seed should come from a cryptographic random number generator.
     pub fn new(init_seed: [u8; 32]) -> Self {
         Self {
             #[cfg(any(feature = "testing", test))]

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -144,8 +144,9 @@ impl Account {
     }
 
     /// Creates a new [`AccountBuilder`] for an account and sets the initial seed from which the
-    /// grinding process for that account's [`AccountId`] will start. This initial seed should
-    /// come from a cryptographic random number generator.
+    /// grinding process for that account's [`AccountId`] will start.
+    ///
+    /// This initial seed should come from a cryptographic random number generator.
     pub fn builder(init_seed: [u8; 32]) -> AccountBuilder {
         AccountBuilder::new(init_seed)
     }

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -143,9 +143,11 @@ impl Account {
         Ok((code, storage))
     }
 
-    /// Returns a new [`AccountBuilder`]. See its documentation for details.
-    pub fn builder() -> AccountBuilder {
-        AccountBuilder::new()
+    /// Creates a new [`AccountBuilder`] for an account and sets the initial seed from which the
+    /// grinding process for that account's [`AccountId`] will start. This initial seed should
+    /// come from a cryptographic random number generator.
+    pub fn builder(init_seed: [u8; 32]) -> AccountBuilder {
+        AccountBuilder::new(init_seed)
     }
 
     // PUBLIC ACCESSORS

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -59,6 +59,11 @@ impl FungibleAsset {
         self.faucet_id
     }
 
+    /// Return ID prefix of the faucet which issued this asset.
+    pub fn faucet_id_prefix(&self) -> AccountIdPrefix {
+        self.faucet_id.prefix()
+    }
+
     /// Returns the amount of this asset.
     pub fn amount(&self) -> u64 {
         self.amount

--- a/objects/src/assets/fungible.rs
+++ b/objects/src/assets/fungible.rs
@@ -5,7 +5,7 @@ use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use vm_processor::DeserializationError;
 
 use super::{is_not_a_non_fungible_asset, AccountType, Asset, AssetError, Felt, Word, ZERO};
-use crate::accounts::AccountId;
+use crate::accounts::{AccountId, AccountIdPrefix};
 
 // FUNGIBLE ASSET
 // ================================================================================================
@@ -203,9 +203,31 @@ impl Serializable for FungibleAsset {
 
 impl Deserializable for FungibleAsset {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let faucet_id: AccountId = source.read()?;
-        let amount: u64 = source.read()?;
+        let faucet_id_prefix: AccountIdPrefix = source.read()?;
+        FungibleAsset::deserialize_with_faucet_id_prefix(faucet_id_prefix, source)
+    }
+}
 
+impl FungibleAsset {
+    /// Deserializes a [`FungibleAsset`] from an [`AccountIdPrefix`] and the remaining data from the
+    /// given `source`.
+    pub(super) fn deserialize_with_faucet_id_prefix<R: ByteReader>(
+        faucet_id_prefix: AccountIdPrefix,
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
+        // The 8 bytes of the prefix have already been read, so we only need to read the remaining 7
+        // bytes of the account ID's 15 total bytes.
+        let suffix_bytes: [u8; 7] = source.read()?;
+        // Convert prefix back to bytes so we can call the TryFrom<[u8; 15]> impl.
+        let prefix_bytes: [u8; 8] = faucet_id_prefix.into();
+        let mut id_bytes: [u8; 15] = [0; 15];
+        id_bytes[..8].copy_from_slice(&prefix_bytes);
+        id_bytes[8..].copy_from_slice(&suffix_bytes);
+
+        let faucet_id = AccountId::try_from(id_bytes)
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+
+        let amount: u64 = source.read()?;
         FungibleAsset::new(faucet_id, amount)
             .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }

--- a/objects/src/assets/mod.rs
+++ b/objects/src/assets/mod.rs
@@ -120,12 +120,12 @@ impl Asset {
 
     /// Returns the prefix of the faucet ID which issued this asset.
     ///
-    /// To get the full [`AccountId`](crate::accounts::AccountId  ) of a fungible asset the asset
+    /// To get the full [`AccountId`](crate::accounts::AccountId) of a fungible asset the asset
     /// must be matched on.
     pub fn faucet_id_prefix(&self) -> AccountIdPrefix {
         match self {
-            Self::Fungible(asset) => asset.faucet_id().prefix(),
-            Self::NonFungible(asset) => asset.faucet_id(),
+            Self::Fungible(asset) => asset.faucet_id_prefix(),
+            Self::NonFungible(asset) => asset.faucet_id_prefix(),
         }
     }
 

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -124,7 +124,7 @@ impl NonFungibleAsset {
         vault_key
     }
 
-    /// Return ID of the faucet which issued this asset.
+    /// Return ID prefix of the faucet which issued this asset.
     pub fn faucet_id_prefix(&self) -> AccountIdPrefix {
         AccountIdPrefix::new_unchecked(self.0[FAUCET_ID_POS])
     }
@@ -206,8 +206,8 @@ impl Deserializable for NonFungibleAsset {
 }
 
 impl NonFungibleAsset {
-    /// Deserializes a [`NonFungibleAsset`] from an [`AccountId`] and the remaining data from the
-    /// given `source`.
+    /// Deserializes a [`NonFungibleAsset`] from an [`AccountIdPrefix`] and the remaining data from
+    /// the given `source`.
     pub(super) fn deserialize_with_faucet_id_prefix<R: ByteReader>(
         faucet_id_prefix: AccountIdPrefix,
         source: &mut R,

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -185,7 +185,7 @@ impl Serializable for NonFungibleAsset {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // All assets should serialize their faucet ID at the first position to allow them to be
         // easily distinguishable during deserialization.
-        target.write(self.0[FAUCET_ID_POS]);
+        target.write(self.faucet_id());
         target.write(self.0[2]);
         target.write(self.0[1]);
         target.write(self.0[0]);
@@ -200,11 +200,23 @@ impl Deserializable for NonFungibleAsset {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let faucet_id_prefix: AccountIdPrefix = source.read()?;
 
+        Self::deserialize_with_faucet_id_prefix(faucet_id_prefix, source)
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
+    }
+}
+
+impl NonFungibleAsset {
+    /// Deserializes a [`NonFungibleAsset`] from an [`AccountId`] and the remaining data from the
+    /// given `source`.
+    pub(super) fn deserialize_with_faucet_id_prefix<R: ByteReader>(
+        faucet_id_prefix: AccountIdPrefix,
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
         let hash_2: Felt = source.read()?;
         let hash_1: Felt = source.read()?;
         let hash_0: Felt = source.read()?;
 
-        // The second felt in the data_hash will be replaced by the faucet id, so we can set it to
+        // The last felt in the data_hash will be replaced by the faucet id, so we can set it to
         // zero here.
         NonFungibleAsset::from_parts(faucet_id_prefix, [hash_0, hash_1, hash_2, Felt::ZERO])
             .map_err(|err| DeserializationError::InvalidValue(err.to_string()))

--- a/objects/src/assets/nonfungible.rs
+++ b/objects/src/assets/nonfungible.rs
@@ -125,7 +125,7 @@ impl NonFungibleAsset {
     }
 
     /// Return ID of the faucet which issued this asset.
-    pub fn faucet_id(&self) -> AccountIdPrefix {
+    pub fn faucet_id_prefix(&self) -> AccountIdPrefix {
         AccountIdPrefix::new_unchecked(self.0[FAUCET_ID_POS])
     }
 
@@ -185,7 +185,7 @@ impl Serializable for NonFungibleAsset {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // All assets should serialize their faucet ID at the first position to allow them to be
         // easily distinguishable during deserialization.
-        target.write(self.faucet_id());
+        target.write(self.faucet_id_prefix());
         target.write(self.0[2]);
         target.write(self.0[1]);
         target.write(self.0[0]);

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -106,12 +106,12 @@ pub enum AccountError {
         account_type: AccountType,
         component_index: usize,
     },
+    #[error("failed to parse account ID from final account header")]
+    FinalAccountHeaderIdParsingFailed(#[source] AccountIdError),
     /// This variant can be used by methods that are not inherent to the account but want to return
     /// this error type.
     #[error("assumption violated: {0}")]
     AssumptionViolated(String),
-    #[error("failed to parse account id from final account header")]
-    FinalAccountHeaderIdParsingFailed(#[source] AccountIdError),
 }
 
 // ACCOUNT ID ERROR
@@ -119,9 +119,9 @@ pub enum AccountError {
 
 #[derive(Debug, Error)]
 pub enum AccountIdError {
-    #[error("failed to convert bytes into account id prefix field element")]
+    #[error("failed to convert bytes into account ID prefix field element")]
     AccountIdInvalidPrefixFieldElement(#[source] DeserializationError),
-    #[error("failed to convert bytes into account id suffix field element")]
+    #[error("failed to convert bytes into account ID suffix field element")]
     AccountIdInvalidSuffixFieldElement(#[source] DeserializationError),
     #[error("`{0}` is not a known account storage mode")]
     UnknownAccountStorageMode(Box<str>),
@@ -129,13 +129,13 @@ pub enum AccountIdError {
     UnknownAccountType(Box<str>),
     // TODO: Make #[source] and remove from msg once HexParseError implements Error trait in
     // no-std.
-    #[error("failed to parse hex string into account id: {0}")]
+    #[error("failed to parse hex string into account ID: {0}")]
     AccountIdHexParseError(HexParseError),
     #[error("`{0}` is not a known account ID version")]
     UnknownAccountIdVersion(u8),
     #[error("anchor epoch in account ID must not be u16::MAX ({})", u16::MAX)]
     AnchorEpochMustNotBeU16Max,
-    #[error("least significant byte of account ID must be zero")]
+    #[error("least significant byte of account ID suffix must be zero")]
     AccountIdSuffixLeastSignificantByteMustBeZero,
     #[error(
         "anchor block must be an epoch block, that is, its block number must be a multiple of 2^{}",

--- a/objects/src/errors.rs
+++ b/objects/src/errors.rs
@@ -101,7 +101,7 @@ pub enum AccountError {
         "procedure which does not access storage (storage size = 0) has non-zero storage offset"
     )]
     PureProcedureWithStorageOffset,
-    #[error("account component at index {component_index} is incompatible with account of type {account_type:?}")]
+    #[error("account component at index {component_index} is incompatible with account of type {account_type}")]
     UnsupportedComponentForAccountType {
         account_type: AccountType,
         component_index: usize,
@@ -123,8 +123,10 @@ pub enum AccountIdError {
     AccountIdInvalidPrefixFieldElement(#[source] DeserializationError),
     #[error("failed to convert bytes into account id suffix field element")]
     AccountIdInvalidSuffixFieldElement(#[source] DeserializationError),
-    #[error("`{0}` is not a valid account storage mode")]
+    #[error("`{0}` is not a known account storage mode")]
     UnknownAccountStorageMode(Box<str>),
+    #[error(r#"`{0}` is not a known account type, expected one of "FungibleFaucet", "NonFungibleFaucet", "RegularAccountImmutableCode" or "RegularAccountUpdatableCode""#)]
+    UnknownAccountType(Box<str>),
     // TODO: Make #[source] and remove from msg once HexParseError implements Error trait in
     // no-std.
     #[error("failed to parse hex string into account id: {0}")]
@@ -197,13 +199,13 @@ pub enum AssetError {
     #[error("faucet account ID in asset is invalid")]
     InvalidFaucetAccountId(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error(
-      "faucet id {0} of type {id_type:?} must be of type {expected_ty:?} for fungible assets",
+      "faucet id {0} of type {id_type} must be of type {expected_ty} for fungible assets",
       id_type = .0.account_type(),
       expected_ty = AccountType::FungibleFaucet
     )]
     FungibleFaucetIdTypeMismatch(AccountId),
     #[error(
-      "faucet id {0} of type {id_type:?} must be of type {expected_ty:?} for non fungible assets",
+      "faucet id {0} of type {id_type} must be of type {expected_ty} for non fungible assets",
       id_type = .0.account_type(),
       expected_ty = AccountType::NonFungibleFaucet
     )]

--- a/objects/src/notes/execution_hint.rs
+++ b/objects/src/notes/execution_hint.rs
@@ -84,7 +84,8 @@ impl NoteExecutionHint {
             .map(|block_number| NoteExecutionHint::AfterBlock { block_num: block_number })
     }
 
-    /// Creates a [NoteExecutionHint::OnBlockSlot] for the given parameters
+    /// Creates a [NoteExecutionHint::OnBlockSlot] for the given parameters. See the variants
+    /// documentation for details on the parameters.
     pub fn on_block_slot(round_len: u8, slot_len: u8, slot_offset: u8) -> Self {
         NoteExecutionHint::OnBlockSlot { round_len, slot_len, slot_offset }
     }

--- a/objects/src/notes/execution_hint.rs
+++ b/objects/src/notes/execution_hint.rs
@@ -32,21 +32,21 @@ pub enum NoteExecutionHint {
     /// The block number cannot be [`u32::MAX`] which is enforced through the [`AfterBlockNumber`]
     /// type.
     AfterBlock { block_num: AfterBlockNumber },
-    /// The note's script can be executed in the specified slot within the specified epoch.
+    /// The note's script can be executed in the specified slot within the specified round.
     ///
     /// The slot is defined as follows:
-    /// - First we define the length of the epoch in powers of 2. For example, epoch_len = 10 is an
-    ///   epoch of 1024 blocks.
-    /// - Then we define the length of a slot within the epoch also using powers of 2. For example,
+    /// - First we define the length of the round in powers of 2. For example, round_len = 10 is a
+    ///   round of 1024 blocks.
+    /// - Then we define the length of a slot within the round also using powers of 2. For example,
     ///   slot_len = 7 is a slot of 128 blocks.
-    /// - Lastly, the offset specifies the index of the slot within the epoch - i.e., 0 is the
+    /// - Lastly, the offset specifies the index of the slot within the round - i.e., 0 is the
     ///   first slot, 1 is the second slot etc.
     ///
-    /// For example: { epoch_len: 10, slot_len: 7, slot_offset: 1 } means that the note can
-    /// be executed in any second 128 block slot of a 1024 block epoch. These would be blocks
+    /// For example: { round_len: 10, slot_len: 7, slot_offset: 1 } means that the note can
+    /// be executed in any second 128 block slot of a 1024 block round. These would be blocks
     /// 128..255, 1152..1279, 2176..2303 etc.
     OnBlockSlot {
-        epoch_len: u8,
+        round_len: u8,
         slot_len: u8,
         slot_offset: u8,
     },
@@ -85,8 +85,8 @@ impl NoteExecutionHint {
     }
 
     /// Creates a [NoteExecutionHint::OnBlockSlot] for the given parameters
-    pub fn on_block_slot(epoch_len: u8, slot_len: u8, slot_offset: u8) -> Self {
-        NoteExecutionHint::OnBlockSlot { epoch_len, slot_len, slot_offset }
+    pub fn on_block_slot(round_len: u8, slot_len: u8, slot_offset: u8) -> Self {
+        NoteExecutionHint::OnBlockSlot { round_len, slot_len, slot_offset }
     }
 
     pub fn from_parts(tag: u8, payload: u32) -> Result<NoteExecutionHint, NoteError> {
@@ -110,10 +110,10 @@ impl NoteExecutionHint {
                     return Err(NoteError::InvalidNoteExecutionHintPayload(tag, payload));
                 }
 
-                let epoch_len = ((payload >> 16) & 0xff) as u8;
+                let round_len = ((payload >> 16) & 0xff) as u8;
                 let slot_len = ((payload >> 8) & 0xff) as u8;
                 let slot_offset = (payload & 0xff) as u8;
-                let hint = NoteExecutionHint::OnBlockSlot { epoch_len, slot_len, slot_offset };
+                let hint = NoteExecutionHint::OnBlockSlot { round_len, slot_len, slot_offset };
 
                 Ok(hint)
             },
@@ -134,14 +134,14 @@ impl NoteExecutionHint {
             NoteExecutionHint::AfterBlock { block_num: hint_block_num } => {
                 Some(block_num >= hint_block_num.as_u32())
             },
-            NoteExecutionHint::OnBlockSlot { epoch_len, slot_len, slot_offset } => {
-                let epoch_len_blocks: u32 = 1 << epoch_len;
+            NoteExecutionHint::OnBlockSlot { round_len, slot_len, slot_offset } => {
+                let round_len_blocks: u32 = 1 << round_len;
                 let slot_len_blocks: u32 = 1 << slot_len;
 
-                let block_epoch_index = block_num / epoch_len_blocks;
+                let block_round_index = block_num / round_len_blocks;
 
                 let slot_start_block =
-                    block_epoch_index * epoch_len_blocks + (*slot_offset as u32) * slot_len_blocks;
+                    block_round_index * round_len_blocks + (*slot_offset as u32) * slot_len_blocks;
                 let slot_end_block = slot_start_block + slot_len_blocks;
 
                 let can_be_consumed = block_num >= slot_start_block && block_num < slot_end_block;
@@ -166,9 +166,9 @@ impl NoteExecutionHint {
             NoteExecutionHint::AfterBlock { block_num } => {
                 (Self::AFTER_BLOCK_TAG, block_num.as_u32())
             },
-            NoteExecutionHint::OnBlockSlot { epoch_len, slot_len, slot_offset } => {
+            NoteExecutionHint::OnBlockSlot { round_len, slot_len, slot_offset } => {
                 let payload: u32 =
-                    ((*epoch_len as u32) << 16) | ((*slot_len as u32) << 8) | (*slot_offset as u32);
+                    ((*round_len as u32) << 16) | ((*slot_len as u32) << 8) | (*slot_offset as u32);
                 (Self::ON_BLOCK_SLOT_TAG, payload)
             },
         }
@@ -270,7 +270,7 @@ mod tests {
         assert_hint_serde(NoteExecutionHint::Always);
         assert_hint_serde(NoteExecutionHint::after_block(15).unwrap());
         assert_hint_serde(NoteExecutionHint::OnBlockSlot {
-            epoch_len: 9,
+            round_len: 9,
             slot_len: 12,
             slot_offset: 18,
         });
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(hint, decoded_hint);
 
         let hint = NoteExecutionHint::OnBlockSlot {
-            epoch_len: 22,
+            round_len: 22,
             slot_len: 33,
             slot_offset: 44,
         };

--- a/objects/src/notes/metadata.rs
+++ b/objects/src/notes/metadata.rs
@@ -325,7 +325,7 @@ mod tests {
 
         let note_type = NoteType::Public;
         let note_execution_hint = NoteExecutionHint::OnBlockSlot {
-            epoch_len: 10,
+            round_len: 10,
             slot_len: 11,
             slot_offset: 12,
         };

--- a/objects/src/testing/account_id.rs
+++ b/objects/src/testing/account_id.rs
@@ -6,38 +6,38 @@ use crate::accounts::{AccountId, AccountStorageMode, AccountType};
 // --------------------------------------------------------------------------------------------
 
 // REGULAR ACCOUNTS - OFF-CHAIN
-pub const ACCOUNT_ID_SENDER: u128 = account_id::<true>(
+pub const ACCOUNT_ID_SENDER: u128 = account_id(
     AccountType::RegularAccountImmutableCode,
     AccountStorageMode::Private,
     0xfabb_ccde,
 );
-pub const ACCOUNT_ID_OFF_CHAIN_SENDER: u128 = account_id::<true>(
+pub const ACCOUNT_ID_OFF_CHAIN_SENDER: u128 = account_id(
     AccountType::RegularAccountImmutableCode,
     AccountStorageMode::Private,
     0xbfcc_dcee,
 );
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN: u128 = account_id::<true>(
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN: u128 = account_id(
     AccountType::RegularAccountUpdatableCode,
     AccountStorageMode::Private,
     0xccdd_eeff,
 );
 // REGULAR ACCOUNTS - ON-CHAIN
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u128 = account_id::<true>(
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN: u128 = account_id(
     AccountType::RegularAccountImmutableCode,
     AccountStorageMode::Public,
     0xaabb_ccdd,
 );
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN_2: u128 = account_id::<true>(
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN_2: u128 = account_id(
     AccountType::RegularAccountImmutableCode,
     AccountStorageMode::Public,
     0xbbcc_ddee,
 );
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u128 = account_id::<true>(
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN: u128 = account_id(
     AccountType::RegularAccountUpdatableCode,
     AccountStorageMode::Public,
     0xacdd_eefc,
 );
-pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN_2: u128 = account_id::<true>(
+pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN_2: u128 = account_id(
     AccountType::RegularAccountUpdatableCode,
     AccountStorageMode::Public,
     0xeeff_ccdd,
@@ -50,34 +50,34 @@ pub const ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN_2: u128 = account_i
 
 // FUNGIBLE TOKENS - OFF-CHAIN
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN: u128 =
-    account_id::<true>(AccountType::FungibleFaucet, AccountStorageMode::Private, 0xfabb_cddd);
+    account_id(AccountType::FungibleFaucet, AccountStorageMode::Private, 0xfabb_cddd);
 // FUNGIBLE TOKENS - ON-CHAIN
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN: u128 =
-    account_id::<true>(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xaabc_bcde);
+    account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xaabc_bcde);
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_1: u128 =
-    account_id::<true>(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xbaca_ddef);
+    account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xbaca_ddef);
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_2: u128 =
-    account_id::<true>(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xccdb_eefa);
+    account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xccdb_eefa);
 pub const ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN_3: u128 =
-    account_id::<true>(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xeeff_cc99);
+    account_id(AccountType::FungibleFaucet, AccountStorageMode::Public, 0xeeff_cc99);
 
 // NON-FUNGIBLE TOKENS - OFF-CHAIN
 pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_OFF_CHAIN: u128 =
-    account_id::<true>(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0xaabc_ccde);
+    account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0xaabc_ccde);
 // NON-FUNGIBLE TOKENS - ON-CHAIN
 pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN: u128 =
-    account_id::<true>(AccountType::NonFungibleFaucet, AccountStorageMode::Public, 0xbcca_ddef);
+    account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Public, 0xbcca_ddef);
 pub const ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN_1: u128 =
-    account_id::<true>(AccountType::NonFungibleFaucet, AccountStorageMode::Public, 0xccdf_eefa);
+    account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Public, 0xccdf_eefa);
 
 // TEST ACCOUNT IDs WITH CERTAIN PROPERTIES
 /// The Account Id with the maximum possible one bits.
 pub const ACCOUNT_ID_MAX_ONES: u128 =
-    account_id::<false>(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0)
+    account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0)
         | 0x7fff_ffff_ffff_ff00_7fff_ffff_ffff_ff00;
 /// The Account Id with the maximum possible zero bits.
 pub const ACCOUNT_ID_MAX_ZEROES: u128 =
-    account_id::<true>(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0x001f_0000);
+    account_id(AccountType::NonFungibleFaucet, AccountStorageMode::Private, 0x001f_0000);
 
 // UTILITIES
 // --------------------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ pub const ACCOUNT_ID_MAX_ZEROES: u128 =
 /// 1st felt: [0xaa | 5 zero bytes | 0xbb | metadata byte]
 /// 2nd felt: [2 zero bytes (epoch) | 0xcc | 3 zero bytes | 0xdd | zero byte]
 /// ```
-pub const fn account_id<const CHECK_MIN_ONES: bool>(
+pub const fn account_id(
     account_type: AccountType,
     storage_mode: AccountStorageMode,
     random: u32,

--- a/objects/src/transaction/chain_mmr.rs
+++ b/objects/src/transaction/chain_mmr.rs
@@ -19,7 +19,8 @@ use crate::{
 ///
 /// [ChainMmr] represents a partial view into the actual MMR and contains authentication paths
 /// for a limited set of blocks. The intent is to include only the blocks relevant for execution
-/// of a specific transaction (i.e., the blocks corresponding to all input notes).
+/// of a specific transaction (i.e., the blocks corresponding to all input notes and the one needed
+/// to validate the seed of a new account, if applicable).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChainMmr {
     /// Partial view of the Chain MMR with authentication paths for the blocks listed below.


### PR DESCRIPTION
This builds on top of #1054 and implements most of the follow-up tasks from #1046, specifically:

- Add `AccountIdError`.
- Make `AccountBuilder::new` take required `init_seed` parameter.
- Implement `Display` and `FromStr` for `AccountType`.
- Add `validate_id` and `build_note_metadata` MASM procedure test.
- Validate storage mode in `validate_id` MASM procedure.
- Rename `OnBlockSlot` "epoch" field to "round".
- Mention account id validation in ChainMMR use cases.
- Rename `NonFungibleAsset::faucet_id` to `faucet_id_prefix`
- Add `FungibleAsset::faucet_id_prefix`.
- Make `u128::to_be_bytes` and `[u8; 15]` account ID representation consistent. Every representation uses big-endian now (hex, u128, [u8; 15]).
    - The consequence was to revert asset deserialization to how it was before.
- Remove POW constants in `constants.masm` and constants patching in `build.rs`.
- Remove `generate_account_seed` since most of it was unused and move the needed parts to the `miden-tx` tests that need it.
- Document how to run multi-threaded and single-threaded account seed benchmark and fix the benchmark by using an RNG to generate different seeds to start grinding from.

The motivation (original review comments) for most of these is linked in the above issue.
