### PR TITLE
Optimize AssetVault serialization to avoid vector allocation

### DIFF
--- a/crates/miden-objects/src/asset/vault.rs
+++ b/crates/miden-objects/src/asset/vault.rs
@@ -261,11 +261,16 @@ impl AssetVault {
 
 impl Serializable for AssetVault {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // TODO: determine total number of assets in the vault without allocating the vector
-        let assets = self.assets().collect::<Vec<_>>();
+        // Count assets without allocating a vector
+        let count = self.asset_tree.entries().count();
 
-        target.write_usize(assets.len());
-        target.write_many(&assets);
+        // Write the count
+        target.write_usize(count);
+
+        // Write each asset directly from the iterator
+        for entry in self.asset_tree.entries() {
+            Asset::new_unchecked(entry.1).write_into(target);
+        }
     }
 
     fn get_size_hint(&self) -> usize {
@@ -278,7 +283,6 @@ impl Serializable for AssetVault {
         }
 
         size += count.get_size_hint();
-
         size
     }
 }


### PR DESCRIPTION
This commit optimizes the serialization of AssetVault by eliminating unnecessary vector allocation.

Previously, the write_into method was collecting all assets into a temporary vector before writing them to the target, which was inefficient for large asset collections. The new implementation counts the assets directly using the iterator's count() method and then iterates through the assets again to write them one by one.

This change improves memory efficiency by avoiding the allocation of a temporary vector, which is especially beneficial for vaults with many assets.

Resolves TODO: "determine total number of assets in the vault without allocating the vector"