### PR TITLE
Hash keys in `StorageMap` before insertion into SMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.9.0 (TBD)
 
+- [BREAKING] Hash keys in storage maps before insertion into the SMT (#1250).
 
 ## 0.8.0 (2025-03-21)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -584,7 +584,10 @@ export.get_map_item
     exec.get_item swapw
     # => [KEY, ROOT]
 
-    # fetch the VALUE located under KEY in the tree
+    exec.hash_map_key
+    # => [HASHED_KEY, ROOT]
+
+    # fetch the VALUE located under HASHED_KEY in the tree
     exec.smt::get
     # => [VALUE, ROOT]
 
@@ -629,13 +632,16 @@ export.set_map_item.12
     emit.ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_EVENT
     # => [index, KEY, NEW_VALUE, OLD_ROOT]
 
-    # duplicate the KEY and the NEW_VALUE to be able to emit an event after an account storage item
-    # is being updated
+    # duplicate the original KEY and the NEW_VALUE to be able to emit an event after the
+    # account storage item was updated
     movdn.12 movupw.2 dupw.2 dupw.2
     # => [KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE, index, ...]
 
-    # set the NEW_VALUE under KEY in the tree
-    # note smt::set expects the stack to be [NEW_VALUE, KEY, OLD_ROOT, ...]
+    exec.hash_map_key
+    # => [HASHED_KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE, index, ...]
+
+    # set the NEW_VALUE under HASHED_KEY in the tree
+    # note smt::set expects the stack to be [NEW_VALUE, HASHED_KEY, OLD_ROOT, ...]
     swapw exec.smt::set
     # => [OLD_MAP_VALUE, NEW_ROOT, KEY, NEW_VALUE, index, ...]
 
@@ -1131,4 +1137,18 @@ export.validate_current_foreign_account
 
     # clean the stack
     dropw drop drop dropw
+end
+
+#! Hashes the map key.
+#!
+#! Inputs:  [KEY]
+#! Outputs: [HASHED_KEY]
+proc.hash_map_key
+  # pad four elements for the capacity of the hasher
+  # pad another four elements so the hash input is a multiple of 8
+  padw swapw padw swapw
+  # => [KEY, pad(8)]
+
+  hperm exec.rpo::squeeze_digest
+  # => [HASHED_KEY]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -584,6 +584,7 @@ export.get_map_item
     exec.get_item swapw
     # => [KEY, ROOT]
 
+    # see hash_map_key's docs for why this is done
     exec.hash_map_key
     # => [HASHED_KEY, ROOT]
 
@@ -637,6 +638,7 @@ export.set_map_item.12
     movdn.12 movupw.2 dupw.2 dupw.2
     # => [KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE, index, ...]
 
+    # see hash_map_key's docs for why this is done
     exec.hash_map_key
     # => [HASHED_KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE, index, ...]
 
@@ -1143,7 +1145,7 @@ end
 #!
 #! Because the keys of the map are user-chosen and thus not necessarily uniformly distributed, the
 #! tree could be imbalanced and made less efficient. To mitigate that, the keys used in the
-#! storage map are hashed before they are inserted into the SMT.
+#! storage map are hashed before they are inserted into the SMT, which creates a uniform distribution.
 #!
 #! Inputs:  [KEY]
 #! Outputs: [HASHED_KEY]

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -1139,16 +1139,15 @@ export.validate_current_foreign_account
     dropw drop drop dropw
 end
 
-#! Hashes the map key.
+#! Hashes the provided map key before using it as the key in an SMT.
+#!
+#! Because the keys of the map are user-chosen and thus not necessarily uniformly distributed, the
+#! tree could be imbalanced and made less efficient. To mitigate that, the keys used in the
+#! storage map are hashed before they are inserted into the SMT.
 #!
 #! Inputs:  [KEY]
 #! Outputs: [HASHED_KEY]
 proc.hash_map_key
-  # pad four elements for the capacity of the hasher
-  # pad another four elements so the hash input is a multiple of 8
-  padw swapw padw swapw
-  # => [KEY, pad(8)]
-
-  hperm exec.rpo::squeeze_digest
+  hash
   # => [HASHED_KEY]
 end

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -26,9 +26,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_set_item
     digest!("0x61104ec016c3ed9b49aee53650ddde9e984a72e4c4e13001cbf98b9cef426758"),
     // account_get_map_item
-    digest!("0x83669d173ad329875f6b437baf0cca81e9c41da21341de22e2fde90cd286f328"),
+    digest!("0xf751b0762e049923d31ec6fd18512254f307f22140a7daa40e71ae7577b03f67"),
     // account_set_map_item
-    digest!("0xde87706076fd489ab7daf2907029652da37feb2b3764a04d502f6278007164b6"),
+    digest!("0x47be5d18f62a46c8c75076d1c63df9a0bbf1bf42b1b865a64cddb52489b7c7d6"),
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
@@ -40,13 +40,13 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0xd9e37bc78345afd12fc87a495486d32fc53bc3fa1aca3a4b7549bf12e96b52e5"),
+    digest!("0xc8f5ec2b280ba12b685b8730b4a8e32c1b9199081fd6070db89dc87af598a317"),
     // faucet_burn_asset
-    digest!("0x7226424c7c3cdeaa8b43ee83890786c2dda7d70363f8c9db91fb706540b97df5"),
+    digest!("0xabf28cea013cbef5838c49f0e4a9118f32437e2086e31d1dea14959c3a7e862d"),
     // faucet_get_total_fungible_asset_issuance
     digest!("0xd2ee4bd330f989165ee2be0f121a4db916f95e58f6fd2d040d57672f2f0cef63"),
     // faucet_is_non_fungible_asset_issued
-    digest!("0x351c2998c5e0f253f1384c5e649f3111f2f5438c3ada41b23898cbf0c17e4639"),
+    digest!("0x1587b082609234cbb46300f8ce342ecf2b7757ae98d13c679df7c439b0b33cbc"),
     // note_get_assets_info
     digest!("0x34e4f1ea83eb4342ab8f5acec89962b2ab4b56d9c631e807d8e4dc8efd270bf2"),
     // note_add_asset

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -26,9 +26,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_set_item
     digest!("0x61104ec016c3ed9b49aee53650ddde9e984a72e4c4e13001cbf98b9cef426758"),
     // account_get_map_item
-    digest!("0x21237825d10004f77d3e7b32aee9052b519752fd03f839c19440e2010f73132e"),
+    digest!("0x83669d173ad329875f6b437baf0cca81e9c41da21341de22e2fde90cd286f328"),
     // account_set_map_item
-    digest!("0x876168292d11aea0e2886ee6d7f9e723a95ec3aa4e467e6f46c898567bfc3604"),
+    digest!("0xde87706076fd489ab7daf2907029652da37feb2b3764a04d502f6278007164b6"),
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
@@ -40,13 +40,13 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0x836ecba4b7caa770b24ffa51115e2c08724ecb7f0854ee3a94848bec5b0ee2ce"),
+    digest!("0xd9e37bc78345afd12fc87a495486d32fc53bc3fa1aca3a4b7549bf12e96b52e5"),
     // faucet_burn_asset
-    digest!("0x37e6b7c80f478c11ea7f12c065013c4bc3a09100fd6ecc4893e17d0abd675254"),
+    digest!("0x7226424c7c3cdeaa8b43ee83890786c2dda7d70363f8c9db91fb706540b97df5"),
     // faucet_get_total_fungible_asset_issuance
     digest!("0xd2ee4bd330f989165ee2be0f121a4db916f95e58f6fd2d040d57672f2f0cef63"),
     // faucet_is_non_fungible_asset_issued
-    digest!("0x04c49c1f9cc628c1447e19d46c307084e995044faa86154353eec6af6b5b5041"),
+    digest!("0x351c2998c5e0f253f1384c5e649f3111f2f5438c3ada41b23898cbf0c17e4639"),
     // note_get_assets_info
     digest!("0x34e4f1ea83eb4342ab8f5acec89962b2ab4b56d9c631e807d8e4dc8efd270bf2"),
     // note_add_asset

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -11,7 +11,6 @@ use super::{
 use crate::{
     Digest, EMPTY_WORD,
     account::{AccountStorage, StorageMap, StorageSlot},
-    crypto::merkle::SmtLeaf,
 };
 // ACCOUNT STORAGE DELTA
 // ================================================================================================
@@ -276,21 +275,7 @@ impl StorageMapDelta {
 /// Converts a [StorageMap] into a [StorageMapDelta] for initial delta construction.
 impl From<StorageMap> for StorageMapDelta {
     fn from(map: StorageMap) -> Self {
-        // TODO: implement `IntoIterator` for `Smt` and get rid of copying keys/values:
-        let mut delta = StorageMapDelta::new(BTreeMap::default());
-        for (_, leaf) in map.leaves() {
-            match leaf {
-                SmtLeaf::Empty(_) => continue,
-                SmtLeaf::Single((key, value)) => {
-                    delta.insert(*key, *value);
-                },
-                SmtLeaf::Multiple(vec) => {
-                    vec.iter().for_each(|(key, value)| delta.insert(*key, *value));
-                },
-            }
-        }
-
-        delta
+        StorageMapDelta::new(map.into_entries())
     }
 }
 

--- a/crates/miden-objects/src/account/storage/header.rs
+++ b/crates/miden-objects/src/account/storage/header.rs
@@ -146,19 +146,13 @@ mod tests {
 
     #[test]
     fn test_from_account_storage() {
+        let storage_map = AccountStorage::mock_map();
+
         // create new storage header from AccountStorage
         let slots = vec![
             (StorageSlotType::Value, [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
             (StorageSlotType::Value, [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]),
-            (
-                StorageSlotType::Map,
-                [
-                    Felt::new(12405212884040084310),
-                    Felt::new(17614307840949763446),
-                    Felt::new(6101527485586301500),
-                    Felt::new(14442045877206841081),
-                ],
-            ),
+            (StorageSlotType::Map, storage_map.root().into()),
         ];
 
         let expected_header = AccountStorageHeader { slots };

--- a/crates/miden-objects/src/account/storage/map.rs
+++ b/crates/miden-objects/src/account/storage/map.rs
@@ -22,7 +22,7 @@ use crate::{
 /// Empty storage map root.
 pub const EMPTY_STORAGE_MAP_ROOT: Digest = *EmptySubtreeRoots::entry(StorageMap::TREE_DEPTH, 0);
 
-/// An account storage map which is a sparse merkle tree of depth [`Self::TREE_DEPTH`] (64).
+/// An account storage map is a sparse merkle tree of depth [`Self::TREE_DEPTH`] (64).
 ///
 /// It can be used to store a large amount of data in an account than would be otherwise possible
 /// using just the account's storage slots. This works by storing the root of the map's underlying
@@ -34,7 +34,7 @@ pub const EMPTY_STORAGE_MAP_ROOT: Digest = *EmptySubtreeRoots::entry(StorageMap:
 /// accessed/modified items are present in the advice provider.
 ///
 /// Because the keys of the map are user-chosen and thus not necessarily uniformly distributed, the
-/// trees could be imbalanced and made less efficient. To mitigate that, the keys used in the
+/// tree could be imbalanced and made less efficient. To mitigate that, the keys used in the
 /// storage map are hashed before they are inserted into the SMT. The original keys are retained in
 /// a separate map. This causes redundancy but allows for introspection of the map, e.g. by querying
 /// the set of stored (original) keys which is useful in debugging and explorer scenarios.
@@ -177,10 +177,7 @@ impl StorageMap {
 
     /// Hashes the given key to get the key of the SMT.
     pub fn hash_key(key: RpoDigest) -> RpoDigest {
-        let padded_input =
-            [Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ZERO, key[0], key[1], key[2], key[3]];
-
-        Hasher::hash_elements(&padded_input)
+        Hasher::hash_elements(key.as_elements())
     }
 }
 

--- a/crates/miden-objects/src/account/storage/map.rs
+++ b/crates/miden-objects/src/account/storage/map.rs
@@ -1,29 +1,52 @@
-use miden_crypto::merkle::{EmptySubtreeRoots, MerkleError};
+use alloc::collections::BTreeMap;
+
+use miden_crypto::merkle::EmptySubtreeRoots;
+use vm_core::{EMPTY_WORD, Felt, FieldElement};
 
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Serializable, Word,
 };
 use crate::{
+    Hasher,
     account::StorageMapDelta,
     crypto::{
         hash::rpo::RpoDigest,
         merkle::{InnerNodeInfo, LeafIndex, SMT_DEPTH, Smt, SmtLeaf, SmtProof},
     },
+    errors::StorageMapError,
 };
 
 // ACCOUNT STORAGE MAP
 // ================================================================================================
 
 /// Empty storage map root.
-pub const EMPTY_STORAGE_MAP_ROOT: Digest =
-    *EmptySubtreeRoots::entry(StorageMap::STORAGE_MAP_TREE_DEPTH, 0);
+pub const EMPTY_STORAGE_MAP_ROOT: Digest = *EmptySubtreeRoots::entry(StorageMap::TREE_DEPTH, 0);
 
-/// Account storage map is a Sparse Merkle Tree of depth 64. It can be used to store more data as
-/// there is in plain usage of the storage slots. The root of the SMT consumes one account storage
-/// slot.
+/// An account storage map which is a sparse merkle tree of depth [`Self::TREE_DEPTH`] (64).
+///
+/// It can be used to store a large amount of data in an account than would be otherwise possible
+/// using just the account's storage slots. This works by storing the root of the map's underlying
+/// SMT in one account storage slot. Each map entry is a leaf in the tree and its inclusion is
+/// proven while retrieving it (e.g. via `account::get_map_item`).
+///
+/// As a side-effect, this also means that _not all_ entries of the map have to be present at
+/// transaction execution time in order to access or modify the map. It is sufficient if _just_ the
+/// accessed/modified items are present in the advice provider.
+///
+/// Because the keys of the map are user-chosen and thus not necessarily uniformly distributed, the
+/// trees could be imbalanced and made less efficient. To mitigate that, the keys used in the
+/// storage map are hashed before they are inserted into the SMT. The original keys are retained in
+/// a separate map. This causes redundancy but allows for introspection of the map, e.g. by querying
+/// the set of stored (original) keys which is useful in debugging and explorer scenarios.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageMap {
+    /// The SMT where each key is the hashed original key.
     map: Smt,
+    /// The entries of the map where the key is the original user-chosen one.
+    ///
+    /// It is an invariant of this type that the map's entries are always consistent with the SMT's
+    /// entries and vice-versa.
+    entries: BTreeMap<RpoDigest, Word>,
 }
 
 impl StorageMap {
@@ -31,7 +54,7 @@ impl StorageMap {
     // --------------------------------------------------------------------------------------------
 
     /// Depth of the storage tree.
-    pub const STORAGE_MAP_TREE_DEPTH: u8 = SMT_DEPTH;
+    pub const TREE_DEPTH: u8 = SMT_DEPTH;
 
     /// The default value of empty leaves.
     pub const EMPTY_VALUE: Word = Smt::EMPTY_VALUE;
@@ -43,60 +66,100 @@ impl StorageMap {
     ///
     /// All leaves in the returned tree are set to [Self::EMPTY_VALUE].
     pub fn new() -> Self {
-        StorageMap { map: Smt::new() }
+        StorageMap {
+            map: Smt::new(),
+            entries: BTreeMap::new(),
+        }
     }
 
     /// Creates a new [`StorageMap`] from the provided key-value entries.
     ///
     /// # Errors
     ///
-    /// Returns an error if the provided entries contain multiple values for the same key.
-    pub fn with_entries(
-        entries: impl IntoIterator<Item = (RpoDigest, Word)>,
-    ) -> Result<Self, MerkleError> {
-        Smt::with_entries(entries).map(|map| StorageMap { map })
+    /// Returns an error if:
+    /// - the provided entries contain multiple values for the same key.
+    pub fn with_entries<I: ExactSizeIterator<Item = (RpoDigest, Word)>>(
+        entries: impl IntoIterator<Item = (RpoDigest, Word), IntoIter = I>,
+    ) -> Result<Self, StorageMapError> {
+        let mut map = BTreeMap::new();
+
+        for (key, value) in entries {
+            if let Some(prev_value) = map.insert(key, value) {
+                return Err(StorageMapError::DuplicateKey {
+                    key,
+                    value0: prev_value,
+                    value1: value,
+                });
+            }
+        }
+
+        Ok(Self::from_btree_map(map))
+    }
+
+    /// Creates a new [`StorageMap`] from the given map. For internal use.
+    fn from_btree_map(entries: BTreeMap<RpoDigest, Word>) -> Self {
+        let hashed_keys_iter = entries.iter().map(|(key, value)| (Self::hash_key(*key), *value));
+        let smt = Smt::with_entries(hashed_keys_iter)
+            .expect("btree maps should not contain duplicate keys");
+
+        StorageMap { map: smt, entries }
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    pub const fn depth(&self) -> u8 {
-        SMT_DEPTH
-    }
-
+    /// Returns the root of the underlying sparse merkle tree.
     pub fn root(&self) -> RpoDigest {
-        self.map.root() // Delegate to Smt's root method
+        self.map.root()
     }
 
-    pub fn get_leaf(&self, key: &RpoDigest) -> SmtLeaf {
-        self.map.get_leaf(key) // Delegate to Smt's get_leaf method
+    /// Returns the value corresponding to the key or [`Self::EMPTY_VALUE`] if the key is not
+    /// associated with a value.
+    pub fn get(&self, key: &RpoDigest) -> Word {
+        self.entries.get(key).copied().unwrap_or_default()
     }
 
-    pub fn get_value(&self, key: &RpoDigest) -> Word {
-        self.map.get_value(key) // Delegate to Smt's get_value method
-    }
-
+    /// Returns an opening of the leaf associated with `key`.
+    ///
+    /// Conceptually, an opening is a Merkle path to the leaf, as well as the leaf itself.
     pub fn open(&self, key: &RpoDigest) -> SmtProof {
-        self.map.open(key) // Delegate to Smt's open method
+        let key = Self::hash_key(*key);
+        self.map.open(&key)
     }
 
     // ITERATORS
     // --------------------------------------------------------------------------------------------
+
+    /// Returns an iterator over the leaves of the underlying [`Smt`].
     pub fn leaves(&self) -> impl Iterator<Item = (LeafIndex<SMT_DEPTH>, &SmtLeaf)> {
         self.map.leaves() // Delegate to Smt's leaves method
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = &(RpoDigest, Word)> {
-        self.map.entries() // Delegate to Smt's entries method
+    /// Returns an iterator over the key value pairs of the map.
+    pub fn entries(&self) -> impl Iterator<Item = (&RpoDigest, &Word)> {
+        self.entries.iter()
     }
 
+    /// Returns an iterator over the inner nodes of the underlying [`Smt`].
     pub fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
         self.map.inner_nodes() // Delegate to Smt's inner_nodes method
     }
 
     // DATA MUTATORS
     // --------------------------------------------------------------------------------------------
+
+    /// Inserts or updates the given key value pair and returns the previous value, or
+    /// [`Self::EMPTY_VALUE`] if no entry was previously present.
+    ///
+    /// If the provided `value` is [`Self::EMPTY_VALUE`] the entry will be removed.
     pub fn insert(&mut self, key: RpoDigest, value: Word) -> Word {
+        if value == EMPTY_WORD {
+            self.entries.remove(&key);
+        } else {
+            self.entries.insert(key, value);
+        }
+
+        let key = Self::hash_key(key);
         self.map.insert(key, value) // Delegate to Smt's insert method
     }
 
@@ -108,6 +171,19 @@ impl StorageMap {
         }
 
         self.root()
+    }
+
+    /// Consumes the map and returns the underlying map of entries.
+    pub fn into_entries(self) -> BTreeMap<RpoDigest, Word> {
+        self.entries
+    }
+
+    /// Hashes the given key to get the key of the SMT.
+    pub fn hash_key(key: RpoDigest) -> RpoDigest {
+        let padded_input =
+            [Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ZERO, key[0], key[1], key[2], key[3]];
+
+        Hasher::hash_elements(&padded_input)
     }
 }
 
@@ -122,7 +198,7 @@ impl Default for StorageMap {
 
 impl Serializable for StorageMap {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.map.write_into(target)
+        self.entries.write_into(target);
     }
 
     fn get_size_hint(&self) -> usize {
@@ -132,17 +208,18 @@ impl Serializable for StorageMap {
 
 impl Deserializable for StorageMap {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let smt = Smt::read_from(source)?;
-        Ok(StorageMap { map: smt })
+        let entries = BTreeMap::read_from(source)?;
+        Ok(Self::from_btree_map(entries))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use miden_crypto::{Felt, hash::rpo::RpoDigest, merkle::MerkleError};
+    use miden_crypto::{Felt, hash::rpo::RpoDigest};
 
     use super::{Deserializable, EMPTY_STORAGE_MAP_ROOT, Serializable, StorageMap, Word};
+    use crate::errors::StorageMapError;
 
     #[test]
     fn account_storage_serialization() {
@@ -165,7 +242,11 @@ mod tests {
         let storage_map = StorageMap::with_entries(storage_map_leaves_2).unwrap();
 
         let bytes = storage_map.to_bytes();
-        assert_eq!(storage_map, StorageMap::read_from_bytes(&bytes).unwrap());
+        let deserialized_map = StorageMap::read_from_bytes(&bytes).unwrap();
+
+        assert_eq!(storage_map.root(), deserialized_map.root());
+
+        assert_eq!(storage_map, deserialized_map);
     }
 
     #[test]
@@ -189,6 +270,6 @@ mod tests {
         ];
 
         let error = StorageMap::with_entries(storage_map_leaves_2).unwrap_err();
-        assert_matches!(error, MerkleError::DuplicateValuesForIndex(_));
+        assert_matches!(error, StorageMapError::DuplicateKey { .. });
     }
 }

--- a/crates/miden-objects/src/account/storage/map.rs
+++ b/crates/miden-objects/src/account/storage/map.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeMap;
 
 use miden_crypto::merkle::EmptySubtreeRoots;
-use vm_core::{EMPTY_WORD, Felt, FieldElement};
+use vm_core::EMPTY_WORD;
 
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Serializable, Word,
@@ -35,9 +35,10 @@ pub const EMPTY_STORAGE_MAP_ROOT: Digest = *EmptySubtreeRoots::entry(StorageMap:
 ///
 /// Because the keys of the map are user-chosen and thus not necessarily uniformly distributed, the
 /// tree could be imbalanced and made less efficient. To mitigate that, the keys used in the
-/// storage map are hashed before they are inserted into the SMT. The original keys are retained in
-/// a separate map. This causes redundancy but allows for introspection of the map, e.g. by querying
-/// the set of stored (original) keys which is useful in debugging and explorer scenarios.
+/// storage map are hashed before they are inserted into the SMT, which creates a uniform
+/// distribution. The original keys are retained in a separate map. This causes redundancy but
+/// allows for introspection of the map, e.g. by querying the set of stored (original) keys which is
+/// useful in debugging and explorer scenarios.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageMap {
     /// The SMT where each key is the hashed original key.

--- a/crates/miden-objects/src/account/storage/mod.rs
+++ b/crates/miden-objects/src/account/storage/mod.rs
@@ -132,7 +132,7 @@ impl AccountStorage {
             slots_len: self.slots.len() as u8,
             index,
         })? {
-            StorageSlot::Map(map) => Ok(map.get_value(&Digest::from(key))),
+            StorageSlot::Map(map) => Ok(map.get(&Digest::from(key))),
             _ => Err(AccountError::StorageSlotNotMap(index)),
         }
     }

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -227,6 +227,18 @@ pub enum AccountDeltaError {
     NotAFungibleFaucetId(AccountId),
 }
 
+// STORAGE MAP ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum StorageMapError {
+    #[error("map entries contain key {key} twice with values {value0} and {value1}",
+      value0 = vm_core::utils::to_hex(Felt::elements_as_bytes(value0)),
+      value1 = vm_core::utils::to_hex(Felt::elements_as_bytes(value1))
+    )]
+    DuplicateKey { key: Digest, value0: Word, value1: Word },
+}
+
 // BATCH ACCOUNT UPDATE ERROR
 // ================================================================================================
 

--- a/crates/miden-tx/src/tests/kernel_tests/test_faucet.rs
+++ b/crates/miden-tx/src/tests/kernel_tests/test_faucet.rs
@@ -11,7 +11,7 @@ use miden_lib::{
 };
 use miden_objects::{
     FieldElement,
-    account::AccountId,
+    account::{AccountId, StorageMap},
     asset::{FungibleAsset, NonFungibleAsset},
     testing::{
         account_id::{
@@ -222,7 +222,7 @@ fn test_mint_non_fungible_asset_succeeds() {
         end
         ",
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset.into()),
-        asset_vault_key = word_to_masm_push_string(&asset_vault_key),
+        asset_vault_key = word_to_masm_push_string(&StorageMap::hash_key(asset_vault_key.into())),
     );
 
     tx_context.execute_code(&code).unwrap();


### PR DESCRIPTION
Hash keys in `StorageMap` before insertion into SMT.

Adds some missing docs to `StorageMap`, cleans up some names and removes unnecessary (imo) APIs. Also adds a dedicated `StorageMapError` instead of re-exporting `MerkleError`, which has a practical reason. It is inconvenient to call `Smt::with_entries` before building the `BTreeMap`, and calling it afterwards wouldn't catch the duplicates because BTreeMap would have deduplicated them.

closes #1129 