### PR TITLE
feat: add de/serialization for proposed batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKING] Refactored config file for `miden-proving-service` to be based on environment variables (#1120).
 - Added block number as a public input to the transaction kernel. Updated prologue logic to validate the global input block number is consistent with the commitment block number (#1126).
 - Made NoteFile and AccountFile more consistent (#1133).
+- Added serialization for `ProposedBatch`, `BatchId`, `BatchNoteTree` and `ProvenBatch` (#1140).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,9 +4979,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fdb702503625f54dcaf9222aa2c7a0b2e868b3eb84b90d1837d68034bf999"
+checksum = "827ef2aa5a5ab663936e0a6326286e0fc83321771df0d9ea20c46c72c8baa90d"
 dependencies = [
  "libm",
  "winter-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,7 @@ dependencies = [
  "criterion",
  "getrandom 0.2.15",
  "log",
+ "miden-air",
  "miden-assembly",
  "miden-core",
  "miden-crypto",
@@ -1934,6 +1935,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "toml",
+ "winter-air",
  "winter-rand-utils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,6 @@ dependencies = [
  "criterion",
  "getrandom 0.2.15",
  "log",
- "miden-air",
  "miden-assembly",
  "miden-core",
  "miden-crypto",

--- a/crates/miden-objects/Cargo.toml
+++ b/crates/miden-objects/Cargo.toml
@@ -48,5 +48,7 @@ anyhow = { version = "1.0.93", default-features = false, features = ["std", "bac
 assert_matches = { workspace = true }
 criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
 miden-objects = { path = ".", features = ["testing"] }
+miden-air ={ version = "0.12" }
 rstest = { version = "0.23" }
 tempfile = { version = "3.14" }
+winter-air = { version = "0.11" }

--- a/crates/miden-objects/Cargo.toml
+++ b/crates/miden-objects/Cargo.toml
@@ -48,7 +48,6 @@ anyhow = { version = "1.0.93", default-features = false, features = ["std", "bac
 assert_matches = { workspace = true }
 criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
 miden-objects = { path = ".", features = ["testing"] }
-miden-air ={ version = "0.12" }
 rstest = { version = "0.23" }
 tempfile = { version = "3.14" }
 winter-air = { version = "0.11" }

--- a/crates/miden-objects/src/batch/batch_id.rs
+++ b/crates/miden-objects/src/batch/batch_id.rs
@@ -1,15 +1,10 @@
 use alloc::{string::String, vec::Vec};
 
-use vm_core::{
-    utils::{ByteReader, ByteWriter, Deserializable, Serializable},
-    Felt, ZERO,
-};
-
 use crate::{
     account::AccountId,
     transaction::{ProvenTransaction, TransactionId},
-    utils::DeserializationError,
-    Digest, Hasher,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    Digest, Felt, Hasher, ZERO,
 };
 
 // BATCH ID

--- a/crates/miden-objects/src/batch/batch_id.rs
+++ b/crates/miden-objects/src/batch/batch_id.rs
@@ -1,7 +1,10 @@
 use alloc::{string::String, vec::Vec};
 
-use vm_core::{Felt, ZERO};
-use vm_processor::Digest;
+use vm_core::{
+    utils::{ByteReader, ByteWriter, Deserializable, Serializable},
+    Felt, ZERO,
+};
+use vm_processor::{DeserializationError, Digest};
 
 use crate::{
     account::AccountId,
@@ -61,5 +64,20 @@ impl BatchId {
 impl core::fmt::Display for BatchId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.to_hex())
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for BatchId {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+    }
+}
+
+impl Deserializable for BatchId {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        Ok(Self(Digest::read_from(source)?))
     }
 }

--- a/crates/miden-objects/src/batch/batch_id.rs
+++ b/crates/miden-objects/src/batch/batch_id.rs
@@ -4,12 +4,12 @@ use vm_core::{
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},
     Felt, ZERO,
 };
-use vm_processor::{DeserializationError, Digest};
 
 use crate::{
     account::AccountId,
     transaction::{ProvenTransaction, TransactionId},
-    Hasher,
+    utils::DeserializationError,
+    Digest, Hasher,
 };
 
 // BATCH ID

--- a/crates/miden-objects/src/batch/note_tree.rs
+++ b/crates/miden-objects/src/batch/note_tree.rs
@@ -4,12 +4,11 @@ use miden_crypto::{
     hash::rpo::RpoDigest,
     merkle::{LeafIndex, MerkleError, SimpleSmt},
 };
-use vm_core::EMPTY_WORD;
 
 use crate::{
     note::{compute_note_hash, NoteId, NoteMetadata},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    BATCH_NOTE_TREE_DEPTH,
+    BATCH_NOTE_TREE_DEPTH, EMPTY_WORD,
 };
 
 /// Wrapper over [SimpleSmt<BATCH_NOTE_TREE_DEPTH>] for batch note tree.

--- a/crates/miden-objects/src/batch/note_tree.rs
+++ b/crates/miden-objects/src/batch/note_tree.rs
@@ -4,14 +4,11 @@ use miden_crypto::{
     hash::rpo::RpoDigest,
     merkle::{LeafIndex, MerkleError, SimpleSmt},
 };
-use vm_core::{
-    utils::{ByteReader, ByteWriter, Deserializable, Serializable},
-    EMPTY_WORD,
-};
-use vm_processor::DeserializationError;
+use vm_core::EMPTY_WORD;
 
 use crate::{
     note::{compute_note_hash, NoteId, NoteMetadata},
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     BATCH_NOTE_TREE_DEPTH,
 };
 

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -395,13 +395,12 @@ impl Deserializable for ProposedBatch {
 mod tests {
     use miden_crypto::merkle::{Mmr, PartialMmr};
     use miden_verifier::ExecutionProof;
-    use vm_core::Felt;
     use winter_air::proof::Proof;
     use winter_rand_utils::rand_array;
 
     use super::*;
     use crate::{
-        account::{Account, AccountComponent, AccountIdVersion, AccountStorageMode, AccountType},
+        account::{AccountIdVersion, AccountStorageMode, AccountType},
         transaction::ProvenTransactionBuilder,
         Digest, Word,
     };

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -408,76 +408,41 @@ impl ProposedBatch {
 
 impl Serializable for ProposedBatch {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_u32(self.transactions.len() as u32);
-        for tx in self.transactions.iter() {
-            tx.as_ref().write_into(target);
-        }
+        self.transactions
+            .iter()
+            .map(|tx| tx.as_ref().clone())
+            .collect::<Vec<ProvenTransaction>>()
+            .write_into(target);
 
         self.block_header.write_into(target);
         self.chain_mmr.write_into(target);
-
-        target.write_u32(self.unauthenticated_note_proofs.len() as u32);
-        for (note_id, proof) in self.unauthenticated_note_proofs.iter() {
-            note_id.write_into(target);
-            proof.write_into(target);
-        }
-
+        self.unauthenticated_note_proofs.write_into(target);
         self.id.write_into(target);
-
-        target.write_u32(self.account_updates.len() as u32);
-        for (account_id, update) in self.account_updates.iter() {
-            account_id.write_into(target);
-            update.write_into(target);
-        }
-
+        self.account_updates.write_into(target);
         self.batch_expiration_block_num.write_into(target);
-
         self.input_notes.write_into(target);
         self.output_notes_tree.write_into(target);
-
-        target.write_u32(self.output_notes.len() as u32);
-        for note in self.output_notes.iter() {
-            note.write_into(target);
-        }
+        self.output_notes.write_into(target);
     }
 }
 
 impl Deserializable for ProposedBatch {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let transactions_len = source.read_u32()? as usize;
-        let transactions = (0..transactions_len)
-            .map(|_| ProvenTransaction::read_from(source).map(Arc::new))
-            .collect::<Result<Vec<Arc<ProvenTransaction>>, _>>()?;
+        let transactions = Vec::<ProvenTransaction>::read_from(source)?
+            .iter()
+            .map(|tx| Arc::new(tx.clone()))
+            .collect::<Vec<Arc<ProvenTransaction>>>();
 
         let block_header = BlockHeader::read_from(source)?;
         let chain_mmr = ChainMmr::read_from(source)?;
-        let unauthenticated_note_proofs_len = source.read_u32()? as usize;
-
-        let mut unauthenticated_note_proofs = BTreeMap::new();
-        for _ in 0..unauthenticated_note_proofs_len {
-            let note_id = NoteId::read_from(source)?;
-            let proof = NoteInclusionProof::read_from(source)?;
-            unauthenticated_note_proofs.insert(note_id, proof);
-        }
-
+        let unauthenticated_note_proofs =
+            BTreeMap::<NoteId, NoteInclusionProof>::read_from(source)?;
         let id = BatchId::read_from(source)?;
-
-        let account_updates_len = source.read_u32()? as usize;
-        let mut account_updates = BTreeMap::new();
-        for _ in 0..account_updates_len {
-            let account_id = AccountId::read_from(source)?;
-            let update = BatchAccountUpdate::read_from(source)?;
-            account_updates.insert(account_id, update);
-        }
-
+        let account_updates = BTreeMap::<AccountId, BatchAccountUpdate>::read_from(source)?;
         let batch_expiration_block_num = BlockNumber::read_from(source)?;
-
         let input_notes = InputNotes::<InputNoteCommitment>::read_from(source)?;
         let output_notes_tree = BatchNoteTree::read_from(source)?;
-        let output_notes_len = source.read_u32()? as usize;
-        let output_notes = (0..output_notes_len)
-            .map(|_| OutputNote::read_from(source))
-            .collect::<Result<Vec<_>, _>>()?;
+        let output_notes = Vec::<OutputNote>::read_from(source)?;
 
         Ok(Self {
             transactions,

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -412,8 +412,8 @@ mod tests {
         for i in 0..3 {
             let block_header = BlockHeader::mock(
                 i,
-                Some(Digest::default()),
-                Some(Digest::default()),
+                None,
+                None,
                 &[],
                 Digest::default(),
             );

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -395,12 +395,13 @@ impl Deserializable for ProposedBatch {
 mod tests {
     use miden_crypto::merkle::{Mmr, PartialMmr};
     use miden_verifier::ExecutionProof;
+    use vm_core::Felt;
     use winter_air::proof::Proof;
     use winter_rand_utils::rand_array;
 
     use super::*;
     use crate::{
-        account::{AccountIdVersion, AccountStorageMode, AccountType},
+        account::{Account, AccountComponent, AccountIdVersion, AccountStorageMode, AccountType},
         transaction::ProvenTransactionBuilder,
         Digest, Word,
     };
@@ -410,18 +411,12 @@ mod tests {
         // create chain MMR with 3 blocks - i.e., 2 peaks
         let mut mmr = Mmr::default();
         for i in 0..3 {
-            let block_header = BlockHeader::new(
-                0,
+            let block_header = BlockHeader::mock(
+                i,
+                Some(Digest::default()),
+                Some(Digest::default()),
+                &[],
                 Digest::default(),
-                i.into(),
-                Digest::default(),
-                Digest::default(),
-                Digest::default(),
-                Digest::default(),
-                Digest::default(),
-                Digest::default(),
-                Digest::default(),
-                0,
             );
             mmr.add(block_header.hash());
         }

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -4,9 +4,6 @@ use alloc::{
     vec::Vec,
 };
 
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
-
 use crate::{
     account::AccountId,
     batch::{BatchAccountUpdate, BatchId, BatchNoteTree, InputOutputNoteTracker},
@@ -14,6 +11,7 @@ use crate::{
     errors::ProposedBatchError,
     note::{NoteId, NoteInclusionProof},
     transaction::{ChainMmr, InputNoteCommitment, InputNotes, OutputNote, ProvenTransaction},
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     MAX_ACCOUNTS_PER_BATCH, MAX_INPUT_NOTES_PER_BATCH, MAX_OUTPUT_NOTES_PER_BATCH,
 };
 
@@ -413,11 +411,8 @@ impl Deserializable for ProposedBatch {
 
 #[cfg(test)]
 mod tests {
-    use miden_air::HashFunction;
     use miden_crypto::merkle::{Mmr, PartialMmr};
     use miden_verifier::ExecutionProof;
-    use vm_core::Word;
-    use vm_processor::Digest;
     use winter_air::proof::Proof;
     use winter_rand_utils::rand_array;
 
@@ -425,6 +420,7 @@ mod tests {
     use crate::{
         account::{AccountIdVersion, AccountStorageMode, AccountType},
         transaction::ProvenTransactionBuilder,
+        Digest, Word,
     };
 
     #[test]
@@ -468,7 +464,7 @@ mod tests {
         let block_num = BlockNumber::from(1);
         let block_ref = header.hash();
         let expiration_block_num = BlockNumber::from(2);
-        let proof = ExecutionProof::new(Proof::new_dummy(), HashFunction::Rpo256);
+        let proof = ExecutionProof::new(Proof::new_dummy(), Default::default());
 
         let tx = ProvenTransactionBuilder::new(
             account_id,

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -367,12 +367,6 @@ impl Serializable for ProposedBatch {
         self.block_header.write_into(target);
         self.chain_mmr.write_into(target);
         self.unauthenticated_note_proofs.write_into(target);
-        self.id.write_into(target);
-        self.account_updates.write_into(target);
-        self.batch_expiration_block_num.write_into(target);
-        self.input_notes.write_into(target);
-        self.output_notes_tree.write_into(target);
-        self.output_notes.write_into(target);
     }
 }
 
@@ -387,25 +381,13 @@ impl Deserializable for ProposedBatch {
         let chain_mmr = ChainMmr::read_from(source)?;
         let unauthenticated_note_proofs =
             BTreeMap::<NoteId, NoteInclusionProof>::read_from(source)?;
-        let id = BatchId::read_from(source)?;
-        let account_updates = BTreeMap::<AccountId, BatchAccountUpdate>::read_from(source)?;
-        let batch_expiration_block_num = BlockNumber::read_from(source)?;
-        let input_notes = InputNotes::<InputNoteCommitment>::read_from(source)?;
-        let output_notes_tree = BatchNoteTree::read_from(source)?;
-        let output_notes = Vec::<OutputNote>::read_from(source)?;
 
-        Ok(Self {
-            transactions,
-            block_header,
-            chain_mmr,
-            unauthenticated_note_proofs,
-            id,
-            account_updates,
-            batch_expiration_block_num,
-            input_notes,
-            output_notes,
-            output_notes_tree,
-        })
+        ProposedBatch::new(transactions, block_header, chain_mmr, unauthenticated_note_proofs)
+            .map_err(|source| {
+                DeserializationError::UnknownError(format!(
+                    "failed to create proposed batch: {source}"
+                ))
+            })
     }
 }
 

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -410,13 +410,7 @@ mod tests {
         // create chain MMR with 3 blocks - i.e., 2 peaks
         let mut mmr = Mmr::default();
         for i in 0..3 {
-            let block_header = BlockHeader::mock(
-                i,
-                None,
-                None,
-                &[],
-                Digest::default(),
-            );
+            let block_header = BlockHeader::mock(i, None, None, &[], Digest::default());
             mmr.add(block_header.hash());
         }
         let partial_mmr: PartialMmr = mmr.peaks().into();

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -1,14 +1,13 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::{DeserializationError, Digest};
-
 use crate::{
     account::AccountId,
     batch::{BatchAccountUpdate, BatchId, BatchNoteTree},
     block::BlockNumber,
     note::Nullifier,
     transaction::{InputNoteCommitment, InputNotes, OutputNote},
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    Digest,
 };
 
 /// A transaction batch with an execution proof.

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -1,5 +1,8 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_processor::DeserializationError;
+
 use crate::{
     account::AccountId,
     batch::{BatchAccountUpdate, BatchId, BatchNoteTree},
@@ -89,5 +92,39 @@ impl ProvenBatch {
     /// Returns the [`BatchNoteTree`] representing the output notes of the batch.
     pub fn output_notes_tree(&self) -> &BatchNoteTree {
         &self.output_notes_smt
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for ProvenBatch {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.id.write_into(target);
+        self.account_updates.write_into(target);
+        self.input_notes.write_into(target);
+        self.output_notes_smt.write_into(target);
+        self.output_notes.write_into(target);
+        self.batch_expiration_block_num.write_into(target);
+    }
+}
+
+impl Deserializable for ProvenBatch {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let id = BatchId::read_from(source)?;
+        let account_updates = BTreeMap::read_from(source)?;
+        let input_notes = InputNotes::<InputNoteCommitment>::read_from(source)?;
+        let output_notes_smt = BatchNoteTree::read_from(source)?;
+        let output_notes = Vec::<OutputNote>::read_from(source)?;
+        let batch_expiration_block_num = BlockNumber::read_from(source)?;
+
+        Ok(Self::new(
+            id,
+            account_updates,
+            input_notes,
+            output_notes_smt,
+            output_notes,
+            batch_expiration_block_num,
+        ))
     }
 }

--- a/crates/miden-objects/src/transaction/chain_mmr.rs
+++ b/crates/miden-objects/src/transaction/chain_mmr.rs
@@ -135,10 +135,7 @@ impl ChainMmr {
 impl Serializable for ChainMmr {
     fn write_into<W: miden_crypto::utils::ByteWriter>(&self, target: &mut W) {
         self.mmr.write_into(target);
-        self.blocks.len().write_into(target);
-        for block in self.blocks.values() {
-            block.write_into(target);
-        }
+        self.blocks.write_into(target);
     }
 }
 
@@ -147,12 +144,7 @@ impl Deserializable for ChainMmr {
         source: &mut R,
     ) -> Result<Self, miden_crypto::utils::DeserializationError> {
         let mmr = PartialMmr::read_from(source)?;
-        let block_count = usize::read_from(source)?;
-        let mut blocks = BTreeMap::new();
-        for _ in 0..block_count {
-            let block = BlockHeader::read_from(source)?;
-            blocks.insert(block.block_num(), block);
-        }
+        let blocks = BTreeMap::<BlockNumber, BlockHeader>::read_from(source)?;
         Ok(Self { mmr, blocks })
     }
 }


### PR DESCRIPTION
This is needed for the remote batch prover (#1131).

This PR depends on a fix on Winterfell (https://github.com/facebook/winterfell/pull/366), due to a bug in the `Proof` and `Context` serialization.