### PR TITLE
fix: Set supported types correctly

### DIFF
--- a/crates/miden-objects/src/account/component/mod.rs
+++ b/crates/miden-objects/src/account/component/mod.rs
@@ -113,7 +113,8 @@ impl AccountComponent {
             storage_slots.extend(entry_storage_slots);
         }
 
-        AccountComponent::new(template.library().clone(), storage_slots)
+        Ok(AccountComponent::new(template.library().clone(), storage_slots)?
+            .with_supported_types(template.metadata().targets().clone()))
     }
 
     // ACCESSORS


### PR DESCRIPTION
Unfortunately I missed this before the latest release. It can be worked around by adding the type after instantiation but still needed to be done here.