### PR TITLE
Move duplicate procedures to shared util modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Made `AccountIdError` public (#1067).
 - Made `BasicFungibleFaucet::MAX_DECIMALS` public (#1063).
 - [BREAKING] Removed `miden-tx-prover` crate and created `miden-proving-service` and `miden-remote-provers` (#1047).
+- Deduplicate `masm` procedures across kernel and miden lib to a shared `util` module (#1070).
 
 ## 0.6.2 (2024-11-20)
 

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -3,6 +3,7 @@ use.std::collections::smt
 use.std::crypto::hashes::rpo
 use.std::mem
 
+use.kernel::util::account_id
 use.kernel::constants
 use.kernel::memory
 
@@ -11,9 +12,6 @@ use.kernel::memory
 
 # Account nonce cannot be increased by a greater than u32 value
 const.ERR_ACCOUNT_NONCE_INCREASE_MUST_BE_U32=0x00020004
-
-# Least significant byte of the account ID suffix must be zero.
-const.ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO=0x00020005
 
 # Account code must be updatable for it to be possible to set new code
 const.ERR_ACCOUNT_CODE_IS_NOT_UPDATABLE=0x00020006
@@ -117,20 +115,6 @@ const.NON_FUNGIBLE_FAUCET_ACCOUNT=0x30 # 0b11_0000
 # Bit pattern for a faucet account, after the account type mask has been applied.
 const.FAUCET_ACCOUNT=0x20 # 0b10_0000
 
-# The maximum number of account interface procedures.
-const.MAX_NUM_PROCEDURES=256
-
-# The account storage slot at which faucet data is stored.
-# Fungible faucet: The faucet data consists of [0, 0, 0, total_issuance]
-# Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
-const.FAUCET_STORAGE_DATA_SLOT=0
-
-# The maximum storage slot index
-const.MAX_STORAGE_SLOT_INDEX=254
-
-# The maximum number of account storage slots.
-const.MAX_NUM_STORAGE_SLOTS=MAX_STORAGE_SLOT_INDEX+1
-
 # Depth of the account database tree.
 const.ACCOUNT_TREE_DEPTH=64
 
@@ -174,9 +158,7 @@ const.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT=131082
 #!
 #! Where:
 #! - faucet_storage_data_slot is the account storage slot at which faucet data is stored.
-export.get_faucet_storage_data_slot
-    push.FAUCET_STORAGE_DATA_SLOT
-end
+export.::kernel::util::account_id::get_faucet_storage_data_slot
 
 #! Returns the maximum number of account storage slots.
 #!
@@ -185,9 +167,7 @@ end
 #!
 #! Where:
 #! - max_num_storage_slots is the maximum number of account storage slots.
-export.get_max_num_storage_slots
-    push.MAX_NUM_STORAGE_SLOTS
-end
+export.::kernel::util::account_id::get_max_num_storage_slots
 
 #! Returns the maximum number of account interface procedures.
 #!
@@ -196,9 +176,7 @@ end
 #!
 #! Where:
 #! - max_num_procedures is the maximum number of account interface procedures.
-export.get_max_num_procedures
-    push.MAX_NUM_PROCEDURES
-end
+export.::kernel::util::account_id::get_max_num_procedures
 
 # PROCEDURES
 # =================================================================================================
@@ -282,10 +260,7 @@ export.memory::get_init_acct_hash->get_initial_hash
 #! Where:
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_fungible_faucet is a boolean indicating whether the account is a fungible faucet.
-export.is_fungible_faucet
-    exec.type push.FUNGIBLE_FAUCET_ACCOUNT eq
-    # => [is_fungible_faucet]
-end
+export.::kernel::util::account_id::is_fungible_faucet
 
 #! Returns a boolean indicating whether the account is a non-fungible faucet.
 #!
@@ -295,10 +270,7 @@ end
 #! Where:
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_non_fungible_faucet is a boolean indicating whether the account is a non-fungible faucet.
-export.is_non_fungible_faucet
-    exec.type push.NON_FUNGIBLE_FAUCET_ACCOUNT eq
-    # => [is_non_fungible_faucet]
-end
+export.::kernel::util::account_id::is_non_fungible_faucet
 
 #! Returns a boolean indicating whether the account is a faucet.
 #!
@@ -308,10 +280,7 @@ end
 #! Where:
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_faucet is a boolean indicating whether the account is a faucet.
-export.is_faucet
-    u32split drop push.FAUCET_ACCOUNT u32and eq.0 not
-    # => [is_faucet]
-end
+export.::kernel::util::account_id::is_faucet
 
 #! Returns a boolean indicating whether the account is a regular updatable account.
 #!
@@ -322,10 +291,7 @@ end
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_updatable_account is a boolean indicating whether the account is a regular updatable
 #!   account.
-export.is_updatable_account
-    exec.type push.REGULAR_ACCOUNT_UPDATABLE_CODE eq
-    # => [is_updatable_account]
-end
+export.::kernel::util::account_id::is_updatable_account
 
 #! Returns a boolean indicating whether the account is a regular immutable account.
 #!
@@ -336,10 +302,7 @@ end
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_immutable_account is a boolean indicating whether the account is a regular immutable
 #!   account.
-export.is_immutable_account
-    exec.type push.REGULAR_ACCOUNT_IMMUTABLE_CODE eq
-    # => [is_immutable_account]
-end
+export.::kernel::util::account_id::is_immutable_account
 
 #! Returns a boolean indicating whether the given account_ids are equal.
 #!
@@ -350,14 +313,7 @@ end
 #! - acct_id_{prefix,suffix} are the prefix and suffix felts of an account ID.
 #! - other_acct_id_{prefix,suffix} are the prefix and suffix felts of the other account ID to compare against.
 #! - is_id_equal is a boolean indicating whether the account IDs are equal.
-export.is_id_eq
-    movup.2 eq
-    # => [is_prefix_equal, acct_id_suffix, other_acct_id_suffix]
-    movdn.2 eq
-    # => [is_suffix_equal, is_prefix_equal]
-    and
-    # => [is_id_equal]
-end
+export.::kernel::util::account_id::is_id_eq
 
 #! Validates an account ID. Note that this does not validate anything about the account type,
 #! since any bit pattern is a valid account type.
@@ -373,43 +329,7 @@ end
 #! - account_id_prefix does not contain either the public or private storage mode.
 #! - account_id_suffix contains an anchor epoch that is greater or equal to 2^16.
 #! - account_id_suffix does not have its lower 8 bits set to zero.
-export.validate_id
-    # Validate version in prefix. For now only version 0 is supported.
-    # ---------------------------------------------------------------------------------------------
-
-    dup exec.id_version
-    # => [id_version, account_id_prefix, account_id_suffix]
-    assertz.err=ERR_ACCOUNT_ID_UNKNOWN_VERSION
-    # => [account_id_prefix, account_id_suffix]
-
-    # Validate storage mode in prefix.
-    # ---------------------------------------------------------------------------------------------
-
-    u32split drop
-    # => [account_id_prefix_lo, account_id_suffix]
-    u32and.ACCOUNT_ID_STORAGE_MODE_MASK_U32 dup eq.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32
-    # => [is_private_storage_mode, id_storage_mode_masked, account_id_suffix]
-    swap eq.ACCOUNT_ID_STORAGE_MODE_PUBLIC_U32
-    # => [is_public_storage_mode, is_private_storage_mode, account_id_suffix]
-    or assert.err=ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE
-    # => [account_id_suffix]
-
-    # Validate anchor epoch is less than u16::MAX (0xffff) in suffix.
-    # ---------------------------------------------------------------------------------------------
-
-    dup exec.id_anchor_epoch
-    # => [anchor_epoch, account_id_suffix]
-    lt.0xffff assert.err=ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX
-    # => [account_id_suffix]
-
-    # Validate lower 8 bits of suffix are zero.
-    # ---------------------------------------------------------------------------------------------
-
-    u32split drop u32and.0xff eq.0
-    # => [is_least_significant_byte_zero]
-    assert.err=ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO
-    # => []
-end
+export.::kernel::util::account_id::validate_id
 
 #! Sets the code of the account the transaction is being executed against.
 #!
@@ -448,15 +368,7 @@ end
 #!
 #! Panics if:
 #! - the computed index is out of bounds
-export.apply_storage_offset
-    # offset index
-    dup movup.3 add
-    # => [offset_slot_index, storage_offset, storage_size]
-
-    # verify that slot_index is in bounds
-    movdn.2 add dup.1 gt assert.err=ERR_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS
-    # => [offset_slot_index]
-end
+export.::kernel::util::account_id::apply_storage_offset
 
 #! Validates all account procedures storage metadata by checking that:
 #! - All storage offsets and sizes are in bounds.
@@ -783,7 +695,7 @@ export.validate_seed
     # => [0, 0, account_id_prefix, account_id_suffix]
 
     # get the anchor block's number
-    dup.3 exec.id_anchor_block_num
+    dup.3 exec.account_id::id_anchor_block_num
     # => [anchor_block_num, 0, 0, account_id_prefix, account_id_suffix]
 
     exec.memory::get_chain_mmr_ptr swap
@@ -847,110 +759,16 @@ export.validate_seed
     # => [account_id_suffix, hashed_account_id_prefix, hashed_account_id_suffix, account_id_prefix]
 
     # extract anchor epoch from ID of the new account
-    dup movdn.4 exec.id_anchor_epoch
+    dup movdn.4 exec.account_id::id_anchor_epoch
     # => [anchor_epoch, hashed_account_id_prefix, hashed_account_id_suffix, account_id_prefix, account_id_suffix]
 
     # shape suffix of hashed id, adding the anchor epoch and setting the lower 8 bits to zero
-    movup.2 exec.shape_suffix swap
+    movup.2 exec.account_id::shape_suffix swap
     # => [hashed_account_id_prefix, hashed_account_id_suffix, account_id_prefix, account_id_suffix]
 
     # assert the account ID matches the account ID of the new account
     exec.is_id_eq assert.err=ERR_ACCOUNT_SEED_ANCHOR_BLOCK_HASH_DIGEST_MISMATCH
     # => []
-end
-
-#! Shapes the suffix so it meets the requirements of the account ID, by overwriting the
-#! upper 16 bits with the anchor epoch and setting the lower 8 bits to zero.
-#!
-#! Inputs:  [seed_digest_suffix, anchor_epoch]
-#! Outputs: [account_id_suffix]
-#!
-#! Where:
-#! - seed_digest_suffix is the suffix of the digest that should be shaped into the suffix
-#!   of an account ID.
-#! - account_id_suffix is the suffix of an account ID.
-#! - anchor_epoch is the epoch number to which this account ID is anchored.
-proc.shape_suffix
-  u32split
-  # => [seed_digest_suffix_hi, seed_digest_suffix_lo, anchor_epoch]
-
-  # clear epoch bits in hi part so we can set them later
-  u32and.0x0000ffff swap
-  # => [seed_digest_suffix_lo, seed_digest_suffix_hi', anchor_epoch]
-
-  # clear lower 8 bits of the lo part
-  u32and.0xffffff00 swap.2
-  # => [anchor_epoch, seed_digest_suffix_hi', seed_digest_suffix_lo']
-
-  # assert epoch is not 2^16
-  # this is technically optional as we will compare this id with the provided one for which
-  # this property was already checked, but since this check is cheap we include it anyway
-  dup eq.0xffff assertz.err=ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX
-  # => [anchor_epoch, seed_digest_suffix_hi', seed_digest_suffix_lo']
-
-  # shift epoch left by 16 bits and set epoch bits on hi part
-  u32shl.16 u32or
-  # => [seed_digest_suffix_hi'', seed_digest_suffix_lo']
-
-  # reassemble the suffix by multiplying the hi part with 2^32 and adding the lo part
-  mul.0x0100000000 add
-  # => [account_id_suffix]
-end
-
-#! Extracts the block number of the anchor block from the suffix of an account ID.
-#!
-#! Inputs:  [account_id_suffix]
-#! Outputs: [anchor_block_num]
-#!
-#! Where:
-#! - account_id_suffix is the suffix of an account ID.
-#! - anchor_block_num is the number of the block to which this account ID is anchored.
-proc.id_anchor_block_num
-  # extract the upper 32 bits
-  u32split swap drop
-  # => [account_id_suffix_hi]
-
-  # to get the epoch's block number we would have to multiply the epoch in the account ID by 2^16
-  # since the epoch is already in the upper 16 bits of the u32, we can simply zero out the
-  # lower 16 bits to achieve the same result.
-  u32and.0xffff0000
-  # => [anchor_block_num]
-end
-
-#! Extracts the epoch from the suffix of an account ID.
-#!
-#! Inputs:  [account_id_suffix]
-#! Outputs: [anchor_epoch]
-#!
-#! Where:
-#! - account_id_suffix is the suffix of an account ID.
-#! - anchor_epoch is the epoch number to which this account ID is anchored.
-proc.id_anchor_epoch
-  # extract the upper 32 bits
-  u32split swap drop
-  # => [account_id_suffix_hi]
-
-  # shift the upper 16 bits to the right to produce the epoch
-  u32shr.16
-  # => [anchor_epoch]
-end
-
-#! Extracts the account ID version from the prefix of an account ID.
-#!
-#! Inputs:  [account_id_prefix]
-#! Outputs: [id_version]
-#!
-#! Where:
-#! - account_id_prefix is the prefix of an account ID.
-#! - id_version is the version number of the ID.
-proc.id_version
-  # extract the lower 32 bits
-  u32split drop
-  # => [account_id_prefix_lo]
-
-  # mask out the version
-  u32and.ACCOUNT_VERSION_MASK_U32
-  # => [id_version]
 end
 
 # DATA LOADERS
@@ -1097,25 +915,6 @@ end
 # HELPER PROCEDURES
 # =================================================================================================
 
-#! Returns the least significant half of an account ID prefix with the account type bits masked out.
-#!
-#! The account type can be obtained by comparing this value with the following constants:
-#! - REGULAR_ACCOUNT_UPDATABLE_CODE
-#! - REGULAR_ACCOUNT_IMMUTABLE_CODE
-#! - FUNGIBLE_FAUCET_ACCOUNT
-#! - NON_FUNGIBLE_FAUCET_ACCOUNT
-#!
-#! Inputs:  [acct_id_prefix]
-#! Outputs: [acct_type]
-#!
-#! Where:
-#! - acct_id_prefix is the prefix of the account ID.
-#! - acct_type is the account type.
-proc.type
-    u32split drop push.ACCOUNT_ID_TYPE_MASK_U32 u32and
-    # => [acct_type]
-end
-
 #! Sets an item in the account storage. Doesn't emit any events.
 #!
 #! Inputs:  [index, NEW_VALUE]
@@ -1233,7 +1032,7 @@ export.get_foreign_account_ptr
 
     # check that the loading of one more account won't exceed the maximum number of the foreign 
     # accounts which can be loaded.
-    dup exec.memory::get_max_foreign_account_ptr lte 
+    dup exec.memory::get_max_foreign_account_ptr lte
     assert.err=ERR_FOREIGN_ACCOUNT_MAX_NUMBER_EXCEEDED
     # => [curr_account_ptr, foreign_account_id_prefix, foreign_account_id_suffix, is_equal_id]
 

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -333,7 +333,7 @@ export.::kernel::util::account_id::is_immutable_account
 #! - acct_id_{prefix,suffix} are the prefix and suffix felts of an account ID.
 #! - other_acct_id_{prefix,suffix} are the prefix and suffix felts of the other account ID to compare against.
 #! - is_id_equal is a boolean indicating whether the account IDs are equal.
-export.::kernel::util::account_id::is_id_eq
+export.::kernel::util::account_id::is_equal->is_id_equal
 
 #! Validates an account ID. Note that this does not validate anything about the account type,
 #! since any bit pattern is a valid account type.
@@ -349,7 +349,7 @@ export.::kernel::util::account_id::is_id_eq
 #! - account_id_prefix does not contain either the public or private storage mode.
 #! - account_id_suffix contains an anchor epoch that is greater or equal to 2^16.
 #! - account_id_suffix does not have its lower 8 bits set to zero.
-export.::kernel::util::account_id::validate_id
+export.::kernel::util::account_id::validate->validate_id
 
 #! Sets the code of the account the transaction is being executed against.
 #!
@@ -795,7 +795,7 @@ export.validate_seed
     # => [hashed_account_id_prefix, hashed_account_id_suffix, account_id_prefix, account_id_suffix]
 
     # assert the account ID matches the account ID of the new account
-    exec.is_id_eq assert.err=ERR_ACCOUNT_SEED_ANCHOR_BLOCK_HASH_DIGEST_MISMATCH
+    exec.is_id_equal assert.err=ERR_ACCOUNT_SEED_ANCHOR_BLOCK_HASH_DIGEST_MISMATCH
     # => []
 end
 
@@ -1018,7 +1018,7 @@ export.get_foreign_account_ptr
     # => [foreign_account_id_prefix, foreign_account_id_suffix]
 
     # check that foreign account ID is not equal to the native account ID
-    dup.1 dup.1 exec.memory::get_native_account_id exec.is_id_eq not
+    dup.1 dup.1 exec.memory::get_native_account_id exec.is_id_equal not
     assert.err=ERR_FOREIGN_ACCOUNT_ID_EQUALS_NATIVE_ACCT_ID
 
     # get the initial account data pointer
@@ -1048,7 +1048,7 @@ export.get_foreign_account_ptr
         # => [is_empty_block, maybe_account_id_prefix, maybe_account_id_suffix, curr_account_ptr', foreign_account_id_prefix, foreign_account_id_suffix]
 
         # check whether the current id matches the foreign id
-        movdn.2 dup.5 dup.5 exec.is_id_eq
+        movdn.2 dup.5 dup.5 exec.is_id_equal
         # => [is_equal_id, is_empty_word, curr_account_ptr', foreign_account_id_prefix, foreign_account_id_suffix]
 
         # get the loop flag

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -79,6 +79,20 @@ const.ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE=0x00020059
 # CONSTANTS
 # =================================================================================================
 
+# The account storage slot at which faucet data is stored.
+# Fungible faucet: The faucet data consists of [0, 0, 0, total_issuance]
+# Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
+const.FAUCET_STORAGE_DATA_SLOT=0
+
+# The maximum storage slot index
+const.MAX_STORAGE_SLOT_INDEX=254
+
+# The maximum number of account storage slots.
+const.MAX_NUM_STORAGE_SLOTS=MAX_STORAGE_SLOT_INDEX+1
+
+# The maximum number of account interface procedures.
+const.MAX_NUM_PROCEDURES=256
+
 # Given the least significant 32 bits of an account ID's prefix, this mask defines the bits used
 # to determine the account version.
 const.ACCOUNT_VERSION_MASK_U32=0x0f # 0b1111
@@ -158,7 +172,9 @@ const.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT=131082
 #!
 #! Where:
 #! - faucet_storage_data_slot is the account storage slot at which faucet data is stored.
-export.::kernel::util::account_id::get_faucet_storage_data_slot
+export.get_faucet_storage_data_slot
+    push.FAUCET_STORAGE_DATA_SLOT
+end
 
 #! Returns the maximum number of account storage slots.
 #!
@@ -167,7 +183,9 @@ export.::kernel::util::account_id::get_faucet_storage_data_slot
 #!
 #! Where:
 #! - max_num_storage_slots is the maximum number of account storage slots.
-export.::kernel::util::account_id::get_max_num_storage_slots
+export.get_max_num_storage_slots
+    push.MAX_NUM_STORAGE_SLOTS
+end
 
 #! Returns the maximum number of account interface procedures.
 #!
@@ -176,7 +194,9 @@ export.::kernel::util::account_id::get_max_num_storage_slots
 #!
 #! Where:
 #! - max_num_procedures is the maximum number of account interface procedures.
-export.::kernel::util::account_id::get_max_num_procedures
+export.get_max_num_procedures
+    push.MAX_NUM_PROCEDURES
+end
 
 # PROCEDURES
 # =================================================================================================
@@ -368,7 +388,15 @@ end
 #!
 #! Panics if:
 #! - the computed index is out of bounds
-export.::kernel::util::account_id::apply_storage_offset
+export.apply_storage_offset
+    # offset index
+    dup movup.3 add
+    # => [offset_slot_index, storage_offset, storage_size]
+
+    # verify that slot_index is in bounds
+    movdn.2 add dup.1 gt assert.err=ERR_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS
+    # => [offset_slot_index]
+end
 
 #! Validates all account procedures storage metadata by checking that:
 #! - All storage offsets and sizes are in bounds.

--- a/miden-lib/asm/kernels/transaction/lib/asset.masm
+++ b/miden-lib/asm/kernels/transaction/lib/asset.masm
@@ -161,7 +161,7 @@ export.validate_fungible_asset_origin
     dup.3 dup.3
     # => [asset_id_prefix, asset_id_suffix, faucet_id_prefix, faucet_id_suffix, ASSET]
 
-    exec.account::is_id_eq assert.err=ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN
+    exec.account::is_id_equal assert.err=ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN
     # => [ASSET]
 
     # assert the fungible asset is valid

--- a/miden-lib/asm/kernels/transaction/lib/asset.masm
+++ b/miden-lib/asm/kernels/transaction/lib/asset.masm
@@ -24,10 +24,8 @@ const.ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN=0x00020026
 # The origin of the non-fungible asset is not this faucet
 const.ERR_NON_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN=0x00020027
 
-# CONSTANTS
+# CONSTANT ACCESSORS
 # =================================================================================================
-
-const.FUNGIBLE_ASSET_MAX_AMOUNT=9223372036854775807
 
 #! Returns the maximum amount of a fungible asset.
 #!
@@ -36,10 +34,7 @@ const.FUNGIBLE_ASSET_MAX_AMOUNT=9223372036854775807
 #!
 #! Where:
 #! - fungible_asset_max_amount is the maximum amount of a fungible asset.
-export.get_fungible_asset_max_amount
-    push.FUNGIBLE_ASSET_MAX_AMOUNT
-    # => [fungible_asset_max_amount]
-end
+export.::kernel::util::asset::get_fungible_asset_max_amount
 
 # PROCEDURES
 # =================================================================================================
@@ -69,7 +64,7 @@ export.validate_fungible_asset
     # => [ASSET]
 
     # assert that the max amount (ASSET[0]) of a fungible asset is not exceeded
-    dup.3 push.FUNGIBLE_ASSET_MAX_AMOUNT lte 
+    dup.3 exec.get_fungible_asset_max_amount lte 
     assert.err=ERR_FUNGIBLE_ASSET_FORMAT_ELEMENT_ZERO_MUST_BE_WITHIN_LIMITS
     # => [ASSET]
 end

--- a/miden-lib/asm/kernels/transaction/lib/constants.masm
+++ b/miden-lib/asm/kernels/transaction/lib/constants.masm
@@ -51,9 +51,7 @@ end
 #!
 #! Where:
 #! - max_inputs_per_note is the max inputs per note.
-export.get_max_inputs_per_note
-    push.MAX_INPUTS_PER_NOTE
-end
+export.::kernel::util::note::get_max_inputs_per_note
 
 #! Returns the max allowed number of assets per note.
 #!

--- a/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -469,7 +469,7 @@ proc.process_account_data
     # assert the account ID matches the account ID in global inputs
     exec.memory::get_global_acct_id
     exec.memory::get_account_id
-    exec.account::is_id_eq assert.err=ERR_PROLOGUE_MISMATCH_OF_ACCOUNT_IDS_FROM_GLOBAL_INPUTS_AND_ADVICE_PROVIDER
+    exec.account::is_id_equal assert.err=ERR_PROLOGUE_MISMATCH_OF_ACCOUNT_IDS_FROM_GLOBAL_INPUTS_AND_ADVICE_PROVIDER
     # => [ACCT_HASH]
 
     # store a copy of the initial nonce in global inputs

--- a/miden-lib/asm/miden/account.masm
+++ b/miden-lib/asm/miden/account.masm
@@ -439,39 +439,6 @@ export.get_vault_commitment
     # => [COM]
 end
 
-# PROCEDURES COPIED FROM KERNEL (TODO: get rid of this duplication)
-# =================================================================================================
-
-# Given the least significant 32 bits of an account ID's prefix, this mask defines the bits used
-# to determine the account type.
-const.ACCOUNT_ID_TYPE_MASK_U32=0x30 # 0b11_0000
-
-# Bit pattern for a fungible faucet w/ immutable code, after the account type mask has been applied.
-const.FUNGIBLE_FAUCET_ACCOUNT=0x20 # 0b10_0000
-
-# Bit pattern for a non-fungible faucet w/ immutable code, after the account type mask has been
-# applied.
-const.NON_FUNGIBLE_FAUCET_ACCOUNT=0x30 # 0b11_0000
-
-#! Returns the most significant half with the account type bits masked out.
-#!
-#! The account type can be defined by comparing this value with the following constants:
-#!
-#! - REGULAR_ACCOUNT_UPDATABLE_CODE
-#! - REGULAR_ACCOUNT_IMMUTABLE_CODE
-#! - FUNGIBLE_FAUCET_ACCOUNT
-#! - NON_FUNGIBLE_FAUCET_ACCOUNT
-#!
-#! Stack: [acct_id_prefix]
-#! Output: [acct_type]
-#!
-#! - acct_id_prefix is the prefix of the account ID.
-#! - acct_type is the account type.
-proc.type
-    u32split drop push.ACCOUNT_ID_TYPE_MASK_U32 u32and
-    # => [acct_type]
-end
-
 #! Returns a boolean indicating whether the account is a fungible faucet.
 #!
 #! Stack: [acct_id]
@@ -479,10 +446,7 @@ end
 #!
 #! - acct_id is the account ID.
 #! - is_fungible_faucet is a boolean indicating whether the account is a fungible faucet.
-export.is_fungible_faucet
-    exec.type push.FUNGIBLE_FAUCET_ACCOUNT eq
-    # => [is_fungible_faucet]
-end
+export.::miden::util::account_id::is_fungible_faucet
 
 #! Returns a boolean indicating whether the account is a non-fungible faucet.
 #!
@@ -491,13 +455,8 @@ end
 #!
 #! - acct_id is the account ID.
 #! - is_non_fungible_faucet is a boolean indicating whether the account is a non-fungible faucet.
-export.is_non_fungible_faucet
-    exec.type push.NON_FUNGIBLE_FAUCET_ACCOUNT eq
-    # => [is_non_fungible_faucet]
-end
+export.::miden::util::account_id::is_non_fungible_faucet
 
-#! TODO: This is a copy; move to utils.
-#!
 #! Returns a boolean indicating whether the given account_ids are equal.
 #!
 #! Inputs:  [acct_id_prefix, acct_id_suffix, other_acct_id_prefix, other_acct_id_suffix]
@@ -507,11 +466,4 @@ end
 #! - acct_id_{prefix,suffix} are the prefix and suffix felts of an account ID.
 #! - other_acct_id_{prefix,suffix} are the prefix and suffix felts of the other account ID to compare against.
 #! - is_id_equal is a boolean indicating whether the account IDs are equal.
-export.is_id_eq
-    movup.2 eq
-    # => [is_prefix_equal, acct_id_suffix, other_acct_id_suffix]
-    movdn.2 eq
-    # => [is_suffix_equal, is_prefix_equal]
-    and
-    # => [is_id_equal]
-end
+export.::miden::util::account_id::is_equal->is_id_equal

--- a/miden-lib/asm/miden/asset.masm
+++ b/miden-lib/asm/miden/asset.masm
@@ -104,18 +104,10 @@ export.create_non_fungible_asset
     # => [ASSET]
 end
 
-# PROCEDURES COPIED FROM KERNEL (TODO: get rid of this duplication)
-# =================================================================================================
-
-const.FUNGIBLE_ASSET_MAX_AMOUNT=9223372036854775807
-
 #! Returns the maximum amount of a fungible asset.
 #!
 #! Stack: []
 #! Outputs: [fungible_asset_max_amount]
 #!
 #! fungible_asset_max_amount is the maximum amount of a fungible asset.
-export.get_fungible_asset_max_amount
-    push.FUNGIBLE_ASSET_MAX_AMOUNT
-    # => [fungible_asset_max_amount]
-end
+export.::miden::util::asset::get_fungible_asset_max_amount

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -265,6 +265,4 @@ const.MAX_INPUTS_PER_NOTE=128
 #! Output: [max_inputs_per_note]
 #!
 #! - max_inputs_per_note is the max inputs per note.
-export.get_max_inputs_per_note
-    push.MAX_INPUTS_PER_NOTE
-end
+export.::miden::util::note::get_max_inputs_per_note

--- a/miden-lib/asm/note_scripts/P2ID.masm
+++ b/miden-lib/asm/note_scripts/P2ID.masm
@@ -98,7 +98,7 @@ begin
     # => [account_id_prefix, account_id_suffix, target_account_id_prefix, target_account_id_suffix, ...]
 
     # ensure account_id = target_account_id, fails otherwise
-    exec.account::is_id_eq assert.err=ERR_P2ID_TARGET_ACCT_MISMATCH
+    exec.account::is_id_equal assert.err=ERR_P2ID_TARGET_ACCT_MISMATCH
     # => []
 
     exec.add_note_assets_to_account

--- a/miden-lib/asm/note_scripts/P2IDR.masm
+++ b/miden-lib/asm/note_scripts/P2IDR.masm
@@ -107,7 +107,7 @@ begin
     # => [account_id_prefix, account_id_suffix, account_id_prefix, account_id_suffix, reclaim_block_height, target_account_id_prefix, target_account_id_suffix, ...]
 
     # determine if the current account is the target account
-    movup.6 movup.6 exec.account::is_id_eq
+    movup.6 movup.6 exec.account::is_id_equal
     # => [is_target, account_id_prefix, account_id_suffix, reclaim_block_height]
 
     if.true
@@ -121,7 +121,7 @@ begin
         # => [sender_account_id_prefix, sender_account_id_suffix, account_id_prefix, account_id_suffix, reclaim_block_height]
 
         # ensure current account ID = sender account ID
-        exec.account::is_id_eq assert.err=ERR_P2IDR_RECLAIM_ACCT_IS_NOT_SENDER
+        exec.account::is_id_equal assert.err=ERR_P2IDR_RECLAIM_ACCT_IS_NOT_SENDER
         # => [reclaim_block_height]
 
         # now check that sender is allowed to reclaim, current block >= reclaim block height

--- a/miden-lib/asm/shared/util/account_id.masm
+++ b/miden-lib/asm/shared/util/account_id.masm
@@ -93,7 +93,7 @@ end
 #! - acct_id_{prefix,suffix} are the prefix and suffix felts of an account ID.
 #! - other_acct_id_{prefix,suffix} are the prefix and suffix felts of the other account ID to compare against.
 #! - is_id_equal is a boolean indicating whether the account IDs are equal.
-export.is_id_eq
+export.is_equal
     movup.2 eq
     # => [is_prefix_equal, acct_id_suffix, other_acct_id_suffix]
     movdn.2 eq
@@ -157,7 +157,7 @@ end
 #! - account_id_prefix does not contain either the public or private storage mode.
 #! - account_id_suffix contains an anchor epoch that is greater or equal to 2^16.
 #! - account_id_suffix does not have its lower 8 bits set to zero.
-export.validate_id
+export.validate
     # Validate version in prefix. For now only version 0 is supported.
     # ---------------------------------------------------------------------------------------------
 

--- a/miden-lib/asm/shared/util/account_id.masm
+++ b/miden-lib/asm/shared/util/account_id.masm
@@ -67,7 +67,7 @@ const.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32=0x80 # 0b1000_0000
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_fungible_faucet is a boolean indicating whether the account is a fungible faucet.
 export.is_fungible_faucet
-    exec.type push.FUNGIBLE_FAUCET_ACCOUNT eq
+    exec.id_type push.FUNGIBLE_FAUCET_ACCOUNT eq
     # => [is_fungible_faucet]
 end
 
@@ -80,7 +80,7 @@ end
 #! - acct_id_prefix is the prefix of the account ID.
 #! - is_non_fungible_faucet is a boolean indicating whether the account is a non-fungible faucet.
 export.is_non_fungible_faucet
-    exec.type push.NON_FUNGIBLE_FAUCET_ACCOUNT eq
+    exec.id_type push.NON_FUNGIBLE_FAUCET_ACCOUNT eq
     # => [is_non_fungible_faucet]
 end
 
@@ -125,7 +125,7 @@ end
 #! - is_updatable_account is a boolean indicating whether the account is a regular updatable
 #!   account.
 export.is_updatable_account
-    exec.type push.REGULAR_ACCOUNT_UPDATABLE_CODE eq
+    exec.id_type push.REGULAR_ACCOUNT_UPDATABLE_CODE eq
     # => [is_updatable_account]
 end
 
@@ -139,7 +139,7 @@ end
 #! - is_immutable_account is a boolean indicating whether the account is a regular immutable
 #!   account.
 export.is_immutable_account
-    exec.type push.REGULAR_ACCOUNT_IMMUTABLE_CODE eq
+    exec.id_type push.REGULAR_ACCOUNT_IMMUTABLE_CODE eq
     # => [is_immutable_account]
 end
 
@@ -195,9 +195,6 @@ export.validate_id
     # => []
 end
 
-# HELPER PROCEDURES
-# =================================================================================================
-
 #! Shapes the suffix so it meets the requirements of the account ID, by overwriting the
 #! upper 16 bits with the anchor epoch and setting the lower 8 bits to zero.
 #!
@@ -209,7 +206,7 @@ end
 #!   of an account ID.
 #! - account_id_suffix is the suffix of an account ID.
 #! - anchor_epoch is the epoch number to which this account ID is anchored.
-proc.shape_suffix
+export.shape_suffix
     u32split
     # => [seed_digest_suffix_hi, seed_digest_suffix_lo, anchor_epoch]
 
@@ -235,6 +232,9 @@ proc.shape_suffix
     mul.0x0100000000 add
     # => [account_id_suffix]
 end
+
+# HELPER PROCEDURES
+# =================================================================================================
 
 #! Extracts the block number of the anchor block from the suffix of an account ID.
 #!
@@ -306,7 +306,7 @@ end
 #! Where:
 #! - acct_id_prefix is the prefix of the account ID.
 #! - acct_type is the account type.
-proc.type
+proc.id_type
     u32split drop push.ACCOUNT_ID_TYPE_MASK_U32 u32and
     # => [acct_type]
 end

--- a/miden-lib/asm/shared/util/account_id.masm
+++ b/miden-lib/asm/shared/util/account_id.masm
@@ -1,0 +1,387 @@
+# ERRORS
+# =================================================================================================
+
+# Unknown version in account ID.
+const.ERR_ACCOUNT_ID_UNKNOWN_VERSION=0x00020057
+
+# Epoch must be less than u16::MAX (0xffff).
+const.ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX=0x00020058
+
+# Unknown account storage mode in account ID.
+const.ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE=0x00020059
+
+# Least significant byte of the account ID suffix must be zero.
+const.ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO=0x00020005
+
+# Provided storage slot index is out of bounds
+const.ERR_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS=0x0002000D
+
+# CONSTANTS
+# =================================================================================================
+
+# The account storage slot at which faucet data is stored.
+# Fungible faucet: The faucet data consists of [0, 0, 0, total_issuance]
+# Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
+const.FAUCET_STORAGE_DATA_SLOT=0
+
+# The maximum storage slot index
+const.MAX_STORAGE_SLOT_INDEX=254
+
+# The maximum number of account storage slots.
+const.MAX_NUM_STORAGE_SLOTS=MAX_STORAGE_SLOT_INDEX+1
+
+# The maximum number of account interface procedures.
+const.MAX_NUM_PROCEDURES=256
+
+# Bit pattern for a faucet account, after the account type mask has been applied.
+const.FAUCET_ACCOUNT=0x20 # 0b10_0000
+
+# Bit pattern for an account w/ updatable code, after the account type mask has been applied.
+const.REGULAR_ACCOUNT_UPDATABLE_CODE=0x10 # 0b01_0000
+
+# Bit pattern for an account w/ immutable code, after the account type mask has been applied.
+const.REGULAR_ACCOUNT_IMMUTABLE_CODE=0 # 0b00_0000
+
+# Bit pattern for a fungible faucet w/ immutable code, after the account type mask has been applied.
+const.FUNGIBLE_FAUCET_ACCOUNT=0x20 # 0b10_0000
+
+# Bit pattern for a non-fungible faucet w/ immutable code, after the account type mask has been
+# applied.
+const.NON_FUNGIBLE_FAUCET_ACCOUNT=0x30 # 0b11_0000
+
+# Given the least significant 32 bits of an account id's first felt, this mask defines the bits used
+# to determine the account type.
+const.ACCOUNT_ID_TYPE_MASK_U32=0x30 # 0b11_0000
+
+# Given the least significant 32 bits of an account id's first felt, this mask defines the bits used
+# to determine the account version.
+const.ACCOUNT_VERSION_MASK_U32=0x0f # 0b1111
+
+# Given the least significant 32 bits of an account ID's first felt, this mask defines the bits used
+# to determine the account storage mode.
+const.ACCOUNT_ID_STORAGE_MODE_MASK_U32=0xC0 # 0b1100_0000
+
+# Given the least significant 32 bits of an account ID's first felt with the storage mode mask
+# applied, this value defines the public storage mode.
+const.ACCOUNT_ID_STORAGE_MODE_PUBLIC_U32=0 # 0b0000_0000
+
+# Given the least significant 32 bits of an account ID's first felt with the storage mode mask
+# applied, this value defines the private storage mode.
+const.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32=0x80 # 0b1000_0000
+
+# CONSTANT ACCESSORS
+# =================================================================================================
+
+#! Returns the account storage slot at which faucet data is stored.
+#! Fungible faucet: The faucet data consists of [0, 0, 0, total_issuance]
+#! Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
+#!
+#! Inputs:  []
+#! Outputs: [faucet_storage_data_slot]
+#!
+#! Where:
+#! - faucet_storage_data_slot is the account storage slot at which faucet data is stored.
+export.get_faucet_storage_data_slot
+    push.FAUCET_STORAGE_DATA_SLOT
+end
+
+#! Returns the maximum number of account storage slots.
+#!
+#! Inputs:  []
+#! Outputs: [max_num_storage_slots]
+#!
+#! Where:
+#! - max_num_storage_slots is the maximum number of account storage slots.
+export.get_max_num_storage_slots
+    push.MAX_NUM_STORAGE_SLOTS
+end
+
+#! Returns the maximum number of account interface procedures.
+#!
+#! Inputs:  []
+#! Outputs: [max_num_procedures]
+#!
+#! Where:
+#! - max_num_procedures is the maximum number of account interface procedures.
+export.get_max_num_procedures
+    push.MAX_NUM_PROCEDURES
+end
+
+# PROCEDURES
+# =================================================================================================
+
+#! Returns a boolean indicating whether the account is a fungible faucet.
+#!
+#! Inputs:  [acct_id_prefix]
+#! Outputs: [is_fungible_faucet]
+#!
+#! Where:
+#! - acct_id_prefix is the prefix of the account ID.
+#! - is_fungible_faucet is a boolean indicating whether the account is a fungible faucet.
+export.is_fungible_faucet
+    exec.type push.FUNGIBLE_FAUCET_ACCOUNT eq
+    # => [is_fungible_faucet]
+end
+
+#! Returns a boolean indicating whether the account is a non-fungible faucet.
+#!
+#! Inputs:  [acct_id_prefix]
+#! Outputs: [is_non_fungible_faucet]
+#!
+#! Where:
+#! - acct_id_prefix is the prefix of the account ID.
+#! - is_non_fungible_faucet is a boolean indicating whether the account is a non-fungible faucet.
+export.is_non_fungible_faucet
+    exec.type push.NON_FUNGIBLE_FAUCET_ACCOUNT eq
+    # => [is_non_fungible_faucet]
+end
+
+#! Returns a boolean indicating whether the given account_ids are equal.
+#!
+#! Inputs:  [acct_id_prefix, acct_id_suffix, other_acct_id_prefix, other_acct_id_suffix]
+#! Outputs: [is_id_equal]
+#!
+#! Where:
+#! - acct_id_{prefix,suffix} are the prefix and suffix felts of an account ID.
+#! - other_acct_id_{prefix,suffix} are the prefix and suffix felts of the other account ID to compare against.
+#! - is_id_equal is a boolean indicating whether the account IDs are equal.
+export.is_id_eq
+    movup.2 eq
+    # => [is_prefix_equal, acct_id_suffix, other_acct_id_suffix]
+    movdn.2 eq
+    # => [is_suffix_equal, is_prefix_equal]
+    and
+    # => [is_id_equal]
+end
+
+#! Returns a boolean indicating whether the account is a faucet.
+#!
+#! Inputs:  [acct_id_prefix]
+#! Outputs: [is_faucet]
+#!
+#! Where:
+#! - acct_id_prefix is the prefix of the account ID.
+#! - is_faucet is a boolean indicating whether the account is a faucet.
+export.is_faucet
+    u32split drop push.FAUCET_ACCOUNT u32and eq.0 not
+    # => [is_faucet]
+end
+
+#! Returns a boolean indicating whether the account is a regular updatable account.
+#!
+#! Inputs:  [acct_id_prefix]
+#! Outputs: [is_updatable_account]
+#!
+#! Where:
+#! - acct_id_prefix is the prefix of the account ID.
+#! - is_updatable_account is a boolean indicating whether the account is a regular updatable
+#!   account.
+export.is_updatable_account
+    exec.type push.REGULAR_ACCOUNT_UPDATABLE_CODE eq
+    # => [is_updatable_account]
+end
+
+#! Returns a boolean indicating whether the account is a regular immutable account.
+#!
+#! Inputs:  [acct_id_prefix]
+#! Outputs: [is_immutable_account]
+#!
+#! Where:
+#! - acct_id_prefix is the prefix of the account ID.
+#! - is_immutable_account is a boolean indicating whether the account is a regular immutable
+#!   account.
+export.is_immutable_account
+    exec.type push.REGULAR_ACCOUNT_IMMUTABLE_CODE eq
+    # => [is_immutable_account]
+end
+
+#! Validates an account ID. Note that this does not validate anything about the account type,
+#! since any bit pattern is a valid account type.
+#!
+#! Inputs:  [account_id_prefix, account_id_suffix]
+#! Outputs: []
+#!
+#! Where:
+#! - account_id_{prefix,suffix} are the prefix and suffix felts of the account ID.
+#!
+#! Panics if:
+#! - account_id_prefix does not contain version zero.
+#! - account_id_prefix does not contain either the public or private storage mode.
+#! - account_id_suffix contains an anchor epoch that is greater or equal to 2^16.
+#! - account_id_suffix does not have its lower 8 bits set to zero.
+export.validate_id
+    # Validate version in prefix. For now only version 0 is supported.
+    # ---------------------------------------------------------------------------------------------
+
+    dup exec.id_version
+    # => [id_version, account_id_prefix, account_id_suffix]
+    assertz.err=ERR_ACCOUNT_ID_UNKNOWN_VERSION
+    # => [account_id_prefix, account_id_suffix]
+
+    # Validate storage mode in prefix.
+    # ---------------------------------------------------------------------------------------------
+
+    u32split drop
+    # => [account_id_prefix_lo, account_id_suffix]
+    u32and.ACCOUNT_ID_STORAGE_MODE_MASK_U32 dup eq.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32
+    # => [is_private_storage_mode, id_storage_mode_masked, account_id_suffix]
+    swap eq.ACCOUNT_ID_STORAGE_MODE_PUBLIC_U32
+    # => [is_public_storage_mode, is_private_storage_mode, account_id_suffix]
+    or assert.err=ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE
+    # => [account_id_suffix]
+
+    # Validate anchor epoch is less than u16::MAX (0xffff) in suffix.
+    # ---------------------------------------------------------------------------------------------
+
+    dup exec.id_anchor_epoch
+    # => [anchor_epoch, account_id_suffix]
+    lt.0xffff assert.err=ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX
+    # => [account_id_suffix]
+
+    # Validate lower 8 bits of suffix are zero.
+    # ---------------------------------------------------------------------------------------------
+
+    u32split drop u32and.0xff eq.0
+    # => [is_least_significant_byte_zero]
+    assert.err=ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO
+    # => []
+end
+
+#! Applies storage offset to provided storage slot index for storage access.
+#!
+#! Inputs:  [storage_offset, storage_size, slot_index]
+#! Outputs: [offset_slot_index]
+#!
+#! Where:
+#! - storage_offset is the offset of the storage for this account component.
+#! - storage_size is the number of storage slots accessible from this account component.
+#! - slot_index is the index of the storage slot to be accessed.
+#! - offset_slot_index is the final index of the storage slot with the storage offset applied to it.
+#!
+#! Panics if:
+#! - the computed index is out of bounds
+export.apply_storage_offset
+    # offset index
+    dup movup.3 add
+    # => [offset_slot_index, storage_offset, storage_size]
+
+    # verify that slot_index is in bounds
+    movdn.2 add dup.1 gt assert.err=ERR_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS
+    # => [offset_slot_index]
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
+
+#! Shapes the suffix so it meets the requirements of the account ID, by overwriting the
+#! upper 16 bits with the anchor epoch and setting the lower 8 bits to zero.
+#!
+#! Inputs:  [seed_digest_suffix, anchor_epoch]
+#! Outputs: [account_id_suffix]
+#!
+#! Where:
+#! - seed_digest_suffix is the suffix of the digest that should be shaped into the suffix
+#!   of an account ID.
+#! - account_id_suffix is the suffix of an account ID.
+#! - anchor_epoch is the epoch number to which this account ID is anchored.
+proc.shape_suffix
+    u32split
+    # => [seed_digest_suffix_hi, seed_digest_suffix_lo, anchor_epoch]
+
+    # clear epoch bits in hi part so we can set them later
+    u32and.0x0000ffff swap
+    # => [seed_digest_suffix_lo, seed_digest_suffix_hi', anchor_epoch]
+
+    # clear lower 8 bits of the lo part
+    u32and.0xffffff00 swap.2
+    # => [anchor_epoch, seed_digest_suffix_hi', seed_digest_suffix_lo']
+
+    # assert epoch is not 2^16
+    # this is technically optional as we will compare this id with the provided one for which
+    # this property was already checked, but since this check is cheap we include it anyway
+    dup eq.0xffff assertz.err=ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX
+    # => [anchor_epoch, seed_digest_suffix_hi', seed_digest_suffix_lo']
+
+    # shift epoch left by 16 bits and set epoch bits on hi part
+    u32shl.16 u32or
+    # => [seed_digest_suffix_hi'', seed_digest_suffix_lo']
+
+    # reassemble the suffix by multiplying the hi part with 2^32 and adding the lo part
+    mul.0x0100000000 add
+    # => [account_id_suffix]
+end
+
+#! Extracts the block number of the anchor block from the suffix of an account ID.
+#!
+#! Inputs:  [account_id_suffix]
+#! Outputs: [anchor_block_num]
+#!
+#! Where:
+#! - account_id_suffix is the suffix of an account ID.
+#! - anchor_block_num is the number of the block to which this account ID is anchored.
+proc.id_anchor_block_num
+    # extract the upper 32 bits
+    u32split swap drop
+    # => [account_id_suffix_hi]
+
+    # to get the epoch's block number we would have to multiply the epoch in the account ID by 2^16
+    # since the epoch is already in the upper 16 bits of the u32, we can simply zero out the
+    # lower 16 bits to achieve the same result.
+    u32and.0xffff0000
+    # => [anchor_block_num]
+end
+
+#! Extracts the epoch from the suffix of an account ID.
+#!
+#! Inputs:  [account_id_suffix]
+#! Outputs: [anchor_epoch]
+#!
+#! Where:
+#! - account_id_suffix is the suffix of an account ID.
+#! - anchor_epoch is the epoch number to which this account ID is anchored.
+proc.id_anchor_epoch
+    # extract the upper 32 bits
+    u32split swap drop
+    # => [account_id_suffix_hi]
+
+    # shift the upper 16 bits to the right to produce the epoch
+    u32shr.16
+    # => [anchor_epoch]
+end
+
+#! Extracts the account ID version from the prefix of an account ID.
+#!
+#! Inputs:  [account_id_prefix]
+#! Outputs: [id_version]
+#!
+#! Where:
+#! - account_id_prefix is the prefix of an account ID.
+#! - id_version is the version number of the ID.
+proc.id_version
+    # extract the lower 32 bits
+    u32split drop
+    # => [account_id_prefix_lo]
+
+    # mask out the version
+    u32and.ACCOUNT_VERSION_MASK_U32
+    # => [id_version]
+end
+
+#! Returns the least significant half of an account ID prefix with the account type bits masked out.
+#!
+#! The account type can be obtained by comparing this value with the following constants:
+#! - REGULAR_ACCOUNT_UPDATABLE_CODE
+#! - REGULAR_ACCOUNT_IMMUTABLE_CODE
+#! - FUNGIBLE_FAUCET_ACCOUNT
+#! - NON_FUNGIBLE_FAUCET_ACCOUNT
+#!
+#! Inputs:  [acct_id_prefix]
+#! Outputs: [acct_type]
+#!
+#! Where:
+#! - acct_id_prefix is the prefix of the account ID.
+#! - acct_type is the account type.
+proc.type
+    u32split drop push.ACCOUNT_ID_TYPE_MASK_U32 u32and
+    # => [acct_type]
+end

--- a/miden-lib/asm/shared/util/account_id.masm
+++ b/miden-lib/asm/shared/util/account_id.masm
@@ -19,20 +19,6 @@ const.ERR_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS=0x0002000D
 # CONSTANTS
 # =================================================================================================
 
-# The account storage slot at which faucet data is stored.
-# Fungible faucet: The faucet data consists of [0, 0, 0, total_issuance]
-# Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
-const.FAUCET_STORAGE_DATA_SLOT=0
-
-# The maximum storage slot index
-const.MAX_STORAGE_SLOT_INDEX=254
-
-# The maximum number of account storage slots.
-const.MAX_NUM_STORAGE_SLOTS=MAX_STORAGE_SLOT_INDEX+1
-
-# The maximum number of account interface procedures.
-const.MAX_NUM_PROCEDURES=256
-
 # Bit pattern for a faucet account, after the account type mask has been applied.
 const.FAUCET_ACCOUNT=0x20 # 0b10_0000
 
@@ -68,44 +54,6 @@ const.ACCOUNT_ID_STORAGE_MODE_PUBLIC_U32=0 # 0b0000_0000
 # Given the least significant 32 bits of an account ID's first felt with the storage mode mask
 # applied, this value defines the private storage mode.
 const.ACCOUNT_ID_STORAGE_MODE_PRIVATE_U32=0x80 # 0b1000_0000
-
-# CONSTANT ACCESSORS
-# =================================================================================================
-
-#! Returns the account storage slot at which faucet data is stored.
-#! Fungible faucet: The faucet data consists of [0, 0, 0, total_issuance]
-#! Non-fungible faucet: The faucet data consists of SMT root containing minted non-fungible assets.
-#!
-#! Inputs:  []
-#! Outputs: [faucet_storage_data_slot]
-#!
-#! Where:
-#! - faucet_storage_data_slot is the account storage slot at which faucet data is stored.
-export.get_faucet_storage_data_slot
-    push.FAUCET_STORAGE_DATA_SLOT
-end
-
-#! Returns the maximum number of account storage slots.
-#!
-#! Inputs:  []
-#! Outputs: [max_num_storage_slots]
-#!
-#! Where:
-#! - max_num_storage_slots is the maximum number of account storage slots.
-export.get_max_num_storage_slots
-    push.MAX_NUM_STORAGE_SLOTS
-end
-
-#! Returns the maximum number of account interface procedures.
-#!
-#! Inputs:  []
-#! Outputs: [max_num_procedures]
-#!
-#! Where:
-#! - max_num_procedures is the maximum number of account interface procedures.
-export.get_max_num_procedures
-    push.MAX_NUM_PROCEDURES
-end
 
 # PROCEDURES
 # =================================================================================================
@@ -245,29 +193,6 @@ export.validate_id
     # => [is_least_significant_byte_zero]
     assert.err=ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO
     # => []
-end
-
-#! Applies storage offset to provided storage slot index for storage access.
-#!
-#! Inputs:  [storage_offset, storage_size, slot_index]
-#! Outputs: [offset_slot_index]
-#!
-#! Where:
-#! - storage_offset is the offset of the storage for this account component.
-#! - storage_size is the number of storage slots accessible from this account component.
-#! - slot_index is the index of the storage slot to be accessed.
-#! - offset_slot_index is the final index of the storage slot with the storage offset applied to it.
-#!
-#! Panics if:
-#! - the computed index is out of bounds
-export.apply_storage_offset
-    # offset index
-    dup movup.3 add
-    # => [offset_slot_index, storage_offset, storage_size]
-
-    # verify that slot_index is in bounds
-    movdn.2 add dup.1 gt assert.err=ERR_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS
-    # => [offset_slot_index]
 end
 
 # HELPER PROCEDURES

--- a/miden-lib/asm/shared/util/asset.masm
+++ b/miden-lib/asm/shared/util/asset.masm
@@ -1,0 +1,19 @@
+# CONSTANTS
+# =================================================================================================
+
+const.FUNGIBLE_ASSET_MAX_AMOUNT=9223372036854775807
+
+# PROCEDURES
+# =================================================================================================
+
+#! Returns the maximum amount of a fungible asset.
+#!
+#! Inputs:  []
+#! Outputs: [fungible_asset_max_amount]
+#!
+#! Where:
+#! - fungible_asset_max_amount is the maximum amount of a fungible asset.
+export.get_fungible_asset_max_amount
+    push.FUNGIBLE_ASSET_MAX_AMOUNT
+    # => [fungible_asset_max_amount]
+end

--- a/miden-lib/asm/shared/util/note.masm
+++ b/miden-lib/asm/shared/util/note.masm
@@ -1,0 +1,19 @@
+# CONSTANTS
+# =================================================================================================
+
+# The maximum number of input values associated with a single note.
+const.MAX_INPUTS_PER_NOTE=128
+
+# PROCEDURES
+# =================================================================================================
+
+#! Returns the max allowed number of input values per note.
+#!
+#! Inputs:  []
+#! Outputs: [max_inputs_per_note]
+#!
+#! Where:
+#! - max_inputs_per_note is the max inputs per note.
+export.get_max_inputs_per_note
+    push.MAX_INPUTS_PER_NOTE
+end


### PR DESCRIPTION
After a lot of back and forth in #1002 I think that making a new PR is easier as the approach in this PR is more minimal than in the other PR and reverting those changes in #1002 is more work than applying the necessary changes to `next`.

This basically implements the conclusion from https://github.com/0xPolygonMiden/miden-base/pull/1002#issuecomment-2592841287

This is the approach with minimal changes to only deduplicate procedures across kernel and miden lib and reexporting procedures from where they were previously used so the public interface is the same.
The `util` module was put in a `shared` directory so we can use `Assembler::add_modules_from_dir` with namespace `kernel` to achieve the desired `kernel::util::module` namespacing. The alternative approach without the `shared` directory would fail since `kernel::util` is not a valid `LibraryNamespace`.

I'm using `util` instead of `utils` in anticipation of #1021, even though `utils` is common and used in `std::utils` for example. I'm fine with using both.

What we're gaining in code deduplication with this approach we're losing with documentation duplication. We're not yet really doing anything with the MASM docs as far as I'm aware, but when we do, I think it would be great if reexports could inherit the docs from the original definition, unless overwritten.

closes #836