### PR TITLE
Add `kernel::account::get_map_item`

### DIFF
--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -254,8 +254,8 @@ end
 #! Outputs: [VALUE, pad(12)]
 #!
 #! Where:
-#! - index is the index of the item to get.
-#! - VALUE is the value of the item.
+#! - index is the index of the storage slot that contains the the map root.
+#! - VALUE is the value of the map item at KEY.
 #!
 #! Panics if:
 #! - the index is out of bounds (>255).
@@ -276,18 +276,17 @@ export.get_account_map_item
     # => [VALUE, pad(12)]
 end
 
-#! Inserts specified NEW_VALUE under specified KEY in map in specified account storage slot.
+#! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.
 #!
 #! Inputs:  [index, KEY, NEW_VALUE, pad(7)]
 #! Outputs: [OLD_MAP_ROOT, OLD_MAP_VALUE, pad(8)]
 #!
 #! Where:
-#! - index is the index of the item to get.
+#! - index is the index of the storage slot which contains the map root.
 #! - NEW_VALUE is the value of the new map item for the respective KEY.
 #! - OLD_VALUE is the value of the old map item for the respective KEY.
 #! - KEY is the key of the new item.
 #! - OLD_MAP_ROOT is the root of the old map before insertion
-#! - NEW_MAP_ROOT is the root of the new map after insertion.
 #!
 #! Panics if:
 #! - the index is out of bounds (>255).

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -27,9 +27,6 @@ const.ERR_FAUCET_STORAGE_DATA_SLOT_IS_RESERVED=0x00020000
 # The get_fungible_faucet_total_issuance procedure can only be called on a fungible faucet
 const.ERR_ACCOUNT_TOTAL_ISSUANCE_PROC_CAN_ONLY_BE_CALLED_ON_FUNGIBLE_FAUCET=0x00020001
 
-# Failed to read an account map item from a non-map storage slot
-const.ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT=0x00020002
-
 # Provided kernel procedure offset is out of bounds
 const.ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS=0x00020003
 
@@ -250,7 +247,8 @@ export.set_account_item
     # => [R', V, pad(8)]
 end
 
-#! Returns VALUE located under specified KEY in map in specified account storage slot.
+#! Returns the VALUE located under the specified KEY within the map contained in the given
+#! account storage slot.
 #!
 #! Inputs:  [index, KEY, pad(11)]
 #! Outputs: [VALUE, pad(12)]
@@ -265,15 +263,6 @@ end
 #!
 #! Invocation: dynexec
 export.get_account_map_item
-    # check if storage type is map
-    dup exec.account::get_storage_slot_type
-    # => [slot_type, index, KEY, pad(11)]
-
-    # check if type == map
-    exec.constants::get_storage_slot_type_map eq 
-    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
-    # => [index, KEY, pad(11)]
-
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [storage_offset, storage_size, index, KEY, pad(11)]
@@ -282,16 +271,8 @@ export.get_account_map_item
     exec.account::apply_storage_offset
     # => [index_with_offset, KEY, pad(11)]
 
-    # fetch the account storage item, which is ROOT of the map
-    exec.account::get_item swapw
-    # => [KEY, ROOT, pad(11)]
-
-    # fetch the VALUE located under KEY in the tree
-    exec.smt::get
-    # => [VALUE, ROOT, pad(11)]
-
-    # remove the ROOT from the stack
-    swapw dropw
+    # fetch the map item from account storage
+    exec.account::get_map_item
     # => [VALUE, pad(12)]
 end
 

--- a/miden-lib/asm/kernels/transaction/api.masm
+++ b/miden-lib/asm/kernels/transaction/api.masm
@@ -444,7 +444,6 @@ export.account_vault_add_asset
     exec.authenticate_account_origin drop drop
     # => [ASSET, pad(12)]
 
-    push.19891 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT
     # => [ASSET, pad(12)]
 
@@ -462,7 +461,6 @@ export.account_vault_add_asset
 
     # emit event to signal that an asset is being added to the account vault
     swapw
-    push.21383 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT dropw
     # => [ASSET', pad(12)]
 end
@@ -491,7 +489,6 @@ export.account_vault_remove_asset
     exec.authenticate_account_origin drop drop
     # => [ASSET, pad(12)]
 
-    push.20071 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT
     # => [ASSET, pad(12)]
 
@@ -504,7 +501,6 @@ export.account_vault_remove_asset
     # => [ASSET, pad(12)]
 
     # emit event to signal that an asset is being removed from the account vault
-    push.20149 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT
     # => [ASSET, pad(12)]
 end

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -624,8 +624,8 @@ end
 #! - We assume that index has been validated and is within bounds.
 #!
 #! Where:
-#! - index is the index of the item to get.
-#! - VALUE is the value of the item.
+#! - index is the index of the storage slot that contains the the map root.
+#! - VALUE is the value of the map item at KEY.
 #!
 #! Panics if:
 #! - the requested storage slot type is not map.
@@ -652,20 +652,21 @@ export.get_map_item
     # => [VALUE, pad(12)]
 end
 
-#! Sets an item in the specified account storage map.
+#! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.
 #!
 #! Note:
 #! - We assume that index has been validated and is within bounds.
 #!
 #! Inputs:  [index, KEY, NEW_VALUE, OLD_ROOT]
-#! Outputs: [OLD_VALUE, NEW_ROOT]
+#! Outputs: [OLD_MAP_ROOT, OLD_MAP_VALUE]
 #!
 #! Where:
+#! - index is the index of the storage slot which contains the map root.
 #! - OLD_ROOT is the root of the map to set the KEY NEW_VALUE pair.
 #! - NEW_VALUE is the value to set under KEY.
 #! - KEY is the key to set.
-#! - OLD_VALUE is the previous value of the item.
-#! - NEW_ROOT is the new root of the map.
+#! - OLD_MAP_VALUE is the previous value of the item.
+#! - OLD_MAP_ROOT is the root of the old map before insertion
 #!
 #! Panics if:
 #! - the storage slot type is not map.
@@ -695,9 +696,9 @@ export.set_map_item.3
     # set the NEW_VALUE under KEY in the tree
     # note smt::set expects the stack to be [NEW_VALUE, KEY, OLD_ROOT, ...]
     swapw exec.smt::set
-    # => [OLD_VALUE, NEW_ROOT, KEY, NEW_VALUE, index, ...]
+    # => [OLD_MAP_VALUE, NEW_ROOT, KEY, NEW_VALUE, index, ...]
 
-    # store OLD_VALUE and NEW_ROOT until the end of the procedure
+    # store OLD_MAP_VALUE and NEW_ROOT until the end of the procedure
     loc_storew.1 dropw loc_storew.2 dropw
     # => [KEY, NEW_VALUE, index, ...]
 
@@ -706,13 +707,13 @@ export.set_map_item.3
     emit.ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_EVENT drop
     # => [KEY, NEW_VALUE, ...]
 
-    # load OLD_VALUE and NEW_ROOT on the top of the stack
+    # load OLD_MAP_VALUE and NEW_ROOT on the top of the stack
     loc_loadw.2 swapw loc_loadw.1 swapw
-    # => [NEW_ROOT, OLD_VALUE, ...]
+    # => [NEW_ROOT, OLD_MAP_VALUE, ...]
 
     # set the root of the map in the respective account storage slot
     loc_load.0 exec.set_item_raw
-    # => [OLD_MAP_ROOT, OLD_VALUE, ...]
+    # => [OLD_MAP_ROOT, OLD_MAP_VALUE, ...]
 end
 
 #! Returns the type of the requested storage slot.

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -632,24 +632,24 @@ end
 export.get_map_item
     # check if storage slot type is map
     dup exec.get_storage_slot_type
-    # => [slot_type, index, KEY, pad(11)]
+    # => [slot_type, index, KEY]
 
     # check if type == map
     exec.constants::get_storage_slot_type_map eq
     assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
-    # => [index, KEY, pad(11)]
+    # => [index, KEY]
 
     # fetch the account storage item, which is ROOT of the map
     exec.get_item swapw
-    # => [KEY, ROOT, pad(11)]
+    # => [KEY, ROOT]
 
     # fetch the VALUE located under KEY in the tree
     exec.smt::get
-    # => [VALUE, ROOT, pad(11)]
+    # => [VALUE, ROOT]
 
     # remove the ROOT from the stack
     swapw dropw
-    # => [VALUE, pad(12)]
+    # => [VALUE]
 end
 
 #! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -78,6 +78,9 @@ const.ERR_ACCOUNT_ID_EPOCH_MUST_BE_LESS_THAN_U16_MAX=0x00020058
 # Unknown account storage mode in account ID.
 const.ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE=0x00020059
 
+# Failed to read an account map item from a non-map storage slot
+const.ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT=0x00020002
+
 # CONSTANTS
 # =================================================================================================
 
@@ -611,6 +614,44 @@ export.set_item
     # => [V]
 end
 
+#! Returns the VALUE located under the specified KEY within the map contained in the given
+#! account storage slot.
+#!
+#! Inputs:  [index, KEY]
+#! Outputs: [VALUE]
+#!
+#! Note:
+#! - We assume that index has been validated and is within bounds.
+#!
+#! Where:
+#! - index is the index of the item to get.
+#! - VALUE is the value of the item.
+#!
+#! Panics if:
+#! - the requested storage slot type is not map.
+export.get_map_item
+    # check if storage slot type is map
+    dup exec.get_storage_slot_type
+    # => [slot_type, index, KEY, pad(11)]
+
+    # check if type == map
+    exec.constants::get_storage_slot_type_map eq
+    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
+    # => [index, KEY, pad(11)]
+
+    # fetch the account storage item, which is ROOT of the map
+    exec.get_item swapw
+    # => [KEY, ROOT, pad(11)]
+
+    # fetch the VALUE located under KEY in the tree
+    exec.smt::get
+    # => [VALUE, ROOT, pad(11)]
+
+    # remove the ROOT from the stack
+    swapw dropw
+    # => [VALUE, pad(12)]
+end
+
 #! Sets an item in the specified account storage map.
 #!
 #! Note:
@@ -639,7 +680,7 @@ export.set_map_item.3
     # => [slot_type, index, KEY, NEW_VALUE, OLD_ROOT]
 
     # check if slot_type == map
-    exec.constants::get_storage_slot_type_map eq 
+    exec.constants::get_storage_slot_type_map eq
     assert.err=ERR_ACCOUNT_SETTING_MAP_ITEM_ON_NON_MAP_SLOT
     # => [index, KEY, NEW_VALUE, OLD_ROOT]
 

--- a/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -237,13 +237,11 @@ export.incr_nonce
     u32assert.err=ERR_ACCOUNT_NONCE_INCREASE_MUST_BE_U32
 
     # emit event to signal that account nonce is being incremented
-    push.20261 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_BEFORE_INCREMENT_NONCE_EVENT
 
     exec.memory::get_acct_nonce add
     exec.memory::set_acct_nonce
 
-    push.20357 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_AFTER_INCREMENT_NONCE_EVENT
 end
 
@@ -586,7 +584,6 @@ end
 #! Panics if:
 #! - the storage slot type is not value.
 export.set_item
-    push.20443 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT
     # => [index, V']
 
@@ -610,7 +607,6 @@ export.set_item
 
     # emit event to signal that an account storage item is being updated
     swapw movup.8
-    push.20551 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_STORAGE_AFTER_SET_ITEM_EVENT drop dropw
     # => [V]
 end
@@ -647,7 +643,6 @@ export.set_map_item.3
     assert.err=ERR_ACCOUNT_SETTING_MAP_ITEM_ON_NON_MAP_SLOT
     # => [index, KEY, NEW_VALUE, OLD_ROOT]
 
-    push.20693 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_EVENT
     # => [index, KEY, NEW_VALUE, OLD_ROOT]
 
@@ -667,7 +662,6 @@ export.set_map_item.3
 
     # emit event to signal that an account storage item is being updated
     movup.8
-    push.20771 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_EVENT drop
     # => [KEY, NEW_VALUE, ...]
 
@@ -749,7 +743,6 @@ end
 #! - the procedure root is not part of the account code.
 export.authenticate_procedure
     # load procedure index
-    push.20897 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT adv_push.1
     # => [index, PROC_ROOT]
 
@@ -804,8 +797,7 @@ export.validate_seed
     # => [0, 0, account_id_prefix, account_id_suffix, ANCHOR_BLOCK_HASH]
 
     # populate first four elements of the rate with the account ID seed
-    adv.push_mapval push.15263 drop         # TODO: remove line, see miden-vm/#1122
-    adv_loadw
+    adv.push_mapval adv_loadw
     # => [SEED, ANCHOR_BLOCK_HASH]
 
     # pad capacity element of hasher
@@ -977,7 +969,7 @@ end
 #! - the computed account storage commitment does not match the provided account storage commitment
 export.save_account_storage_data
     # move storage slot data from the advice map to the advice stack
-    adv.push_mapvaln push.15160 drop                # TODO: remove line, see miden-vm/#1122
+    adv.push_mapvaln
     # OS => [STORAGE_COMMITMENT]
     # AS => [storage_slot_data_len, [STORAGE_SLOT_DATA]]
 
@@ -1046,7 +1038,7 @@ end
 #! - the computed account code commitment does not match the provided account code commitment
 export.save_account_procedure_data
     # move procedure data from the advice map to the advice stack
-    adv.push_mapvaln push.15161 drop               # TODO: remove line, see miden-vm/#1122
+    adv.push_mapvaln
     # OS => [CODE_COMMITMENT]
     # AS => [account_procedure_data_len, [ACCOUNT_PROCEDURE_DATA]]
 

--- a/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -151,7 +151,7 @@ export.add_fungible_asset
     # we therefore overwrite the faucet id with the faucet id from ASSET to account for this edge case
     mem_loadw swapw
     # => [ASSET_KEY, VAULT_ROOT, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
-    adv.push_smtpeek push.15329 drop            # TODO: remove line, see miden-vm/#1122
+    adv.push_smtpeek
     adv_loadw
     # => [CUR_VAULT_VALUE, VAULT_ROOT, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
     swapw
@@ -312,7 +312,7 @@ export.remove_fungible_asset
     # To account for the edge case in which CUR_VAULT_VALUE is an EMPTY_WORD, we replace the most
     # significant element with the faucet_id to construct the CUR_ASSET.
     padw dup.14 mem_loadw swapw
-    adv.push_smtpeek push.15413 drop            # TODO: remove line, see miden-vm/#1122
+    adv.push_smtpeek
     adv_loadw dupw movdnw.2 drop movup.11
     # => [CUR_ASSET, VAULT_ROOT, CUR_VAULT_VALUE, amount, ASSET, vault_root_ptr]
 

--- a/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -58,7 +58,7 @@ proc.copy_output_notes_to_advice_map
         # => [OUTPUT_NOTES_COMMITMENT, output_note_ptr, output_notes_end_ptr]
 
         # insert created data into the advice map
-        adv.insert_mem push.15511 drop          # TODO: remove line, see miden-vm/#1122
+        adv.insert_mem
         # => [OUTPUT_NOTES_COMMITMENT, output_note_ptr, output_notes_end_ptr]
 
         # drop output note pointers
@@ -274,7 +274,7 @@ export.finalize_transaction
     # => [FINAL_ACCOUNT_HASH, acct_data_ptr, acct_data_end_ptr, INIT_ACCT_HASH]
 
     # insert final account data into the advice map
-    adv.insert_mem push.15619 drop              # TODO: remove line, see miden-vm/#1122
+    adv.insert_mem
     # => [FINAL_ACCOUNT_HASH, acct_data_ptr, acct_data_end_ptr, INIT_ACCT_HASH]
 
     # drop account data section pointers
@@ -294,8 +294,6 @@ export.finalize_transaction
         # get current nonce from memory
         exec.memory::get_acct_nonce
         # => [current_nonce, init_nonce, FINAL_ACCOUNT_HASH, INIT_ACCT_HASH]
-
-        push.1005 drop                              # TODO: remove line, see miden-vm/#1122
 
         # assert that initial nonce is less than current nonce
         lt assert.err=ERR_ACCOUNT_NONCE_DID_NOT_INCREASE_AFTER_STATE_CHANGE

--- a/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -374,7 +374,6 @@ proc.validate_new_account
             exec.constants::get_empty_smt_root 
             assert_eqw.err=ERR_PROLOGUE_NEW_NON_FUNGIBLE_FAUCET_RESERVED_SLOT_MUST_BE_VALID_EMPY_SMT
             # => []
-            push.1001 drop                              # TODO: remove line, see miden-vm/#1122
 
             # get the faucet reserved storage data slot type
             exec.account::get_faucet_storage_data_slot exec.account::get_storage_slot_type
@@ -982,7 +981,7 @@ proc.process_input_notes_data
     dup neq.0
     if.true
         exec.memory::get_input_notes_commitment
-        adv.push_mapval push.15787 drop         # TODO: remove line, see miden-vm/#1122
+        adv.push_mapval
         dropw
     end
     # => [num_notes]

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -477,7 +477,6 @@ end
 #! - the note_tag starts with anything but 0b11 and note_type is not public.
 #! - the number of output notes exceeds the maximum limit of 1024.
 export.create_note
-    push.20983 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.NOTE_BEFORE_CREATED_EVENT
 
     exec.build_note_metadata
@@ -495,7 +494,6 @@ export.create_note
     # => [NOTE_METADATA, note_ptr, RECIPIENT, note_idx]
 
     # emit event to signal that a new note is created
-    push.21067 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.NOTE_AFTER_CREATED_EVENT
 
     # set the metadata for the output note
@@ -539,7 +537,6 @@ export.add_asset_to_note
     # => [ASSET, note_ptr, num_of_assets, note_idx]
 
     # emit event to signal that a new asset is going to be added to the note.
-    push.21169 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.NOTE_BEFORE_ADD_ASSET_EVENT
     # => [ASSET, note_ptr]
 
@@ -559,7 +556,6 @@ export.add_asset_to_note
     # => [note_ptr, note_idx]
 
     # emit event to signal that a new asset was added to the note.
-    push.21277 drop                                     # TODO: remove line, see miden-vm/#1122
     emit.NOTE_AFTER_ADD_ASSET_EVENT
 
     drop

--- a/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -538,7 +538,7 @@ export.add_asset_to_note
 
     # emit event to signal that a new asset is going to be added to the note.
     emit.NOTE_BEFORE_ADD_ASSET_EVENT
-    # => [ASSET, note_ptr]
+    # => [ASSET, note_ptr, num_of_assets, note_idx]
 
     # Check if ASSET to add is fungible
     exec.asset::is_fungible_asset

--- a/miden-lib/asm/kernels/transaction/main.masm
+++ b/miden-lib/asm/kernels/transaction/main.masm
@@ -61,19 +61,16 @@ const.EPILOGUE_END=131081
 proc.main.1
     # Prologue
     # ---------------------------------------------------------------------------------------------
-    push.0 drop                         # TODO: remove line, see miden-vm/#1122
     trace.PROLOGUE_START
 
     exec.prologue::prepare_transaction
     # => []
 
-    push.1 drop                         # TODO: remove line, see miden-vm/#1122
     trace.PROLOGUE_END
 
     # Note Processing
     # ---------------------------------------------------------------------------------------------
 
-    push.2 drop                         # TODO: remove line, see miden-vm/#1122
     trace.NOTES_PROCESSING_START
 
     exec.memory::get_num_input_notes
@@ -87,7 +84,6 @@ proc.main.1
     # => [should_loop]
 
     while.true
-        push.4 drop                     # TODO: remove line, see miden-vm/#1122
         trace.NOTE_EXECUTION_START
         # => []
 
@@ -109,20 +105,17 @@ proc.main.1
         loc_load.0 neq
         # => [should_loop]
 
-        push.5 drop                     # TODO: remove line, see miden-vm/#1122
         trace.NOTE_EXECUTION_END
     end
 
     exec.note::note_processing_teardown
     # => []
 
-    push.3 drop                         # TODO: remove line, see miden-vm/#1122
     trace.NOTES_PROCESSING_END
 
     # Transaction Script Processing
     # ---------------------------------------------------------------------------------------------
 
-    push.6 drop                         # TODO: remove line, see miden-vm/#1122
     trace.TX_SCRIPT_PROCESSING_START
 
     # get the memory address of the transaction script root and load it to the stack
@@ -147,13 +140,11 @@ proc.main.1
         # => []
     end
 
-    push.7 drop                         # TODO: remove line, see miden-vm/#1122
     trace.TX_SCRIPT_PROCESSING_END
 
     # Epilogue
     # ---------------------------------------------------------------------------------------------
 
-    push.8 drop                         # TODO: remove line, see miden-vm/#1122
     trace.EPILOGUE_START
 
     # execute the transaction epilogue
@@ -163,7 +154,6 @@ proc.main.1
     # truncate the stack
     movupw.3 dropw movupw.3 dropw movup.9 drop
 
-    push.9 drop                         # TODO: remove line, see miden-vm/#1122
     trace.EPILOGUE_END
     # => [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH, tx_expiration_block_num]
 end

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -66,7 +66,7 @@ export.get_assets
     # => [ASSETS_HASH, num_assets, dest_ptr]
 
     # load the asset data from the advice map to the advice stack
-    adv.push_mapval push.15887 drop             # TODO: remove line, see miden-vm/#1122
+    adv.push_mapval
     # => [ASSETS_HASH, num_assets, dest_ptr]
 
     # calculate number of assets rounded up to an even number
@@ -113,7 +113,7 @@ export.get_inputs
     # => [INPUTS_HASH, dest_ptr]
 
     # load the inputs from the advice map to the advice stack
-    adv.push_mapval push.15973 drop             # TODO: remove line, see miden-vm/#1122
+    adv.push_mapval
     # => [INPUTS_HASH, dest_ptr]
 
     adv_push.1

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -8,19 +8,19 @@ use miden_objects::{digest, Digest};
 /// Hashes of all dynamically executed procedures from the kernel 0.
 pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // account_vault_add_asset
-    digest!("0x78d6a2544fcb8d8749165ece83cd72f73ffed433f39543f87090691f5c052838"),
+    digest!("0x2dc318c6659b20f5d145fd4153fe48a14f2c8dc4573fa98bf80d2df1db0e63bc"),
     // account_vault_get_balance
     digest!("0xbe5819bf5aabf1a7c9d8ebfc330a7869f610ca4f86e3708265d8d361b5b82f14"),
     // account_vault_has_non_fungible_asset
     digest!("0xce07ab13a9320a39642412ee6673eeee228a0173e00047c8b05bc259343b209a"),
     // account_vault_remove_asset
-    digest!("0x80c0cdf81ff7f845ee45a6473627611e1b251b3c8368c3764cdc8d48f2e7b806"),
+    digest!("0xbda7b544551c540ef9e67f3b1ee00d4292c419812c035c5bf53b9de28bcdeb48"),
     // get_account_id
     digest!("0x48964aab4326214daa06292e147f7f1107666c3f833d8f06ae9003cc50a32dd7"),
     // get_account_item
-    digest!("0x1a73504fc477eb17c9c9fcedd97ba4f397c9827c562aff1822a2fd08f8e9da18"),
+    digest!("0x677538ad2411983435f0b942b1fc6b3e5df0cf0d10bae34d56b48c54311b773a"),
     // get_account_map_item
-    digest!("0x2b3ad4c92f7cbce843eae3ef56e061317b41a46116cdc7bdd9da1b5318228523"),
+    digest!("0xa20686331cca5fa283c51cb5cc516b45f93870c987b4d93d3153e43eb389b6e6"),
     // get_account_nonce
     digest!("0x7456aa74a3bddeacfbcf02eb04130b8aea0772b5b15f0aeb49f91b1269d16bf7"),
     // get_account_vault_commitment
@@ -30,23 +30,23 @@ pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // get_initial_account_hash
     digest!("0xcfcc31f2fbac64efaeb0a193cfc8b91c308823bde9eef572beb96433c6ae6b32"),
     // incr_account_nonce
-    digest!("0xfc2da7d93bd401f08dfa9dd24523db712ea17d528db992e29fd3a6504f5aafe5"),
+    digest!("0x1760c860042c6e36b6b1b1f9f177c86b113db1d7a7c6445ac5414284fcc6f311"),
     // set_account_code
-    digest!("0x9e2110e69e5373b0dfa6ef13a35d7ecbb82f89493a79012fcc8e83c74c715b8f"),
+    digest!("0x6a9b0c63249503123be0446d9ba7b7d5c7395cd7bb91e6f58caa12ab3a81a9b1"),
     // set_account_item
-    digest!("0x4d2ef9eac1e0560f763cc09c1d669f6f47cf4d0c3deea54e4cb77bfcda9a3602"),
+    digest!("0xebfa25d6653e1ed501d4af35a37b00071097ff9dadf10c5a7d87f3dba65d757c"),
     // set_account_map_item
-    digest!("0x02befd8e777bacc5f4c3b14267b7e5558c9557d82970e74612c5aa6d7febf9c2"),
+    digest!("0x64cf602d692a3efbd72f2b4031c0a384cbc56e5a8929b4031aeafbee6a9ff8a3"),
     // burn_asset
-    digest!("0x27f721dba5a5710e295ac9404e17a9497f2052bbbb73293cd0fe0ba1ad63bad6"),
+    digest!("0x94686503a323b4fbefb758210a41c2e27d9c22f14cc07e9a28be2e564508eb20"),
     // get_fungible_faucet_total_issuance
     digest!("0xe56c3538757d5e2cee385028a5ba4e78eca3982698a4e6a3d5ddb17ea59fc13a"),
     // mint_asset
-    digest!("0x83521ee1aec0ffb09cfc65c47bb08aa5ad3924da42ab5a4bff9152d6534d4918"),
+    digest!("0x475215f1e401eb72d4760f860fd7ac022e92472b767fd4a5e9c60e8483cb8764"),
     // add_asset_to_note
-    digest!("0xf0ae3bde840b005661422bcf64d1700602aae19f5bcff038ed7fed95b384a42f"),
+    digest!("0x0018adf033ed13ae21864b028a959c7ca358fb5b34d305f9f1aaf96a0fded537"),
     // create_note
-    digest!("0x1f4f867434fc2704a16a15edd783f3825b1b5d932e04412b46eee3c85adcf1d2"),
+    digest!("0x1df987f8f3bb9fbfec3f3252031e146c0318772d45efcde56cc50275c766276a"),
     // get_input_notes_commitment
     digest!("0x44a86433c9a03c7ee99d046b0cd16e05df275f05ebb176b60193207229eae8b5"),
     // get_note_assets_info
@@ -66,7 +66,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // get_block_number
     digest!("0x17da2a77b878820854bfff2b5f9eb969a4e2e76a998f97f4967b2b1a7696437c"),
     // start_foreign_context
-    digest!("0x8c3adb3aff1686205283a59d3908e074c1f4768ac4c7a778ef2b873693ca9101"),
+    digest!("0xa44071231dad1165c9e785a780044347da436cfd97def777d4af4771f3de8c43"),
     // end_foreign_context
     digest!("0x132b50feca8ecec10937c740640c59733e643e89c1d8304cf4523120e27a0428"),
     // update_expiration_block_num

--- a/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -20,7 +20,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 33] = [
     // get_account_item
     digest!("0x677538ad2411983435f0b942b1fc6b3e5df0cf0d10bae34d56b48c54311b773a"),
     // get_account_map_item
-    digest!("0xa20686331cca5fa283c51cb5cc516b45f93870c987b4d93d3153e43eb389b6e6"),
+    digest!("0xac89c3cd71f8f96e15b8f4c83b6c5b4abd9e161d3b195ebb4e1f885d7ce94b94"),
     // get_account_nonce
     digest!("0x7456aa74a3bddeacfbcf02eb04130b8aea0772b5b15f0aeb49f91b1269d16bf7"),
     // get_account_vault_commitment

--- a/miden-tx/src/host/mod.rs
+++ b/miden-tx/src/host/mod.rs
@@ -176,7 +176,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
 
     /// Adds an asset at the top of the [OutputNoteBuilder] identified by the note pointer.
     ///
-    /// Expected stack state: [ASSET, note_ptr, ...]
+    /// Expected stack state: [ASSET, note_ptr, num_of_assets, note_idx]
     fn on_note_before_add_asset<S: ProcessState>(
         &mut self,
         process: &S,


### PR DESCRIPTION
Refactors the `get_account_map_item` kernel procedure to call an underlying `kernel::account::get_map_item` which is responsible for checking the slot type and retrieving the actual data.

Removes the extra decorator operations which I believe can now be removed due to https://github.com/0xPolygonMiden/miden-vm/issues/1122 being fixed.

Fixes some outdated MASM docs.

This implements #768 except for any event refactoring.

