### PR TITLE
refactor: Take `AsRef<NoteRecipient>` to extend expected output notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 ## 0.9.0 (TBD)
+=======
+## 0.8.1 (2025-03-26)
+>>>>>>> 24ef53f5 (reviews: Changelog for main)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,11 @@
 # Changelog
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-## 0.9.0 (TBD)
-=======
 ## 0.8.1 (2025-03-26)
->>>>>>> 24ef53f5 (reviews: Changelog for main)
 
 ### Changes
 
 - [BREAKING] Changed `TransactionArgs` API to accept `AsRef<NoteRecipient>` for extending the advice map in relation to output notes (#1251).
 
->>>>>>> 7774259a (refactor: Take AsRef<NoteRecipient> to extend expected output notes)
 ## 0.8.0 (2025-03-21)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+<<<<<<< HEAD
+=======
+## 0.9.0 (TBD)
+
+### Changes
+
+- [BREAKING] Changed `TransactionArgs` API to accept `AsRef<NoteRecipient>` for extending the advice map in relation to output notes (#1251).
+
+>>>>>>> 7774259a (refactor: Take AsRef<NoteRecipient> to extend expected output notes)
 ## 0.8.0 (2025-03-21)
 
 ### Features

--- a/crates/miden-objects/src/note/details.rs
+++ b/crates/miden-objects/src/note/details.rs
@@ -75,6 +75,15 @@ impl NoteDetails {
     }
 }
 
+// AS REF
+// ================================================================================================
+
+impl AsRef<NoteRecipient> for NoteDetails {
+    fn as_ref(&self) -> &NoteRecipient {
+        self.recipient()
+    }
+}
+
 // SERIALIZATION
 // ================================================================================================
 

--- a/crates/miden-objects/src/note/mod.rs
+++ b/crates/miden-objects/src/note/mod.rs
@@ -1,4 +1,3 @@
-use core::ops::Deref;
 
 use miden_crypto::{
     Word,
@@ -161,14 +160,12 @@ impl Note {
     }
 }
 
-// DEREFERENCING
+// AS REF
 // ================================================================================================
 
-impl Deref for Note {
-    type Target = NoteDetails;
-
-    fn deref(&self) -> &Self::Target {
-        &self.details
+impl AsRef<NoteRecipient> for Note {
+    fn as_ref(&self) -> &NoteRecipient {
+        self.recipient()
     }
 }
 

--- a/crates/miden-objects/src/note/mod.rs
+++ b/crates/miden-objects/src/note/mod.rs
@@ -1,4 +1,3 @@
-
 use miden_crypto::{
     Word,
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -122,7 +122,7 @@ impl TransactionArgs {
     /// The advice inputs' map is extended with the following keys:
     ///
     /// - recipient |-> recipient details (inputs_hash, script_root, serial_num).
-    /// - inputs_key |-> inputs.
+    /// - inputs_commitment |-> inputs.
     /// - script_root |-> script.
     pub fn extend_output_note_recipients<T, L>(&mut self, notes: L)
     where

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -100,13 +100,9 @@ impl TransactionArgs {
     /// The advice inputs' map is extended with the following keys:
     ///
     /// - recipient_digest |-> recipient details (inputs_hash, script_root, serial_num).
-    /// - inputs_key |-> inputs, where inputs_key is computed by taking note inputs commitment and
-    ///   adding ONE to its most significant element.
+    /// - inputs_commitment |-> inputs.
     /// - script_root |-> script.
-    pub fn add_output_note_recipient_details<T: AsRef<NoteRecipient>>(
-        &mut self,
-        note_recipient: T,
-    ) {
+    pub fn add_output_note_recipient<T: AsRef<NoteRecipient>>(&mut self, note_recipient: T) {
         let note_recipient = note_recipient.as_ref();
         let inputs = note_recipient.inputs();
         let script = note_recipient.script();
@@ -125,17 +121,16 @@ impl TransactionArgs {
     ///
     /// The advice inputs' map is extended with the following keys:
     ///
-    /// - recipient |-> recipient details (inputs_hash, script_root, serial_num)
-    /// - inputs_key |-> inputs, where inputs_key is computed by taking note inputs commitment and
-    ///   adding ONE to its most significant element.
-    /// - script_root |-> script
-    pub fn extend_output_note_recipient_details<T, L>(&mut self, notes: L)
+    /// - recipient |-> recipient details (inputs_hash, script_root, serial_num).
+    /// - inputs_key |-> inputs.
+    /// - script_root |-> script.
+    pub fn extend_output_note_recipients<T, L>(&mut self, notes: L)
     where
         L: IntoIterator<Item = T>,
         T: AsRef<NoteRecipient>,
     {
         for note in notes {
-            self.add_output_note_recipient_details(note);
+            self.add_output_note_recipient(note);
         }
     }
 

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -95,16 +95,19 @@ impl TransactionArgs {
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Populates the advice inputs with the specified note details.
+    /// Populates the advice inputs with the expected recipient data for creating output notes.
     ///
     /// The advice inputs' map is extended with the following keys:
     ///
-    /// - recipient |-> recipient details (inputs_hash, script_root, serial_num).
+    /// - recipient_digest |-> recipient details (inputs_hash, script_root, serial_num).
     /// - inputs_key |-> inputs, where inputs_key is computed by taking note inputs commitment and
     ///   adding ONE to its most significant element.
     /// - script_root |-> script.
-    pub fn add_expected_output_note<T: AsRef<NoteRecipient>>(&mut self, recipient: T) {
-        let note_recipient = recipient.as_ref();
+    pub fn add_output_note_recipient_details<T: AsRef<NoteRecipient>>(
+        &mut self,
+        note_recipient: T,
+    ) {
+        let note_recipient = note_recipient.as_ref();
         let inputs = note_recipient.inputs();
         let script = note_recipient.script();
         let script_encoded: Vec<Felt> = script.into();
@@ -118,7 +121,7 @@ impl TransactionArgs {
         self.advice_inputs.extend_map(new_elements);
     }
 
-    /// Populates the advice inputs with the specified note details.
+    /// Populates the advice inputs with the specified note recipient details.
     ///
     /// The advice inputs' map is extended with the following keys:
     ///
@@ -126,13 +129,13 @@ impl TransactionArgs {
     /// - inputs_key |-> inputs, where inputs_key is computed by taking note inputs commitment and
     ///   adding ONE to its most significant element.
     /// - script_root |-> script
-    pub fn extend_expected_output_notes<T, L>(&mut self, notes: L)
+    pub fn extend_output_note_recipient_details<T, L>(&mut self, notes: L)
     where
         L: IntoIterator<Item = T>,
         T: AsRef<NoteRecipient>,
     {
         for note in notes {
-            self.add_expected_output_note(note);
+            self.add_output_note_recipient_details(note);
         }
     }
 

--- a/crates/miden-tx/src/testing/tx_context/builder.rs
+++ b/crates/miden-tx/src/testing/tx_context/builder.rs
@@ -657,7 +657,7 @@ impl TransactionContextBuilder {
             TransactionArgs::new(self.tx_script, Some(self.note_args), AdviceMap::default())
                 .with_advice_inputs(self.advice_inputs.clone());
 
-        tx_args.extend_expected_output_notes(self.expected_output_notes.clone());
+        tx_args.extend_output_note_recipient_details(self.expected_output_notes.clone());
 
         TransactionContext {
             expected_output_notes: self.expected_output_notes,

--- a/crates/miden-tx/src/testing/tx_context/builder.rs
+++ b/crates/miden-tx/src/testing/tx_context/builder.rs
@@ -657,7 +657,7 @@ impl TransactionContextBuilder {
             TransactionArgs::new(self.tx_script, Some(self.note_args), AdviceMap::default())
                 .with_advice_inputs(self.advice_inputs.clone());
 
-        tx_args.extend_output_note_recipient_details(self.expected_output_notes.clone());
+        tx_args.extend_output_note_recipients(self.expected_output_notes.clone());
 
         TransactionContext {
             expected_output_notes: self.expected_output_notes,

--- a/crates/miden-tx/src/tests/mod.rs
+++ b/crates/miden-tx/src/tests/mod.rs
@@ -765,8 +765,8 @@ fn executed_transaction_output_notes() {
         tx_context.tx_args().advice_inputs().clone().map,
     );
 
-    tx_args.add_expected_output_note(&expected_output_note_2);
-    tx_args.add_expected_output_note(&expected_output_note_3);
+    tx_args.add_output_note_recipient_details(&expected_output_note_2);
+    tx_args.add_output_note_recipient_details(&expected_output_note_3);
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context

--- a/crates/miden-tx/src/tests/mod.rs
+++ b/crates/miden-tx/src/tests/mod.rs
@@ -765,8 +765,8 @@ fn executed_transaction_output_notes() {
         tx_context.tx_args().advice_inputs().clone().map,
     );
 
-    tx_args.add_output_note_recipient_details(&expected_output_note_2);
-    tx_args.add_output_note_recipient_details(&expected_output_note_3);
+    tx_args.add_output_note_recipient(&expected_output_note_2);
+    tx_args.add_output_note_recipient(&expected_output_note_3);
 
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let note_ids = tx_context


### PR DESCRIPTION
The full `NoteDetails` is not necessary for pushing note recipient data to the advice map, so this PR proposes changing the transaction args API. 
I had been thinking of making this change for a while but it makes more sense now, as it's related to https://github.com/0xPolygonMiden/miden-client/issues/470.

Since 0.8 was released already I could rebase this to `main` but was not entirely sure if it was preferred because it's fairly low priority (logic can be copied in the client for now, since it's a concise function anyway). Also it would technically be a breaking change. 