### PR TITLE
chore: update axum and tokio in proving service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,8 +230,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -239,7 +266,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -264,6 +291,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
  "bytes",
  "futures-util",
  "http",
@@ -1758,6 +1804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,7 +2055,7 @@ name = "miden-proving-service"
 version = "0.9.0"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.1",
  "bytes",
  "clap 4.5.32",
  "miden-block-prover",
@@ -4224,7 +4276,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64",
  "bytes",
  "h2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,32 +2452,47 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "768ee97dc5cd695a4dd4a69a0678fb42789666b5a89e8c0af48bb06c6e427120"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
  "http",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror 2.0.12",
  "tokio",
  "tonic",
  "tracing",
@@ -2485,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2497,26 +2512,25 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3310,6 +3324,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4480,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/bin/proving-service/Cargo.toml
+++ b/bin/proving-service/Cargo.toml
@@ -21,7 +21,7 @@ concurrent = ["miden-tx/concurrent"]
 
 [dependencies]
 async-trait = "0.1"
-axum = { version = "0.7" }
+axum = { version = "0.8" }
 bytes = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
 miden-block-prover = { workspace = true, default-features = false }
@@ -42,7 +42,7 @@ pingora-limits = "0.4"
 reqwest = { version = "0.12" }
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = { version = "0.13" }
-tokio = { version = "1.38", features = ["full"] }
+tokio = { version = "1.44", features = ["full"] }
 tokio-stream = { version = "0.1", features = [ "net" ]}
 thiserror = { workspace = true }
 tonic = { version = "0.12", default-features = false, features = ["codegen", "prost", "transport"] }
@@ -51,7 +51,7 @@ tonic-web = { version = "0.12" }
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3", features = ["fmt",  "json",  "env-filter"] }
-uuid = { version = "1.11", features = ["v4"] }
+uuid = { version = "1.16", features = ["v4"] }
 
 [dev-dependencies]
 miden-lib = { workspace = true , default-features = false, features = ["testing"]}
@@ -59,7 +59,7 @@ miden-objects = { workspace = true, default-features = false, features = ["testi
 miden-tx = { workspace = true, default-features = false, features = ["testing"] }
 
 [build-dependencies]
-miette = { version = "7.2", features = ["fancy"] }
+miette = { version = "7.5", features = ["fancy"] }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 prost-build = { version = "0.13" }
 protox = { version = "0.7" }

--- a/bin/proving-service/Cargo.toml
+++ b/bin/proving-service/Cargo.toml
@@ -29,10 +29,10 @@ miden-lib = { workspace = true, default-features = false }
 miden-objects = { workspace = true, default-features = false, features = ["std"] }
 miden-tx = { workspace = true, default-features = false, features = ["std"] }
 miden-tx-batch-prover = { workspace = true, default-features = false, features = ["std"] }
-opentelemetry = { version = "0.27", features = ["metrics", "trace"] }
-opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.27", features = ["metrics", "rt-tokio"] }
-opentelemetry-semantic-conventions = "0.27"
+opentelemetry = { version = "0.29", features = ["metrics", "trace"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.29", features = ["metrics", "rt-tokio"] }
+opentelemetry-semantic-conventions = "0.29"
 prometheus = "0.13"
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 pingora = { version = "0.4", features = [ "lb" ] }
@@ -49,7 +49,7 @@ tonic = { version = "0.12", default-features = false, features = ["codegen", "pr
 tonic-health = { version = "0.12" }
 tonic-web = { version = "0.12" }
 tracing = { version = "0.1" }
-tracing-opentelemetry = "0.28"
+tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3", features = ["fmt",  "json",  "env-filter"] }
 uuid = { version = "1.16", features = ["v4"] }
 

--- a/bin/proving-service/src/proxy/health_check.rs
+++ b/bin/proving-service/src/proxy/health_check.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
-use axum::async_trait;
 use pingora::{prelude::sleep, server::ShutdownWatch, services::background::BackgroundService};
-use tonic::transport::Channel;
+use tonic::{async_trait, transport::Channel};
 use tonic_health::pb::health_client::HealthClient;
 use tracing::debug_span;
 
@@ -32,7 +31,7 @@ impl BackgroundService for LoadBalancerState {
     ///
     /// # Errors
     /// - If the worker has an invalid URI.
-    async fn start(&self, _shutdown: ShutdownWatch) {
+    async fn start(&self, mut _shutdown: ShutdownWatch) {
         Box::pin(async move {
             loop {
                 // Create a new spawn to perform the health check

--- a/bin/proving-service/src/proxy/update_workers.rs
+++ b/bin/proving-service/src/proxy/update_workers.rs
@@ -1,13 +1,13 @@
 use core::fmt;
 use std::sync::Arc;
 
-use axum::async_trait;
 use pingora::{
     apps::{HttpServerApp, HttpServerOptions},
     http::ResponseHeader,
     protocols::{Stream, http::ServerSession},
     server::ShutdownWatch,
 };
+use tonic::async_trait;
 use tracing::{error, info};
 
 use super::LoadBalancerState;

--- a/bin/proving-service/src/utils.rs
+++ b/bin/proving-service/src/utils.rs
@@ -25,11 +25,12 @@ const RESOURCE_EXHAUSTED_CODE: u16 = 8;
 /// This function sets up a tracing pipeline that includes:
 ///
 /// - An OpenTelemetry (OTLP) exporter, which sends span data to an OTLP endpoint using gRPC.
-/// - A [TracerProvider] configured with a [Sampler::ParentBased] sampler at a `1.0` sampling ratio,
-///   ensuring that all traces are recorded.
+/// - A [SdkTracerProvider] configured with a [Sampler::ParentBased] sampler at a `1.0` sampling
+///   ratio, ensuring that all traces are recorded.
 /// - A resource containing the service name and version extracted from the crate's metadata.
-/// - A `tracing` subscriber that integrates the configured [TracerProvider] with the Rust `tracing`
-///   ecosystem, applying filters from the environment and enabling formatted console logs.
+/// - A `tracing` subscriber that integrates the configured [SdkTracerProvider] with the Rust
+///   `tracing` ecosystem, applying filters from the environment and enabling formatted console
+///   logs.
 ///
 /// **Process:**
 /// 1. **OTLP Exporter**:   Creates an OTLP span exporter that sends trace data to a collector
@@ -38,7 +39,7 @@ const RESOURCE_EXHAUSTED_CODE: u16 = 8;
 /// 2. **Resource Setup**:   Creates a [Resource] containing service metadata (name and version),
 ///    which is attached to all emitted telemetry data to identify the originating service.
 ///
-/// 3. **TracerProvider and Sampler**:   Builds a [TracerProvider] using a [Sampler::ParentBased]
+/// 3. **TracerProvider and Sampler**:   Builds a [SdkTracerProvider] using a [Sampler::ParentBased]
 ///    sampler layered over a [Sampler::TraceIdRatioBased] sampler set to `1.0`, ensuring all traces
 ///    are recorded. A random ID generator is used to produce trace and span IDs. The tracer is
 ///    retrieved from this provider, which can then be used by the OpenTelemetry layer of `tracing`.


### PR DESCRIPTION
part of #1244 

Could not update `opentelemetry` because `tracing-opentelemetry` is not updated yet. The PR in the `tracing-opentelemetry` that uses the new OTel version was merged a couple hours ago, but I don't know when it is going to be released. (https://github.com/tokio-rs/tracing-opentelemetry/pull/196)