### PR TITLE
Enhance FPI tests

### DIFF
--- a/crates/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -1044,7 +1044,7 @@ fn test_fpi_memory_two_accounts() {
             # push the index of desired storage item
             push.0
 
-            # get the hash of the `get_item_foreign_1` procedure of the foreign account 1
+            # get the hash of the `get_item_foreign_2` procedure of the foreign account 2
             push.{get_item_foreign_2_hash}
 
             # push the foreign account ID
@@ -1062,7 +1062,7 @@ fn test_fpi_memory_two_accounts() {
             # push the index of desired storage item
             push.0
 
-            # get the hash of the `get_item_foreign` procedure of the foreign account 
+            # get the hash of the `get_item_foreign_1` procedure of the foreign account 1
             push.{get_item_foreign_1_hash}
 
             # push the foreign account ID
@@ -1304,7 +1304,7 @@ fn get_mock_fpi_adv_inputs(
             foreign_account.code(),
             &foreign_account.storage().get_header(),
             // Provide the merkle path of the foreign account to be able to verify that the account
-            // database has the hash of this foreign account. Verification is done during the
+            // tree has the commitment of this foreign account. Verification is done during the
             // execution of the `kernel::account::validate_current_foreign_account` procedure.
             &MerklePath::new(
                 mock_chain


### PR DESCRIPTION
This small PR adds a new memory test for FPI to check the correctness of the memory layout during the foreign procedure invocations of two different foreign accounts. 