### PR TITLE
feat: add remote block prover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [BREAKING] Implemented a `RemoteBatchProver`. `miden-proving-service` workers can prove batches (#1142).
 - [BREAKING] Implement `LocalBlockProver` and rename `Block` to `ProvenBlock` (#1152, #1168).
 - [BREAKING] Added native types to `AccountComponentTemplate` (#1124).
-- Implemented `RemoteBlockProver`. `miden-proving-service` workers can prove blocks (#????).
+- Implemented `RemoteBlockProver`. `miden-proving-service` workers can prove blocks (#1169).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [BREAKING] Implemented a `RemoteBatchProver`. `miden-proving-service` workers can prove batches (#1142).
 - [BREAKING] Implement `LocalBlockProver` and rename `Block` to `ProvenBlock` (#1152, #1168).
 - [BREAKING] Added native types to `AccountComponentTemplate` (#1124).
+- Implemented `RemoteBlockProver`. `miden-proving-service` workers can prove blocks (#????).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap 4.5.30",
+ "miden-block-prover",
  "miden-lib",
  "miden-objects",
  "miden-tx",
@@ -2032,8 +2033,10 @@ version = "0.8.0"
 dependencies = [
  "async-trait",
  "getrandom 0.2.15",
+ "miden-block-prover",
  "miden-objects",
  "miden-tx",
+ "miden-tx-batch-prover",
  "miette",
  "prost",
  "prost-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,6 @@ dependencies = [
  "getrandom 0.2.15",
  "miden-objects",
  "miden-tx",
- "miden-tx-batch-prover",
  "miette",
  "prost",
  "prost-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,7 +2033,6 @@ version = "0.8.0"
 dependencies = [
  "async-trait",
  "getrandom 0.2.15",
- "miden-block-prover",
  "miden-objects",
  "miden-tx",
  "miden-tx-batch-prover",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ lto = true
 [workspace.dependencies]
 assembly = { package = "miden-assembly", version = "0.12", default-features = false }
 assert_matches = { version = "1.5", default-features = false }
+miden-block-prover = { path = "crates/miden-block-prover", version = "0.8", default-features = false }
 miden-crypto = { version = "0.13", default-features = false }
 miden-lib = { path = "crates/miden-lib", version = "0.8", default-features = false }
 miden-objects = { path = "crates/miden-objects", version = "0.8", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ BUILD_GENERATED_FILES_IN_SRC=BUILD_GENERATED_FILES_IN_SRC=1
 # Enable backtraces for tests where we return an anyhow::Result. If enabled, anyhow::Error will
 # then contain a `Backtrace` and print it when a test returns an error.
 BACKTRACE=RUST_BACKTRACE=1
+ALL_REMOTE_PROVER_FEATURES=--features tx-prover,batch-prover,block-prover
 
 # -- linting --------------------------------------------------------------------------------------
 
@@ -25,7 +26,7 @@ clippy: ## Runs Clippy with configs
 
 .PHONY: clippy-no-std
 clippy-no-std: ## Runs Clippy with configs
-	cargo clippy --no-default-features --target wasm32-unknown-unknown --workspace --lib --features tx-prover,batch-prover --exclude miden-proving-service -- -D warnings
+	cargo clippy --no-default-features --target wasm32-unknown-unknown --workspace --lib $(ALL_REMOTE_PROVER_FEATURES) --exclude miden-proving-service -- -D warnings
 
 
 .PHONY: fix
@@ -106,12 +107,12 @@ build: ## By default we should build in release mode
 
 .PHONY: build-no-std
 build-no-std: ## Build without the standard library
-	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --lib --features tx-prover,batch-prover --exclude miden-proving-service
+	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --lib $(ALL_REMOTE_PROVER_FEATURES) --exclude miden-proving-service
 
 
 .PHONY: build-no-std-testing
 build-no-std-testing: ## Build without the standard library. Includes the `testing` feature
-	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx --features testing,tx-prover,batch-prover --exclude miden-proving-service
+	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx --features testing $(ALL_REMOTE_PROVER_FEATURES) --exclude miden-proving-service
 
 
 .PHONY: build-async

--- a/bin/proving-service/Cargo.toml
+++ b/bin/proving-service/Cargo.toml
@@ -24,11 +24,11 @@ async-trait = "0.1"
 axum = { version = "0.7" }
 bytes = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
-miden-block-prover ={ workspace = true, default-features = false }
+miden-block-prover = { workspace = true, default-features = false }
 miden-lib = { workspace = true, default-features = false }
 miden-objects = { workspace = true, default-features = false, features = ["std"] }
 miden-tx = { workspace = true, default-features = false, features = ["std"] }
-miden-tx-batch-prover = { workspace = true, default-features = false, features = ["std"]}
+miden-tx-batch-prover = { workspace = true, default-features = false, features = ["std"] }
 opentelemetry = { version = "0.27", features = ["metrics", "trace"] }
 opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.27", features = ["metrics", "rt-tokio"] }

--- a/bin/proving-service/Cargo.toml
+++ b/bin/proving-service/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1"
 axum = { version = "0.7" }
 bytes = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
+miden-block-prover ={ workspace = true, default-features = false }
 miden-lib = { workspace = true, default-features = false }
 miden-objects = { workspace = true, default-features = false, features = ["std"] }
 miden-tx = { workspace = true, default-features = false, features = ["std"] }

--- a/bin/proving-service/README.md
+++ b/bin/proving-service/README.md
@@ -1,6 +1,6 @@
 # Miden proving service
 
-A service for generating Miden proofs on-demand. The binary enables spawning workers and a proxy for Miden's remote proving service. It currently supports proving individual transactions, transaction batches and blocks.
+A service for generating Miden proofs on-demand. The binary enables spawning workers and a proxy for Miden's remote proving service. It currently supports proving individual transactions, transaction batches, and blocks.
 
 The worker is a gRPC service that can receive transaction witnesses or proposed batches and returns the proof. It can only handle one request at a time and returns an error if it is already in use.
 
@@ -26,7 +26,7 @@ miden-proving-service start-worker --host 0.0.0.0 --port 8082 --tx-prover --batc
 
 This will spawn a worker using the hosts and ports defined in the command options. In case that one of the values is not present, it will default to `0.0.0.0` for the host and `50051` for the port. This command will start a worker that can handle transaction and batch proving requests.
 
-Note that the worker service can be started with the `--tx-prover`, `--batch-prover` and `--block-prover` flags, to handle transaction, batch and block proving requests, respectively, or it can be with any combination of them to handle multiple types of requests.
+Note that the worker service can be started with the `--tx-prover`, `--batch-prover`, and `--block-prover` flags, to handle transaction, batch, and block proving requests, respectively, or it can be with any combination of them to handle multiple types of requests.
 
 ## Proxy
 

--- a/bin/proving-service/README.md
+++ b/bin/proving-service/README.md
@@ -1,6 +1,6 @@
 # Miden proving service
 
-A service for generating Miden proofs on-demand. The binary enables spawning workers and a proxy for Miden's remote proving service. It currently supports proving individual transactions and transaction batches.
+A service for generating Miden proofs on-demand. The binary enables spawning workers and a proxy for Miden's remote proving service. It currently supports proving individual transactions, transaction batches and blocks.
 
 The worker is a gRPC service that can receive transaction witnesses or proposed batches and returns the proof. It can only handle one request at a time and returns an error if it is already in use.
 
@@ -26,7 +26,7 @@ miden-proving-service start-worker --host 0.0.0.0 --port 8082 --tx-prover --batc
 
 This will spawn a worker using the hosts and ports defined in the command options. In case that one of the values is not present, it will default to `0.0.0.0` for the host and `50051` for the port. This command will start a worker that can handle transaction and batch proving requests.
 
-Note that the worker service can be started with the `--tx-prover` and `--batch-prover` flags, to handle transaction or batch proving requests, respectively, or it can be started with both flags to handle both types of requests.
+Note that the worker service can be started with the `--tx-prover`, `--batch-prover` and `--block-prover` flags, to handle transaction, batch and block proving requests, respectively, or it can be with any combination of them to handle multiple types of requests.
 
 ## Proxy
 

--- a/bin/proving-service/src/api/mod.rs
+++ b/bin/proving-service/src/api/mod.rs
@@ -123,13 +123,13 @@ impl ProverRpcApi {
             .as_ref()
             .ok_or(Status::unimplemented("Batch prover is not enabled"))?;
 
-        let proof = prover.prove(proposed_batch).map_err(internal_error)?;
+        let proven_batch = prover.prove(proposed_batch).map_err(internal_error)?;
 
         // Record the batch_id in the current tracing span
-        let batch_id = proof.id();
+        let batch_id = proven_batch.id();
         tracing::Span::current().record("id", tracing::field::display(&batch_id));
 
-        Ok(Response::new(ProvingResponse { payload: proof.to_bytes() }))
+        Ok(Response::new(ProvingResponse { payload: proven_batch.to_bytes() }))
     }
 
     #[instrument(
@@ -154,14 +154,14 @@ impl ProverRpcApi {
             .as_ref()
             .ok_or(Status::unimplemented("Block prover is not enabled"))?;
 
-        let proof = prover.prove(proposed_block).map_err(internal_error)?;
+        let proven_block = prover.prove(proposed_block).map_err(internal_error)?;
 
         // Record the commitment of the block in the current tracing span
-        let block_id = proof.hash();
+        let block_id = proven_block.hash();
 
         tracing::Span::current().record("id", tracing::field::display(&block_id));
 
-        Ok(Response::new(ProvingResponse { payload: proof.to_bytes() }))
+        Ok(Response::new(ProvingResponse { payload: proven_block.to_bytes() }))
     }
 }
 

--- a/bin/proving-service/src/api/mod.rs
+++ b/bin/proving-service/src/api/mod.rs
@@ -1,9 +1,9 @@
 use miden_block_prover::LocalBlockProver;
 use miden_objects::{
     batch::ProposedBatch, block::ProposedBlock, transaction::TransactionWitness,
-    MIN_PROOF_SECURITY_LEVEL,
+    utils::Serializable, MIN_PROOF_SECURITY_LEVEL,
 };
-use miden_tx::{utils::Serializable, LocalTransactionProver, TransactionProver};
+use miden_tx::{LocalTransactionProver, TransactionProver};
 use miden_tx_batch_prover::LocalBatchProver;
 use tokio::{net::TcpListener, sync::Mutex};
 use tonic::{Request, Response, Status};

--- a/bin/proving-service/src/api/mod.rs
+++ b/bin/proving-service/src/api/mod.rs
@@ -1,5 +1,7 @@
+use miden_block_prover::LocalBlockProver;
 use miden_objects::{
-    batch::ProposedBatch, transaction::TransactionWitness, MIN_PROOF_SECURITY_LEVEL,
+    batch::ProposedBatch, block::ProposedBlock, transaction::TransactionWitness,
+    MIN_PROOF_SECURITY_LEVEL,
 };
 use miden_tx::{utils::Serializable, LocalTransactionProver, TransactionProver};
 use miden_tx_batch_prover::LocalBatchProver;
@@ -31,6 +33,7 @@ impl RpcListener {
 struct Provers {
     tx_prover: Option<LocalTransactionProver>,
     batch_prover: Option<LocalBatchProver>,
+    block_prover: Option<LocalBlockProver>,
 }
 
 impl Provers {
@@ -47,7 +50,13 @@ impl Provers {
             None
         };
 
-        Self { tx_prover, batch_prover }
+        let block_prover = if prover_type_support.supports_block() {
+            Some(LocalBlockProver::new(MIN_PROOF_SECURITY_LEVEL))
+        } else {
+            None
+        };
+
+        Self { tx_prover, batch_prover, block_prover }
     }
 }
 
@@ -122,6 +131,38 @@ impl ProverRpcApi {
 
         Ok(Response::new(ProvingResponse { payload: proof.to_bytes() }))
     }
+
+    #[instrument(
+        target = MIDEN_PROVING_SERVICE,
+        name = "proving_service:prove_block",
+        skip_all,
+        ret(level = "debug"),
+        fields(id = tracing::field::Empty),
+        err
+    )]
+    pub fn prove_block(
+        &self,
+        proposed_block: ProposedBlock,
+    ) -> Result<Response<ProvingResponse>, tonic::Status> {
+        let prover = self
+            .provers
+            .try_lock()
+            .map_err(|_| Status::resource_exhausted("Server is busy handling another request"))?;
+
+        let prover = prover
+            .block_prover
+            .as_ref()
+            .ok_or(Status::unimplemented("Block prover is not enabled"))?;
+
+        let proof = prover.prove(proposed_block).map_err(internal_error)?;
+
+        // Record the commitment of the block in the current tracing span
+        let block_id = proof.hash();
+
+        tracing::Span::current().record("id", tracing::field::display(&block_id));
+
+        Ok(Response::new(ProvingResponse { payload: proof.to_bytes() }))
+    }
 }
 
 #[async_trait::async_trait]
@@ -147,7 +188,10 @@ impl ProverApi for ProverRpcApi {
                 let proposed_batch = request.into_inner().try_into().map_err(invalid_argument)?;
                 self.prove_batch(proposed_batch)
             },
-            _ => Err(internal_error("Invalid proof type")),
+            ProofType::Block => {
+                let proposed_block = request.into_inner().try_into().map_err(invalid_argument)?;
+                self.prove_block(proposed_block)
+            },
         }
     }
 }

--- a/bin/proving-service/src/commands/worker.rs
+++ b/bin/proving-service/src/commands/worker.rs
@@ -15,6 +15,9 @@ pub struct ProverTypeSupport {
     /// Mark the worker as a batch prover
     #[clap(short, long, default_value = "false")]
     batch_prover: bool,
+    /// Mark the worker as a block prover
+    #[clap(short, long, default_value = "false")]
+    block_prover: bool,
 }
 
 impl ProverTypeSupport {
@@ -28,6 +31,11 @@ impl ProverTypeSupport {
         self.batch_prover
     }
 
+    /// Checks if the worker is a block prover.
+    pub fn supports_block(&self) -> bool {
+        self.block_prover
+    }
+
     /// Mark the worker as a transaction prover.
     pub fn with_transaction(mut self) -> Self {
         self.tx_prover = true;
@@ -37,6 +45,12 @@ impl ProverTypeSupport {
     /// Mark the worker as a batch prover.
     pub fn with_batch(mut self) -> Self {
         self.batch_prover = true;
+        self
+    }
+
+    /// Mark the worker as a block prover.
+    pub fn with_block(mut self) -> Self {
+        self.block_prover = true;
         self
     }
 }

--- a/bin/proving-service/src/commands/worker.rs
+++ b/bin/proving-service/src/commands/worker.rs
@@ -6,16 +6,17 @@ use tracing::{info, instrument};
 
 use crate::{api::RpcListener, generated::api_server::ApiServer, utils::MIDEN_PROVING_SERVICE};
 
-/// Defines the possible types of provers that a worker can be.
+/// Specifies the types of proving tasks a worker can handle.
+/// Multiple options can be enabled simultaneously.
 #[derive(Debug, Parser, Clone, Copy, Default)]
 pub struct ProverTypeSupport {
-    /// Mark the worker as a transaction prover
+    /// Enables transaction proving.
     #[clap(short, long, default_value = "false")]
     tx_prover: bool,
-    /// Mark the worker as a batch prover
+    /// Enables batch proving.
     #[clap(short, long, default_value = "false")]
     batch_prover: bool,
-    /// Mark the worker as a block prover
+    /// Enables block proving.
     #[clap(short, long, default_value = "false")]
     block_prover: bool,
 }

--- a/bin/proving-service/src/generated/mod.rs
+++ b/bin/proving-service/src/generated/mod.rs
@@ -1,5 +1,6 @@
 use miden_objects::{
     batch::ProposedBatch,
+    block::ProposedBlock,
     transaction::{ProvenTransaction, TransactionWitness},
 };
 use miden_tx::utils::{Deserializable, DeserializationError, Serializable};
@@ -39,5 +40,13 @@ impl TryFrom<ProvingRequest> for ProposedBatch {
 
     fn try_from(request: ProvingRequest) -> Result<Self, Self::Error> {
         ProposedBatch::read_from_bytes(&request.payload)
+    }
+}
+
+impl TryFrom<ProvingRequest> for ProposedBlock {
+    type Error = DeserializationError;
+
+    fn try_from(request: ProvingRequest) -> Result<Self, Self::Error> {
+        ProposedBlock::read_from_bytes(&request.payload)
     }
 }

--- a/crates/miden-objects/src/block/account_update_witness.rs
+++ b/crates/miden-objects/src/block/account_update_witness.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
 
 use miden_crypto::merkle::MerklePath;
-use vm_processor::Digest;
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_processor::{DeserializationError, Digest};
 
 use crate::{account::delta::AccountUpdateDetails, transaction::TransactionId};
 
@@ -99,5 +100,35 @@ impl AccountUpdateWitness {
             self.details,
             self.transactions,
         )
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for AccountUpdateWitness {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.initial_state_commitment);
+        target.write(self.final_state_commitment);
+        target.write(&self.initial_state_proof);
+        target.write(&self.details);
+        target.write(&self.transactions);
+    }
+}
+
+impl Deserializable for AccountUpdateWitness {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let initial_state_commitment = source.read()?;
+        let final_state_commitment = source.read()?;
+        let initial_state_proof = source.read()?;
+        let details = source.read()?;
+        let transactions = source.read()?;
+        Ok(AccountUpdateWitness {
+            initial_state_commitment,
+            final_state_commitment,
+            initial_state_proof,
+            details,
+            transactions,
+        })
     }
 }

--- a/crates/miden-objects/src/block/nullifier_witness.rs
+++ b/crates/miden-objects/src/block/nullifier_witness.rs
@@ -1,4 +1,6 @@
 use miden_crypto::merkle::SmtProof;
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_processor::DeserializationError;
 
 // NULLIFIER WITNESS
 // ================================================================================================
@@ -23,5 +25,18 @@ impl NullifierWitness {
     /// Consumes the witness and returns the underlying [`SmtProof`].
     pub fn into_proof(self) -> SmtProof {
         self.proof
+    }
+}
+
+impl Serializable for NullifierWitness {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(&self.proof);
+    }
+}
+
+impl Deserializable for NullifierWitness {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let proof = source.read()?;
+        Ok(Self::new(proof))
     }
 }

--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -17,7 +17,8 @@ crate-type = ["lib"]
 default = ["std"]
 std = ["miden-objects/std", "miden-tx/std"]
 tx-prover = ["miden-tx/async"]
-batch-prover = ["miden-tx/async", "dep:tokio"]
+batch-prover = ["miden-tx/async", "dep:tokio", "dep:miden-tx-batch-prover"]
+block-prover = ["miden-tx/async", "dep:tokio", "dep:miden-block-prover"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 tonic-web-wasm-client = { version = "0.6", default-features = false }
@@ -30,8 +31,10 @@ tonic-web = { version = "0.12", optional = true }
 
 [dependencies]
 async-trait = "0.1"
+miden-block-prover = { workspace = true, default-features = false, optional = true }
 miden-objects = { workspace = true, default-features = false }
 miden-tx = { workspace = true, default-features = false }
+miden-tx-batch-prover = { workspace = true, default-features = false, optional = true}
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.38", default-features = false, features = ["sync"], optional = true }

--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -18,7 +18,7 @@ default = ["std"]
 std = ["miden-objects/std", "miden-tx/std"]
 tx-prover = ["miden-tx/async"]
 batch-prover = ["miden-tx/async", "dep:tokio", "dep:miden-tx-batch-prover"]
-block-prover = ["miden-tx/async", "dep:tokio", "dep:miden-block-prover"]
+block-prover = ["miden-tx/async", "dep:tokio"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 tonic-web-wasm-client = { version = "0.6", default-features = false }
@@ -31,7 +31,6 @@ tonic-web = { version = "0.12", optional = true }
 
 [dependencies]
 async-trait = "0.1"
-miden-block-prover = { workspace = true, default-features = false, optional = true }
 miden-objects = { workspace = true, default-features = false }
 miden-tx = { workspace = true, default-features = false }
 miden-tx-batch-prover = { workspace = true, default-features = false, optional = true}

--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["lib"]
 [features]
 default = ["std"]
 std = ["miden-objects/std", "miden-tx/std"]
-tx-prover = ["miden-tx/async"]
+tx-prover = ["miden-tx/async", "dep:tokio"]
 batch-prover = ["dep:miden-tx", "dep:tokio"]
 block-prover = ["dep:miden-tx", "dep:tokio"]
 

--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["lib"]
 [features]
 default = ["std"]
 std = ["miden-objects/std", "miden-tx/std"]
-tx-prover = ["miden-tx/async", "dep:tokio"]
-batch-prover = ["dep:miden-tx", "dep:tokio"]
-block-prover = ["dep:miden-tx", "dep:tokio"]
+tx-prover = ["miden-tx/async", "dep:tokio", "dep:miden-objects"]
+batch-prover = ["dep:tokio", "dep:miden-objects"]
+block-prover = ["dep:tokio", "dep:miden-objects"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 tonic-web-wasm-client = { version = "0.6", default-features = false }
@@ -31,7 +31,7 @@ tonic-web = { version = "0.12", optional = true }
 
 [dependencies]
 async-trait = "0.1"
-miden-objects = { workspace = true, default-features = false }
+miden-objects = { workspace = true, default-features = false, optional = true }
 miden-tx = { workspace = true, default-features = false, optional = true }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 thiserror = "2.0"

--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["lib"]
 default = ["std"]
 std = ["miden-objects/std", "miden-tx/std"]
 tx-prover = ["miden-tx/async"]
-batch-prover = ["miden-tx/async", "dep:tokio", "dep:miden-tx-batch-prover"]
-block-prover = ["miden-tx/async", "dep:tokio"]
+batch-prover = ["dep:miden-tx", "dep:tokio"]
+block-prover = ["dep:miden-tx", "dep:tokio"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 tonic-web-wasm-client = { version = "0.6", default-features = false }
@@ -32,8 +32,7 @@ tonic-web = { version = "0.12", optional = true }
 [dependencies]
 async-trait = "0.1"
 miden-objects = { workspace = true, default-features = false }
-miden-tx = { workspace = true, default-features = false }
-miden-tx-batch-prover = { workspace = true, default-features = false, optional = true}
+miden-tx = { workspace = true, default-features = false, optional = true }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.38", default-features = false, features = ["sync"], optional = true }

--- a/crates/miden-proving-service-client/README.md
+++ b/crates/miden-proving-service-client/README.md
@@ -1,6 +1,6 @@
 # Miden remote provers
 
-This crate contains protobuf definition for the Miden transaction proving services. It also provides an optional `RemoteTransactionProver`, `RemoteBatchProver` and `RemoteBlockProver`, which can be used to interact with a remote proving service.
+This crate contains protobuf definition for the Miden transaction proving services. It also provides an optional `RemoteTransactionProver`, `RemoteBatchProver` and `RemoteBlockProver` structs, which can be used to interact with a remote proving service.
 
 ## Features
 

--- a/crates/miden-proving-service-client/README.md
+++ b/crates/miden-proving-service-client/README.md
@@ -1,6 +1,6 @@
 # Miden remote provers
 
-This crate contains protobuf definition for the Miden transaction proving services. It also provides an optional `RemoteTransactionProver` and `RemoteBatchProver`, which can be used to interact with a remote proving service.
+This crate contains protobuf definition for the Miden transaction proving services. It also provides an optional `RemoteTransactionProver`, `RemoteBatchProver` and `RemoteBlockProver`, which can be used to interact with a remote proving service.
 
 ## Features
 
@@ -11,6 +11,7 @@ Description of this crate's features:
 | `std`         | Enable usage of Rust's `std`, use `--no-default-features` for `no-std` support.                             |
 | `tx-prover`   | Makes the `RemoteTransactionProver` struct public.                                                          |
 | `batch-prover`| Makes the `RemoteBatchProver` struct public.                                                                |
+| `block-prover`| Makes the `RemoteBlockProver` struct public.                                                                |
 
 ## License
 

--- a/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
@@ -1,5 +1,4 @@
 use alloc::{
-    boxed::Box,
     string::{String, ToString},
     sync::Arc,
 };

--- a/crates/miden-proving-service-client/src/proving_service/block_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/block_prover.rs
@@ -1,5 +1,4 @@
 use alloc::{
-    boxed::Box,
     string::{String, ToString},
     sync::Arc,
 };

--- a/crates/miden-proving-service-client/src/proving_service/generated/mod.rs
+++ b/crates/miden-proving-service-client/src/proving_service/generated/mod.rs
@@ -1,10 +1,3 @@
-use miden_objects::{
-    batch::{ProposedBatch, ProvenBatch},
-    block::{ProposedBlock, ProvenBlock},
-    transaction::{ProvenTransaction, TransactionWitness},
-};
-use miden_tx::utils::{Deserializable, DeserializationError, Serializable};
-
 #[cfg(all(feature = "std", target_arch = "wasm32"))]
 compile_error!("The `std` feature cannot be used when targeting `wasm32`.");
 
@@ -17,63 +10,3 @@ pub use std::proving_service::*;
 mod nostd;
 #[cfg(not(feature = "std"))]
 pub use nostd::proving_service::*;
-
-// CONVERSIONS
-// ================================================================================================
-
-impl From<ProvenTransaction> for ProvingResponse {
-    fn from(value: ProvenTransaction) -> Self {
-        ProvingResponse { payload: value.to_bytes() }
-    }
-}
-
-impl TryFrom<ProvingResponse> for ProvenTransaction {
-    type Error = DeserializationError;
-
-    fn try_from(response: ProvingResponse) -> Result<Self, Self::Error> {
-        ProvenTransaction::read_from_bytes(&response.payload)
-    }
-}
-
-impl From<TransactionWitness> for ProvingRequest {
-    fn from(witness: TransactionWitness) -> Self {
-        ProvingRequest {
-            proof_type: ProofType::Transaction.into(),
-            payload: witness.to_bytes(),
-        }
-    }
-}
-
-impl From<ProposedBatch> for ProvingRequest {
-    fn from(proposed_batch: ProposedBatch) -> Self {
-        ProvingRequest {
-            proof_type: ProofType::Batch.into(),
-            payload: proposed_batch.to_bytes(),
-        }
-    }
-}
-
-impl TryFrom<ProvingResponse> for ProvenBatch {
-    type Error = DeserializationError;
-
-    fn try_from(response: ProvingResponse) -> Result<Self, Self::Error> {
-        ProvenBatch::read_from_bytes(&response.payload)
-    }
-}
-
-impl TryFrom<ProvingResponse> for ProvenBlock {
-    type Error = DeserializationError;
-
-    fn try_from(value: ProvingResponse) -> Result<Self, Self::Error> {
-        ProvenBlock::read_from_bytes(&value.payload)
-    }
-}
-
-impl From<ProposedBlock> for ProvingRequest {
-    fn from(proposed_block: ProposedBlock) -> Self {
-        ProvingRequest {
-            proof_type: ProofType::Block.into(),
-            payload: proposed_block.to_bytes(),
-        }
-    }
-}

--- a/crates/miden-proving-service-client/src/proving_service/generated/mod.rs
+++ b/crates/miden-proving-service-client/src/proving_service/generated/mod.rs
@@ -1,5 +1,6 @@
 use miden_objects::{
     batch::{ProposedBatch, ProvenBatch},
+    block::{ProposedBlock, ProvenBlock},
     transaction::{ProvenTransaction, TransactionWitness},
 };
 use miden_tx::utils::{Deserializable, DeserializationError, Serializable};
@@ -57,5 +58,22 @@ impl TryFrom<ProvingResponse> for ProvenBatch {
 
     fn try_from(response: ProvingResponse) -> Result<Self, Self::Error> {
         ProvenBatch::read_from_bytes(&response.payload)
+    }
+}
+
+impl TryFrom<ProvingResponse> for ProvenBlock {
+    type Error = DeserializationError;
+
+    fn try_from(value: ProvingResponse) -> Result<Self, Self::Error> {
+        ProvenBlock::read_from_bytes(&value.payload)
+    }
+}
+
+impl From<ProposedBlock> for ProvingRequest {
+    fn from(proposed_block: ProposedBlock) -> Self {
+        ProvingRequest {
+            proof_type: ProofType::Block.into(),
+            payload: proposed_block.to_bytes(),
+        }
     }
 }

--- a/crates/miden-proving-service-client/src/proving_service/mod.rs
+++ b/crates/miden-proving-service-client/src/proving_service/mod.rs
@@ -16,3 +16,6 @@ pub mod tx_prover;
 
 #[cfg(feature = "batch-prover")]
 pub mod batch_prover;
+
+#[cfg(feature = "block-prover")]
+pub mod block_prover;

--- a/crates/miden-proving-service-client/src/proving_service/mod.rs
+++ b/crates/miden-proving-service-client/src/proving_service/mod.rs
@@ -1,14 +1,5 @@
 pub mod generated;
 
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-};
-
-use generated::api_client::ApiClient;
-use miden_objects::transaction::{ProvenTransaction, TransactionWitness};
-use miden_tx::{utils::sync::RwLock, TransactionProver, TransactionProverError};
-
 use crate::RemoteProverError;
 
 #[cfg(feature = "tx-prover")]


### PR DESCRIPTION
Closes #1034 

This PR adds a block prover to the `miden-proving-service` workers, and a `RemoteBlockProver` in the `miden-proving-service-client` crate.