### PR TITLE
Add padding for inputs in `compute_inputs_commitment` procedure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,9 +431,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -1783,8 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72269e041e915d6c34325a8906f08a8ff6ec9b92c79ae07f3a0de8c3588694b5"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1794,8 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5680a0e75470389b65cc00900422ad7e1aa7972477c75ff88f63c3a01671e9"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1839,8 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ba125a31e9ec0e732f47e639525c753973e553126cfc46cc63674049ea4134"
 dependencies = [
  "lock_api",
  "loom",
@@ -1971,8 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5f362138a7bfe6c20246de651e848566843a0d5062cc4a7a8ebff6bd14668d"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1983,8 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6531711c8f3e25be9c607f82fc456594aba061acd3cde1df5d23eed88579340"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -2057,8 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "116d30a8db5167f88944509007b8bb7aad4fa0d9d03f2610b4e80be3a198ad37"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2102,8 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.14.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae6636d1e7a9d78a973fd59ffcfd87964eee235ecdf3264569add5ff89b0d91"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2885,7 +2892,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3102,7 +3109,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5299,11 +5306,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -5319,9 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,9 +1783,8 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72269e041e915d6c34325a8906f08a8ff6ec9b92c79ae07f3a0de8c3588694b5"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1795,9 +1794,8 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5680a0e75470389b65cc00900422ad7e1aa7972477c75ff88f63c3a01671e9"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1841,9 +1839,8 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ba125a31e9ec0e732f47e639525c753973e553126cfc46cc63674049ea4134"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "lock_api",
  "loom",
@@ -1974,9 +1971,8 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5f362138a7bfe6c20246de651e848566843a0d5062cc4a7a8ebff6bd14668d"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1987,9 +1983,8 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6531711c8f3e25be9c607f82fc456594aba061acd3cde1df5d23eed88579340"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -2062,9 +2057,8 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2694c29b37e953fec31bb912db604f16d4c1e9a692618eac876eb6d3c0473c36"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2108,9 +2102,8 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae6636d1e7a9d78a973fd59ffcfd87964eee235ecdf3264569add5ff89b0d91"
+version = "0.14.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=andrew-split-hash-memory#1230c072002aacdeb1029307f1de0fff601d0f41"
 dependencies = [
  "miden-air",
  "miden-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,18 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
+assembly = { package = "miden-assembly", version = "0.13", default-features = false }
 assert_matches = { version = "1.5", default-features = false }
 miden-block-prover = { path = "crates/miden-block-prover", version = "0.8", default-features = false }
 miden-crypto = { version = "0.14", default-features = false }
 miden-lib = { path = "crates/miden-lib", version = "0.8", default-features = false }
 miden-objects = { path = "crates/miden-objects", version = "0.8", default-features = false }
-miden-prover = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
-miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
+miden-prover = { version = "0.13", default-features = false }
+miden-stdlib = { version = "0.13", default-features = false }
 miden-tx = { path = "crates/miden-tx", version = "0.8", default-features = false }
 miden-tx-batch-prover = { path = "crates/miden-tx-batch-prover", version = "0.8", default-features = false }
-miden-verifier = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
+miden-verifier = { version = "0.13", default-features = false }
 rand = { version = "0.9", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
-vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
+vm-core = { package = "miden-core", version = "0.13", default-features = false }
+vm-processor = { package = "miden-processor", version = "0.13", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,18 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies]
-assembly = { package = "miden-assembly", version = "0.13", default-features = false }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
 assert_matches = { version = "1.5", default-features = false }
 miden-block-prover = { path = "crates/miden-block-prover", version = "0.8", default-features = false }
 miden-crypto = { version = "0.14", default-features = false }
 miden-lib = { path = "crates/miden-lib", version = "0.8", default-features = false }
 miden-objects = { path = "crates/miden-objects", version = "0.8", default-features = false }
-miden-prover = { version = "0.13", default-features = false }
-miden-stdlib = { version = "0.13", default-features = false }
+miden-prover = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
 miden-tx = { path = "crates/miden-tx", version = "0.8", default-features = false }
 miden-tx-batch-prover = { path = "crates/miden-tx-batch-prover", version = "0.8", default-features = false }
-miden-verifier = { version = "0.13", default-features = false }
+miden-verifier = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
 rand = { version = "0.9", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-vm-core = { package = "miden-core", version = "0.13", default-features = false }
-vm-processor = { package = "miden-processor", version = "0.13", default-features = false }
+vm-core = { package = "miden-core", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }
+vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "andrew-split-hash-memory", default-features = false }

--- a/crates/miden-lib/asm/miden/note.masm
+++ b/crates/miden-lib/asm/miden/note.masm
@@ -198,16 +198,17 @@ export.get_serial_number
     # => [SERIAL_NUMBER]
 end
 
-#! Computes hash of note inputs starting at the specified memory address.
+#! Computes commitment of note inputs starting at the specified memory address.
 #!
 #! This procedure checks that the provided number of inputs is within limits and then computes the
-#! hash using the procedure from the standard library. See the documentation of the
-#! `std::crypto::hashes::rpo::hash_memory` for the more detailed description.
+#! hash. 
+#!
+#! Notice that the note inputs are padded with zeros in case their number is not multiple of 8.
 #!
 #! If the number if inputs is 0, procedure returns the empty word: [0, 0, 0, 0].
 #!
 #! Inputs:  [inputs_ptr, num_inputs]
-#! Outputs: [HASH]
+#! Outputs: [COMMITMENT]
 #!
 #! Cycles:
 #! - If number of elements divides by 8: 56 cycles + 3 * words
@@ -217,13 +218,19 @@ end
 #! - num_inputs is greater than 128.
 #!
 #! Invocation: exec
-export.compute_inputs_hash
+export.compute_inputs_commitment
     # check that number of inputs is less than 128
     dup.1 push.128 u32assert2 u32lte assert.err=ERR_PROLOGUE_NUMBER_OF_NOTE_INPUTS_EXCEEDED_LIMIT
+    # => [inputs_ptr, num_inputs]
 
-    # compute the hash
-    exec.rpo::hash_memory
-    # => [HASH]
+    # push 1 as the pad_inputs flag: we should pad the stack while computing the note inputs 
+    # commitment
+    push.1 movdn.2
+    # => [inputs_ptr, num_inputs, pad_inputs_flag]
+    exec.rpo::prepare_hasher_state
+
+    exec.rpo::hash_memory_with_state
+    # => [COMMITMENT]
 end
 
 #! Returns the script root of the note currently being processed.

--- a/crates/miden-lib/asm/miden/note.masm
+++ b/crates/miden-lib/asm/miden/note.masm
@@ -198,12 +198,12 @@ export.get_serial_number
     # => [SERIAL_NUMBER]
 end
 
-#! Computes commitment of note inputs starting at the specified memory address.
+#! Computes commitment to the note inputs starting at the specified memory address.
 #!
 #! This procedure checks that the provided number of inputs is within limits and then computes the
-#! hash. 
+#! commitment.
 #!
-#! Notice that the note inputs are padded with zeros in case their number is not multiple of 8.
+#! Notice that the note inputs are padded with zeros in case their number is not a multiple of 8.
 #!
 #! If the number if inputs is 0, procedure returns the empty word: [0, 0, 0, 0].
 #!
@@ -215,6 +215,7 @@ end
 #! - Else: 189 cycles + 3 * words
 #!
 #! Panics if:
+#! - inputs_ptr is not word-aligned (i.e., is not a multiple of 4).
 #! - num_inputs is greater than 128.
 #!
 #! Invocation: exec


### PR DESCRIPTION
This PR adds a padding of values provided to the `compute_inputs_commitment` procedure, making the resulting commitment match the one obtained from the `commitment()` method of the `NoteInputs` structure. 

Closes: #1237 