### PR TITLE
Enable timestamp customization on `MockChain::seal_block`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Implement user-facing bech32 encoding for `AccountId`s (#1185).
 - [BREAKING] Added `InitStorageData::from_toml()`, improved storage entry validations in `AccountComponentMetadata` (#1170).
 - [BREAKING] Rework miden-lib error codes into categories (#1196).
+- [BREAKING] Enable timestamp customization on `MockChain::seal_block` (#1208).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/crates/miden-block-prover/src/tests/proposed_block_errors.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_errors.rs
@@ -29,7 +29,7 @@ fn proposed_block_fails_on_too_many_batches() -> anyhow::Result<()> {
     let account0 = accounts.get(&0).unwrap();
     let accountx = generate_account(&mut chain);
     let notex = generate_tracked_note(&mut chain, account0.id(), accountx.id());
-    chain.seal_block(None);
+    chain.seal_next_block();
     let tx = generate_tx_with_authenticated_notes(&mut chain, accountx.id(), &[notex.id()]);
     txs.insert(count, tx);
 
@@ -91,7 +91,7 @@ fn proposed_block_fails_on_expired_batches() -> anyhow::Result<()> {
     let batch0 = generate_batch(&mut chain, vec![tx0]);
     let batch1 = generate_batch(&mut chain, vec![tx1]);
 
-    let _block2 = chain.seal_block(None);
+    let _block2 = chain.seal_next_block();
 
     let batches = vec![batch0.clone(), batch1.clone()];
 
@@ -154,7 +154,7 @@ fn proposed_block_fails_on_chain_mmr_and_prev_block_inconsistency() -> anyhow::R
     // Select the chain MMR which is valid for the current block but pass the next block in the
     // chain, which is an inconsistent combination.
     let mut chain_mmr = chain.latest_chain_mmr();
-    let block2 = chain.clone().seal_block(None);
+    let block2 = chain.clone().seal_next_block();
 
     let block_inputs = BlockInputs::new(
         block2.header().clone(),
@@ -203,7 +203,7 @@ fn proposed_block_fails_on_missing_batch_reference_block() -> anyhow::Result<()>
     let batch0 = generate_batch(&mut chain, vec![proven_tx0.clone()]);
     let batches = vec![batch0.clone()];
 
-    let block2 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
 
     let (_, chain_mmr) = chain.latest_selective_chain_mmr([BlockNumber::from(0)]);
 
@@ -244,7 +244,7 @@ fn proposed_block_fails_on_duplicate_input_note() -> anyhow::Result<()> {
     assert_ne!(note0.id(), note1.id());
 
     // Add notes to the chain.
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     // Create two different transactions against the same account consuming the same note.
     let tx0 =
@@ -280,7 +280,7 @@ fn proposed_block_fails_on_duplicate_output_note() -> anyhow::Result<()> {
     chain.add_pending_note(note0.clone());
     chain.add_pending_note(note1.clone());
 
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     // Create two different transactions against the same account creating the same note.
     // We use the same account because the sender of the created output note is set to the account
@@ -323,12 +323,12 @@ fn proposed_block_fails_on_invalid_proof_or_missing_note_inclusion_reference_blo
 
     // Add the note to the chain so we can retrieve an inclusion proof for it.
     chain.add_pending_note(note0.clone());
-    let block2 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
 
     // Seal another block so that the next block will use this one as the reference block and block2
     // is only needed for the note inclusion proof so we can safely remove it to only trigger the
     // error condition we want to trigger.
-    let _block3 = chain.seal_block(None);
+    let _block3 = chain.seal_next_block();
 
     let batches = vec![batch0.clone()];
 
@@ -423,7 +423,7 @@ fn proposed_block_fails_on_missing_nullifier_witness() -> anyhow::Result<()> {
 
     // Add the note to the chain so we can retrieve an inclusion proof for it.
     chain.add_pending_note(note0.clone());
-    let _block2 = chain.seal_block(None);
+    let _block2 = chain.seal_next_block();
 
     let batches = vec![batch0.clone()];
 
@@ -461,7 +461,7 @@ fn proposed_block_fails_on_spent_nullifier_witness() -> anyhow::Result<()> {
 
     // Add the note to the chain so we can consume it in the next step.
     chain.add_pending_note(note0.clone());
-    let _block2 = chain.seal_block(None);
+    let _block2 = chain.seal_next_block();
 
     // Create an alternative chain where we consume the note so it is marked as spent in the
     // nullifier tree.
@@ -472,7 +472,7 @@ fn proposed_block_fails_on_spent_nullifier_witness() -> anyhow::Result<()> {
         &[note0.id()],
     );
     alternative_chain.apply_executed_transaction(&transaction);
-    alternative_chain.seal_block(None);
+    alternative_chain.seal_next_block();
     let spent_proof = alternative_chain.nullifiers().open(&note0.nullifier().inner());
 
     let batches = vec![batch0.clone()];
@@ -508,7 +508,7 @@ fn proposed_block_fails_on_conflicting_transactions_updating_same_account() -> a
     assert_ne!(note0.id(), note1.id());
 
     // Add notes to the chain.
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     // Create two different transactions against the same account consuming the same note.
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account1.id(), &[]);
@@ -579,7 +579,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
     let note2 = generate_tracked_note_with_asset(&mut chain, account0.id(), account1.id(), asset);
 
     // Add notes to the chain.
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     // Create three transactions on the same account that build on top of each other.
     // The MockChain only updates the account state when sealing a block, but we don't want the
@@ -593,7 +593,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         &[note0.id()],
     );
     alternative_chain.apply_executed_transaction(&executed_tx0);
-    alternative_chain.seal_block(None);
+    alternative_chain.seal_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
         &mut alternative_chain,
@@ -601,7 +601,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         &[note1.id()],
     );
     alternative_chain.apply_executed_transaction(&executed_tx1);
-    alternative_chain.seal_block(None);
+    alternative_chain.seal_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
         &mut alternative_chain,

--- a/crates/miden-block-prover/src/tests/proposed_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proposed_block_success.rs
@@ -107,7 +107,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
     let note2 = generate_tracked_note_with_asset(&mut chain, account0.id(), account1.id(), asset);
 
     // Add notes to the chain.
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     // Create three transactions on the same account that build on top of each other.
     // The MockChain only updates the account state when sealing a block, but we don't want the
@@ -121,7 +121,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         &[note0.id()],
     );
     alternative_chain.apply_executed_transaction(&executed_tx0);
-    alternative_chain.seal_block(None);
+    alternative_chain.seal_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
         &mut alternative_chain,
@@ -129,7 +129,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         &[note1.id()],
     );
     alternative_chain.apply_executed_transaction(&executed_tx1);
-    alternative_chain.seal_block(None);
+    alternative_chain.seal_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
         &mut alternative_chain,
@@ -192,7 +192,7 @@ fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
 
     chain.add_pending_note(note0.clone());
     chain.add_pending_note(note1.clone());
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     let batches = [batch0, batch1];
     // This block will use block2 as the reference block.
@@ -237,7 +237,7 @@ fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
     // sanity check: batch 1 should expire at block 3.
     assert_eq!(batch1.batch_expiration_block_num().as_u32(), 3);
 
-    let _block2 = chain.seal_block(None);
+    let _block2 = chain.seal_next_block();
 
     let batches = vec![batch0.clone(), batch1.clone()];
 

--- a/crates/miden-block-prover/src/tests/proven_block_error.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_error.rs
@@ -32,7 +32,7 @@ fn witness_test_setup() -> WitnessTestSetup {
 
     let note = generate_tracked_note(&mut chain, account1.id(), account0.id());
     // Add note to chain.
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     let tx0 =
         generate_executed_tx_with_authenticated_notes(&mut chain, account0.id(), &[note.id()]);
@@ -48,7 +48,7 @@ fn witness_test_setup() -> WitnessTestSetup {
 
     // Apply the executed tx and seal a block. This invalidates the block inputs we've just fetched.
     chain.apply_executed_transaction(&tx0);
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     let valid_block_inputs = chain.get_block_inputs(&batches);
 

--- a/crates/miden-block-prover/src/tests/proven_block_success.rs
+++ b/crates/miden-block-prover/src/tests/proven_block_success.rs
@@ -50,7 +50,7 @@ fn proven_block_success() -> anyhow::Result<()> {
     chain.add_pending_note(input_note1.clone());
     chain.add_pending_note(input_note2.clone());
     chain.add_pending_note(input_note3.clone());
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[input_note0.id()]);
     let tx1 = generate_tx_with_authenticated_notes(&mut chain, account1.id(), &[input_note1.id()]);
@@ -217,7 +217,7 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
     chain.add_pending_note(note0.clone());
     chain.add_pending_note(note2.clone());
     chain.add_pending_note(note3.clone());
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[note0.id()]);
     let tx1 =
@@ -344,7 +344,7 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     // Add notes to the chain we can consume.
     let note0 = generate_tracked_note(&mut chain, account1.id(), account0.id());
     let note1 = generate_tracked_note(&mut chain, account0.id(), account1.id());
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     let tx0 =
         generate_executed_tx_with_authenticated_notes(&mut chain, account0.id(), &[note0.id()]);
@@ -353,7 +353,7 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
 
     chain.apply_executed_transaction(&tx0);
     chain.apply_executed_transaction(&tx1);
-    let blockx = chain.seal_block(None);
+    let blockx = chain.seal_next_block();
 
     // Build a block with empty inputs whose account tree and nullifier tree root are not the empty
     // roots.

--- a/crates/miden-block-prover/src/tests/utils.rs
+++ b/crates/miden-block-prover/src/tests/utils.rs
@@ -221,7 +221,7 @@ pub fn setup_chain(num_accounts: usize) -> TestSetup {
         notes.insert(i, note);
     }
 
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     for i in 0..num_accounts {
         let tx =

--- a/crates/miden-lib/asm/kernels/transaction/main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/main.masm
@@ -49,7 +49,7 @@ const.EPILOGUE_END=131081
 #! the advice provider.
 #!
 #! Inputs:  [BLOCK_HASH, account_id, INITIAL_ACCOUNT_HASH, INPUT_NOTES_COMMITMENT]
-#! Outputs: [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH]
+#! Outputs: [OUTPUT_NOTES_COMMITMENT, FINAL_ACCOUNT_HASH, tx_expiration_block_num]
 #!
 #! Where:
 #! - BLOCK_HASH is the reference block for the transaction execution.

--- a/crates/miden-objects/src/testing/constants.rs
+++ b/crates/miden-objects/src/testing/constants.rs
@@ -1,5 +1,3 @@
-use vm_core::Felt;
-
 pub const FUNGIBLE_ASSET_AMOUNT: u64 = 100;
 pub const FUNGIBLE_FAUCET_INITIAL_BALANCE: u64 = 50000;
 
@@ -10,9 +8,3 @@ pub const CONSUMED_ASSET_4_AMOUNT: u64 = 100;
 
 pub const NON_FUNGIBLE_ASSET_DATA: [u8; 4] = [1, 2, 3, 4];
 pub const NON_FUNGIBLE_ASSET_DATA_2: [u8; 4] = [5, 6, 7, 8];
-
-pub const CHILD_ROOT_PARENT_LEAF_INDEX: u8 = 10;
-pub const CHILD_SMT_DEPTH: u8 = 64;
-pub const CHILD_STORAGE_INDEX_0: u64 = 40;
-pub const CHILD_STORAGE_VALUE_0: [Felt; 4] =
-    [Felt::new(11), Felt::new(12), Felt::new(13), Felt::new(14)];

--- a/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
+++ b/crates/miden-tx-batch-prover/src/tests/proposed_batch.rs
@@ -45,7 +45,7 @@ fn setup_chain() -> TestSetup {
     let mut chain = MockChain::new();
     let account1 = chain.add_new_wallet(Auth::NoAuth);
     let account2 = chain.add_new_wallet(Auth::NoAuth);
-    chain.seal_block(None);
+    chain.seal_next_block();
 
     TestSetup { chain, account1, account2 }
 }
@@ -71,7 +71,7 @@ fn empty_transaction_batch() -> anyhow::Result<()> {
 fn note_created_and_consumed_in_same_batch() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
 
     let note = mock_note(40);
     let tx1 = MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.hash())
@@ -140,7 +140,7 @@ fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
 
     let tx1 = MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.hash())
         .block_reference(block1.hash())
@@ -178,7 +178,7 @@ fn duplicate_mixed_input_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
 
     let tx1 = MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.hash())
         .block_reference(block1.hash())
@@ -253,9 +253,9 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
     let note0 = chain.add_p2id_note(account2.id(), account1.id(), &[], NoteType::Private, None)?;
     let note1 = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     // The just created note will be provable against block2.
-    let block2 = chain.seal_block(None);
-    let block3 = chain.seal_block(None);
-    let block4 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
+    let block3 = chain.seal_next_block();
+    let block4 = chain.seal_next_block();
 
     // Consume the authenticated note as an unauthenticated one in the transaction.
     let tx1 = MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.hash())
@@ -357,7 +357,7 @@ fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_block(None);
+    let block2 = chain.seal_next_block();
 
     let note0 = mock_note(50);
     let tx1 = MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.hash())

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -222,7 +222,7 @@ impl PendingObjects {
 ///       None,
 ///     )
 ///   .unwrap();
-/// mock_chain.seal_block(None);
+/// mock_chain.seal_next_block();
 /// let tx_context = mock_chain.build_tx_context(sender.id(), &[note.id()], &[]).build();
 /// let result = tx_context.execute();
 /// ```

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -796,7 +796,7 @@ impl MockChain {
     /// This will make all the objects currently pending available for use.
     ///
     /// If `block_num` is `None`, the next block is created, otherwise all blocks from the next
-    /// block up to and including `block_num`.
+    /// block up to and including `block_num` will be created.
     ///
     /// If a `timestamp` is provided, it will be set on the block with `block_num`.
     pub fn seal_block(&mut self, block_num: Option<u32>, timestamp: Option<u32>) -> ProvenBlock {
@@ -805,9 +805,10 @@ impl MockChain {
 
         let target_block_num = block_num.unwrap_or(next_block_num);
 
-        if target_block_num < next_block_num {
-            panic!("Input block number should be higher than the last block number");
-        }
+        assert!(
+            target_block_num >= next_block_num,
+            "target block number must be greater or equal to the number of the next block in the chain"
+        );
 
         let mut last_block: Option<ProvenBlock> = None;
 
@@ -857,8 +858,8 @@ impl MockChain {
                 if let Some(provided_timestamp) = timestamp {
                     if let Some(prev_block) = previous {
                         assert!(
-                            prev_block.header().timestamp() < provided_timestamp,
-                            "timestamp must increase monotonically"
+                            provided_timestamp > prev_block.header().timestamp(),
+                            "provided timestamp must be strictly greater than the previous block's timestamp"
                         );
                     }
                     block_timestamp = provided_timestamp;

--- a/crates/miden-tx/src/testing/tx_context/builder.rs
+++ b/crates/miden-tx/src/testing/tx_context/builder.rs
@@ -638,8 +638,8 @@ impl TransactionContextBuilder {
                     mock_chain.add_pending_note(i);
                 }
 
-                mock_chain.seal_block(None);
-                mock_chain.seal_block(None);
+                mock_chain.seal_next_block();
+                mock_chain.seal_next_block();
 
                 let input_note_ids: Vec<NoteId> =
                     mock_chain.available_notes().iter().map(|n| n.id()).collect();

--- a/crates/miden-tx/src/tests/kernel_tests/test_note.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_note.rs
@@ -2,22 +2,30 @@ use alloc::{collections::BTreeMap, string::String};
 
 use miden_lib::{
     errors::tx_kernel_errors::ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SENDER_FROM_INCORRECT_CONTEXT,
-    transaction::memory::CURRENT_INPUT_NOTE_PTR,
+    transaction::{memory::CURRENT_INPUT_NOTE_PTR, TransactionKernel},
 };
 use miden_objects::{
     account::AccountId,
     note::{Note, NoteExecutionHint, NoteExecutionMode, NoteMetadata, NoteTag, NoteType},
-    testing::{account_id::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, prepare_word},
+    testing::{
+        account_id::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, note::NoteBuilder,
+        prepare_word,
+    },
     transaction::TransactionArgs,
     Hasher, WORD_SIZE,
 };
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 use vm_processor::{ProcessState, Word, EMPTY_WORD, ONE};
 
 use super::{Felt, Process, ZERO};
 use crate::{
     assert_execution_error,
-    testing::{utils::input_note_data_ptr, TransactionContext, TransactionContextBuilder},
+    testing::{
+        utils::input_note_data_ptr, Auth, MockChain, TransactionContext, TransactionContextBuilder,
+    },
     tests::kernel_tests::read_root_mem_word,
+    TransactionExecutorError,
 };
 
 #[test]
@@ -607,4 +615,71 @@ fn test_build_note_metadata() {
 
         assert_eq!(Word::from(test_metadata), metadata_word, "failed in iteration {iteration}");
     }
+}
+
+/// This serves as a test that setting a custom timestamp on mock chain blocks works.
+#[test]
+pub fn test_timelock() {
+    let mut mock_chain = MockChain::new();
+    let account = mock_chain.add_existing_wallet(Auth::NoAuth, vec![]);
+    const TIMESTAMP_ERROR: u32 = 123;
+
+    let code = format!(
+        "
+      use.miden::note
+      use.miden::tx
+
+      begin
+          # store the note inputs to memory starting at address 0
+          push.0 exec.note::get_inputs
+          # => [num_inputs, inputs_ptr]
+
+          # make sure the number of inputs is 1
+          eq.1 assert.err=789
+          # => [inputs_ptr]
+
+          # read the timestamp at which the note can be consumed
+          mem_load
+          # => [timestamp]
+
+          exec.tx::get_block_timestamp
+          # => [block_timestamp, timestamp]
+
+          # ensure block timestamp is newer than timestamp
+          lte assert.err={TIMESTAMP_ERROR}
+          # => []
+      end"
+    );
+
+    let lock_timestamp = 2_000_000_000;
+    let timelock_note = NoteBuilder::new(account.id(), &mut ChaCha20Rng::from_entropy())
+        .note_inputs([Felt::from(lock_timestamp)])
+        .unwrap()
+        .code(code.clone())
+        .build(&TransactionKernel::testing_assembler_with_mock_account())
+        .unwrap();
+
+    mock_chain.add_pending_note(timelock_note.clone());
+    mock_chain.seal_block(None, Some(lock_timestamp - 100));
+
+    // Attempt to consume note too early.
+    // ----------------------------------------------------------------------------------------
+    let tx_inputs =
+        mock_chain.get_transaction_inputs(account.clone(), None, &[timelock_note.id()], &[]);
+    let tx_context = TransactionContextBuilder::new(account.clone())
+        .tx_inputs(tx_inputs.clone())
+        .build();
+    let err = tx_context.execute().unwrap_err();
+    let TransactionExecutorError::TransactionProgramExecutionFailed(err) = err else {
+        panic!("unexpected error")
+    };
+    assert_execution_error!(Err::<(), _>(err), TIMESTAMP_ERROR);
+
+    // Consume note where lock timestamp matches the block timestamp.
+    // ----------------------------------------------------------------------------------------
+    mock_chain.seal_block(None, Some(lock_timestamp));
+    let tx_inputs =
+        mock_chain.get_transaction_inputs(account.clone(), None, &[timelock_note.id()], &[]);
+    let tx_context = TransactionContextBuilder::new(account).tx_inputs(tx_inputs).build();
+    tx_context.execute().unwrap();
 }

--- a/crates/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -492,7 +492,7 @@ pub fn create_accounts_with_anchor_block_zero() -> anyhow::Result<()> {
 
     // Seal one more block to test the case where the transaction reference block is not the anchor
     // block.
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     create_multiple_accounts_test(&mock_chain, &genesis_block_header, AccountStorageMode::Public)
 }
@@ -504,7 +504,7 @@ pub fn create_accounts_with_anchor_block_zero() -> anyhow::Result<()> {
 #[test]
 pub fn create_accounts_with_non_zero_anchor_block() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(Some(1 << 16));
+    mock_chain.seal_block(Some(1 << 16), None);
 
     // Choose epoch block 1 whose block number is 2^16 as the anchor block.
     // Here the transaction reference block is also the anchor block.
@@ -514,7 +514,7 @@ pub fn create_accounts_with_non_zero_anchor_block() -> anyhow::Result<()> {
 
     // Seal one more block to test the case where the transaction reference block is not the anchor
     // block.
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     create_multiple_accounts_test(&mock_chain, &epoch1_block_header, AccountStorageMode::Public)
 }
@@ -559,7 +559,7 @@ fn compute_valid_account_id(
 #[test]
 pub fn create_account_fungible_faucet_invalid_initial_balance() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
@@ -583,7 +583,7 @@ pub fn create_account_fungible_faucet_invalid_initial_balance() -> anyhow::Resul
 #[test]
 pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
@@ -609,7 +609,7 @@ pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> any
 #[test]
 pub fn create_account_invalid_seed() {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 

--- a/crates/miden-tx/src/tests/kernel_tests/test_tx.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_tx.rs
@@ -771,7 +771,7 @@ fn test_fpi_memory() {
 
     let mut mock_chain =
         MockChain::with_accounts(&[native_account.clone(), foreign_account.clone()]);
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
     let advice_inputs = get_mock_fpi_adv_inputs(vec![&foreign_account], &mock_chain);
 
     let tx_context = mock_chain
@@ -1035,7 +1035,7 @@ fn test_fpi_memory_two_accounts() {
         foreign_account_1.clone(),
         foreign_account_2.clone(),
     ]);
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
     let advice_inputs =
         get_mock_fpi_adv_inputs(vec![&foreign_account_1, &foreign_account_2], &mock_chain);
 
@@ -1231,7 +1231,7 @@ fn test_fpi_execute_foreign_procedure() {
 
     let mut mock_chain =
         MockChain::with_accounts(&[native_account.clone(), foreign_account.clone()]);
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
     let advice_inputs = get_mock_fpi_adv_inputs(vec![&foreign_account], &mock_chain);
 
     let code = format!(

--- a/crates/miden-tx/tests/integration/scripts/faucet.rs
+++ b/crates/miden-tx/tests/integration/scripts/faucet.rs
@@ -196,7 +196,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     let note = get_note_with_fungible_asset_and_script(fungible_asset, note_script);
 
     mock_chain.add_pending_note(note.clone());
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------

--- a/crates/miden-tx/tests/integration/scripts/p2id.rs
+++ b/crates/miden-tx/tests/integration/scripts/p2id.rs
@@ -50,7 +50,7 @@ fn p2id_script_multiple_assets() {
         )
         .unwrap();
 
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ fn p2id_script_multiple_assets() {
     // A "malicious" account tries to consume the note, we expect an error (not the correct target)
 
     let malicious_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     // Execute the transaction and get the result
     let executed_transaction_2 = mock_chain
@@ -112,7 +112,7 @@ fn prove_consume_note_with_new_account() {
         )
         .unwrap();
 
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
@@ -165,7 +165,7 @@ fn prove_consume_multiple_notes() {
         )
         .unwrap();
 
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[note_1.id(), note_2.id()], &[])
@@ -216,7 +216,7 @@ fn test_create_consume_multiple_notes() {
         )
         .unwrap();
 
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     let output_note_1 = create_p2id_note(
         account.id(),

--- a/crates/miden-tx/tests/integration/scripts/p2idr.rs
+++ b/crates/miden-tx/tests/integration/scripts/p2idr.rs
@@ -14,7 +14,7 @@ use crate::assert_transaction_executor_error;
 #[test]
 fn p2idr_script() {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(Some(3));
+    mock_chain.seal_block(Some(3), None);
 
     // Create assets
     let fungible_asset: Asset = FungibleAsset::mock(100);
@@ -49,7 +49,7 @@ fn p2idr_script() {
         )
         .unwrap();
 
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     // --------------------------------------------------------------------------------------------
     // Case "in time": Only the target account can consume the note.

--- a/crates/miden-tx/tests/integration/scripts/swap.rs
+++ b/crates/miden-tx/tests/integration/scripts/swap.rs
@@ -85,7 +85,7 @@ fn prove_consume_swap_note() {
 
     let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![requested_asset]);
     mock_chain.add_pending_note(note.clone());
-    mock_chain.seal_block(None);
+    mock_chain.seal_next_block();
 
     let consume_swap_note_tx = mock_chain
         .build_tx_context(target_account.id(), &[note.id()], &[])


### PR DESCRIPTION
Enable setting the timestamp on `MockChain::seal_block` and rename the existing `seal_block` to `seal_next_block` for convenience.

Small fixes: Remove unused testing constants and fix tx kernel `main.masm` output docs

fixes #788