### PR TITLE
Prepares v0.7.1 release of `miden-objects` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.1 (2025-01-24) - `miden-objects` crate only
+
+### Fixes
+
+- Added missing doc comments (#1100).
+- Fixed setting of supporting types when instantiating `AccountComponent` from templates (#1103).
+
 ## 0.7.0 (2025-01-22)
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
@@ -4462,9 +4462,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f14b5c02a137632f68194ec657ecb92304138948e8957c932127eb1b58c23be"
+checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4499,9 +4499,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-linebreak"

--- a/crates/miden-objects/Cargo.toml
+++ b/crates/miden-objects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-objects"
-version = "0.7.0"
+version = "0.7.1"
 description = "Core components of the Miden rollup"
 readme = "README.md"
 categories = ["no-std"]


### PR DESCRIPTION
This release incorporates changes from #1100 and #1103.