### PR TITLE
fix: dead link `miden-objects/README.md`

### DIFF
--- a/crates/miden-objects/README.md
+++ b/crates/miden-objects/README.md
@@ -11,13 +11,13 @@ Here is a broad overview of each module, with links to additional documentation.
 
 Structures used to define accounts, including abstractions over its code, storage, and vault.
 
-[Documentation](https://0xpolygonmiden.github.io/miden-base/architecture/accounts.html).
+[Documentation](https://0xpolygonmiden.github.io/miden-base/account.html).
 
 ### Assets
 
 Structures used to define fungible and non-fungible assets. Accounts own assets and store them in their vaults.
 
-[Documentation](https://0xpolygonmiden.github.io/miden-base/architecture/assets.html)
+[Documentation](https://0xpolygonmiden.github.io/miden-base/asset.html)
 
 
 ### Block
@@ -28,13 +28,13 @@ Structures used to define a block. These objects contain authentication structur
 
 Structures used to define notes. Notes are messages that contain code and assets. They describe their own behavior and allow for interaction among accounts. Notes come in multiple flavors, refer to the docs for additional details.
 
-[Documentation](https://0xpolygonmiden.github.io/miden-base/architecture/notes.html)
+[Documentation](https://0xpolygonmiden.github.io/miden-base/note.html)
 
 ### Transaction
 
 Structures used to define Miden rollup transactions. Transactions describe changes to an account, and may include consumption and production of notes. The objects in this module allow for the representation of transactions at multiple stages of its lifecycle, from creation, to data aggregation, execution with trace collection, and finally an executed transaction with a corresponding STARK proof.
 
-[Documentation](https://0xpolygonmiden.github.io/miden-base/architecture/transactions.html).
+[Documentation](https://0xpolygonmiden.github.io/miden-base/transaction.html).
 
 ## Features
 
@@ -48,4 +48,4 @@ Description of this crate's feature:
 
 ## License
 
-This project is [MIT licensed](../LICENSE).
+This project is [MIT licensed](../../LICENSE).


### PR DESCRIPTION
Hi! I fixed multiple broken documentation links in the Miden Objects crate's README, updating them to match the current documentation structure.