### PR TITLE
Check for expired transactions and batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Added serialization for `ProposedBatch`, `BatchId`, `BatchNoteTree` and `ProvenBatch` (#1140).
 - Added `prefix` to `Nullifier` (#1153).
 - [BREAKING] Implemented a `RemoteBatchProver`. `miden-proving-service` workers can prove batches (#1142).
-- [BREAKING] Implement `LocalBlockProver` and rename `Block` to `ProvenBlock` (#1152).
+- [BREAKING] Implement `LocalBlockProver` and rename `Block` to `ProvenBlock` (#1152, #1168).
 - [BREAKING] Added native types to `AccountComponentTemplate` (#1124).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,7 +2034,6 @@ dependencies = [
  "getrandom 0.2.15",
  "miden-objects",
  "miden-tx",
- "miden-tx-batch-prover",
  "miette",
  "prost",
  "prost-build",

--- a/crates/miden-block-prover/src/tests/proposed_block_errors.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_errors.rs
@@ -357,12 +357,10 @@ fn proposed_block_fails_on_invalid_proof_or_missing_note_inclusion_reference_blo
     // --------------------------------------------------------------------------------------------
 
     let mut invalid_block_inputs = original_block_inputs.clone();
-    // For completeness, we should also untrack it, but this currently panics.
-    // Uncomment when https://github.com/0xPolygonMiden/crypto/issues/379 is fixed.
-    // invalid_block_inputs
-    //     .chain_mmr_mut()
-    //     .partial_mmr_mut()
-    //     .untrack(block2.header().block_num().as_usize());
+    invalid_block_inputs
+        .chain_mmr_mut()
+        .partial_mmr_mut()
+        .untrack(block2.header().block_num().as_usize());
     invalid_block_inputs
         .chain_mmr_mut()
         .block_headers_mut()

--- a/crates/miden-block-prover/src/tests/proposed_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_success.rs
@@ -198,7 +198,7 @@ fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
 
 /// Tests that a batch that expires at the block being proposed is still accepted.
 #[test]
-fn proposed_block_unexpired_batches() -> anyhow::Result<()> {
+fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
     let TestSetup { mut chain, mut accounts, .. } = setup_chain(2);
     let block1_num = chain.block_header(1).block_num();
     let account0 = accounts.remove(&0).unwrap();

--- a/crates/miden-block-prover/src/tests/proven_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_success.rs
@@ -251,7 +251,14 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
 
     let batches = [batch0.clone(), batch1];
     // This block will use block2 as the reference block.
-    let block_inputs = chain.get_block_inputs(&batches);
+    let mut block_inputs = chain.get_block_inputs(&batches);
+
+    // Remove the nullifier witness for output_note0 which will be erased, to check that the
+    // proposed block does not _require_ nullifier witnesses for erased notes.
+    block_inputs
+        .nullifier_witnesses_mut()
+        .remove(&output_note0.nullifier())
+        .unwrap();
 
     let proposed_block = ProposedBlock::new(block_inputs.clone(), batches.to_vec())
         .context("failed to build proposed block")?;

--- a/crates/miden-block-prover/src/tests/proven_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_success.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, vec::Vec};
 use anyhow::Context;
 use miden_crypto::merkle::LeafIndex;
 use miden_objects::{
+    batch::BatchNoteTree,
     block::{BlockNoteIndex, BlockNoteTree, ProposedBlock},
     transaction::InputNoteCommitment,
     Felt, FieldElement, MIN_PROOF_SECURITY_LEVEL,
@@ -303,7 +304,10 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
     let actual_block_note_tree = proven_block.build_output_note_tree();
 
     // Remove the erased note to get the expected batch note tree.
-    let mut batch_tree = batch0.output_notes_tree().clone();
+    let mut batch_tree = BatchNoteTree::with_contiguous_leaves(
+        batch0.output_notes().iter().map(|note| (note.id(), note.metadata())),
+    )
+    .unwrap();
     batch_tree.remove(erased_note_idx as u64).unwrap();
 
     let mut expected_block_note_tree = BlockNoteTree::empty();

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -108,8 +108,8 @@ impl ProposedBatch {
     ///   potentially result in the same [`BatchId`] for two empty batches which would mean batch
     ///   IDs are no longer unique.
     /// - There are duplicate transactions.
-    /// - If the minimum of all transaction's expiration block number is less than or equal to the
-    ///   batch's reference block.
+    /// - If any transaction's expiration block number is less than or equal to the batch's
+    ///   reference block.
     pub fn new(
         transactions: Vec<Arc<ProvenTransaction>>,
         block_header: BlockHeader,

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 
 use crate::{
     account::AccountId,
-    batch::{BatchAccountUpdate, BatchId, BatchNoteTree},
+    batch::{BatchAccountUpdate, BatchId},
     block::BlockNumber,
     note::Nullifier,
     transaction::{InputNoteCommitment, InputNotes, OutputNote},
@@ -18,7 +18,6 @@ pub struct ProvenBatch {
     reference_block_num: BlockNumber,
     account_updates: BTreeMap<AccountId, BatchAccountUpdate>,
     input_notes: InputNotes<InputNoteCommitment>,
-    output_notes_smt: BatchNoteTree,
     output_notes: Vec<OutputNote>,
     batch_expiration_block_num: BlockNumber,
 }
@@ -35,7 +34,6 @@ impl ProvenBatch {
         reference_block_num: BlockNumber,
         account_updates: BTreeMap<AccountId, BatchAccountUpdate>,
         input_notes: InputNotes<InputNoteCommitment>,
-        output_notes_smt: BatchNoteTree,
         output_notes: Vec<OutputNote>,
         batch_expiration_block_num: BlockNumber,
     ) -> Self {
@@ -45,7 +43,6 @@ impl ProvenBatch {
             reference_block_num,
             account_updates,
             input_notes,
-            output_notes_smt,
             output_notes,
             batch_expiration_block_num,
         }
@@ -109,11 +106,6 @@ impl ProvenBatch {
     pub fn output_notes(&self) -> &[OutputNote] {
         &self.output_notes
     }
-
-    /// Returns the [`BatchNoteTree`] representing the output notes of the batch.
-    pub fn output_notes_tree(&self) -> &BatchNoteTree {
-        &self.output_notes_smt
-    }
 }
 
 // SERIALIZATION
@@ -126,7 +118,6 @@ impl Serializable for ProvenBatch {
         self.reference_block_num.write_into(target);
         self.account_updates.write_into(target);
         self.input_notes.write_into(target);
-        self.output_notes_smt.write_into(target);
         self.output_notes.write_into(target);
         self.batch_expiration_block_num.write_into(target);
     }
@@ -139,7 +130,6 @@ impl Deserializable for ProvenBatch {
         let reference_block_num = BlockNumber::read_from(source)?;
         let account_updates = BTreeMap::read_from(source)?;
         let input_notes = InputNotes::<InputNoteCommitment>::read_from(source)?;
-        let output_notes_smt = BatchNoteTree::read_from(source)?;
         let output_notes = Vec::<OutputNote>::read_from(source)?;
         let batch_expiration_block_num = BlockNumber::read_from(source)?;
 
@@ -149,7 +139,6 @@ impl Deserializable for ProvenBatch {
             reference_block_num,
             account_updates,
             input_notes,
-            output_notes_smt,
             output_notes,
             batch_expiration_block_num,
         ))

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -29,7 +29,7 @@ impl ProvenBatch {
 
     /// Creates a new [`ProvenBatch`] from the provided parts.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_unchecked(
         id: BatchId,
         reference_block_commitment: Digest,
         reference_block_num: BlockNumber,
@@ -143,7 +143,7 @@ impl Deserializable for ProvenBatch {
         let output_notes = Vec::<OutputNote>::read_from(source)?;
         let batch_expiration_block_num = BlockNumber::read_from(source)?;
 
-        Ok(Self::new(
+        Ok(Self::new_unchecked(
             id,
             reference_block_commitment,
             reference_block_num,

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -552,6 +552,13 @@ pub enum ProposedBlockError {
     #[error("block must contain at most {MAX_BATCHES_PER_BLOCK} transaction batches")]
     TooManyBatches,
 
+    #[error("batch {batch_id} expired at block {batch_expiration_block_num} but the current block number is {current_block_num}")]
+    ExpiredBatch {
+        batch_id: BatchId,
+        batch_expiration_block_num: BlockNumber,
+        current_block_num: BlockNumber,
+    },
+
     #[error("batch {batch_id} appears twice in the block inputs")]
     DuplicateBatch { batch_id: BatchId },
 

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -468,8 +468,14 @@ pub enum ProposedBatchError {
 
     #[error(
       "transaction batch has {0} account updates but at most {MAX_ACCOUNTS_PER_BATCH} are allowed"
-  )]
+    )]
     TooManyAccountUpdates(usize),
+
+    #[error("transaction batch's expiration number is {batch_expiration_num} which is not greater than the number of its reference block {reference_block_num}")]
+    ExpiredBatch {
+        batch_expiration_num: BlockNumber,
+        reference_block_num: BlockNumber,
+    },
 
     #[error("transaction batch must contain at least one transaction")]
     EmptyTransactionBatch,

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -471,9 +471,10 @@ pub enum ProposedBatchError {
     )]
     TooManyAccountUpdates(usize),
 
-    #[error("transaction batch's expiration number is {batch_expiration_num} which is not greater than the number of its reference block {reference_block_num}")]
-    ExpiredBatch {
-        batch_expiration_num: BlockNumber,
+    #[error("transaction {transaction_id} expires at block number {transaction_expiration_num} which is not greater than the number of the batch's reference block {reference_block_num}")]
+    ExpiredTransaction {
+        transaction_id: TransactionId,
+        transaction_expiration_num: BlockNumber,
         reference_block_num: BlockNumber,
     },
 

--- a/crates/miden-objects/src/transaction/executed_tx.rs
+++ b/crates/miden-objects/src/transaction/executed_tx.rs
@@ -9,7 +9,7 @@ use super::{
     InputNotes, NoteId, OutputNotes, TransactionArgs, TransactionId, TransactionInputs,
     TransactionOutputs, TransactionWitness,
 };
-use crate::account::AccountCode;
+use crate::{account::AccountCode, block::BlockNumber};
 
 // EXECUTED TRANSACTION
 // ================================================================================================
@@ -99,6 +99,11 @@ impl ExecutedTransaction {
     /// Returns the notes created in this transaction.
     pub fn output_notes(&self) -> &OutputNotes {
         &self.tx_outputs.output_notes
+    }
+
+    /// Returns the block number at which the transaction will expire.
+    pub fn expiration_block_num(&self) -> BlockNumber {
+        self.tx_outputs.expiration_block_num
     }
 
     /// Returns a reference to the transaction args.

--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -32,7 +32,6 @@ tonic-web = { version = "0.12", optional = true }
 async-trait = "0.1"
 miden-objects = { workspace = true, default-features = false }
 miden-tx = { workspace = true, default-features = false }
-miden-tx-batch-prover = { workspace = true, default-features = false }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.38", default-features = false, features = ["sync"], optional = true }

--- a/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
@@ -5,7 +5,6 @@ use alloc::{
 };
 
 use miden_objects::batch::{ProposedBatch, ProvenBatch};
-use miden_tx_batch_prover::errors::BatchProveError;
 use tokio::sync::Mutex;
 
 use super::generated::api_client::ApiClient;

--- a/crates/miden-tx-batch-prover/src/errors.rs
+++ b/crates/miden-tx-batch-prover/src/errors.rs
@@ -3,7 +3,7 @@ use miden_tx::TransactionVerifierError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum BatchProveError {
+pub enum ProvenBatchError {
     #[error("failed to verify transaction {transaction_id} in transaction batch")]
     TransactionVerificationFailed {
         transaction_id: TransactionId,

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -46,7 +46,7 @@ impl LocalBatchProver {
             })?;
         }
 
-        Ok(ProvenBatch::new(
+        Ok(ProvenBatch::new_unchecked(
             id,
             block_header.hash(),
             block_header.block_num(),

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -33,7 +33,6 @@ impl LocalBatchProver {
             id,
             updated_accounts,
             input_notes,
-            output_notes_smt,
             output_notes,
             batch_expiration_block_num,
         ) = proposed_batch.into_parts();
@@ -52,7 +51,6 @@ impl LocalBatchProver {
             block_header.block_num(),
             updated_accounts,
             input_notes,
-            output_notes_smt,
             output_notes,
             batch_expiration_block_num,
         ))

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -1,7 +1,7 @@
 use miden_objects::batch::{ProposedBatch, ProvenBatch};
 use miden_tx::TransactionVerifier;
 
-use crate::errors::BatchProveError;
+use crate::errors::ProvenBatchError;
 
 // LOCAL BATCH PROVER
 // ================================================================================================
@@ -24,7 +24,7 @@ impl LocalBatchProver {
     ///
     /// Returns an error if:
     /// - a proof of any transaction in the batch fails to verify.
-    pub fn prove(&self, proposed_batch: ProposedBatch) -> Result<ProvenBatch, BatchProveError> {
+    pub fn prove(&self, proposed_batch: ProposedBatch) -> Result<ProvenBatch, ProvenBatchError> {
         let (
             transactions,
             block_header,
@@ -42,7 +42,7 @@ impl LocalBatchProver {
 
         for tx in transactions {
             verifier.verify(&tx).map_err(|source| {
-                BatchProveError::TransactionVerificationFailed { transaction_id: tx.id(), source }
+                ProvenBatchError::TransactionVerificationFailed { transaction_id: tx.id(), source }
             })?;
         }
 

--- a/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
+++ b/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
@@ -515,9 +515,11 @@ fn batch_expiration() -> anyhow::Result<()> {
         .block_reference(block1.hash())
         .expiration_block_num(BlockNumber::from(35))
         .build()?;
+    // This transaction has the smallest valid expiration block num that allows it to still be
+    // included in the batch.
     let tx2 = MockProvenTxBuilder::with_account(account2.id(), Digest::default(), account2.hash())
         .block_reference(block1.hash())
-        .expiration_block_num(BlockNumber::from(30))
+        .expiration_block_num(block1.block_num() + 1)
         .build()?;
 
     let batch = ProposedBatch::new(
@@ -527,7 +529,7 @@ fn batch_expiration() -> anyhow::Result<()> {
         BTreeMap::default(),
     )?;
 
-    assert_eq!(batch.batch_expiration_block_num(), BlockNumber::from(30));
+    assert_eq!(batch.batch_expiration_block_num(), block1.block_num() + 1);
 
     Ok(())
 }

--- a/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
+++ b/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
@@ -92,7 +92,6 @@ fn note_created_and_consumed_in_same_batch() -> anyhow::Result<()> {
 
     assert_eq!(batch.input_notes().num_notes(), 0);
     assert_eq!(batch.output_notes().len(), 0);
-    assert_eq!(batch.output_notes_tree().num_leaves(), 0);
 
     Ok(())
 }
@@ -379,7 +378,6 @@ fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
 
     assert_eq!(batch.input_notes().num_notes(), 1);
     assert_eq!(batch.output_notes().len(), 1);
-    assert_eq!(batch.output_notes_tree().num_leaves(), 1);
 
     Ok(())
 }
@@ -489,8 +487,6 @@ fn input_and_output_notes_commitment() -> anyhow::Result<()> {
 
     assert_eq!(batch.output_notes().len(), 3);
     assert_eq!(batch.output_notes(), expected_output_notes);
-
-    assert_eq!(batch.output_notes_tree().num_leaves(), 3);
 
     // Input notes are sorted by the order in which they appeared in the batch.
     assert_eq!(batch.input_notes().num_notes(), 2);

--- a/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
+++ b/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
@@ -610,7 +610,7 @@ fn expired_transaction() -> anyhow::Result<()> {
         .build()?;
 
     let error = ProposedBatch::new(
-        [tx1, tx2].into_iter().map(Arc::new).collect(),
+        [tx1.clone(), tx2].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_chain_mmr(),
         BTreeMap::default(),
@@ -619,11 +619,13 @@ fn expired_transaction() -> anyhow::Result<()> {
 
     assert_matches!(
         error,
-        ProposedBatchError::ExpiredBatch {
-            batch_expiration_num,
+        ProposedBatchError::ExpiredTransaction {
+            transaction_id,
+            transaction_expiration_num,
             reference_block_num
-        } if batch_expiration_num == block1.block_num() &&
-          reference_block_num == block1.block_num()
+        }  if transaction_id == tx1.id() &&
+            transaction_expiration_num == block1.block_num() &&
+            reference_block_num == block1.block_num()
     );
 
     Ok(())

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -461,7 +461,6 @@ impl MockChain {
             id,
             account_updates,
             input_notes,
-            output_notes_tree,
             output_notes,
             batch_expiration_block_num,
         ) = proposed_batch.into_parts();
@@ -472,7 +471,6 @@ impl MockChain {
             block_header.block_num(),
             account_updates,
             input_notes,
-            output_notes_tree,
             output_notes,
             batch_expiration_block_num,
         )

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -466,7 +466,7 @@ impl MockChain {
             batch_expiration_block_num,
         ) = proposed_batch.into_parts();
 
-        ProvenBatch::new(
+        ProvenBatch::new_unchecked(
             id,
             block_header.hash(),
             block_header.block_num(),


### PR DESCRIPTION
## Changes

- Batches: Check that none of the transactions in a batch are expired and tests expired and unexpired transactions.
- Batches: Removes the `BatchNoteTree` from `ProposedBatch` and `ProvenBatch`.
- Block: Check that the batches included in the block are unexpired and tests expired and unexpired batches.
- Rename `ProvenBatch::new` -> `ProvenBatch::new_unchecked` to match `ProvenBlock::new_unchecked` (both of which don't do any validation).
- Simplify the transaction reference block check in the batch to avoid allocating a new `BTreeSet`.
- Rename `BatchProveError` to `ProvenBatchError` to align with `ProvenBlockError`, `ProposedBlockError` and `ProposedBatchError`.

closes #1156
closes #1159
closes #920