### PR TITLE
feat: remove external dependencies from proving-service-client and tx-batch-prover

### DIFF
--- a/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/batch_prover.rs
@@ -1,8 +1,3 @@
-use alloc::{
-    string::{String, ToString},
-    sync::Arc,
-};
-
 use miden_objects::{
     batch::{ProposedBatch, ProvenBatch},
     utils::{Deserializable, DeserializationError, Serializable},
@@ -11,6 +6,10 @@ use tokio::sync::Mutex;
 
 use super::generated::api_client::ApiClient;
 use crate::{
+    alloc::{
+        string::{String, ToString},
+        sync::Arc,
+    },
     proving_service::generated::{ProofType, ProvingRequest, ProvingResponse},
     RemoteProverError,
 };

--- a/crates/miden-proving-service-client/src/proving_service/block_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/block_prover.rs
@@ -1,8 +1,3 @@
-use alloc::{
-    string::{String, ToString},
-    sync::Arc,
-};
-
 use miden_objects::{
     block::{ProposedBlock, ProvenBlock},
     utils::{Deserializable, DeserializationError, Serializable},
@@ -11,6 +6,10 @@ use tokio::sync::Mutex;
 
 use super::generated::api_client::ApiClient;
 use crate::{
+    alloc::{
+        string::{String, ToString},
+        sync::Arc,
+    },
     proving_service::generated::{ProofType, ProvingRequest, ProvingResponse},
     RemoteProverError,
 };

--- a/crates/miden-proving-service-client/src/proving_service/tx_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/tx_prover.rs
@@ -1,9 +1,3 @@
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    sync::Arc,
-};
-
 use miden_objects::{
     transaction::{ProvenTransaction, TransactionWitness},
     utils::{Deserializable, DeserializationError, Serializable},
@@ -13,6 +7,11 @@ use tokio::sync::Mutex;
 
 use super::generated::api_client::ApiClient;
 use crate::{
+    alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        sync::Arc,
+    },
     proving_service::{
         generated,
         generated::{ProofType, ProvingRequest, ProvingResponse},

--- a/crates/miden-tx-batch-prover/src/testing/proven_tx_builder.rs
+++ b/crates/miden-tx-batch-prover/src/testing/proven_tx_builder.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use anyhow::Context;
 use miden_crypto::merkle::MerklePath;
 use miden_objects::{
@@ -11,6 +9,8 @@ use miden_objects::{
 };
 use vm_processor::Digest;
 use winterfell::Proof;
+
+use crate::alloc::vec::Vec;
 
 /// A builder to build mocked [`ProvenTransaction`]s.
 pub struct MockProvenTxBuilder {

--- a/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
+++ b/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
@@ -1,6 +1,3 @@
-use alloc::sync::Arc;
-use std::collections::BTreeMap;
-
 use anyhow::Context;
 use miden_crypto::merkle::MerkleError;
 use miden_lib::transaction::TransactionKernel;
@@ -18,7 +15,7 @@ use rand::{rngs::SmallRng, SeedableRng};
 use vm_core::assert_matches;
 use vm_processor::Digest;
 
-use crate::testing::MockProvenTxBuilder;
+use crate::{alloc::sync::Arc, std::collections::BTreeMap, testing::MockProvenTxBuilder};
 
 fn mock_account_id(num: u8) -> AccountId {
     AccountIdBuilder::new().build_with_rng(&mut SmallRng::from_seed([num; 32]))


### PR DESCRIPTION
Part of breakup for https://github.com/0xPolygonMiden/miden-base/pull/1154 (see comments)

- Removed external dependency imports from `miden-proving-service-client`
- Removed external dependency imports from `miden-tx-batch-prover`