### PR TITLE
Remove `Copy` from `BlockHeader`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,11 @@ rand = { version = "0.8", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 vm-core = { package = "miden-core", version = "0.12", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.12", default-features = false }
+
+# Lints are set to warn for development, which are promoted to errors in CI.
+[workspace.lints.clippy]
+# Pedantic lints are set to a lower priority which allows lints in the group to be selectively enabled.
+pedantic = { level = "warn", priority = -1 }
+
+large_types_passed_by_value = "allow" # Triggered by BlockHeader being Copy + 334 bytes.
+# End of pedantic lints.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,3 @@ rand = { version = "0.8", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 vm-core = { package = "miden-core", version = "0.12", default-features = false }
 vm-processor = { package = "miden-processor", version = "0.12", default-features = false }
-
-# Lints are set to warn for development, which are promoted to errors in CI.
-[workspace.lints.clippy]
-# Pedantic lints are set to a lower priority which allows lints in the group to be selectively enabled.
-pedantic = { level = "warn", priority = -1 }
-
-large_types_passed_by_value = "allow" # Triggered by BlockHeader being Copy + 334 bytes.
-# End of pedantic lints.

--- a/crates/miden-block-prover/src/tests/proposed_block_errors.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_errors.rs
@@ -157,7 +157,7 @@ fn proposed_block_fails_on_chain_mmr_and_prev_block_inconsistency() -> anyhow::R
     let block2 = chain.clone().seal_block(None);
 
     let block_inputs = BlockInputs::new(
-        block2.header(),
+        block2.header().clone(),
         chain_mmr.clone(),
         BTreeMap::default(),
         BTreeMap::default(),
@@ -179,7 +179,7 @@ fn proposed_block_fails_on_chain_mmr_and_prev_block_inconsistency() -> anyhow::R
     chain_mmr.partial_mmr_mut().add(block2.header().nullifier_root(), true);
 
     let block_inputs = BlockInputs::new(
-        block2.header(),
+        block2.header().clone(),
         chain_mmr.clone(),
         BTreeMap::default(),
         BTreeMap::default(),
@@ -210,7 +210,7 @@ fn proposed_block_fails_on_missing_batch_reference_block() -> anyhow::Result<()>
     // The proposed block references block 2 but the chain MMR only contains block 0 but not
     // block 1 which is referenced by the batch.
     let block_inputs = BlockInputs::new(
-        block2.header(),
+        block2.header().clone(),
         chain_mmr.clone(),
         BTreeMap::default(),
         BTreeMap::default(),

--- a/crates/miden-block-prover/src/tests/proven_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_success.rs
@@ -374,7 +374,7 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     assert_eq!(empty_chain_mmr.block_headers().count(), 0);
 
     let block_inputs = BlockInputs::new(
-        latest_block_header,
+        latest_block_header.clone(),
         empty_chain_mmr.clone(),
         BTreeMap::default(),
         BTreeMap::default(),

--- a/crates/miden-objects/src/block/header.rs
+++ b/crates/miden-objects/src/block/header.rs
@@ -28,7 +28,7 @@ use crate::{
 ///   representation is sufficient to represent time up to year 2106.
 /// - `sub_hash` is a sequential hash of all fields except the note_root.
 /// - `hash` is a 2-to-1 hash of the sub_hash and the note_root.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct BlockHeader {
     version: u32,
     prev_hash: Digest,

--- a/crates/miden-objects/src/block/proven_block.rs
+++ b/crates/miden-objects/src/block/proven_block.rs
@@ -71,8 +71,8 @@ impl ProvenBlock {
     }
 
     /// Returns the header of this block.
-    pub fn header(&self) -> BlockHeader {
-        self.header
+    pub fn header(&self) -> &BlockHeader {
+        &self.header
     }
 
     /// Returns the slice of [`BlockAccountUpdate`]s for all accounts updated in this block.

--- a/crates/miden-objects/src/transaction/chain_mmr.rs
+++ b/crates/miden-objects/src/transaction/chain_mmr.rs
@@ -50,16 +50,17 @@ impl ChainMmr {
         let chain_length = mmr.forest();
         let mut block_map = BTreeMap::new();
         for block in blocks {
+            let block_num = block.block_num();
             if block.block_num().as_usize() >= chain_length {
-                return Err(ChainMmrError::block_num_too_big(chain_length, block.block_num()));
+                return Err(ChainMmrError::block_num_too_big(chain_length, block_num));
             }
 
-            if block_map.insert(block.block_num(), block).is_some() {
-                return Err(ChainMmrError::duplicate_block(block.block_num()));
+            if !mmr.is_tracked(block_num.as_usize()) {
+                return Err(ChainMmrError::untracked_block(block_num));
             }
 
-            if !mmr.is_tracked(block.block_num().as_usize()) {
-                return Err(ChainMmrError::untracked_block(block.block_num()));
+            if block_map.insert(block_num, block).is_some() {
+                return Err(ChainMmrError::duplicate_block(block_num));
             }
         }
 

--- a/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
+++ b/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
@@ -85,7 +85,7 @@ fn note_created_and_consumed_in_same_batch() -> anyhow::Result<()> {
 
     let batch = ProposedBatch::new(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
-        block2.header(),
+        block2.header().clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )?;
@@ -153,7 +153,7 @@ fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
 
     let error = ProposedBatch::new(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
-        block2.header(),
+        block2.header().clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )
@@ -191,7 +191,7 @@ fn duplicate_mixed_input_notes() -> anyhow::Result<()> {
 
     let error = ProposedBatch::new(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
-        block2.header(),
+        block2.header().clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )
@@ -278,7 +278,7 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
 
     let error = ProposedBatch::new(
         [tx1.clone()].into_iter().map(Arc::new).collect(),
-        block4.header(),
+        block4.header().clone(),
         chain_mmr.clone(),
         BTreeMap::from_iter([(input_note1.id(), note_inclusion_proof0.clone())]),
     )
@@ -301,11 +301,11 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
     let blocks = chain_mmr
         .block_headers()
         .filter(|header| header.block_num() != block2.header().block_num())
-        .copied();
+        .cloned();
 
     let error = ProposedBatch::new(
         [tx1.clone()].into_iter().map(Arc::new).collect(),
-        block4.header(),
+        block4.header().clone(),
         ChainMmr::new(mmr, blocks).context("failed to build chain mmr with missing block")?,
         BTreeMap::from_iter([(input_note1.id(), note_inclusion_proof1.clone())]),
     )
@@ -325,7 +325,7 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
 
     let batch = ProposedBatch::new(
         [tx1].into_iter().map(Arc::new).collect(),
-        block4.header(),
+        block4.header().clone(),
         chain_mmr,
         BTreeMap::from_iter([(input_note1.id(), note_inclusion_proof1.clone())]),
     )?;
@@ -371,7 +371,7 @@ fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
 
     let batch = ProposedBatch::new(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
-        block2.header(),
+        block2.header().clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )?;
@@ -408,7 +408,7 @@ fn multiple_transactions_against_same_account() -> anyhow::Result<()> {
     // Success: Transactions are correctly ordered.
     let batch = ProposedBatch::new(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
-        block1,
+        block1.clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )?;
@@ -520,7 +520,7 @@ fn batch_expiration() -> anyhow::Result<()> {
 
     let batch = ProposedBatch::new(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
-        block1,
+        block1.clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )?;
@@ -607,7 +607,7 @@ fn expired_transaction() -> anyhow::Result<()> {
 
     let error = ProposedBatch::new(
         [tx1.clone(), tx2].into_iter().map(Arc::new).collect(),
-        block1,
+        block1.clone(),
         chain.latest_chain_mmr(),
         BTreeMap::default(),
     )

--- a/crates/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -228,7 +228,7 @@ fn block_data_memory_assertions(process: &Process, inputs: &TransactionContext) 
 fn chain_mmr_memory_assertions(process: &Process, prepared_tx: &TransactionContext) {
     // update the chain MMR to point to the block against which this transaction is being executed
     let mut chain_mmr = prepared_tx.tx_inputs().block_chain().clone();
-    chain_mmr.add_block(*prepared_tx.tx_inputs().block_header(), true);
+    chain_mmr.add_block(prepared_tx.tx_inputs().block_header().clone(), true);
 
     assert_eq!(
         read_root_mem_word(&process.into(), CHAIN_MMR_NUM_LEAVES_PTR)[0],


### PR DESCRIPTION
Remove `Copy` from `BlockHeader`.

closes https://github.com/0xPolygonMiden/miden-base/issues/1076

Technically, the issue says we should enforce the clippy lint, but I tried setting those up and I think it's easier to enable them all at once in a separate PR. Should I create an issue for adding pedantic lints like in https://github.com/0xPolygonMiden/miden-node/pull/623? 