### PR TITLE
fix: missing BlockNumber update in error struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Made `BasicFungibleFaucet::MAX_DECIMALS` public (#1063).
 - [BREAKING] Removed `miden-tx-prover` crate and created `miden-proving-service` and `miden-proving-service-client` (#1047).
 - Deduplicate `masm` procedures across kernel and miden lib to a shared `util` module (#1070).
-- [BREAKING] Added `BlockNumber` struct (#1043, #1080).
+- [BREAKING] Added `BlockNumber` struct (#1043, #1080, #1082).
 
 ## 0.6.2 (2024-11-20)
 

--- a/miden-tx/src/errors/mod.rs
+++ b/miden-tx/src/errors/mod.rs
@@ -2,8 +2,8 @@ use alloc::{boxed::Box, string::String};
 use core::error::Error;
 
 use miden_objects::{
-    accounts::AccountId, notes::NoteId, AccountError, Felt, ProvenTransactionError,
-    TransactionInputError, TransactionOutputError,
+    accounts::AccountId, block::BlockNumber, notes::NoteId, AccountError, Felt,
+    ProvenTransactionError, TransactionInputError, TransactionOutputError,
 };
 use miden_verifier::VerificationError;
 use thiserror::Error;
@@ -115,7 +115,7 @@ pub enum DataStoreError {
     #[error("account with id {0} not found in data store")]
     AccountNotFound(AccountId),
     #[error("block with number {0} not found in data store")]
-    BlockNotFound(u32),
+    BlockNotFound(BlockNumber),
     #[error("failed to create transaction inputs")]
     InvalidTransactionInput(#[source] TransactionInputError),
     #[error("note with id {0} is already consumed")]


### PR DESCRIPTION
In my previous PR i missed this `u32`.