### PR TITLE
Turn miden-vm and miden-crypto errors into source errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Added Format Guidebook to the `miden-lib` crate (#987).
 - Added conversion from `Account` to `AccountDelta` for initial account state representation as delta (#983).
 - [BREAKING] Added `miden::note::get_script_hash` procedure (#995).
-- [BREAKING] Refactor error messages in `miden-lib` and `miden-tx` and use `thiserror` 2.0 (#1005).
+- [BREAKING] Refactor error messages in `miden-lib` and `miden-tx` and use `thiserror` 2.0 (#1005, #1090).
 - Added health check endpoints to the prover service (#1006).
 - [BREAKING] Extend `AccountId` to two `Felt`s and require block hash in derivation (#982).
 - Removed workers list from the proxy configuration file (#1018).

--- a/miden-lib/asm/miden/note.masm
+++ b/miden-lib/asm/miden/note.masm
@@ -254,12 +254,6 @@ export.get_script_hash
     # => [SCRIPT_HASH]
 end
 
-# PROCEDURES COPIED FROM KERNEL (TODO: get rid of this duplication)
-# =================================================================================================
-
-# The maximum number of input values associated with a single note.
-const.MAX_INPUTS_PER_NOTE=128
-
 #! Returns the max allowed number of input values per note.
 #!
 #! Stack: []

--- a/miden-tx/src/errors/mod.rs
+++ b/miden-tx/src/errors/mod.rs
@@ -14,9 +14,8 @@ use vm_processor::ExecutionError;
 
 #[derive(Debug, Error)]
 pub enum TransactionExecutorError {
-    // TODO: Turn into source error after upgrading to latest miden-vm.
-    #[error("failed to execute transaction kernel program: {0}")]
-    TransactionProgramExecutionFailed(ExecutionError),
+    #[error("failed to execute transaction kernel program")]
+    TransactionProgramExecutionFailed(#[source] ExecutionError),
     #[error("failed to fetch transaction inputs from the data store")]
     FetchTransactionInputsFailed(#[source] DataStoreError),
     #[error("input account ID {input_id} does not match output account ID {output_id}")]
@@ -46,9 +45,8 @@ pub enum TransactionProverError {
     TransactionOutputConstructionFailed(#[source] TransactionOutputError),
     #[error("failed to build proven transaction")]
     ProvenTransactionBuildFailed(#[source] ProvenTransactionError),
-    // TODO: Turn into source error after upgrading to latest miden-vm.
-    #[error("failed to execute transaction kernel program: {0}")]
-    TransactionProgramExecutionFailed(ExecutionError),
+    #[error("failed to execute transaction kernel program")]
+    TransactionProgramExecutionFailed(#[source] ExecutionError),
     #[error("failed to create transaction host")]
     TransactionHostCreationFailed(#[source] TransactionHostError),
     /// Custom error variant for errors not covered by the other variants.
@@ -87,9 +85,8 @@ impl TransactionProverError {
 
 #[derive(Debug, Error)]
 pub enum TransactionVerifierError {
-    // TODO: Turn into source error after upgrading to latest miden-vm.
-    #[error("failed to verify transaction: {0}")]
-    TransactionVerificationFailed(VerificationError),
+    #[error("failed to verify transaction")]
+    TransactionVerificationFailed(#[source] VerificationError),
     #[error(
         "transaction proof security level is {actual} but must be at least {expected_minimum}"
     )]

--- a/miden-tx/src/tests/mod.rs
+++ b/miden-tx/src/tests/mod.rs
@@ -861,8 +861,7 @@ fn test_tx_script() {
         push.{key}
 
         # load the tx script input value from the map and read it onto the stack
-        adv.push_mapval push.16073 drop         # TODO: remove line, see miden-vm/#1122
-        adv_loadw
+        adv.push_mapval adv_loadw
 
         # assert that the value is correct
         push.{value} assert_eqw

--- a/objects/src/accounts/code/mod.rs
+++ b/objects/src/accounts/code/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeSet, string::ToString, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
 
 use vm_core::mast::MastForest;
 
@@ -75,7 +75,7 @@ impl AccountCode {
     ) -> Result<Self, AccountError> {
         let (merged_mast_forest, _) =
             MastForest::merge(components.iter().map(|component| component.mast_forest()))
-                .map_err(|err| AccountError::AccountComponentMergeError(err.to_string()))?;
+                .map_err(AccountError::AccountComponentMastForestMergeError)?;
 
         let mut procedures = Vec::new();
         let mut proc_root_set = BTreeSet::new();
@@ -94,9 +94,9 @@ impl AccountCode {
                     // procedures where the offset has already been inserted would cause that
                     // procedure of the earlier component to write to the wrong slot.
                     if !proc_root_set.insert(proc_mast_root) {
-                        return Err(AccountError::AccountComponentMergeError(format!(
-                            "procedure with MAST root {proc_mast_root} is present in multiple account components"
-                        )));
+                        return Err(AccountError::AccountComponentDuplicateProcedureRoot(
+                            proc_mast_root,
+                        ));
                     }
 
                     // Components that do not access storage need to have offset and size set to 0.

--- a/objects/src/accounts/mod.rs
+++ b/objects/src/accounts/mod.rs
@@ -641,6 +641,6 @@ mod tests {
         )
         .unwrap_err();
 
-        assert_matches!(err, AccountError::AccountComponentMergeError(_))
+        assert_matches!(err, AccountError::AccountComponentDuplicateProcedureRoot(_))
     }
 }


### PR DESCRIPTION
Turns miden-vm and miden-crypto errors into source errors now that we've upgraded to the latest versions.

Removes two outdated TODOs that were handled in previous PRs.

Builds on top of #1084.

closes #981