### PR TITLE
Rename TransactionScript:hash() into TransactionScript::root()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [BREAKING] Moved the `TransactionScriptBuilder` from `miden-client` to `miden-base` (#1206).
 - [BREAKING] Enable timestamp customization on `MockChain::seal_block` (#1208).
 - [BREAKING] Renamed constants and comments: `OnChain` -> `Public` and `OffChain` -> `Private` (#1218).
-- [BREAKING] Replace "hash" with "commitment" in `BlockHeader::{prev_hash, chain_root, kernel_root, tx_hash, proof_hash, sub_hash, hash}` (#1209, #1221).
+- [BREAKING] Replace "hash" with "commitment" in `BlockHeader::{prev_hash, chain_root, kernel_root, tx_hash, proof_hash, sub_hash, hash}` (#1209, #1221, #1226).
 
 ## 0.7.2 (2025-01-28) - `miden-objects` crate only
 

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -107,7 +107,7 @@ fn build_advice_stack(
     inputs.extend_stack([Felt::from(tx_inputs.input_notes().num_notes() as u32)]);
 
     // push tx_script root onto the stack
-    inputs.extend_stack(tx_script.map_or(Word::default(), |script| *script.hash()));
+    inputs.extend_stack(tx_script.map_or(Word::default(), |script| *script.root()));
 }
 
 // CHAIN MMR INJECTOR

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -235,8 +235,8 @@ impl TransactionScript {
         self.mast.clone()
     }
 
-    /// Returns a reference to the code hash.
-    pub fn hash(&self) -> Digest {
+    /// Returns a MAST root of this transaction script.
+    pub fn root(&self) -> Digest {
         self.mast[self.entrypoint].digest()
     }
 

--- a/crates/miden-tx/src/tests/kernel_tests/test_prologue.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_prologue.rs
@@ -145,7 +145,7 @@ fn global_input_memory_assertions(process: &Process, inputs: &TransactionContext
 
     assert_eq!(
         read_root_mem_word(&process.into(), TX_SCRIPT_ROOT_PTR),
-        *inputs.tx_args().tx_script().as_ref().unwrap().hash(),
+        *inputs.tx_args().tx_script().as_ref().unwrap().root(),
         "The transaction script root should be stored at the TX_SCRIPT_ROOT_PTR"
     );
 }


### PR DESCRIPTION
This small PR renames `TransactionScript:hash()` into `TransactionScript::root()` as a follow-up to #1221.