### PR TITLE
Replace `TxAccountUpdate` and `BlockAccountUpdate` with `AccountUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [BREAKING] Incremented minimum supported Rust version to 1.84.
+- [BREAKING] Refactor `TxAccountUpdate` and `BlockAccountUpdate` into `AccountUpdate` (#1099).
 
 ## 0.7.0 (2025-01-22)
 

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -14,6 +14,9 @@ pub use vault::{
     AccountVaultDelta, FungibleAssetDelta, NonFungibleAssetDelta, NonFungibleDeltaAction,
 };
 
+mod update;
+pub use update::AccountUpdate;
+
 // ACCOUNT DELTA
 // ================================================================================================
 

--- a/crates/miden-objects/src/account/delta/update.rs
+++ b/crates/miden-objects/src/account/delta/update.rs
@@ -28,20 +28,20 @@ pub struct AccountUpdate {
     /// Commitment to the state of the account after this update is applied.
     final_state_commitment: Digest,
 
+    /// IDs of all transactions that updated the account.
+    transactions: Vec<TransactionId>,
+
     /// A set of changes which can be applied to the previous account state (i.e. `initial_state`)
     /// to get the new account state. For private accounts, this is set to
     /// [`AccountUpdateDetails::Private`].
     details: AccountUpdateDetails,
-
-    /// IDs of all transactions that updated the account.
-    transactions: Vec<TransactionId>,
 }
 
 impl AccountUpdate {
     // CONSTANTS
     // --------------------------------------------------------------------------------------------
 
-    /// The maximum allowed size of an account update. Set to 32 KiB.
+    /// The maximum allowed size of an account update in bytes. Set to 32 KiB.
     pub const MAX_SIZE: u16 = 2u16.pow(15);
 
     // CONSTRUCTORS
@@ -52,15 +52,15 @@ impl AccountUpdate {
         account_id: AccountId,
         initial_state_commitment: Digest,
         final_state_commitment: Digest,
-        details: AccountUpdateDetails,
         transactions: Vec<TransactionId>,
+        details: AccountUpdateDetails,
     ) -> Self {
         Self {
             account_id,
             initial_state_commitment,
             final_state_commitment,
-            details,
             transactions,
+            details,
         }
     }
 
@@ -80,6 +80,14 @@ impl AccountUpdate {
     /// Returns the commitment to the account's final state.
     pub fn final_state_commitment(&self) -> Digest {
         self.final_state_commitment
+    }
+
+    /// Returns a slice of [`TransactionId`]s that updated this account's state.
+    ///
+    /// This slice is generally non-empty, but may be empty in the special case of an account update
+    /// representing an account created in the genesis.
+    pub fn transactions(&self) -> &[TransactionId] {
+        &self.transactions
     }
 
     /// Returns the contained [`AccountUpdateDetails`].
@@ -144,8 +152,8 @@ impl Serializable for AccountUpdate {
         self.account_id.write_into(target);
         self.initial_state_commitment.write_into(target);
         self.final_state_commitment.write_into(target);
-        self.details.write_into(target);
         self.transactions.write_into(target);
+        self.details.write_into(target);
     }
 }
 
@@ -155,8 +163,8 @@ impl Deserializable for AccountUpdate {
             account_id: AccountId::read_from(source)?,
             initial_state_commitment: Digest::read_from(source)?,
             final_state_commitment: Digest::read_from(source)?,
-            details: AccountUpdateDetails::read_from(source)?,
             transactions: <Vec<TransactionId>>::read_from(source)?,
+            details: AccountUpdateDetails::read_from(source)?,
         })
     }
 }
@@ -195,8 +203,8 @@ mod tests {
             AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap(),
             Digest::new(EMPTY_WORD),
             Digest::new(EMPTY_WORD),
-            details,
             Vec::new(),
+            details,
         )
         .validate()
         .unwrap();
@@ -225,8 +233,8 @@ mod tests {
             AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap(),
             Digest::new(EMPTY_WORD),
             Digest::new(EMPTY_WORD),
-            details,
             Vec::new(),
+            details,
         )
         .validate()
         .unwrap_err();

--- a/crates/miden-objects/src/account/delta/update.rs
+++ b/crates/miden-objects/src/account/delta/update.rs
@@ -1,0 +1,253 @@
+use alloc::vec::Vec;
+
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_processor::{DeserializationError, Digest};
+
+use crate::{
+    account::{delta::AccountUpdateDetails, AccountId},
+    errors::AccountUpdateError,
+    transaction::{ProvenTransaction, TransactionId},
+    ProvenTransactionError,
+};
+
+// ACCOUNT UPDATE
+// ================================================================================================
+
+/// Describes the changes made to an account state resulting from executing a single transaction, a
+/// batch of transactions or multiple transaction batches in a block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountUpdate {
+    /// ID of the updated account.
+    account_id: AccountId,
+
+    /// Commitment to the state of the account before this update is applied.
+    ///
+    /// Equal to `Digest::default()` for new accounts.
+    initial_state_commitment: Digest,
+
+    /// Commitment to the state of the account after this update is applied.
+    final_state_commitment: Digest,
+
+    /// A set of changes which can be applied to the previous account state (i.e. `initial_state`)
+    /// to get the new account state. For private accounts, this is set to
+    /// [`AccountUpdateDetails::Private`].
+    details: AccountUpdateDetails,
+
+    /// IDs of all transactions that updated the account.
+    transactions: Vec<TransactionId>,
+}
+
+impl AccountUpdate {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// The maximum allowed size of an account update. Set to 32 KiB.
+    pub const ACCOUNT_UPDATE_MAX_SIZE: u16 = 2u16.pow(15);
+
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a new [`AccountUpdate`] instantiated from the provided parts.
+    pub const fn new(
+        account_id: AccountId,
+        initial_state_commitment: Digest,
+        final_state_commitment: Digest,
+        details: AccountUpdateDetails,
+        transactions: Vec<TransactionId>,
+    ) -> Self {
+        Self {
+            account_id,
+            initial_state_commitment,
+            final_state_commitment,
+            details,
+            transactions,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the ID of the updated account.
+    pub fn account_id(&self) -> AccountId {
+        self.account_id
+    }
+
+    /// Returns the commitment to the account's initial state.
+    pub fn initial_state_commitment(&self) -> Digest {
+        self.initial_state_commitment
+    }
+
+    /// Returns the commitment to the account's final state.
+    pub fn final_state_commitment(&self) -> Digest {
+        self.final_state_commitment
+    }
+
+    /// Returns the contained [`AccountUpdateDetails`].
+    ///
+    /// This update can be used to build the new account state from the previous account state.
+    pub fn details(&self) -> &AccountUpdateDetails {
+        &self.details
+    }
+
+    /// Returns `true` if the account update details are for a private account.
+    pub fn is_private(&self) -> bool {
+        self.details.is_private()
+    }
+
+    /// Validates the following properties of the account update:
+    ///
+    /// - The size of the serialized account update does not exceed [`ACCOUNT_UPDATE_MAX_SIZE`].
+    pub(crate) fn validate(&self) -> Result<(), ProvenTransactionError> {
+        let account_update_size = self.details().get_size_hint();
+        if account_update_size > Self::ACCOUNT_UPDATE_MAX_SIZE as usize {
+            Err(ProvenTransactionError::AccountUpdateSizeLimitExceeded {
+                account_id: self.account_id(),
+                update_size: account_update_size,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    // MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Merges the transaction's update into this account update.
+    fn merge_proven_tx(&mut self, tx: &ProvenTransaction) -> Result<(), AccountUpdateError> {
+        if self.account_id != tx.account_id() {
+            return Err(AccountUpdateError::AccountUpdateIdMismatch {
+                transaction: tx.id(),
+                expected_account_id: self.account_id,
+                actual_account_id: tx.account_id(),
+            });
+        }
+
+        if self.final_state_commitment != tx.account_update().init_state_hash() {
+            return Err(AccountUpdateError::AccountUpdateInitialStateMismatch(tx.id()));
+        }
+
+        self.details = self.details.clone().merge(tx.account_update().details().clone()).map_err(
+            |source_err| AccountUpdateError::TransactionUpdateMergeError(tx.id(), source_err),
+        )?;
+        self.final_state_commitment = tx.account_update().final_state_hash();
+        self.transactions.push(tx.id());
+
+        Ok(())
+    }
+}
+
+// CONVERSIONS TO ACCOUNT UPDATE
+// ================================================================================================
+
+impl From<&ProvenTransaction> for AccountUpdate {
+    fn from(tx: &ProvenTransaction) -> Self {
+        Self {
+            account_id: tx.account_id(),
+            initial_state_commitment: tx.account_update().init_state_hash(),
+            final_state_commitment: tx.account_update().final_state_hash(),
+            transactions: vec![tx.id()],
+            details: tx.account_update().details().clone(),
+        }
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for AccountUpdate {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.account_id.write_into(target);
+        self.initial_state_commitment.write_into(target);
+        self.final_state_commitment.write_into(target);
+        self.details.write_into(target);
+        self.transactions.write_into(target);
+    }
+}
+
+impl Deserializable for AccountUpdate {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        Ok(Self {
+            account_id: AccountId::read_from(source)?,
+            initial_state_commitment: Digest::read_from(source)?,
+            final_state_commitment: Digest::read_from(source)?,
+            details: AccountUpdateDetails::read_from(source)?,
+            transactions: <Vec<TransactionId>>::read_from(source)?,
+        })
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::{collections::BTreeMap, vec::Vec};
+
+    use winter_rand_utils::rand_array;
+
+    use crate::{
+        account::{
+            delta::{AccountUpdate, AccountUpdateDetails},
+            AccountDelta, AccountId, AccountStorageDelta, AccountVaultDelta, StorageMapDelta,
+        },
+        testing::account_id::ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN,
+        utils::Serializable,
+        Digest, ProvenTransactionError, ACCOUNT_UPDATE_MAX_SIZE, EMPTY_WORD, ONE, ZERO,
+    };
+
+    #[test]
+    fn account_update_size_limit_not_exceeded() {
+        // A small delta does not exceed the limit.
+        let storage_delta = AccountStorageDelta::from_iters(
+            [1, 2, 3, 4],
+            [(2, [ONE, ONE, ONE, ONE]), (3, [ONE, ONE, ZERO, ONE])],
+            [],
+        );
+        let delta =
+            AccountDelta::new(storage_delta, AccountVaultDelta::default(), Some(ONE)).unwrap();
+        let details = AccountUpdateDetails::Delta(delta);
+        AccountUpdate::new(
+            AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap(),
+            Digest::new(EMPTY_WORD),
+            Digest::new(EMPTY_WORD),
+            details,
+            Vec::new(),
+        )
+        .validate()
+        .unwrap();
+    }
+
+    #[test]
+    fn account_update_size_limit_exceeded() {
+        let mut map = BTreeMap::new();
+        // The number of entries in the map required to exceed the limit.
+        // We divide by each entry's size which consists of a key (digest) and a value (word), both
+        // 32 bytes in size.
+        let required_entries = ACCOUNT_UPDATE_MAX_SIZE / (2 * 32);
+        for _ in 0..required_entries {
+            map.insert(Digest::new(rand_array()), rand_array());
+        }
+        let storage_delta = StorageMapDelta::new(map);
+
+        // A delta that exceeds the limit returns an error.
+        let storage_delta = AccountStorageDelta::from_iters([], [], [(4, storage_delta)]);
+        let delta =
+            AccountDelta::new(storage_delta, AccountVaultDelta::default(), Some(ONE)).unwrap();
+        let details = AccountUpdateDetails::Delta(delta);
+        let details_size = details.get_size_hint();
+
+        let err = AccountUpdate::new(
+            AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_IMMUTABLE_CODE_ON_CHAIN).unwrap(),
+            Digest::new(EMPTY_WORD),
+            Digest::new(EMPTY_WORD),
+            details,
+            Vec::new(),
+        )
+        .validate()
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ProvenTransactionError::AccountUpdateSizeLimitExceeded { update_size, .. } if update_size == details_size)
+        );
+    }
+}

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -29,7 +29,7 @@ pub use component::{
 
 pub mod delta;
 pub use delta::{
-    AccountDelta, AccountStorageDelta, AccountVaultDelta, FungibleAssetDelta,
+    AccountDelta, AccountStorageDelta, AccountUpdate, AccountVaultDelta, FungibleAssetDelta,
     NonFungibleAssetDelta, NonFungibleDeltaAction, StorageMapDelta,
 };
 

--- a/crates/miden-objects/src/constants.rs
+++ b/crates/miden-objects/src/constants.rs
@@ -1,9 +1,6 @@
 /// Depth of the account database tree.
 pub const ACCOUNT_TREE_DEPTH: u8 = 64;
 
-/// The maximum allowed size of an account update is 32 KiB.
-pub const ACCOUNT_UPDATE_MAX_SIZE: u16 = 2u16.pow(15);
-
 /// The maximum number of assets that can be stored in a single note.
 pub const MAX_ASSETS_PER_NOTE: usize = 255;
 

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -17,13 +17,13 @@ use super::{
 };
 use crate::{
     account::{
-        AccountCode, AccountIdPrefix, AccountStorage, AccountType, PlaceholderType,
+        AccountCode, AccountIdPrefix, AccountStorage, AccountType, AccountUpdate, PlaceholderType,
         StoragePlaceholder,
     },
     block::BlockNumber,
     note::{NoteAssets, NoteExecutionHint, NoteTag, NoteType, Nullifier},
     transaction::TransactionId,
-    ACCOUNT_UPDATE_MAX_SIZE, MAX_INPUTS_PER_NOTE, MAX_INPUT_NOTES_PER_TX, MAX_OUTPUT_NOTES_PER_TX,
+    MAX_INPUTS_PER_NOTE, MAX_INPUT_NOTES_PER_TX, MAX_OUTPUT_NOTES_PER_TX,
 };
 
 // ACCOUNT COMPONENT TEMPLATE ERROR
@@ -439,7 +439,8 @@ pub enum ProvenTransactionError {
     #[error("failed to construct output notes for proven transaction")]
     OutputNotesError(TransactionOutputError),
     #[error(
-      "account update of size {update_size} for account {account_id} exceeds maximum update size of {ACCOUNT_UPDATE_MAX_SIZE}",
+      "account update of size {update_size} for account {account_id} exceeds maximum update size of {update_max_size}",
+      update_max_size = AccountUpdate::MAX_SIZE
     )]
     AccountUpdateSizeLimitExceeded {
         account_id: AccountId,

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     block::BlockNumber,
     note::{NoteAssets, NoteExecutionHint, NoteTag, NoteType, Nullifier},
+    transaction::TransactionId,
     ACCOUNT_UPDATE_MAX_SIZE, MAX_INPUTS_PER_NOTE, MAX_INPUT_NOTES_PER_TX, MAX_OUTPUT_NOTES_PER_TX,
 };
 
@@ -180,6 +181,23 @@ pub enum AccountDeltaError {
     InconsistentNonceUpdate(String),
     #[error("account ID {0} in fungible asset delta is not of type fungible faucet")]
     NotAFungibleFaucetId(AccountId),
+}
+
+// ACCOUNT UPDATE ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum AccountUpdateError {
+    #[error("account update for account {expected_account_id} cannot be merged with update from transaction {transaction} which was executed against account {actual_account_id}")]
+    AccountUpdateIdMismatch {
+        transaction: TransactionId,
+        expected_account_id: AccountId,
+        actual_account_id: AccountId,
+    },
+    #[error("final state commitment in account update from transaction {0} does not match initial state of current update")]
+    AccountUpdateInitialStateMismatch(TransactionId),
+    #[error("failed to merge account delta from transaction {0}")]
+    TransactionUpdateMergeError(TransactionId, #[source] AccountDeltaError),
 }
 
 // ASSET ERROR

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -22,7 +22,6 @@ use crate::{
     },
     block::BlockNumber,
     note::{NoteAssets, NoteExecutionHint, NoteTag, NoteType, Nullifier},
-    transaction::TransactionId,
     MAX_INPUTS_PER_NOTE, MAX_INPUT_NOTES_PER_TX, MAX_OUTPUT_NOTES_PER_TX,
 };
 
@@ -181,23 +180,6 @@ pub enum AccountDeltaError {
     InconsistentNonceUpdate(String),
     #[error("account ID {0} in fungible asset delta is not of type fungible faucet")]
     NotAFungibleFaucetId(AccountId),
-}
-
-// ACCOUNT UPDATE ERROR
-// ================================================================================================
-
-#[derive(Debug, Error)]
-pub enum AccountUpdateError {
-    #[error("account update for account {expected_account_id} cannot be merged with update from transaction {transaction} which was executed against account {actual_account_id}")]
-    AccountUpdateIdMismatch {
-        transaction: TransactionId,
-        expected_account_id: AccountId,
-        actual_account_id: AccountId,
-    },
-    #[error("final state commitment in account update from transaction {0} does not match initial state of current update")]
-    AccountUpdateInitialStateMismatch(TransactionId),
-    #[error("failed to merge account delta from transaction {0}")]
-    TransactionUpdateMergeError(TransactionId, #[source] AccountDeltaError),
 }
 
 // ASSET ERROR

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -24,9 +24,9 @@ mod errors;
 
 pub use constants::*;
 pub use errors::{
-    AccountDeltaError, AccountError, AccountIdError, AssetError, AssetVaultError, BlockError,
-    ChainMmrError, NoteError, ProvenTransactionError, TransactionInputError,
-    TransactionOutputError, TransactionScriptError,
+    AccountDeltaError, AccountError, AccountIdError, AccountUpdateError, AssetError,
+    AssetVaultError, BlockError, ChainMmrError, NoteError, ProvenTransactionError,
+    TransactionInputError, TransactionOutputError, TransactionScriptError,
 };
 pub use miden_crypto::hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest};
 pub use vm_core::{Felt, FieldElement, StarkField, Word, EMPTY_WORD, ONE, WORD_SIZE, ZERO};

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -24,9 +24,9 @@ mod errors;
 
 pub use constants::*;
 pub use errors::{
-    AccountDeltaError, AccountError, AccountIdError, AccountUpdateError, AssetError,
-    AssetVaultError, BlockError, ChainMmrError, NoteError, ProvenTransactionError,
-    TransactionInputError, TransactionOutputError, TransactionScriptError,
+    AccountDeltaError, AccountError, AccountIdError, AssetError, AssetVaultError, BlockError,
+    ChainMmrError, NoteError, ProvenTransactionError, TransactionInputError,
+    TransactionOutputError, TransactionScriptError,
 };
 pub use miden_crypto::hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest};
 pub use vm_core::{Felt, FieldElement, StarkField, Word, EMPTY_WORD, ONE, WORD_SIZE, ZERO};

--- a/crates/miden-objects/src/transaction/mod.rs
+++ b/crates/miden-objects/src/transaction/mod.rs
@@ -19,9 +19,7 @@ pub use chain_mmr::ChainMmr;
 pub use executed_tx::{ExecutedTransaction, TransactionMeasurements};
 pub use inputs::{InputNote, InputNotes, ToInputNoteCommitments, TransactionInputs};
 pub use outputs::{OutputNote, OutputNotes, TransactionOutputs};
-pub use proven_tx::{
-    InputNoteCommitment, ProvenTransaction, ProvenTransactionBuilder, TxAccountUpdate,
-};
+pub use proven_tx::{InputNoteCommitment, ProvenTransaction, ProvenTransactionBuilder};
 pub use transaction_id::TransactionId;
 pub use tx_args::{TransactionArgs, TransactionScript};
 pub use tx_witness::TransactionWitness;

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -303,8 +303,8 @@ impl ProvenTransactionBuilder {
             self.account_id,
             self.initial_account_hash,
             self.final_account_hash,
-            self.account_update_details,
             vec![id],
+            self.account_update_details,
         );
 
         let proven_transaction = ProvenTransaction {

--- a/crates/miden-objects/src/transaction/transaction_id.rs
+++ b/crates/miden-objects/src/transaction/transaction_id.rs
@@ -76,8 +76,8 @@ impl Display for TransactionId {
 impl From<&ProvenTransaction> for TransactionId {
     fn from(tx: &ProvenTransaction) -> Self {
         Self::new(
-            tx.account_update().init_state_hash(),
-            tx.account_update().final_state_hash(),
+            tx.account_update().initial_state_commitment(),
+            tx.account_update().final_state_commitment(),
             tx.input_notes().commitment(),
             tx.output_notes().commitment(),
         )

--- a/crates/miden-tx/src/verifier/mod.rs
+++ b/crates/miden-tx/src/verifier/mod.rs
@@ -34,12 +34,12 @@ impl TransactionVerifier {
         // build stack inputs and outputs
         let stack_inputs = TransactionKernel::build_input_stack(
             transaction.account_id(),
-            transaction.account_update().init_state_hash(),
+            transaction.account_update().initial_state_commitment(),
             transaction.input_notes().commitment(),
             transaction.block_ref(),
         );
         let stack_outputs = TransactionKernel::build_output_stack(
-            transaction.account_update().final_state_hash(),
+            transaction.account_update().final_state_commitment(),
             transaction.output_notes().commitment(),
             transaction.expiration_block_num(),
         );


### PR DESCRIPTION
Replace `TxAccountUpdate` and `BlockAccountUpdate` with `AccountUpdate`.

With the introduction of the batch kernel we would possibly need a third `BatchAccountUpdate` type which would look similar to the existing account update types, so it seemed useful to refactor the existing two into a single type that will also be usable for the batch kernel.

This uses the terminology of commitment over hash, i.e. `final_state_commitment` rather than `final_state_hash`. This is in anticipation of https://github.com/0xPolygonMiden/miden-base/issues/1092 to avoid extra work when implementing that PR.

Part of #1095.