### PR TITLE
Implement bech32 encoding for `AccountId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [BREAKING] Added native types to `AccountComponentTemplate` (#1124).
 - Implemented `RemoteBlockProver`. `miden-proving-service` workers can prove blocks (#1169).
 - Use `Smt::with_entries` to error on duplicates in `StorageMap::with_entries` (#1167)
+- Implement user-facing bech32 encoding for `AccountId`s (#1185).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +1943,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "bech32",
  "criterion",
  "getrandom 0.2.15",
  "log",

--- a/crates/miden-objects/Cargo.toml
+++ b/crates/miden-objects/Cargo.toml
@@ -26,6 +26,7 @@ testing = ["dep:winter-rand-utils", "dep:rand", "dep:rand_xoshiro"]
 
 [dependencies]
 assembly = { workspace = true }
+bech32 = { version = "0.11", default-features = false, features = ["alloc"] }
 log = { version = "0.4", optional = true }
 miden-crypto = { workspace = true }
 miden-verifier = { workspace = true }

--- a/crates/miden-objects/src/account/account_id/address_type.rs
+++ b/crates/miden-objects/src/account/account_id/address_type.rs
@@ -1,0 +1,6 @@
+/// The type of an address in Miden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum AddressType {
+    AccountId = 0,
+}

--- a/crates/miden-objects/src/account/account_id/mod.rs
+++ b/crates/miden-objects/src/account/account_id/mod.rs
@@ -322,8 +322,8 @@ impl AccountId {
     /// This is an example of an account ID in hex and bech32 representations:
     ///
     /// ```text
-    /// hex:    0x140fa04a1e61fc900000126ef8f1d6
-    /// bech32: mm1qzgpgraqfg0xrlqqqqfxa7836czc9qzl
+    /// hex:    0x140fa04a1e61fc100000126ef8f1d6
+    /// bech32: mm1qq2qlgz2reslcyqqqqfxa7836chrjcvk
     /// ```
     ///
     /// ## Rationale

--- a/crates/miden-objects/src/account/account_id/network_id.rs
+++ b/crates/miden-objects/src/account/account_id/network_id.rs
@@ -1,5 +1,5 @@
+use alloc::string::ToString;
 use core::str::FromStr;
-use std::string::ToString;
 
 use bech32::Hrp;
 

--- a/crates/miden-objects/src/account/account_id/network_id.rs
+++ b/crates/miden-objects/src/account/account_id/network_id.rs
@@ -1,0 +1,107 @@
+use core::str::FromStr;
+use std::string::ToString;
+
+use bech32::Hrp;
+
+use crate::errors::NetworkIdError;
+
+// This is essentially a wrapper around [`bech32::Hrp`] but that type does not actually appear in
+// the public API since that crate does not have a stable release.
+
+/// The identifier of a Miden network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NetworkId {
+    Mainnet,
+    Testnet,
+    Devnet,
+    Custom(Hrp),
+}
+
+impl NetworkId {
+    const MAINNET: &str = "mm";
+    const TESTNET: &str = "mtst";
+    const DEVNET: &str = "mdev";
+
+    /// Constructs a new [`NetworkId`] from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the string does not contain between 1 to 83 US-ASCII characters.
+    /// - each character is not in the range 33-126.
+    pub fn new(string: &str) -> Result<Self, NetworkIdError> {
+        Hrp::parse(string)
+            .map(Self::from_hrp)
+            .map_err(|source| NetworkIdError::NetworkIdParseError(source.to_string().into()))
+    }
+
+    /// Constructs a new [`NetworkId`] from an [`Hrp`].
+    ///
+    /// This method should not be made public to avoid having `bech32` types in the public API.
+    pub(crate) fn from_hrp(hrp: Hrp) -> Self {
+        match hrp.as_str() {
+            NetworkId::MAINNET => NetworkId::Mainnet,
+            NetworkId::TESTNET => NetworkId::Testnet,
+            NetworkId::DEVNET => NetworkId::Devnet,
+            _ => NetworkId::Custom(hrp),
+        }
+    }
+
+    /// Returns the [`Hrp`] of this network ID.
+    ///
+    /// This method should not be made public to avoid having `bech32` types in the public API.
+    pub(crate) fn into_hrp(self) -> Hrp {
+        match self {
+            NetworkId::Mainnet => {
+                Hrp::parse(NetworkId::MAINNET).expect("mainnet hrp should be valid")
+            },
+            NetworkId::Testnet => {
+                Hrp::parse(NetworkId::TESTNET).expect("testnet hrp should be valid")
+            },
+            NetworkId::Devnet => Hrp::parse(NetworkId::DEVNET).expect("devnet hrp should be valid"),
+            NetworkId::Custom(custom) => custom,
+        }
+    }
+
+    /// Returns the string representation of the network ID.
+    pub fn as_str(&self) -> &str {
+        match self {
+            NetworkId::Mainnet => NetworkId::MAINNET,
+            NetworkId::Testnet => NetworkId::TESTNET,
+            NetworkId::Devnet => NetworkId::DEVNET,
+            NetworkId::Custom(custom) => custom.as_str(),
+        }
+    }
+
+    /// Returns `true` if the network ID is the Miden mainnet, `false` otherwise.
+    pub fn is_mainnet(&self) -> bool {
+        matches!(self, NetworkId::Mainnet)
+    }
+
+    /// Returns `true` if the network ID is the Miden testnet, `false` otherwise.
+    pub fn is_testnet(&self) -> bool {
+        matches!(self, NetworkId::Testnet)
+    }
+
+    /// Returns `true` if the network ID is the Miden devnet, `false` otherwise.
+    pub fn is_devnet(&self) -> bool {
+        matches!(self, NetworkId::Devnet)
+    }
+}
+
+impl FromStr for NetworkId {
+    type Err = NetworkIdError;
+
+    /// Constructs a new [`NetworkId`] from a string.
+    ///
+    /// See [`NetworkId::new`] for details on errors.
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        Self::new(string)
+    }
+}
+
+impl core::fmt::Display for NetworkId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/miden-objects/src/account/account_id/v0/mod.rs
+++ b/crates/miden-objects/src/account/account_id/v0/mod.rs
@@ -233,9 +233,8 @@ impl AccountIdV0 {
     pub fn to_bech32(&self, network_id: NetworkId) -> String {
         let mut id_bytes: [u8; Self::SERIALIZED_SIZE] = (*self).into();
 
-        let metadata_byte = id_bytes[Self::METADATA_BYTE_IDX];
-        id_bytes.copy_within(0..7, 1);
-        id_bytes[0] = metadata_byte;
+        // Swap first byte with the metadata byte so it is more easily accessible.
+        id_bytes.swap(0, Self::METADATA_BYTE_IDX);
 
         let mut data = [0; Self::SERIALIZED_SIZE + 1];
         data[0] = AddressType::AccountId as u8;
@@ -286,10 +285,8 @@ impl AccountIdV0 {
             id_bytes[i] = byte;
         }
 
-        // Revert the remove-insert of the metadata byte during encoding.
-        let metadata_byte = id_bytes[0];
-        id_bytes.copy_within(1..8, 0);
-        id_bytes[Self::METADATA_BYTE_IDX] = metadata_byte;
+        // Revert the swap of the metadata byte during encoding.
+        id_bytes.swap(0, Self::METADATA_BYTE_IDX);
 
         let account_id = Self::try_from(id_bytes)?;
 

--- a/crates/miden-objects/src/account/account_id/v0/mod.rs
+++ b/crates/miden-objects/src/account/account_id/v0/mod.rs
@@ -69,9 +69,6 @@ impl AccountIdV0 {
     /// The bit at index 5 of the prefix encodes whether the account is a faucet.
     pub(crate) const IS_FAUCET_MASK: u64 = 0b10 << Self::TYPE_SHIFT;
 
-    /// The index of the metadata byte in the [u8; 15] format.
-    const METADATA_BYTE_IDX: usize = 7;
-
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
@@ -231,10 +228,7 @@ impl AccountIdV0 {
 
     /// See [`AccountId::to_bech32`](super::AccountId::to_bech32) for details.
     pub fn to_bech32(&self, network_id: NetworkId) -> String {
-        let mut id_bytes: [u8; Self::SERIALIZED_SIZE] = (*self).into();
-
-        // Swap first byte with the metadata byte so it is more easily accessible.
-        id_bytes.swap(0, Self::METADATA_BYTE_IDX);
+        let id_bytes: [u8; Self::SERIALIZED_SIZE] = (*self).into();
 
         let mut data = [0; Self::SERIALIZED_SIZE + 1];
         data[0] = AddressType::AccountId as u8;
@@ -284,9 +278,6 @@ impl AccountIdV0 {
         for (i, byte) in byte_iter.enumerate() {
             id_bytes[i] = byte;
         }
-
-        // Revert the swap of the metadata byte during encoding.
-        id_bytes.swap(0, Self::METADATA_BYTE_IDX);
 
         let account_id = Self::try_from(id_bytes)?;
 

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 mod account_id;
 pub use account_id::{
     AccountId, AccountIdAnchor, AccountIdPrefix, AccountIdPrefixV0, AccountIdV0, AccountIdVersion,
-    AccountStorageMode, AccountType,
+    AccountStorageMode, AccountType, AddressType, NetworkId,
 };
 
 pub mod auth;

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::{
     account::{
-        AccountCode, AccountIdPrefix, AccountStorage, AccountType, StorageValueName,
+        AccountCode, AccountIdPrefix, AccountStorage, AccountType, AddressType, StorageValueName,
         StorageValueNameError, TemplateTypeError,
     },
     batch::BatchId,
@@ -154,6 +154,32 @@ pub enum AccountIdError {
         BlockNumber::EPOCH_LENGTH_EXPONENT
     )]
     AnchorBlockMustBeEpochBlock,
+    #[error("failed to decode bech32 string into account ID")]
+    Bech32DecodeError(#[source] Bech32Error),
+}
+
+// BECH32 ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum Bech32Error {
+    #[error("failed to decode bech32 string")]
+    DecodeError(#[source] Box<dyn Error + Send + Sync + 'static>),
+    #[error("found unknown address type {0} which is not the expected {account_addr} account ID address type",
+      account_addr = AddressType::AccountId as u8
+    )]
+    UnknownAddressType(u8),
+    #[error("expected bech32 data to be of length {expected} but it was of length {actual}")]
+    InvalidDataLength { expected: usize, actual: usize },
+}
+
+// NETWORK ID ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum NetworkIdError {
+    #[error("failed to parse string into a network ID")]
+    NetworkIdParseError(#[source] Box<dyn Error + Send + Sync + 'static>),
 }
 
 // ACCOUNT DELTA ERROR


### PR DESCRIPTION
Implement bech32 encoding for `AccountId`.

Copy of `AccountId::to_bech32` docs:

# Encoding

The encoding of an account ID into bech32 is done as follows:
- Convert the account ID into its `[u8; 15]` data format.
- Insert the address type [`AddressType::AccountId`] byte at index 0, shifting all other
elements to the right.
- Choose an HRP, defined as a [`NetworkId`], for example [`NetworkId::Mainnet`] whose string
representation is `mm`.
- Encode the resulting HRP together with the data into a bech32 string using the
[`bech32::Bech32m`] checksum algorithm.

This is an example of an account ID in hex and bech32 representations:

```text
hex:    0x140fa04a1e61fc900000126ef8f1d6
bech32: mm1qzgpgraqfg0xrlqqqqfxa7836czc9qzl
```

## Rationale

Having the address type at the very beginning is so that it can be decoded to detect the
type of the address without having to decode the entire data. Moreover, choosing the
address type as a multiple of 8 means the first character of the bech32 string after the
`1` separator will be different for every address type. This makes the type of the address
conveniently human-readable.

The only allowed checksum algorithm is [`Bech32m`](bech32::Bech32m) due to being the best
available checksum algorithm with no known weaknesses (unlike [`Bech32`](bech32::Bech32)).
No checksum is also not allowed since the intended use of bech32 is to have error
detection capabilities.

closes #1024 