### PR TITLE
feat: add `prefix` to `Nullifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [BREAKING] Implement most block constraints in `ProposedBlock` (#1123).
 - [BREAKING] Added the `get_block_timestamp` procedure to the `miden` library (#1138).
 - Added serialization for `ProposedBatch`, `BatchId`, `BatchNoteTree` and `ProvenBatch` (#1140).
+- Added `prefix` to `Nullifier` (#1153).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/crates/miden-objects/src/note/nullifier.rs
+++ b/crates/miden-objects/src/note/nullifier.rs
@@ -61,6 +61,8 @@ impl Nullifier {
     }
 
     /// Returns the prefix of this nullifier.
+    ///
+    /// Nullifier prefix is defined as the 16 most significant bits of the nullifier value.
     pub fn prefix(&self) -> u16 {
         (self.inner()[3].as_int() >> NULLIFIER_PREFIX_SHIFT) as u16
     }

--- a/crates/miden-objects/src/note/nullifier.rs
+++ b/crates/miden-objects/src/note/nullifier.rs
@@ -7,6 +7,11 @@ use super::{
 };
 use crate::utils::{hex_to_bytes, HexParseError};
 
+// CONSTANTS
+// ================================================================================================
+
+const NULLIFIER_PREFIX_SHIFT: u8 = 48;
+
 // NULLIFIER
 // ================================================================================================
 
@@ -53,6 +58,11 @@ impl Nullifier {
     /// Returns the digest defining this nullifier.
     pub fn inner(&self) -> Digest {
         self.0
+    }
+
+    /// Returns the prefix of this nullifier.
+    pub fn prefix(&self) -> u16 {
+        (self.inner()[3].as_int() >> NULLIFIER_PREFIX_SHIFT) as u16
     }
 
     /// Creates a Nullifier from a hex string. Assumes that the string starts with "0x" and


### PR DESCRIPTION
based on [this comment](https://github.com/0xPolygonMiden/miden-client/pull/650#discussion_r1954620127)

The Nullifier should have a method to get its prefix. The prefix is sent in the sync state request to get nullifier updates without exposing the specific nullifiers that the client is interested in.