### PR TITLE
Implement `get_block_timestamp` procedure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKING] Refactored config file for `miden-proving-service` to be based on environment variables (#1120).
 - Added block number as a public input to the transaction kernel. Updated prologue logic to validate the global input block number is consistent with the commitment block number (#1126).
 - Made NoteFile and AccountFile more consistent (#1133).
+- [BREAKING] Added the `get_block_timestamp` procedure to the `miden` library (#1138).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -894,6 +894,23 @@ export.tx_get_block_number
     # => [num, pad(15)]
 end
 
+#! Returns the block timestamp of the last known block.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [timestamp, pad(15)]
+#!
+#! Where:
+#! - timestamp is the block timestamp of the last known block.
+export.tx_get_block_timestamp
+    # get the last known block timestamp
+    exec.tx::get_block_timestamp
+    # => [timestamp, pad(16)]
+
+    # truncate the stack
+    swap drop
+    # => [timestamp, pad(15)]
+end
+
 #! Tells the transaction kernel that we are about to execute a procedure on a foreign account.
 #!
 #! Checks whether the current foreign account was already loaded to the memory, and loads it if not.

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -894,13 +894,13 @@ export.tx_get_block_number
     # => [num, pad(15)]
 end
 
-#! Returns the block timestamp of the last known block.
+#! Returns the block timestamp of the reference block for this transaction.
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [timestamp, pad(15)]
 #!
 #! Where:
-#! - timestamp is the block timestamp of the last known block.
+#! - timestamp is the timestamp of the reference block for this transaction.
 export.tx_get_block_timestamp
     # get the last known block timestamp
     exec.tx::get_block_timestamp

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -499,13 +499,13 @@ export.get_blk_version
     padw push.BLOCK_METADATA_PTR mem_loadw drop drop swap drop
 end
 
-#! Returns the block timestamp of the last known block.
+#! Returns the block timestamp of the reference block for this transaction.
 #!
 #! Inputs:  []
 #! Outputs: [timestamp]
 #!
 #! Where:
-#! - timestamp is the block timestamp of the last known block.
+#! - timestamp is the timestamp of the reference block for this transaction.
 export.get_blk_timestamp
     padw push.BLOCK_METADATA_PTR mem_loadw drop movdn.2 drop drop
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -105,13 +105,13 @@ export.memory::get_block_hash
 #! - num is the last known block number.
 export.memory::get_blk_num->get_block_number
 
-#! Returns the block timestamp of the last known block.
+#! Returns the block timestamp of the reference block for this transaction.
 #!
 #! Inputs:  []
 #! Outputs: [timestamp]
 #!
 #! Where:
-#! - timestamp is the block timestamp of the last known block.
+#! - timestamp is the timestamp of the reference block for this transaction.
 export.memory::get_blk_timestamp->get_block_timestamp
 
 #! Returns the input notes commitment hash.

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -84,6 +84,9 @@ const.NOTE_BEFORE_ADD_ASSET_EVENT=131085
 # Event emitted after an ASSET is added to a note
 const.NOTE_AFTER_ADD_ASSET_EVENT=131086
 
+# PROCEDURES
+# =================================================================================================
+
 #! Returns the block hash of the reference block to memory.
 #!
 #! Inputs:  []
@@ -101,6 +104,15 @@ export.memory::get_block_hash
 #! Where:
 #! - num is the last known block number.
 export.memory::get_blk_num->get_block_number
+
+#! Returns the block timestamp of the last known block.
+#!
+#! Inputs:  []
+#! Outputs: [timestamp]
+#!
+#! Where:
+#! - timestamp is the block timestamp of the last known block.
+export.memory::get_blk_timestamp->get_block_timestamp
 
 #! Returns the input notes commitment hash.
 #!

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -61,14 +61,15 @@ const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=28
 # block info
 const.TX_GET_BLOCK_HASH_OFFSET=29
 const.TX_GET_BLOCK_NUMBER_OFFSET=30
+const.TX_GET_BLOCK_TIMESTAMP_OFFSET=31
 
 # foreign context
-const.TX_START_FOREIGN_CONTEXT_OFFSET=31
-const.TX_END_FOREIGN_CONTEXT_OFFSET=32
+const.TX_START_FOREIGN_CONTEXT_OFFSET=32
+const.TX_END_FOREIGN_CONTEXT_OFFSET=33
 
 # expiration data
-const.TX_GET_EXPIRATION_DELTA_OFFSET=33          # accessor
-const.TX_UPDATE_EXPIRATION_BLOCK_NUM_OFFSET=34   # mutator
+const.TX_GET_EXPIRATION_DELTA_OFFSET=34          # accessor
+const.TX_UPDATE_EXPIRATION_BLOCK_NUM_OFFSET=35   # mutator
 
 
 # ACCESSORS
@@ -454,6 +455,18 @@ end
 #!   address where this procedure is stored.
 export.tx_get_block_number_offset
     push.TX_GET_BLOCK_NUMBER_OFFSET
+end
+
+#! Returns the offset of the `tx_get_block_timestamp` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `tx_get_block_timestamp` kernel procedure required to get the
+#!   address where this procedure is stored.
+export.tx_get_block_timestamp_offset
+    push.TX_GET_BLOCK_TIMESTAMP_OFFSET
 end
 
 #! Returns the offset of the `tx_start_foreign_context` kernel procedure.

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -50,16 +50,33 @@ export.get_block_hash
     # => [BLOCK_HASH]
 end
 
-#! Returns the block timestamp of the reference block for this transaction.
+#! Returns the timestamp of the reference block for this transaction.
+#!
+#! WARNING: the returned timestamp is not guaranteed to be precise (i.e., could be several seconds
+#! off) or recent, unless recency is separately enforced by setting transaction expiration delta.
+#!
+#! Specifically, the reference blocks (and therefore the corresponding block timestamp) can be
+#! chosen somewhat arbitrarily by the transaction executor. While this does not allow executors to
+#! choose future timestamps, they can choose older timestamps for their benefit.
+#!
+#! For example, consider a script that includes a "time boundary", where before time 10 account X
+#! can consume the note and after time 10 another account Y can consume the note. Even if the latest
+#! block in the chain is at time 11, the owner of account X can choose to create a transaction
+#! referencing the block at time 5 and still consume the note, while account Y would also be able
+#! to consume the note when referencing the latest block. This is not necessarily a problem in all
+#! cases, but must be taken into consideration by script developers.
 #! 
-#! WARNING: the returned timestamp is not precise, potentially it may be off by more that a couple
-#! of seconds. 
+#! If the above is undesired, then one possible countermeasure is to set a transaction expiration
+#! delta. For example, with a delta of 3, the oldest block account X could reference is the one at
+#! time 8. This still allows for consumption by both accounts during a period of time, but shortens
+#! that window.
 #!
 #! Inputs:  []
 #! Outputs: [timestamp]
 #!
 #! Where:
-#! - timestamp is the timestamp of the reference block for this transaction.
+#! - timestamp is the timestamp of the reference block for this transaction. The underlying value is
+#!   of type u32, so u32 operations can be safely used on it.
 export.get_block_timestamp
     # pad the stack
     padw padw padw push.0.0.0

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -27,7 +27,7 @@ end
 
 #! Returns the block hash of the reference block.
 #!
-#! Inputs:  [EMPTY_WORD]
+#! Inputs:  []
 #! Outputs: [BLOCK_HASH]
 #!
 #! Where:
@@ -48,6 +48,32 @@ export.get_block_hash
     # clean the stack
     swapdw dropw dropw swapw dropw
     # => [BLOCK_HASH]
+end
+
+#! Returns the block timestamp of the last known block.
+#! 
+#! WARNING: the returned timestamp is not precise, potentially it may be off by more that a couple
+#! of seconds. 
+#!
+#! Inputs:  []
+#! Outputs: [timestamp]
+#!
+#! Where:
+#! - timestamp is the block timestamp of the last known block.
+export.get_block_timestamp
+    # pad the stack
+    padw padw padw push.0.0.0
+    # => [pad(15)]
+
+    exec.kernel_proc_offsets::tx_get_block_timestamp_offset
+    # => [offset, pad(15)]
+
+    syscall.exec_kernel_proc
+    # => [timestamp, pad(15)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw movdn.3 drop drop drop
+    # => [timestamp]
 end
 
 #! Returns the input notes commitment hash.

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -50,7 +50,7 @@ export.get_block_hash
     # => [BLOCK_HASH]
 end
 
-#! Returns the block timestamp of the last known block.
+#! Returns the block timestamp of the reference block for this transaction.
 #! 
 #! WARNING: the returned timestamp is not precise, potentially it may be off by more that a couple
 #! of seconds. 
@@ -59,7 +59,7 @@ end
 #! Outputs: [timestamp]
 #!
 #! Where:
-#! - timestamp is the block timestamp of the last known block.
+#! - timestamp is the timestamp of the reference block for this transaction.
 export.get_block_timestamp
     # pad the stack
     padw padw padw push.0.0.0

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -6,7 +6,7 @@ use miden_objects::{digest, Digest};
 // ================================================================================================
 
 /// Hashes of all dynamically executed procedures from the kernel 0.
-pub const KERNEL0_PROCEDURES: [Digest; 35] = [
+pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_initial_hash
     digest!("0x920898348bacd6d98a399301eb308478fd32b32eab019a5a6ef7a6b44abb61f6"),
     // account_get_current_hash
@@ -69,6 +69,8 @@ pub const KERNEL0_PROCEDURES: [Digest; 35] = [
     digest!("0xe474b491a64d222397fcf83ee5db7b048061988e5e83ce99b91bae6fd75a3522"),
     // tx_get_block_number
     digest!("0x297797dff54b8108dd2df254b95d43895d3f917ab10399efc62adaf861c905ae"),
+    // tx_get_block_timestamp
+    digest!("0x786863e6dbcd5026619afd3831b7dcbf824cda54950b0e0724ebf9d9370ec723"),
     // tx_start_foreign_context
     digest!("0xdaf9052e4c583124c5b56703d6b726ddce7a8b69333262d4570991df10b34ad2"),
     // tx_end_foreign_context


### PR DESCRIPTION
This small PR implements the `get_block_timestamp` procedure in the `miden::tx` file, adding the corresponding `tx_get_block_hash` procedure to the kernel.