### PR TITLE
Reintroduce moving pre-defined account components' source code into masm files

### DIFF
--- a/crates/miden-lib/src/account/auth/mod.rs
+++ b/crates/miden-lib/src/account/auth/mod.rs
@@ -8,11 +8,16 @@ use crate::account::components::rpo_falcon_512_library;
 /// An [`AccountComponent`] implementing the RpoFalcon512 signature scheme for authentication of
 /// transactions.
 ///
-/// Its exported procedures are:
+/// It reexports the procedures from `miden::contracts::auth::basic`. When linking against this
+/// component, the `miden` library (i.e. [`MidenLib`](crate::MidenLib)) must be available to the
+/// assembler which is the case when using [`TransactionKernel::assembler()`][kasm]. The procedures
+/// of this component are:
 /// - `auth_tx_rpo_falcon512`, which can be used to verify a signature provided via the advice stack
 ///   to authenticate a transaction.
 ///
 /// This component supports all account types.
+///
+/// [kasm]: crate::transaction::TransactionKernel::assembler
 pub struct RpoFalcon512 {
     public_key: PublicKey,
 }

--- a/crates/miden-lib/src/account/faucets/mod.rs
+++ b/crates/miden-lib/src/account/faucets/mod.rs
@@ -15,7 +15,10 @@ use crate::account::{auth::RpoFalcon512, components::basic_fungible_faucet_libra
 
 /// An [`AccountComponent`] implementing a basic fungible faucet.
 ///
-/// Its exported procedures are:
+/// It reexports the procedures from `miden::contracts::faucets::basic_fungible`. When linking
+/// against this component, the `miden` library (i.e. [`MidenLib`](crate::MidenLib)) must be
+/// available to the assembler which is the case when using
+/// [`TransactionKernel::assembler()`][kasm]. The procedures of this component are:
 /// - `distribute`, which mints an assets and create a note for the provided recipient.
 /// - `burn`, which burns the provided asset.
 ///
@@ -24,6 +27,8 @@ use crate::account::{auth::RpoFalcon512, components::basic_fungible_faucet_libra
 /// authentication.
 ///
 /// This component supports accounts of type [`AccountType::FungibleFaucet`].
+///
+/// [kasm]: crate::transaction::TransactionKernel::assembler
 pub struct BasicFungibleFaucet {
     symbol: TokenSymbol,
     decimals: u8,

--- a/crates/miden-lib/src/account/wallets/mod.rs
+++ b/crates/miden-lib/src/account/wallets/mod.rs
@@ -15,7 +15,10 @@ use crate::account::{auth::RpoFalcon512, components::basic_wallet_library};
 
 /// An [`AccountComponent`] implementing a basic wallet.
 ///
-/// Its exported procedures are:
+/// It reexports the procedures from `miden::contracts::wallets::basic`. When linking against this
+/// component, the `miden` library (i.e. [`MidenLib`](crate::MidenLib)) must be available to the
+/// assembler which is the case when using [`TransactionKernel::assembler()`][kasm]. The procedures
+/// of this component are:
 /// - `receive_asset`, which can be used to add an asset to the account.
 /// - `create_note`, which can be used to create a new note without any assets attached to it.
 /// - `move_asset_to_note`, which can be used to remove the specified asset from the account and add
@@ -25,6 +28,8 @@ use crate::account::{auth::RpoFalcon512, components::basic_wallet_library};
 /// providing authentication.
 ///
 /// This component supports all account types.
+///
+/// [kasm]: crate::transaction::TransactionKernel::assembler
 pub struct BasicWallet;
 
 impl From<BasicWallet> for AccountComponent {


### PR DESCRIPTION
This PR reintroduces the changes from #960 parts of which have somehow gone missing on `next`.

This mainly compiles account components from the files introduced in #960 instead of defining the code in constants.