### PR TITLE
Final changes for mdbook

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/book
+          path: ./docs/book/html
 
   # Deployment job only runs on push to next.
   deploy:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -57,6 +57,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         uses: actions/upload-pages-artifact@v3
         with:
+          # We specify multiple [output] sections in our book.toml which causes mdbook to create separate folders for each. This moves the generated `html` into its own `html` subdirectory.
           path: ./docs/book/html
 
   # Deployment job only runs on push to next.

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,41 +1,74 @@
-# Builds and deploys the mdbook
+# Performs checks, builds and deploys the documentation mdbook.
+#
+# Flow is based on the official github and mdbook documentation:
+#
+#   https://github.com/actions/starter-workflows/blob/main/pages/mdbook.yml
+#   https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions
 
 name: book
 
+# Documentation should be built and tested on every pull-request, and additionally deployed on push onto next.
 on:
+  workflow_dispatch:
+  pull_request:
+    path: ['docs/**']
   push:
-    branches: [main]
+    branches: [next]
+    path: ['docs/**']
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy mdbook
+  # Always build and test the mdbook documentation whenever the docs folder is changed.
+  #
+  # The documentation is uploaded as a github artifact IFF it is required for deployment i.e. on push into next.
+  build:
+    name: Build documentation
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
     steps:
       - uses: actions/checkout@main
-      - name: Install katex, alerts and linkcheck
-        run: |
-          rustup update --no-self-update stable
-          cargo +stable install mdbook-katex mdbook-linkcheck mdbook-alerts
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
+      # Installation from source takes a fair while, so we install the binaries directly instead.
+      - name: Install mdbook and plugins
+        uses: taiki-e/install-action@v2
         with:
-          mdbook-version: "latest"
+          tool: mdbook, mdbook-linkcheck, mdbook-alerts, mdbook-katex
 
-      - name: Build miden book
+      - name: Build book
         run: mdbook build docs/
 
+      # Only Upload documentation if we want to deploy (i.e. push to next).
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+        id: pages
+        uses: actions/configure-pages@v5
 
-      - name: Upload artifact
+      - name: Upload book artifact
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "docs/book/html"
+          path: ./docs/book
 
+  # Deployment job only runs on push to next.
+  deploy:
+    name: Deploy documentation
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,17 +45,3 @@ jobs:
           rustup target add wasm32-unknown-unknown
           make build-no-std
           make build-no-std-testing
-
-  book:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup mdbook and extensions
-        run: |
-          # Update Rust and install mdbook, katex, linkcheck and alerts
-          rustup update --no-self-update stable
-          cargo +stable install mdbook mdbook-katex mdbook-linkcheck mdbook-alerts
-      - name: Build book
-        run: mdbook build docs
-
-

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "The Miden protocol"
 authors = ["Miden team"]
-description = "Description and core structures for the Miden Rollup protocol"
+description = "Description and core structures for the Miden rollup protocol"
 multilingual = false
 language = "en"
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,5 +1,5 @@
 [book]
-authors      = ["Miden team"]
+authors      = ["Miden contributors"]
 description  = "Description and core structures for the Miden rollup protocol"
 language     = "en"
 multilingual = false

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,12 +1,12 @@
 [book]
-title = "The Miden protocol"
-authors = ["Miden team"]
-description = "Description and core structures for the Miden rollup protocol"
+title        = "The Miden Node"
+authors      = ["Miden team"]
+description  = "Description and core structures for the Miden rollup protocol"
+language     = "en"
 multilingual = false
-language = "en"
 
 [output.html]
-git-repository-url = "https://github.com/0xPolygonMiden/miden-base"
+git-repository-url = "https://github.com/0xPolygonMiden/miden-node"
 
 [preprocessor.katex]
 after = ["links"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,7 +3,7 @@ authors      = ["Miden team"]
 description  = "Description and core structures for the Miden rollup protocol"
 language     = "en"
 multilingual = false
-title        = "The Miden Node"
+title        = "The Miden Protocol"
 
 [output.html]
 git-repository-url = "https://github.com/0xPolygonMiden/miden-node"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,9 +1,9 @@
 [book]
-title        = "The Miden Node"
 authors      = ["Miden team"]
 description  = "Description and core structures for the Miden rollup protocol"
 language     = "en"
 multilingual = false
+title        = "The Miden Node"
 
 [output.html]
 git-repository-url = "https://github.com/0xPolygonMiden/miden-node"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,7 +3,7 @@ authors      = ["Miden contributors"]
 description  = "Description and core structures for the Miden rollup protocol"
 language     = "en"
 multilingual = false
-title        = "The Miden Protocol"
+title        = "The Miden protocol"
 
 [output.html]
 git-repository-url = "https://github.com/0xPolygonMiden/miden-base"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,7 @@ multilingual = false
 title        = "The Miden Protocol"
 
 [output.html]
-git-repository-url = "https://github.com/0xPolygonMiden/miden-node"
+git-repository-url = "https://github.com/0xPolygonMiden/miden-base"
 
 [preprocessor.katex]
 after = ["links"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,8 +7,6 @@ language = "en"
 
 [output.html]
 git-repository-url = "https://github.com/0xPolygonMiden/miden-base"
-no-section-label = true
-
 
 [preprocessor.katex]
 after = ["links"]


### PR DESCRIPTION
In this PR I: 
- Backport the changes made to `book.toml` in the miden-node
- Update the `book.toml` file to have sane defaults and support `katex, linkcheck, alerts`
- Remove book building from `build.yml`

Those changes will need to get backported in the next branch. Potentially during the next release.

Waiting to merge it the node before passing this PR as ready for review: https://github.com/0xPolygonMiden/miden-node/pull/748
