### PR TITLE
fix: make batch provers clonable

### DIFF
--- a/crates/miden-block-prover/src/local_block_prover.rs
+++ b/crates/miden-block-prover/src/local_block_prover.rs
@@ -20,6 +20,7 @@ use crate::errors::ProvenBlockError;
 // ================================================================================================
 
 /// A local prover for blocks, proving a [`ProposedBlock`] and returning a [`ProvenBlock`].
+#[derive(Clone)]
 pub struct LocalBlockProver {}
 
 impl LocalBlockProver {

--- a/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
@@ -25,6 +25,7 @@ use crate::{
 /// transport. Otherwise, it uses the built-in `tonic::transport` for native platforms.
 ///
 /// The transport layer connection is established lazily when the first batch is proven.
+#[derive(Clone)]
 pub struct RemoteBatchProver {
     #[cfg(target_arch = "wasm32")]
     client: Arc<Mutex<Option<ApiClient<tonic_web_wasm_client::Client>>>>,

--- a/crates/miden-proving-service-client/src/proving_service/block_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/block_prover.rs
@@ -25,6 +25,7 @@ use crate::{
 /// transport. Otherwise, it uses the built-in `tonic::transport` for native platforms.
 ///
 /// The transport layer connection is established lazily when the first transaction is proven.
+#[derive(Clone)]
 pub struct RemoteBlockProver {
     #[cfg(target_arch = "wasm32")]
     client: Arc<Mutex<Option<ApiClient<tonic_web_wasm_client::Client>>>>,

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -8,6 +8,7 @@ use crate::errors::ProvenBatchError;
 
 /// A local prover for transaction batches, proving the transactions in a [`ProposedBatch`] and
 /// returning a [`ProvenBatch`].
+#[derive(Clone, Copy)]
 pub struct LocalBatchProver {
     proof_security_level: u32,
 }

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -8,7 +8,7 @@ use crate::errors::ProvenBatchError;
 
 /// A local prover for transaction batches, proving the transactions in a [`ProposedBatch`] and
 /// returning a [`ProvenBatch`].
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct LocalBatchProver {
     proof_security_level: u32,
 }


### PR DESCRIPTION
derives `Clone` to the remote and local batch provers.

We use it in the node side to send a copies of the client when spawning batch builders.