### PR TITLE
Allow blocks with empty batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Added serialization for `ProposedBatch`, `BatchId`, `BatchNoteTree` and `ProvenBatch` (#1140).
 - Added `prefix` to `Nullifier` (#1153).
 - [BREAKING] Implemented a `RemoteBatchProver`. `miden-proving-service` workers can prove batches (#1142).
-- [BREAKING] Implement `LocalBlockProver` and rename `Block` to `ProvenBlock` (#1152, #1168).
+- [BREAKING] Implement `LocalBlockProver` and rename `Block` to `ProvenBlock` (#1152, #1168, #1172).
 - [BREAKING] Added native types to `AccountComponentTemplate` (#1124).
 - Implemented `RemoteBlockProver`. `miden-proving-service` workers can prove blocks (#1169).
 

--- a/crates/miden-block-prover/src/local_block_prover.rs
+++ b/crates/miden-block-prover/src/local_block_prover.rs
@@ -182,6 +182,11 @@ fn compute_nullifiers(
     prev_block_header: &BlockHeader,
     block_num: BlockNumber,
 ) -> Result<(Vec<Nullifier>, Digest), ProvenBlockError> {
+    // If no nullifiers were created, the nullifier tree root is unchanged.
+    if created_nullifiers.is_empty() {
+        return Ok((Vec::new(), prev_block_header.nullifier_root()));
+    }
+
     let nullifiers: Vec<Nullifier> = created_nullifiers.keys().copied().collect();
 
     let mut partial_nullifier_tree = PartialNullifierTree::new();
@@ -234,6 +239,11 @@ fn compute_account_root(
     updated_accounts: &mut Vec<(AccountId, AccountUpdateWitness)>,
     prev_block_header: &BlockHeader,
 ) -> Result<Digest, ProvenBlockError> {
+    // If no accounts were updated, the account tree root is unchanged.
+    if updated_accounts.is_empty() {
+        return Ok(prev_block_header.account_root());
+    }
+
     let mut partial_account_tree = PartialMerkleTree::new();
 
     // First reconstruct the current account tree from the provided merkle paths.

--- a/crates/miden-block-prover/src/local_block_prover.rs
+++ b/crates/miden-block-prover/src/local_block_prover.rs
@@ -296,7 +296,8 @@ fn compute_block_note_tree(output_note_batches: &[OutputNoteBatch]) -> BlockNote
                     // SAFETY: The proposed block contains at most the max allowed number of
                     // batches and each batch is guaranteed to contain at most
                     // the max allowed number of output notes.
-                    BlockNoteIndex::new(batch_idx, *note_idx_in_batch),
+                    BlockNoteIndex::new(batch_idx, *note_idx_in_batch)
+                        .expect("max batches in block and max notes in batches should be enforced"),
                     note.id(),
                     *note.metadata(),
                 )

--- a/crates/miden-block-prover/src/tests/proposed_block_errors.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_errors.rs
@@ -18,25 +18,6 @@ use crate::tests::utils::{
     generate_untracked_note_with_output_note, setup_chain, ProvenTransactionExt, TestSetup,
 };
 
-/// Tests that empty batches produce an error.
-#[test]
-fn proposed_block_fails_on_empty_batches() -> anyhow::Result<()> {
-    let TestSetup { chain, .. } = setup_chain(2);
-
-    let block_inputs = BlockInputs::new(
-        chain.latest_block_header(),
-        chain.latest_chain_mmr(),
-        BTreeMap::default(),
-        BTreeMap::default(),
-        BTreeMap::default(),
-    );
-    let error = ProposedBlock::new(block_inputs, Vec::new()).unwrap_err();
-
-    assert_matches!(error, ProposedBlockError::EmptyBlock);
-
-    Ok(())
-}
-
 /// Tests that too many batches produce an error.
 #[test]
 fn proposed_block_fails_on_too_many_batches() -> anyhow::Result<()> {

--- a/crates/miden-block-prover/src/tests/proposed_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_success.rs
@@ -31,7 +31,7 @@ fn proposed_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
 
     assert_eq!(block.affected_accounts().count(), 0);
     assert_eq!(block.output_note_batches().len(), 0);
-    assert_eq!(block.nullifiers().len(), 0);
+    assert_eq!(block.created_nullifiers().len(), 0);
     assert_eq!(block.batches().len(), 0);
 
     Ok(())
@@ -72,12 +72,12 @@ fn proposed_block_basic_success() -> anyhow::Result<()> {
         proven_tx1.account_update().final_state_hash()
     );
     // Each tx consumes one note.
-    assert_eq!(proposed_block.nullifiers().len(), 2);
+    assert_eq!(proposed_block.created_nullifiers().len(), 2);
     assert!(proposed_block
-        .nullifiers()
+        .created_nullifiers()
         .contains_key(&proven_tx0.input_notes().get_note(0).nullifier()));
     assert!(proposed_block
-        .nullifiers()
+        .created_nullifiers()
         .contains_key(&proven_tx1.input_notes().get_note(0).nullifier()));
 
     // There are two batches in the block...
@@ -208,9 +208,9 @@ fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
 
     // We expect both notes to have been authenticated and therefore should be part of the
     // nullifiers of this block.
-    assert_eq!(proposed_block.nullifiers().len(), 2);
-    assert!(proposed_block.nullifiers().contains_key(&note0.nullifier()));
-    assert!(proposed_block.nullifiers().contains_key(&note1.nullifier()));
+    assert_eq!(proposed_block.created_nullifiers().len(), 2);
+    assert!(proposed_block.created_nullifiers().contains_key(&note0.nullifier()));
+    assert!(proposed_block.created_nullifiers().contains_key(&note1.nullifier()));
     // There are two batches in the block...
     assert_eq!(proposed_block.output_note_batches().len(), 2);
     // ... but none of them create notes.

--- a/crates/miden-block-prover/src/tests/proposed_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_success.rs
@@ -2,8 +2,10 @@ use std::{collections::BTreeMap, vec::Vec};
 
 use anyhow::Context;
 use miden_objects::{
-    account::AccountId, block::ProposedBlock,
-    testing::account_id::ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, transaction::ProvenTransaction,
+    account::AccountId,
+    block::{BlockInputs, ProposedBlock},
+    testing::account_id::ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
+    transaction::ProvenTransaction,
 };
 
 use crate::tests::utils::{
@@ -12,6 +14,28 @@ use crate::tests::utils::{
     generate_tx_with_unauthenticated_notes, generate_untracked_note, setup_chain,
     ProvenTransactionExt, TestSetup,
 };
+
+/// Tests that we can build empty blocks.
+#[test]
+fn proposed_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
+    let TestSetup { chain, .. } = setup_chain(2);
+
+    let block_inputs = BlockInputs::new(
+        chain.latest_block_header(),
+        chain.latest_chain_mmr(),
+        BTreeMap::default(),
+        BTreeMap::default(),
+        BTreeMap::default(),
+    );
+    let block = ProposedBlock::new(block_inputs, Vec::new()).context("failed to propose block")?;
+
+    assert_eq!(block.affected_accounts().count(), 0);
+    assert_eq!(block.output_note_batches().len(), 0);
+    assert_eq!(block.nullifiers().len(), 0);
+    assert_eq!(block.batches().len(), 0);
+
+    Ok(())
+}
 
 /// Tests that a proposed block from two batches with one transaction each can be successfully
 /// built.

--- a/crates/miden-block-prover/src/tests/proven_block_error.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_error.rs
@@ -213,7 +213,7 @@ fn proven_block_fails_on_nullifier_tree_root_mismatch() -> anyhow::Result<()> {
 
     // Make the block inputs invalid by using a single stale nullifier witnesses.
     let mut invalid_nullifier_witness_block_inputs = valid_block_inputs.clone();
-    let batch_nullifier0 = batches[0].produced_nullifiers().next().unwrap();
+    let batch_nullifier0 = batches[0].created_nullifiers().next().unwrap();
     core::mem::swap(
         invalid_nullifier_witness_block_inputs
             .nullifier_witnesses_mut()

--- a/crates/miden-block-prover/src/tests/proven_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_success.rs
@@ -84,7 +84,11 @@ fn proven_block_success() -> anyhow::Result<()> {
 
     let expected_block_note_tree = BlockNoteTree::with_entries(batch0_iter.chain(batch1_iter).map(
         |(batch_idx, note_idx_in_batch, note)| {
-            (BlockNoteIndex::new(batch_idx, note_idx_in_batch), note.id(), *note.metadata())
+            (
+                BlockNoteIndex::new(batch_idx, note_idx_in_batch).unwrap(),
+                note.id(),
+                *note.metadata(),
+            )
         },
     ))
     .unwrap();

--- a/crates/miden-block-prover/src/tests/proven_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_success.rs
@@ -93,7 +93,7 @@ fn proven_block_success() -> anyhow::Result<()> {
     // --------------------------------------------------------------------------------------------
 
     let mut expected_nullifier_tree = chain.nullifiers().clone();
-    for nullifier in proposed_block.nullifiers().keys() {
+    for nullifier in proposed_block.created_nullifiers().keys() {
         expected_nullifier_tree.insert(
             nullifier.inner(),
             [Felt::from(proposed_block.block_num()), Felt::ZERO, Felt::ZERO, Felt::ZERO],
@@ -266,10 +266,10 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
 
     // The output note should have been erased, so we expect only the nullifiers of note0, note2 and
     // note3 to be created.
-    assert_eq!(proposed_block.nullifiers().len(), 3);
-    assert!(proposed_block.nullifiers().contains_key(&note0.nullifier()));
-    assert!(proposed_block.nullifiers().contains_key(&note2.nullifier()));
-    assert!(proposed_block.nullifiers().contains_key(&note3.nullifier()));
+    assert_eq!(proposed_block.created_nullifiers().len(), 3);
+    assert!(proposed_block.created_nullifiers().contains_key(&note0.nullifier()));
+    assert!(proposed_block.created_nullifiers().contains_key(&note2.nullifier()));
+    assert!(proposed_block.created_nullifiers().contains_key(&note3.nullifier()));
 
     // There are two batches in the block.
     assert_eq!(proposed_block.output_note_batches().len(), 2);

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -183,7 +183,6 @@ impl ProposedBatch {
 
         // Populate batch output notes and updated accounts.
         let mut account_updates = BTreeMap::<AccountId, BatchAccountUpdate>::new();
-        let mut batch_expiration_block_num = BlockNumber::from(u32::MAX);
         for tx in transactions.iter() {
             // Merge account updates so that state transitions A->B->C become A->C.
             match account_updates.entry(tx.account_id()) {
@@ -202,10 +201,6 @@ impl ProposedBatch {
                     })?;
                 },
             };
-
-            // The expiration block of the batch is the minimum of all transaction's expiration
-            // block.
-            batch_expiration_block_num = batch_expiration_block_num.min(tx.expiration_block_num());
         }
 
         if account_updates.len() > MAX_ACCOUNTS_PER_BATCH {

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -149,15 +149,21 @@ impl ProposedBatch {
         }
 
         // Verify all block references from the transactions are in the chain MMR, except for the
-        // batch's reference block. Note that a block X is only added to the blockchain MMR by
-        // block X + 1. This is because block X cannot compute its own block commitment and
-        // thus cannot add itself to the chain. So, more generally, a parent block is added to the
-        // blockchain by its child block.
+        // batch's reference block.
+        //
+        // Note that some block X is only added to the blockchain MMR by block X + 1. This is
+        // because block X cannot compute its own block commitment and thus cannot add itself to the
+        // chain. So, more generally, a parent block is added to the blockchain by its child block.
+        //
         // The reference block of a batch may be the latest block in the chain and, as mentioned,
         // block is not yet part of the blockchain MMR, so its inclusion cannot be proven. Since the
         // inclusion cannot be proven in all cases, the batch kernel instead commits to this
-        // reference block's commitment as a public input, which means the block kernel will
-        // prove this block's inclusion when including this batch and verifying its ZK proof.
+        // reference block's commitment as a public input, which means the block kernel will prove
+        // this block's inclusion when including this batch and verifying its ZK proof.
+        //
+        // Finally, note that we don't verify anything cryptographically here. We have previously
+        // verified that the batch reference block's chain root matches the hashed peaks of the
+        // `ChainMmr`, and so we only have to check if the chain MMR contains the block here.
         // --------------------------------------------------------------------------------------------
 
         for tx in transactions.iter() {

--- a/crates/miden-objects/src/batch/proposed_batch.rs
+++ b/crates/miden-objects/src/batch/proposed_batch.rs
@@ -64,7 +64,8 @@ impl ProposedBatch {
     ///   matches the account state before any transactions are executed and B's initial account
     ///   state commitment matches the final account state commitment of A, then A must come before
     ///   B.
-    /// - The chain MMR should contain all block headers
+    /// - The chain MMR's hashed peaks must match the reference block's `chain_root` and it must
+    ///   contain all block headers:
     ///   - that are referenced by note inclusion proofs in `unauthenticated_note_proofs`.
     ///   - that are referenced by a transaction in the batch.
     /// - The `unauthenticated_note_proofs` should contain [`NoteInclusionProof`]s for any

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -94,8 +94,8 @@ impl ProvenBatch {
         &self.input_notes
     }
 
-    /// Returns an iterator over the nullifiers produced in this batch.
-    pub fn produced_nullifiers(&self) -> impl Iterator<Item = Nullifier> + use<'_> {
+    /// Returns an iterator over the nullifiers created in this batch.
+    pub fn created_nullifiers(&self) -> impl Iterator<Item = Nullifier> + use<'_> {
         self.input_notes.iter().map(InputNoteCommitment::nullifier)
     }
 

--- a/crates/miden-objects/src/block/note_tree.rs
+++ b/crates/miden-objects/src/block/note_tree.rs
@@ -108,15 +108,16 @@ pub struct BlockNoteIndex {
 impl BlockNoteIndex {
     /// Creates a new [BlockNoteIndex].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the batch index is equal to or greater than [`MAX_BATCHES_PER_BLOCK`] or if the
-    /// note index is equal to or greater than [`MAX_OUTPUT_NOTES_PER_BATCH`].
-    pub fn new(batch_idx: usize, note_idx_in_batch: usize) -> Self {
-        assert!(note_idx_in_batch < MAX_OUTPUT_NOTES_PER_BATCH);
-        assert!(batch_idx < MAX_BATCHES_PER_BLOCK);
+    /// Returns `None` if the batch index is equal to or greater than [`MAX_BATCHES_PER_BLOCK`] or
+    /// if the note index is equal to or greater than [`MAX_OUTPUT_NOTES_PER_BATCH`].
+    pub fn new(batch_idx: usize, note_idx_in_batch: usize) -> Option<Self> {
+        if batch_idx >= MAX_BATCHES_PER_BLOCK || note_idx_in_batch >= MAX_OUTPUT_NOTES_PER_BATCH {
+            return None;
+        }
 
-        Self { batch_idx, note_idx_in_batch }
+        Some(Self { batch_idx, note_idx_in_batch })
     }
 
     /// Returns the batch index.

--- a/crates/miden-objects/src/block/proposed_block.rs
+++ b/crates/miden-objects/src/block/proposed_block.rs
@@ -277,7 +277,7 @@ impl ProposedBlock {
     }
 
     /// Returns the map of nullifiers to their proofs from the proposed block.
-    pub fn nullifiers(&self) -> &BTreeMap<Nullifier, NullifierWitness> {
+    pub fn created_nullifiers(&self) -> &BTreeMap<Nullifier, NullifierWitness> {
         &self.created_nullifiers
     }
 

--- a/crates/miden-objects/src/block/proposed_block.rs
+++ b/crates/miden-objects/src/block/proposed_block.rs
@@ -77,7 +77,7 @@ impl ProposedBlock {
     ///
     /// ## Batches
     ///
-    /// - The number of batches is zero or exceeds [`MAX_BATCHES_PER_BLOCK`].
+    /// - The number of batches exceeds [`MAX_BATCHES_PER_BLOCK`].
     /// - There are duplicate batches, i.e. they have the same [`BatchId`].
     /// - The expiration block number of any batch is less than the block number of the currently
     ///   proposed block.
@@ -130,12 +130,8 @@ impl ProposedBlock {
         batches: Vec<ProvenBatch>,
         timestamp: u32,
     ) -> Result<Self, ProposedBlockError> {
-        // Check for empty or duplicate batches.
+        // Check for duplicate and max number of batches.
         // --------------------------------------------------------------------------------------------
-
-        if batches.is_empty() {
-            return Err(ProposedBlockError::EmptyBlock);
-        }
 
         if batches.len() > MAX_BATCHES_PER_BLOCK {
             return Err(ProposedBlockError::TooManyBatches);

--- a/crates/miden-objects/src/block/proven_block.rs
+++ b/crates/miden-objects/src/block/proven_block.rs
@@ -96,7 +96,8 @@ impl ProvenBlock {
                     // SAFETY: The proven block contains at most the max allowed number of batches
                     // and each batch is guaranteed to contain at most the
                     // max allowed number of output notes.
-                    BlockNoteIndex::new(batch_idx, *note_idx_in_batch),
+                    BlockNoteIndex::new(batch_idx, *note_idx_in_batch)
+                        .expect("max batches in block and max notes in batches should be enforced"),
                     note,
                 )
             })

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -761,7 +761,7 @@ impl MockChain {
             self.account_witnesses(batch_iterator.clone().flat_map(ProvenBatch::updated_accounts));
 
         let nullifier_proofs =
-            self.nullifier_witnesses(batch_iterator.flat_map(ProvenBatch::produced_nullifiers));
+            self.nullifier_witnesses(batch_iterator.flat_map(ProvenBatch::created_nullifiers));
 
         BlockInputs::new(
             block_reference_block,

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -185,7 +185,13 @@ impl PendingObjects {
         let entries =
             self.output_note_batches.iter().enumerate().flat_map(|(batch_index, batch)| {
                 batch.iter().map(move |(note_index, note)| {
-                    (BlockNoteIndex::new(batch_index, *note_index), note.id(), *note.metadata())
+                    (
+                        BlockNoteIndex::new(batch_index, *note_index).expect(
+                            "max batches in block and max notes in batches should be enforced",
+                        ),
+                        note.id(),
+                        *note.metadata(),
+                    )
                 })
             });
 
@@ -865,7 +871,10 @@ impl MockChain {
                 for (note_index, note) in note_batch.iter() {
                     match note {
                         OutputNote::Full(note) => {
-                            let block_note_index = BlockNoteIndex::new(batch_index, *note_index);
+                            let block_note_index = BlockNoteIndex::new(batch_index, *note_index)
+                                .expect(
+                                "max batches in block and max notes in batches should be enforced",
+                            );
                             let note_path = notes_tree.get_note_path(block_note_index);
                             let note_inclusion_proof = NoteInclusionProof::new(
                                 block.header().block_num(),


### PR DESCRIPTION
Allow blocks with empty batches so we can build new blocks in the node even if no transactions or batches are available.

Also clarifies comments in the proposed batch.

Consistently name `created_nullifiers` method across `ProposedBatch`, `ProposedBlock` and `ProvenBlock`.