### PR TITLE
Pin cargo machete to a specific version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,6 +108,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: machete
-        # Use a pinned commit until we migrate to Rust Edition 2024.
-        uses: bnjbvr/cargo-machete@929a77bed5046af583806eb91f257f1bbdba2f56
+      - name: Install cargo-machete
+        uses: clechasseur/rs-cargo@v2
+        with:
+          command: install
+          args: cargo-machete@0.7.0
+      - name: Machete
+        uses: clechasseur/rs-cargo@v2
+        with:
+          command: machete

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -109,4 +109,5 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - name: machete
-        uses: bnjbvr/cargo-machete@main
+        # Use a pinned commit until we migrate to Rust Edition 2024.
+        uses: bnjbvr/cargo-machete@929a77bed5046af583806eb91f257f1bbdba2f56


### PR DESCRIPTION
Pin cargo machete to a specific ~~commit~~ version since the latest version requires Rust Edition 2024.