### PR TITLE
feat: update workers service in proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [BREAKING] Incremented minimum supported Rust version to 1.84.
 - [BREAKING] Moved `generated` module from `miden-proving-service-client` crate to `tx_prover::generated` hierarchy (#1102).
+- Added a service to the `miden-proving-service` to update the workers (#1107).
 
 ## 0.7.1 (2025-01-24) - `miden-objects` crate only
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [BREAKING] Incremented minimum supported Rust version to 1.84.
 - [BREAKING] Moved `generated` module from `miden-proving-service-client` crate to `tx_prover::generated` hierarchy (#1102).
-- Added a service to the `miden-proving-service` to update the workers (#1107).
+- Added an endpoint to the `miden-proving-service` to update the workers (#1107).
 
 ## 0.7.1 (2025-01-24) - `miden-objects` crate only
 

--- a/bin/proving-service/src/commands/mod.rs
+++ b/bin/proving-service/src/commands/mod.rs
@@ -45,6 +45,8 @@ pub struct ProxyConfig {
     pub prometheus_host: String,
     /// Prometheus metrics port.
     pub prometheus_port: u16,
+    /// Worker update service port.
+    pub workers_update_port: u16,
 }
 
 impl Default for ProxyConfig {
@@ -61,6 +63,7 @@ impl Default for ProxyConfig {
             health_check_interval_secs: 1,
             prometheus_host: "127.0.0.1".into(),
             prometheus_port: 6192,
+            workers_update_port: 8083,
         }
     }
 }

--- a/bin/proving-service/src/commands/mod.rs
+++ b/bin/proving-service/src/commands/mod.rs
@@ -27,6 +27,8 @@ pub struct ProxyConfig {
     pub host: String,
     /// Port of the proxy.
     pub port: u16,
+    /// Worker update service port.
+    pub workers_update_port: u16,
     /// Maximum time in seconds to complete the entire request.
     pub timeout_secs: u64,
     /// Maximum time in seconds to establish a connection.
@@ -45,8 +47,6 @@ pub struct ProxyConfig {
     pub prometheus_host: String,
     /// Prometheus metrics port.
     pub prometheus_port: u16,
-    /// Worker update service port.
-    pub workers_update_port: u16,
 }
 
 impl Default for ProxyConfig {

--- a/bin/proving-service/src/commands/proxy.rs
+++ b/bin/proving-service/src/commands/proxy.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 
 use crate::{
     error::TxProverServiceError,
-    proxy::{update_workers::LBUpdaterService, LoadBalancer, LoadBalancerState},
+    proxy::{update_workers::LoadBalanceUpdateService, LoadBalancer, LoadBalancerState},
     utils::MIDEN_PROVING_SERVICE,
 };
 
@@ -62,7 +62,7 @@ impl StartProxy {
 
         let worker_lb = health_check_service.task();
 
-        let updater_service = LBUpdaterService::new(worker_lb.clone());
+        let updater_service = LoadBalanceUpdateService::new(worker_lb.clone());
 
         let mut update_workers_service =
             Service::new("update_workers".to_string(), updater_service);

--- a/bin/proving-service/src/commands/proxy.rs
+++ b/bin/proving-service/src/commands/proxy.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 
 use crate::{
     error::TxProverServiceError,
-    proxy::{update_workers::LoadBalanceUpdateService, LoadBalancer, LoadBalancerState},
+    proxy::{update_workers::LoadBalancerUpdateService, LoadBalancer, LoadBalancerState},
     utils::MIDEN_PROVING_SERVICE,
 };
 
@@ -62,7 +62,7 @@ impl StartProxy {
 
         let worker_lb = health_check_service.task();
 
-        let updater_service = LoadBalanceUpdateService::new(worker_lb.clone());
+        let updater_service = LoadBalancerUpdateService::new(worker_lb.clone());
 
         let mut update_workers_service =
             Service::new("update_workers".to_string(), updater_service);

--- a/bin/proving-service/src/commands/update_workers.rs
+++ b/bin/proving-service/src/commands/update_workers.rs
@@ -40,19 +40,17 @@ pub struct UpdateWorkers {
 }
 
 impl UpdateWorkers {
-    /// Makes a requests to the proxy to update the workers.
+    /// Makes a requests to the update workers endpoint to update the workers.
     ///
     /// It works by sending a GET request to the proxy with the query parameters. The query
     /// parameters are serialized from the struct fields.
     ///
-    /// This method will work only if the proxy is running and the user is in the same computer as
-    /// the proxy, since the proxy checks for the source IP address and checks that the sender is
-    /// localhost.
+    /// It will use the same host as the proxy and the workers update port from the configuration
+    /// file.
     ///
     /// The request will return the new number of workers in the X-Worker-Count header.
     ///
     /// # Errors
-    /// - If a tokio runtime cannot be created.
     /// - If the query parameters cannot be serialized.
     /// - If the request fails.
     /// - If the status code is not successful.

--- a/bin/proving-service/src/commands/update_workers.rs
+++ b/bin/proving-service/src/commands/update_workers.rs
@@ -74,7 +74,10 @@ impl UpdateWorkers {
         );
 
         // Create an HTTP/2 client
-        let client = Client::builder().http1_only().build().map_err(|err| err.to_string())?;
+        let client = Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .map_err(|err| err.to_string())?;
 
         // Make the request
         let response = client.get(url).send().await.map_err(|err| err.to_string())?;

--- a/bin/proving-service/src/commands/update_workers.rs
+++ b/bin/proving-service/src/commands/update_workers.rs
@@ -68,13 +68,13 @@ impl UpdateWorkers {
         let proxy_config = ProxyConfig::load_config_from_file()?;
 
         // Create the full URL
-        let url = format!("http://{}:{}?{}", proxy_config.host, proxy_config.port, query_params);
+        let url = format!(
+            "http://{}:{}?{}",
+            proxy_config.host, proxy_config.workers_update_port, query_params
+        );
 
         // Create an HTTP/2 client
-        let client = Client::builder()
-            .http2_prior_knowledge()
-            .build()
-            .map_err(|err| err.to_string())?;
+        let client = Client::builder().http1_only().build().map_err(|err| err.to_string())?;
 
         // Make the request
         let response = client.get(url).send().await.map_err(|err| err.to_string())?;

--- a/bin/proving-service/src/proxy/health_check.rs
+++ b/bin/proving-service/src/proxy/health_check.rs
@@ -54,7 +54,7 @@ impl BackgroundService for LoadBalancerState {
                 WORKER_UNHEALTHY.inc_by(unhealthy_workers as u64);
 
                 // Sleep for the defined interval before the next health check
-                sleep(self.health_check_frequency).await;
+                sleep(self.health_check_interval).await;
             }
         })
         .await;

--- a/bin/proving-service/src/proxy/health_check.rs
+++ b/bin/proving-service/src/proxy/health_check.rs
@@ -1,0 +1,57 @@
+use axum::async_trait;
+use pingora::{prelude::sleep, server::ShutdownWatch, services::background::BackgroundService};
+use tracing::debug_span;
+
+use super::{
+    metrics::{WORKER_COUNT, WORKER_UNHEALTHY},
+    LoadBalancerState,
+};
+
+/// Implement the BackgroundService trait for the LoadBalancer
+///
+/// A [BackgroundService] can be run as part of a Pingora application to add supporting logic that
+/// exists outside of the request/response lifecycle.
+///
+/// We use this implementation to periodically check the health of the workers and update the list
+/// of available workers.
+#[async_trait]
+impl BackgroundService for LoadBalancerState {
+    /// Starts the health check background service.
+    ///
+    /// This function is called when the Pingora server tries to start all the services. The
+    /// background service can return at anytime or wait for the `shutdown` signal.
+    ///
+    /// The health check background service will periodically check the health of the workers
+    /// using the gRPC health check protocol. If a worker is not healthy, it will be removed from
+    /// the list of available workers.
+    ///
+    /// # Errors
+    /// - If the worker has an invalid URI.
+    async fn start(&self, _shutdown: ShutdownWatch) {
+        Box::pin(async move {
+            loop {
+                // Create a new spawn to perform the health check
+                let span = debug_span!("proxy:health_check");
+                let _guard = span.enter();
+
+                let mut workers = self.workers.write().await;
+                let initial_workers_len = workers.len();
+
+                // Perform health checks on workers and retain healthy ones
+                let healthy_workers = self.check_workers_health(workers.iter_mut()).await;
+
+                // Update the worker list with healthy workers
+                *workers = healthy_workers;
+
+                // Update the worker count and worker unhealhy count metrics
+                WORKER_COUNT.set(workers.len() as i64);
+                let unhealthy_workers = initial_workers_len - workers.len();
+                WORKER_UNHEALTHY.inc_by(unhealthy_workers as u64);
+
+                // Sleep for the defined interval before the next health check
+                sleep(self.health_check_frequency).await;
+            }
+        })
+        .await;
+    }
+}

--- a/bin/proving-service/src/proxy/mod.rs
+++ b/bin/proving-service/src/proxy/mod.rs
@@ -56,7 +56,7 @@ pub struct LoadBalancerState {
     max_retries_per_request: usize,
     max_req_per_sec: isize,
     available_workers_polling_time: Duration,
-    health_check_frequency: Duration,
+    health_check_interval: Duration,
 }
 
 impl LoadBalancerState {
@@ -94,7 +94,7 @@ impl LoadBalancerState {
             available_workers_polling_time: Duration::from_millis(
                 config.available_workers_polling_time_ms,
             ),
-            health_check_frequency: Duration::from_secs(config.health_check_interval_secs),
+            health_check_interval: Duration::from_secs(config.health_check_interval_secs),
         })
     }
 

--- a/bin/proving-service/src/proxy/mod.rs
+++ b/bin/proving-service/src/proxy/mod.rs
@@ -1,7 +1,5 @@
 use std::{
     collections::VecDeque,
-    future::Future,
-    pin::Pin,
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
@@ -11,22 +9,20 @@ use bytes::Bytes;
 use metrics::{
     QUEUE_LATENCY, QUEUE_SIZE, RATE_LIMITED_REQUESTS, RATE_LIMIT_VIOLATIONS, REQUEST_COUNT,
     REQUEST_FAILURE_COUNT, REQUEST_LATENCY, REQUEST_RETRIES, WORKER_BUSY, WORKER_COUNT,
-    WORKER_REQUEST_COUNT, WORKER_UNHEALTHY,
+    WORKER_REQUEST_COUNT,
 };
 use pingora::{
     http::ResponseHeader,
     lb::Backend,
     prelude::*,
     protocols::Digest,
-    server::ShutdownWatch,
-    services::background::BackgroundService,
     upstreams::peer::{Peer, ALPN},
 };
 use pingora_core::{upstreams::peer::HttpPeer, Result};
 use pingora_limits::rate::Rate;
 use pingora_proxy::{ProxyHttp, Session};
-use tokio::{sync::RwLock, time::sleep};
-use tracing::{debug_span, error, info, info_span, warn, Span};
+use tokio::sync::RwLock;
+use tracing::{error, info, info_span, warn, Span};
 use uuid::Uuid;
 use worker::Worker;
 
@@ -38,15 +34,14 @@ use crate::{
     error::TxProverServiceError,
     utils::{
         create_queue_full_response, create_response_with_error_message,
-        create_too_many_requests_response, create_workers_updated_response, MIDEN_PROVING_SERVICE,
+        create_too_many_requests_response, MIDEN_PROVING_SERVICE,
     },
 };
 
+mod health_check;
 pub mod metrics;
+pub(crate) mod update_workers;
 mod worker;
-
-/// Localhost address
-const LOCALHOST_ADDR: &str = "127.0.0.1";
 
 // LOAD BALANCER STATE
 // ================================================================================================
@@ -189,66 +184,6 @@ impl LoadBalancerState {
     /// Get the number of busy workers.
     pub async fn num_busy_workers(&self) -> usize {
         self.workers.read().await.iter().filter(|w| !w.is_available()).count()
-    }
-
-    /// Handles the update workers request.
-    ///
-    /// # Behavior
-    /// - Reads the HTTP request from the session.
-    /// - If query parameters are present, attempts to parse them as an `UpdateWorkers` object.
-    /// - If the parsing fails, returns an error response.
-    /// - If successful, updates the list of workers by calling `update_workers`.
-    /// - If the update is successful, returns the count of available workers.
-    ///
-    /// # Errors
-    /// - If the HTTP request cannot be read.
-    /// - If the query parameters cannot be parsed.
-    /// - If the workers cannot be updated.
-    /// - If the response cannot be created.
-    pub async fn handle_update_workers_request(
-        &self,
-        session: &mut Session,
-    ) -> Option<Result<bool>> {
-        let http_session = session.as_downstream_mut();
-
-        // Attempt to read the HTTP request
-        if let Err(err) = http_session.read_request().await {
-            let error_message = format!("Failed to read request: {}", err);
-            error!("{}", error_message);
-            return Some(create_response_with_error_message(session, error_message).await);
-        }
-
-        // Extract and parse query parameters, if there are not any, return early to continue
-        // processing the request as a regular proving request.
-        let query_params = match http_session.req_header().as_ref().uri.query() {
-            Some(params) => params,
-            None => {
-                return None;
-            },
-        };
-
-        // Parse the query parameters
-        let update_workers: Result<UpdateWorkers, _> = serde_qs::from_str(query_params);
-        let update_workers = match update_workers {
-            Ok(workers) => workers,
-            Err(err) => {
-                let error_message = format!("Failed to parse query parameters: {}", err);
-                error!("{}", error_message);
-                return Some(create_response_with_error_message(session, error_message).await);
-            },
-        };
-
-        // Update workers and handle potential errors
-        if let Err(err) = self.update_workers(update_workers).await {
-            let error_message = format!("Failed to update workers: {}", err);
-            error!("{}", error_message);
-            return Some(create_response_with_error_message(session, error_message).await);
-        }
-
-        // Successfully updated workers
-        info!("Workers updated successfully");
-        let workers_count = self.num_workers().await;
-        Some(create_workers_updated_response(session, workers_count).await)
     }
 
     /// Check the health of the workers and returns a list of healthy workers.
@@ -425,7 +360,7 @@ impl ProxyHttp for LoadBalancer {
             Some(addr) => addr.to_string(),
             None => {
                 return create_response_with_error_message(
-                    session,
+                    session.as_downstream_mut(),
                     "No socket address".to_string(),
                 )
                 .await;
@@ -433,13 +368,6 @@ impl ProxyHttp for LoadBalancer {
         };
 
         info!("Client address: {:?}", client_addr);
-
-        // Special handling for localhost
-        if client_addr.contains(LOCALHOST_ADDR) {
-            if let Some(response) = self.0.handle_update_workers_request(session).await {
-                return response;
-            }
-        }
 
         // Increment the request count
         REQUEST_COUNT.inc();
@@ -744,59 +672,5 @@ impl ProxyHttp for ProxyHttpDefaultImpl {
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
         unimplemented!("This is a dummy implementation, should not be called")
-    }
-}
-
-/// Implement the BackgroundService trait for the LoadBalancer
-///
-/// A [BackgroundService] can be run as part of a Pingora application to add supporting logic that
-/// exists outside of the request/response lifecycle.
-///
-/// We use this implementation to periodically check the health of the workers and update the list
-/// of available workers.
-impl BackgroundService for LoadBalancerState {
-    /// Starts the health check background service.
-    ///
-    /// This function is called when the Pingora server tries to start all the services. The
-    /// background service can return at anytime or wait for the `shutdown` signal.
-    ///
-    /// The health check background service will periodically check the health of the workers
-    /// using the gRPC health check protocol. If a worker is not healthy, it will be removed from
-    /// the list of available workers.
-    ///
-    /// # Errors
-    /// - If the worker has an invalid URI.
-    fn start<'life0, 'async_trait>(
-        &'life0 self,
-        _shutdown: ShutdownWatch,
-    ) -> Pin<Box<dyn Future<Output = ()> + ::core::marker::Send + 'async_trait>>
-    where
-        'life0: 'async_trait,
-        Self: 'async_trait,
-    {
-        Box::pin(async move {
-            loop {
-                // Create a new spawn to perform the health check
-                let span = debug_span!("proxy:health_check");
-                let _guard = span.enter();
-
-                let mut workers = self.workers.write().await;
-                let initial_workers_len = workers.len();
-
-                // Perform health checks on workers and retain healthy ones
-                let healthy_workers = self.check_workers_health(workers.iter_mut()).await;
-
-                // Update the worker list with healthy workers
-                *workers = healthy_workers;
-
-                // Update the worker count and worker unhealhy count metrics
-                WORKER_COUNT.set(workers.len() as i64);
-                let unhealthy_workers = initial_workers_len - workers.len();
-                WORKER_UNHEALTHY.inc_by(unhealthy_workers as u64);
-
-                // Sleep for the defined interval before the next health check
-                sleep(self.health_check_frequency).await;
-            }
-        })
     }
 }

--- a/bin/proving-service/src/proxy/update_workers.rs
+++ b/bin/proving-service/src/proxy/update_workers.rs
@@ -20,7 +20,7 @@ use crate::{
 /// The Load Balancer Updater Service.
 ///
 /// This service is responsible for updating the list of workers in the load balancer.
-pub(crate) struct LBUpdaterService {
+pub(crate) struct LoadBalanceUpdateService {
     lb_state: Arc<LoadBalancerState>,
     server_opts: HttpServerOptions,
 }
@@ -28,13 +28,13 @@ pub(crate) struct LBUpdaterService {
 /// Manually implement Debug for LBUpdaterService
 /// [HttpServerOptions] does not implement Debug, so we cannot derive Debug for [LBUpdaterService],
 /// which is needed for the tracing instrumentation.
-impl fmt::Debug for LBUpdaterService {
+impl fmt::Debug for LoadBalanceUpdateService {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LBUpdaterService").field("lb_state", &self.lb_state).finish()
     }
 }
 
-impl LBUpdaterService {
+impl LoadBalanceUpdateService {
     pub(crate) fn new(lb_state: Arc<LoadBalancerState>) -> Self {
         let mut server_opts = HttpServerOptions::default();
         server_opts.h2c = true;
@@ -44,7 +44,7 @@ impl LBUpdaterService {
 }
 
 #[async_trait]
-impl HttpServerApp for LBUpdaterService {
+impl HttpServerApp for LoadBalanceUpdateService {
     /// Handles the update workers request.
     ///
     /// # Behavior

--- a/bin/proving-service/src/proxy/update_workers.rs
+++ b/bin/proving-service/src/proxy/update_workers.rs
@@ -92,11 +92,13 @@ impl HttpServerApp for LoadBalanceUpdateService {
 
         info!("Successfully get a new request to update workers");
 
-        // Extract and parse query parameters, if there are not any, return early to continue
-        // processing the request as a regular proving request.
+        // Extract and parse query parameters, if there are not any, return early.
         let query_params = match http.req_header().as_ref().uri.query() {
             Some(params) => params,
             None => {
+                let error_message = "No query parameters provided".to_string();
+                error!("{}", error_message);
+                create_response_with_error_message(&mut http, error_message).await.ok();
                 return None;
             },
         };

--- a/bin/proving-service/src/proxy/update_workers.rs
+++ b/bin/proving-service/src/proxy/update_workers.rs
@@ -19,21 +19,21 @@ use crate::{
 /// The Load Balancer Updater Service.
 ///
 /// This service is responsible for updating the list of workers in the load balancer.
-pub(crate) struct LoadBalanceUpdateService {
+pub(crate) struct LoadBalancerUpdateService {
     lb_state: Arc<LoadBalancerState>,
     server_opts: HttpServerOptions,
 }
 
-/// Manually implement Debug for LBUpdaterService
-/// [HttpServerOptions] does not implement Debug, so we cannot derive Debug for [LBUpdaterService],
-/// which is needed for the tracing instrumentation.
-impl fmt::Debug for LoadBalanceUpdateService {
+/// Manually implement Debug for LoadBalancerUpdateService.
+/// [HttpServerOptions] does not implement Debug, so we cannot derive Debug for
+/// [LoadBalancerUpdateService], which is needed for the tracing instrumentation.
+impl fmt::Debug for LoadBalancerUpdateService {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LBUpdaterService").field("lb_state", &self.lb_state).finish()
     }
 }
 
-impl LoadBalanceUpdateService {
+impl LoadBalancerUpdateService {
     pub(crate) fn new(lb_state: Arc<LoadBalancerState>) -> Self {
         let mut server_opts = HttpServerOptions::default();
         server_opts.h2c = true;
@@ -43,7 +43,7 @@ impl LoadBalanceUpdateService {
 }
 
 #[async_trait]
-impl HttpServerApp for LoadBalanceUpdateService {
+impl HttpServerApp for LoadBalancerUpdateService {
     /// Handles the update workers request.
     ///
     /// # Behavior

--- a/bin/proving-service/src/proxy/update_workers.rs
+++ b/bin/proving-service/src/proxy/update_workers.rs
@@ -143,7 +143,7 @@ impl HttpServerApp for LoadBalancerUpdateService {
 /// Create a 200 response for updated workers
 ///
 /// It will set the X-Worker-Count header to the number of workers.
-pub async fn create_workers_updated_response(
+async fn create_workers_updated_response(
     session: &mut ServerSession,
     workers: usize,
 ) -> pingora_core::Result<bool> {

--- a/bin/proving-service/src/proxy/worker.rs
+++ b/bin/proving-service/src/proxy/worker.rs
@@ -7,7 +7,8 @@ use tonic_health::pb::{
 };
 use tracing::error;
 
-use crate::{error::TxProverServiceError, utils::create_health_check_client};
+use super::health_check::create_health_check_client;
+use crate::error::TxProverServiceError;
 
 // WORKER
 // ================================================================================================

--- a/bin/proving-service/src/utils.rs
+++ b/bin/proving-service/src/utils.rs
@@ -10,7 +10,7 @@ use opentelemetry_semantic_conventions::{
     resource::{SERVICE_NAME, SERVICE_VERSION},
     SCHEMA_URL,
 };
-use pingora::{http::ResponseHeader, Error, ErrorType};
+use pingora::{http::ResponseHeader, protocols::http::ServerSession, Error, ErrorType};
 use pingora_proxy::Session;
 use tonic::transport::Channel;
 use tonic_health::pb::health_client::HealthClient;
@@ -141,13 +141,13 @@ pub async fn create_too_many_requests_response(
 ///
 /// It will set the X-Worker-Count header to the number of workers.
 pub async fn create_workers_updated_response(
-    session: &mut Session,
+    session: &mut ServerSession,
     workers: usize,
 ) -> pingora_core::Result<bool> {
     let mut header = ResponseHeader::build(200, None)?;
     header.insert_header("X-Worker-Count", workers.to_string())?;
     session.set_keepalive(None);
-    session.write_response_header(Box::new(header), true).await?;
+    session.write_response_header(Box::new(header)).await?;
     Ok(true)
 }
 
@@ -155,13 +155,13 @@ pub async fn create_workers_updated_response(
 ///
 /// It will set the X-Error-Message header to the error message.
 pub async fn create_response_with_error_message(
-    session: &mut Session,
+    session: &mut ServerSession,
     error_msg: String,
 ) -> pingora_core::Result<bool> {
     let mut header = ResponseHeader::build(400, None)?;
     header.insert_header("X-Error-Message", error_msg)?;
     session.set_keepalive(None);
-    session.write_response_header(Box::new(header), true).await?;
+    session.write_response_header(Box::new(header)).await?;
     Ok(true)
 }
 

--- a/bin/proving-service/src/utils.rs
+++ b/bin/proving-service/src/utils.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use opentelemetry::{trace::TracerProvider as _, KeyValue};
 use opentelemetry_sdk::{
     runtime,
@@ -12,11 +10,9 @@ use opentelemetry_semantic_conventions::{
 };
 use pingora::{http::ResponseHeader, protocols::http::ServerSession, Error, ErrorType};
 use pingora_proxy::Session;
-use tonic::transport::Channel;
-use tonic_health::pb::health_client::HealthClient;
 use tracing_subscriber::{layer::SubscriberExt, Registry};
 
-use crate::{error::TxProverServiceError, proxy::metrics::QUEUE_DROP_COUNT};
+use crate::proxy::metrics::QUEUE_DROP_COUNT;
 
 pub const MIDEN_PROVING_SERVICE: &str = "miden-proving-service";
 
@@ -137,20 +133,6 @@ pub async fn create_too_many_requests_response(
     Ok(true)
 }
 
-/// Create a 200 response for updated workers
-///
-/// It will set the X-Worker-Count header to the number of workers.
-pub async fn create_workers_updated_response(
-    session: &mut ServerSession,
-    workers: usize,
-) -> pingora_core::Result<bool> {
-    let mut header = ResponseHeader::build(200, None)?;
-    header.insert_header("X-Worker-Count", workers.to_string())?;
-    session.set_keepalive(None);
-    session.write_response_header(Box::new(header)).await?;
-    Ok(true)
-}
-
 /// Create a 400 response with an error message
 ///
 /// It will set the X-Error-Message header to the error message.
@@ -163,25 +145,4 @@ pub async fn create_response_with_error_message(
     session.set_keepalive(None);
     session.write_response_header(Box::new(header)).await?;
     Ok(true)
-}
-
-/// Create a gRPC [HealthClient] for the given worker address.
-///
-/// # Errors
-/// - [TxProverServiceError::InvalidURI] if the worker address is invalid.
-/// - [TxProverServiceError::ConnectionFailed] if the connection to the worker fails.
-pub async fn create_health_check_client(
-    address: String,
-    connection_timeout: Duration,
-    total_timeout: Duration,
-) -> Result<HealthClient<Channel>, TxProverServiceError> {
-    let channel = Channel::from_shared(format!("http://{}", address))
-        .map_err(|err| TxProverServiceError::InvalidURI(err, address.clone()))?
-        .connect_timeout(connection_timeout)
-        .timeout(total_timeout)
-        .connect()
-        .await
-        .map_err(|err| TxProverServiceError::ConnectionFailed(err, address))?;
-
-    Ok(HealthClient::new(channel))
 }


### PR DESCRIPTION
This PR adds a new service to the proxy server, which is in charge of updating the workers in the load balancer. This allows of removing the responsibility from the proxy itself.

closes #1003 