### PR TITLE
Remove `GENESIS_BLOCK` public constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [BREAKING] Removed `miden-tx-prover` crate and created `miden-proving-service` and `miden-proving-service-client` (#1047).
 - Deduplicate `masm` procedures across kernel and miden lib to a shared `util` module (#1070).
 - [BREAKING] Added `BlockNumber` struct (#1043, #1080, #1082).
+- [BREAKING] Removed `GENESIS_BLOCK` public constant (#1088).
 
 ## 0.6.2 (2024-11-20)
 

--- a/miden-lib/src/accounts/faucets/mod.rs
+++ b/miden-lib/src/accounts/faucets/mod.rs
@@ -121,7 +121,9 @@ pub fn create_basic_fungible_faucet(
 
 #[cfg(test)]
 mod tests {
-    use miden_objects::{crypto::dsa::rpo_falcon512, digest, BlockHeader, FieldElement, ONE};
+    use miden_objects::{
+        block::BlockHeader, crypto::dsa::rpo_falcon512, digest, FieldElement, ONE,
+    };
     use vm_processor::Word;
 
     use super::{create_basic_fungible_faucet, AccountStorageMode, AuthScheme, Felt, TokenSymbol};

--- a/miden-lib/src/accounts/wallets/mod.rs
+++ b/miden-lib/src/accounts/wallets/mod.rs
@@ -80,7 +80,7 @@ pub fn create_basic_wallet(
 #[cfg(test)]
 mod tests {
 
-    use miden_objects::{crypto::dsa::rpo_falcon512, digest, BlockHeader, ONE};
+    use miden_objects::{block::BlockHeader, crypto::dsa::rpo_falcon512, digest, ONE};
     use vm_processor::utils::{Deserializable, Serializable};
 
     use super::{create_basic_wallet, Account, AccountStorageMode, AccountType, AuthScheme};

--- a/miden-tx/src/testing/mock_chain/mod.rs
+++ b/miden-tx/src/testing/mock_chain/mod.rs
@@ -12,8 +12,8 @@ use miden_objects::{
     },
     assets::{Asset, FungibleAsset, TokenSymbol},
     block::{
-        compute_tx_hash, Block, BlockAccountUpdate, BlockNoteIndex, BlockNoteTree, BlockNumber,
-        NoteBatch,
+        compute_tx_hash, Block, BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree,
+        BlockNumber, NoteBatch,
     },
     crypto::{
         dsa::rpo_falcon512::SecretKey,
@@ -25,7 +25,7 @@ use miden_objects::{
         ChainMmr, ExecutedTransaction, InputNote, InputNotes, OutputNote, ToInputNoteCommitments,
         TransactionId, TransactionInputs, TransactionScript,
     },
-    AccountError, BlockHeader, NoteError, ACCOUNT_TREE_DEPTH,
+    AccountError, NoteError, ACCOUNT_TREE_DEPTH,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;

--- a/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -32,6 +32,7 @@ use miden_objects::{
         Account, AccountBuilder, AccountId, AccountIdAnchor, AccountIdVersion,
         AccountProcedureInfo, AccountStorageMode, AccountType, StorageSlot,
     },
+    block::{BlockHeader, BlockNumber},
     testing::{
         account_component::AccountMockComponent,
         account_id::{
@@ -40,7 +41,6 @@ use miden_objects::{
         constants::FUNGIBLE_FAUCET_INITIAL_BALANCE,
     },
     transaction::{TransactionArgs, TransactionScript},
-    BlockHeader, GENESIS_BLOCK,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -487,7 +487,7 @@ pub fn create_accounts_with_anchor_block_zero() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
     // Choose epoch block 0 as the anchor block.
     // Here the transaction reference block is also the anchor block.
-    let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
+    let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
     create_multiple_accounts_test(&mock_chain, &genesis_block_header, AccountStorageMode::Private)?;
 
@@ -562,7 +562,7 @@ pub fn create_account_fungible_faucet_invalid_initial_balance() -> anyhow::Resul
     let mut mock_chain = MockChain::new();
     mock_chain.seal_block(None);
 
-    let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
+    let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
     let account = Account::mock_fungible_faucet(
         ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
@@ -586,7 +586,7 @@ pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> any
     let mut mock_chain = MockChain::new();
     mock_chain.seal_block(None);
 
-    let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
+    let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
     let account = Account::mock_non_fungible_faucet(
         ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
@@ -612,7 +612,7 @@ pub fn create_account_invalid_seed() {
     let mut mock_chain = MockChain::new();
     mock_chain.seal_block(None);
 
-    let genesis_block_header = mock_chain.block_header(GENESIS_BLOCK as usize);
+    let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
     let (account, seed) = AccountBuilder::new(ChaCha20Rng::from_entropy().gen())
         .anchor(AccountIdAnchor::try_from(&genesis_block_header).unwrap())

--- a/miden-tx/tests/integration/wallet/mod.rs
+++ b/miden-tx/tests/integration/wallet/mod.rs
@@ -8,7 +8,8 @@ fn wallet_creation() {
     use miden_lib::accounts::{auth::RpoFalcon512, wallets::BasicWallet};
     use miden_objects::{
         accounts::{AccountCode, AccountStorageMode, AccountType},
-        digest, BlockHeader,
+        block::BlockHeader,
+        digest,
     };
 
     // we need a Falcon Public Key to create the wallet account

--- a/objects/src/accounts/account_id/id_anchor.rs
+++ b/objects/src/accounts/account_id/id_anchor.rs
@@ -1,4 +1,8 @@
-use crate::{block::BlockNumber, errors::AccountIdError, BlockHeader, Digest, EMPTY_WORD};
+use crate::{
+    block::{BlockHeader, BlockNumber},
+    errors::AccountIdError,
+    Digest, EMPTY_WORD,
+};
 
 // ACCOUNT ID ANCHOR
 // ================================================================================================

--- a/objects/src/block/block_number.rs
+++ b/objects/src/block/block_number.rs
@@ -22,7 +22,7 @@ impl BlockNumber {
     /// exponent.
     pub const EPOCH_LENGTH_EXPONENT: u8 = 16;
 
-    /// Genesis BlockNumber
+    /// The block height of the genesis block.
     pub const GENESIS: Self = Self(0);
 
     /// Returns the previous block number

--- a/objects/src/constants.rs
+++ b/objects/src/constants.rs
@@ -68,6 +68,3 @@ pub const MAX_INPUT_NOTES_PER_BLOCK: usize = MAX_OUTPUT_NOTES_PER_BLOCK;
 pub const MAX_ACCOUNTS_PER_BLOCK: usize = MAX_ACCOUNTS_PER_BATCH * MAX_BATCHES_PER_BLOCK;
 const _: () = assert!(MAX_ACCOUNTS_PER_BLOCK >= MAX_ACCOUNTS_PER_BATCH);
 const _: () = assert!(MAX_ACCOUNTS_PER_BLOCK >= MAX_BATCHES_PER_BLOCK);
-
-/// The block height of the genesis block
-pub const GENESIS_BLOCK: u32 = 0;

--- a/objects/src/lib.rs
+++ b/objects/src/lib.rs
@@ -22,7 +22,6 @@ mod errors;
 // RE-EXPORTS
 // ================================================================================================
 
-pub use block::BlockHeader;
 pub use constants::*;
 pub use errors::{
     AccountDeltaError, AccountError, AccountIdError, AssetError, AssetVaultError, BlockError,

--- a/objects/src/testing/block.rs
+++ b/objects/src/testing/block.rs
@@ -6,7 +6,11 @@ use vm_processor::Digest;
 #[cfg(not(target_family = "wasm"))]
 use winter_rand_utils::{rand_array, rand_value};
 
-use crate::{accounts::Account, block::BlockNumber, BlockHeader, ACCOUNT_TREE_DEPTH};
+use crate::{
+    accounts::Account,
+    block::{BlockHeader, BlockNumber},
+    ACCOUNT_TREE_DEPTH,
+};
 
 impl BlockHeader {
     /// Creates a mock block. The account tree is formed from the provided `accounts`,

--- a/objects/src/transaction/chain_mmr.rs
+++ b/objects/src/transaction/chain_mmr.rs
@@ -3,9 +3,9 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use vm_core::utils::{Deserializable, Serializable};
 
 use crate::{
-    block::BlockNumber,
+    block::{BlockHeader, BlockNumber},
     crypto::merkle::{InnerNodeInfo, MmrPeaks, PartialMmr},
-    BlockHeader, ChainMmrError,
+    ChainMmrError,
 };
 
 // CHAIN MMR
@@ -154,9 +154,9 @@ mod tests {
     use super::ChainMmr;
     use crate::{
         alloc::vec::Vec,
-        block::BlockNumber,
+        block::{BlockHeader, BlockNumber},
         crypto::merkle::{Mmr, PartialMmr},
-        BlockHeader, Digest,
+        Digest,
     };
 
     #[test]

--- a/objects/src/transaction/mod.rs
+++ b/objects/src/transaction/mod.rs
@@ -1,8 +1,9 @@
 use super::{
     accounts::{Account, AccountDelta, AccountHeader, AccountId},
+    block::BlockHeader,
     notes::{NoteId, Nullifier},
     vm::AdviceInputs,
-    BlockHeader, Digest, Felt, Hasher, Word, WORD_SIZE, ZERO,
+    Digest, Felt, Hasher, Word, WORD_SIZE, ZERO,
 };
 
 mod chain_mmr;


### PR DESCRIPTION
This PR removes `GENESIS_BLOCK` public constant in favor of `BlockNumber::GENESIS`. It also removes the redundant `BlockHeader` re-export from the root namespace.