### PR TITLE
fix: Script builder newline

### DIFF
--- a/crates/miden-lib/src/account/interface/component.rs
+++ b/crates/miden-lib/src/account/interface/component.rs
@@ -244,7 +244,7 @@ impl AccountComponentInterface {
                         // stack => [note_idx]
                     }
 
-                    body.push_str("dropw dropw dropw drop");
+                    body.push_str("dropw dropw dropw drop\n");
                     // stack => []
                 },
                 _ => {


### PR DESCRIPTION
Should fix failing tests [here](https://github.com/0xPolygonMiden/miden-client/pull/781).
As an aside, there is probably some room for adding some util functions that help avoid these issues (eg, a `push_line()` function) or maybe a more builder-like approach 