### PR TITLE
Add `no_std` Makefile recipes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,22 @@ jobs:
           rustup component add clippy
           make clippy
 
+  clippy-no-std:
+    name: clippy no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only update the cache on push onto the next branch. This strikes a nice balance between
+          # cache hits and cache evictions (github has a 10GB cache limit). 
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Clippy no_std
+        run: |
+          rustup update --no-self-update
+          rustup component add clippy
+          make clippy-no-std
+
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ format-check: ## Runs Format using nightly toolchain but only in check mode
 
 
 .PHONY: lint
-lint: format fix clippy ## Runs all linting tasks at once (Clippy, fixing, formatting)
+lint: format fix clippy clippy-no-std ## Runs all linting tasks at once (Clippy, fixing, formatting)
 
 # --- docs ----------------------------------------------------------------------------------------
 
@@ -83,7 +83,7 @@ check: ## Check all targets and features for errors without code generation
 
 
 .PHONY: check-no-std
-check-no-std: ## Check all targets and features for errors without code generation
+check-no-std: ## Check the no-std target without any features for errors without code generation
 	${BUILD_KERNEL_ERRORS} cargo check --no-default-features --target wasm32-unknown-unknown --workspace --lib
 
 # --- building ------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ clippy: ## Runs Clippy with configs
 	cargo clippy --workspace --all-targets $(ALL_FEATURES_BUT_ASYNC) -- -D warnings
 
 
+.PHONY: clippy-no-std
+clippy-no-std: ## Runs Clippy with configs
+	cargo clippy --no-default-features --target wasm32-unknown-unknown --workspace --lib -- -D warnings
+
+
 .PHONY: fix
 fix: ## Runs Fix with configs
 	cargo fix --workspace --allow-staged --allow-dirty --all-targets $(ALL_FEATURES_BUT_ASYNC)
@@ -75,6 +80,11 @@ test: test-default test-prove ## Run all tests
 .PHONY: check
 check: ## Check all targets and features for errors without code generation
 	${BUILD_KERNEL_ERRORS} cargo check --all-targets $(ALL_FEATURES_BUT_ASYNC)
+
+
+.PHONY: check-no-std
+check-no-std: ## Check all targets and features for errors without code generation
+	${BUILD_KERNEL_ERRORS} cargo check --no-default-features --target wasm32-unknown-unknown --workspace --lib
 
 # --- building ------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ test-default: ## Run default tests excluding `prove`
 	$(DEBUG_ASSERTIONS) $(BACKTRACE) cargo nextest run --profile default --cargo-profile test-release --features concurrent,testing --filter-expr "not test(prove)"
 
 
+.PHONY: test-dev
+test-dev: ## Run default tests excluding slow tests (prove and ID anchor block tests) in debug mode intended to be run locally
+	$(DEBUG_ASSERTIONS) $(BACKTRACE) cargo nextest run --profile default --features concurrent,testing --filter-expr "not test(prove) & not test(create_accounts_with_non_zero_anchor_block)"
+
+
 .PHONY: test-prove
 test-prove: ## Run `prove` tests (tests which use the Miden prover)
 	$(DEBUG_ASSERTIONS) $(BACKTRACE) cargo nextest run --profile prove --cargo-profile test-release --features concurrent,testing --filter-expr "test(prove)"

--- a/objects/src/accounts/component/template/storage/mod.rs
+++ b/objects/src/accounts/component/template/storage/mod.rs
@@ -311,57 +311,6 @@ impl Deserializable for StorageEntry {
     }
 }
 
-// STORAGE VALUES
-// ================================================================================================
-
-/// Represents the type of values that can be found in a storage slot's `values` field.
-#[cfg(feature = "std")]
-#[derive(serde::Deserialize, serde::Serialize)]
-#[serde(untagged)]
-enum StorageValues {
-    /// List of individual words (for multi-slot entries).
-    Words(Vec<WordRepresentation>),
-    /// List of key-value entries (for map storage slots).
-    MapEntries(Vec<MapEntry>),
-    /// A placeholder value, represented as "{{key}}".
-    Template(StoragePlaceholder),
-}
-
-#[cfg(feature = "std")]
-impl StorageValues {
-    pub fn is_list_of_words(&self) -> bool {
-        match self {
-            StorageValues::Words(_) => true,
-            StorageValues::MapEntries(_) => false,
-            StorageValues::Template(_) => false,
-        }
-    }
-
-    pub fn into_words(self) -> Option<Vec<WordRepresentation>> {
-        match self {
-            StorageValues::Words(vec) => Some(vec),
-            StorageValues::MapEntries(_) => None,
-            StorageValues::Template(_) => None,
-        }
-    }
-
-    pub fn into_map_entries(self) -> Option<Vec<MapEntry>> {
-        match self {
-            StorageValues::Words(_) => None,
-            StorageValues::MapEntries(vec) => Some(vec),
-            StorageValues::Template(_) => None,
-        }
-    }
-
-    pub fn len(&self) -> Option<usize> {
-        match self {
-            StorageValues::Words(vec) => Some(vec.len()),
-            StorageValues::MapEntries(vec) => Some(vec.len()),
-            StorageValues::Template(_) => None,
-        }
-    }
-}
-
 // MAP ENTRY
 // ================================================================================================
 

--- a/objects/src/accounts/component/template/storage/mod.rs
+++ b/objects/src/accounts/component/template/storage/mod.rs
@@ -315,6 +315,7 @@ impl Deserializable for StorageEntry {
 // ================================================================================================
 
 /// Represents the type of values that can be found in a storage slot's `values` field.
+#[cfg(feature = "std")]
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "std", serde(untagged))]
 enum StorageValues {
@@ -326,6 +327,7 @@ enum StorageValues {
     Template(StoragePlaceholder),
 }
 
+#[cfg(feature = "std")]
 impl StorageValues {
     pub fn is_list_of_words(&self) -> bool {
         match self {

--- a/objects/src/accounts/component/template/storage/mod.rs
+++ b/objects/src/accounts/component/template/storage/mod.rs
@@ -316,8 +316,8 @@ impl Deserializable for StorageEntry {
 
 /// Represents the type of values that can be found in a storage slot's `values` field.
 #[cfg(feature = "std")]
-#[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "std", serde(untagged))]
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
 enum StorageValues {
     /// List of individual words (for multi-slot entries).
     Words(Vec<WordRepresentation>),

--- a/objects/src/accounts/component/template/storage/toml.rs
+++ b/objects/src/accounts/component/template/storage/toml.rs
@@ -8,11 +8,10 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use vm_core::Felt;
 use vm_processor::Digest;
 
-use super::{
-    FeltRepresentation, StorageEntry, StoragePlaceholder, StorageValues, WordRepresentation,
-};
+use super::{FeltRepresentation, StorageEntry, StoragePlaceholder, WordRepresentation};
 use crate::{
-    accounts::AccountComponentMetadata, errors::AccountComponentTemplateError,
+    accounts::{component::template::MapEntry, AccountComponentMetadata},
+    errors::AccountComponentTemplateError,
     utils::parse_hex_string_as_word,
 };
 
@@ -195,6 +194,55 @@ impl<'de> serde::Deserialize<'de> for StoragePlaceholder {
     {
         let s = String::deserialize(deserializer)?;
         StoragePlaceholder::try_from(s.as_str()).map_err(serde::de::Error::custom)
+    }
+}
+
+// STORAGE VALUES
+// ================================================================================================
+
+/// Represents the type of values that can be found in a storage slot's `values` field.
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+enum StorageValues {
+    /// List of individual words (for multi-slot entries).
+    Words(Vec<WordRepresentation>),
+    /// List of key-value entries (for map storage slots).
+    MapEntries(Vec<MapEntry>),
+    /// A placeholder value, represented as "{{key}}".
+    Template(StoragePlaceholder),
+}
+
+impl StorageValues {
+    pub fn is_list_of_words(&self) -> bool {
+        match self {
+            StorageValues::Words(_) => true,
+            StorageValues::MapEntries(_) => false,
+            StorageValues::Template(_) => false,
+        }
+    }
+
+    pub fn into_words(self) -> Option<Vec<WordRepresentation>> {
+        match self {
+            StorageValues::Words(vec) => Some(vec),
+            StorageValues::MapEntries(_) => None,
+            StorageValues::Template(_) => None,
+        }
+    }
+
+    pub fn into_map_entries(self) -> Option<Vec<MapEntry>> {
+        match self {
+            StorageValues::Words(_) => None,
+            StorageValues::MapEntries(vec) => Some(vec),
+            StorageValues::Template(_) => None,
+        }
+    }
+
+    pub fn len(&self) -> Option<usize> {
+        match self {
+            StorageValues::Words(vec) => Some(vec.len()),
+            StorageValues::MapEntries(vec) => Some(vec.len()),
+            StorageValues::Template(_) => None,
+        }
     }
 }
 

--- a/objects/src/testing/block.rs
+++ b/objects/src/testing/block.rs
@@ -52,8 +52,17 @@ impl BlockHeader {
         };
 
         #[cfg(target_family = "wasm")]
-        let (prev_hash, chain_root, nullifier_root, note_root, tx_hash, proof_hash, timestamp) =
-            Default::default();
+        let (prev_hash, chain_root, nullifier_root, note_root, tx_hash, proof_hash, timestamp) = {
+            (
+                Default::default(),
+                chain_root.unwrap_or_default(),
+                Default::default(),
+                note_root.unwrap_or_default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
+        };
 
         BlockHeader::new(
             0,


### PR DESCRIPTION
- Add `no_std` Makefile recipes to `cargo check` and `cargo clippy` the no_std target.
- Fix the issues flagged by `make clippy-no-std` (unused variables in no_std).
- Add a CI check for `clippy-no-std` (totally optional I think, it would mostly find unused variables, but should not take much time anyway).
- I took this opportunity to add a `test-dev` command to execute the majority of tests (excluding slow ones like prove tests) in debug mode, convenient when iterating on a PR locally. I was missing this and always ran `cargo nextest` directly because the existing `make test-*` recipes all use release mode which takes minutes to compile alone. This target makes it convenient to run tests from all crates with one command. `make test-dev` takes roughly 30s for me, with the slowest tests being the P2ID script tests, but it's probably fine to keep them in the set of tests:

```
...
PASS [   2.735s] miden-tx tests::test_send_note_proc
PASS [   9.119s] miden-tx::miden-tx wallet::wallet_creation
PASS [   9.306s] miden-tx::miden-tx scripts::faucet::faucet_contract_mint_fungible_asset_fails_exceeds_max_supply
PASS [   9.813s] miden-tx::miden-tx scripts::p2id::test_create_consume_multiple_notes
PASS [  26.761s] miden-tx::miden-tx scripts::p2id::p2id_script_multiple_assets
PASS [  28.013s] miden-tx::miden-tx scripts::p2idr::p2idr_script
```

closes #862