### PR TITLE
feat: implement retry strategy for worker health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [BREAKING] Hash keys in storage maps before insertion into the SMT (#1250).
 - Added getter for proof security level in `ProvenBatch` and `ProvenBlock` (#1259).
 - [BREAKING] Replaced the `ProvenBatch::new_unchecked` with the `ProvenBatch::new` method to initialize the struct with validations (#1260).
+- Added a retry strategy for worker's health check (#1255).
 
 ## 0.8.1 (2025-03-26)
 

--- a/bin/proving-service/grafana_dashboard.json
+++ b/bin/proving-service/grafana_dashboard.json
@@ -1,41 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_TX_PROVER",
-      "label": "tx_prover",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "11.4.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -55,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
+  "id": 1,
   "links": [],
   "panels": [
     {
@@ -74,7 +37,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -203,7 +166,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "editorMode": "code",
           "expr": "sum(rate(request_count[1m]))",
@@ -216,7 +179,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "editorMode": "code",
           "expr": "sum(rate(request_count[1m])) - sum(rate(rate_limited_requests[1m])) - sum(rate(queue_drop_count[1m]))",
@@ -227,15 +190,15 @@
           "refId": "C"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "behiuc5qk89vkb"
+          },
           "editorMode": "code",
           "expr": "sum(rate(request_failure_count[1m]))",
           "legendFormat": "Failed requests",
           "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
-          }
+          "refId": "A"
         }
       ],
       "title": "Requests",
@@ -244,7 +207,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -353,7 +316,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "editorMode": "code",
           "expr": "rate(rate_limited_requests[1m])",
@@ -366,7 +329,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "editorMode": "code",
           "expr": "rate(queue_drop_count[1m])",
@@ -383,7 +346,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -463,15 +426,15 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "behiuc5qk89vkb"
+          },
           "editorMode": "code",
           "expr": "rate(request_retries[1m])",
           "legendFormat": "Retry rate",
           "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
-          }
+          "refId": "A"
         }
       ],
       "title": "Request retry rate",
@@ -480,7 +443,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -560,15 +523,15 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "behiuc5qk89vkb"
+          },
           "editorMode": "code",
           "expr": "(1 - rate(request_failure_count[1m]) / rate(request_count[1m])) * 100",
           "legendFormat": "Success rate over time",
           "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
-          }
+          "refId": "A"
         }
       ],
       "title": "Success rate",
@@ -577,7 +540,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -657,20 +620,20 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "behiuc5qk89vkb"
+          },
           "editorMode": "code",
           "expr": "rate(request_latency_sum[1m]) / rate(request_latency_count[1m])",
           "legendFormat": "Average request latency",
           "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
-          }
+          "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "editorMode": "code",
           "expr": "rate(queue_latency_sum[1m]) / rate(queue_latency_count[1m])",
@@ -700,7 +663,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -781,7 +744,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -798,7 +761,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -819,7 +782,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -833,7 +796,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 10,
+            "axisSoftMax": 3,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -900,15 +863,15 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
-          "editorMode": "code",
-          "expr": "worker_unhealthy",
-          "legendFormat": "Unhealthy workers",
-          "range": true,
-          "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
-          }
+            "uid": "behiuc5qk89vkb"
+          },
+          "editorMode": "code",
+          "expr": "worker_unhealthy",
+          "legendFormat": "{{worker_id}}",
+          "range": true,
+          "refId": "A"
         }
       ],
       "title": "Unhealthy workers",
@@ -917,7 +880,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -971,15 +934,15 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "behiuc5qk89vkb"
+          },
           "editorMode": "code",
           "expr": "rate(worker_request_count[1m])",
           "legendFormat": "{{worker_id}}",
           "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
-          }
+          "refId": "A"
         }
       ],
       "title": "Requests per worker",
@@ -1001,7 +964,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_TX_PROVER}"
+        "uid": "behiuc5qk89vkb"
       },
       "fieldConfig": {
         "defaults": {
@@ -1082,7 +1045,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_TX_PROVER}"
+            "uid": "behiuc5qk89vkb"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -1099,6 +1062,7 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "5s",
   "schemaVersion": 40,
   "tags": [],
@@ -1106,13 +1070,13 @@
     "list": []
   },
   "time": {
-    "from": "now-2d",
-    "to": "now"
+    "from": "2025-03-31T19:02:51.110Z",
+    "to": "2025-03-31T19:04:03.015Z"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "tx_prover",
   "uid": "be7bobzl5fr40f",
-  "version": 40,
+  "version": 6,
   "weekStart": ""
 }

--- a/bin/proving-service/src/commands/mod.rs
+++ b/bin/proving-service/src/commands/mod.rs
@@ -24,9 +24,6 @@ pub(crate) struct ProxyConfig {
     /// Health check interval in seconds.
     #[clap(long, default_value = "10", env = "MPS_HEALTH_CHECK_INTERVAL_SECS")]
     pub(crate) health_check_interval_secs: u64,
-    /// Maximum number of health check retries before permanently removing a worker.
-    #[clap(long, default_value = "3", env = "MPS_MAX_HEALTH_CHECK_RETRIES")]
-    pub(crate) max_health_check_retries: usize,
     /// Maximum number of items in the queue.
     #[clap(long, default_value = "10", env = "MPS_MAX_QUEUE_ITEMS")]
     pub(crate) max_queue_items: usize,

--- a/bin/proving-service/src/commands/mod.rs
+++ b/bin/proving-service/src/commands/mod.rs
@@ -24,6 +24,9 @@ pub(crate) struct ProxyConfig {
     /// Health check interval in seconds.
     #[clap(long, default_value = "10", env = "MPS_HEALTH_CHECK_INTERVAL_SECS")]
     pub(crate) health_check_interval_secs: u64,
+    /// Maximum number of health check retries before permanently removing a worker.
+    #[clap(long, default_value = "3", env = "MPS_MAX_HEALTH_CHECK_RETRIES")]
+    pub(crate) max_health_check_retries: usize,
     /// Maximum number of items in the queue.
     #[clap(long, default_value = "10", env = "MPS_MAX_QUEUE_ITEMS")]
     pub(crate) max_queue_items: usize,

--- a/bin/proving-service/src/commands/proxy.rs
+++ b/bin/proving-service/src/commands/proxy.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use pingora::{
     apps::HttpServerOptions,
-    lb::Backend,
     prelude::{Opt, background_service},
     server::Server,
     services::listening::Service,
@@ -60,17 +59,11 @@ impl StartProxy {
 
         info!("Proxy starting with workers: {:?}", self.workers);
 
-        let workers = self
-            .workers
-            .iter()
-            .map(|worker| Backend::new(worker).map_err(ProvingServiceError::BackendCreationFailed))
-            .collect::<Result<Vec<Backend>, ProvingServiceError>>()?;
-
-        if workers.is_empty() {
+        if self.workers.is_empty() {
             warn!("Starting the proxy without any workers");
         }
 
-        let worker_lb = LoadBalancerState::new(workers, &self.proxy_config).await?;
+        let worker_lb = LoadBalancerState::new(self.workers.clone(), &self.proxy_config).await?;
 
         let health_check_service = background_service("health_check", worker_lb);
 

--- a/bin/proving-service/src/proxy/health_check.rs
+++ b/bin/proving-service/src/proxy/health_check.rs
@@ -5,7 +5,7 @@ use tonic::{async_trait, transport::Channel};
 use tonic_health::pb::health_client::HealthClient;
 use tracing::debug_span;
 
-use super::{LoadBalancerState, metrics::WORKER_COUNT};
+use super::LoadBalancerState;
 use crate::error::ProvingServiceError;
 
 /// Implement the BackgroundService trait for the LoadBalancer
@@ -39,16 +39,8 @@ impl BackgroundService for LoadBalancerState {
 
                     // Perform health checks on workers and retain healthy ones
                     self.check_workers_health(workers.iter_mut()).await;
-
-                    // Filter out unhealthy workers that exceed retry limit
-                    workers
-                        .retain(|worker| worker.retries_amount() < self.max_health_check_retries);
-
-                    // Update total worker count
-                    WORKER_COUNT.set(workers.len() as i64);
-
-                    // Sleep for the defined interval before the next health check
                 }
+                // Sleep for the defined interval before the next health check
                 sleep(self.health_check_interval).await;
             }
         })

--- a/bin/proving-service/src/proxy/metrics.rs
+++ b/bin/proving-service/src/proxy/metrics.rs
@@ -35,10 +35,11 @@ pub static QUEUE_DROP_COUNT: LazyLock<IntCounter> = LazyLock::new(|| {
 
 pub static WORKER_COUNT: LazyLock<IntGauge> =
     LazyLock::new(|| register_int_gauge!("worker_count", "Total number of workers").unwrap());
-pub static WORKER_UNHEALTHY: LazyLock<IntCounter> = LazyLock::new(|| {
-    register_int_counter!(
+pub static WORKER_UNHEALTHY: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "worker_unhealthy",
-        "Number of times that workers were registered as unhealthy"
+        "Number of times that each worker was registered as unhealthy",
+        &["worker_id"]
     )
     .unwrap()
 });

--- a/bin/proving-service/src/proxy/mod.rs
+++ b/bin/proving-service/src/proxy/mod.rs
@@ -118,13 +118,18 @@ impl LoadBalancerState {
         })
     }
 
-    /// Marks the given worker as available.
+    /// Marks the given worker as available and moves it to the end of the list.
     ///
     /// If the worker is not in the list, it won't be added.
     pub async fn add_available_worker(&self, worker: Worker) {
-        let mut available_workers = self.workers.write().await;
-        if let Some(w) = available_workers.iter_mut().find(|w| *w == &worker) {
+        let mut workers = self.workers.write().await;
+        if let Some(pos) = workers.iter().position(|w| *w == worker) {
+            // Remove the worker from its current position
+            let mut w = workers.remove(pos);
+            // Mark it as available
             w.set_availability(true);
+            // Add it to the end of the list
+            workers.push(w);
         }
     }
 

--- a/bin/proving-service/src/proxy/worker.rs
+++ b/bin/proving-service/src/proxy/worker.rs
@@ -38,16 +38,18 @@ impl Worker {
     /// - Returns [ProvingServiceError::InvalidURI] if the worker address is invalid.
     /// - Returns [ProvingServiceError::ConnectionFailed] if the connection to the worker fails.
     pub async fn new(
-        worker: Backend,
+        worker_addr: String,
         connection_timeout: Duration,
         total_timeout: Duration,
     ) -> Result<Self, ProvingServiceError> {
+        let backend =
+            Backend::new(&worker_addr).map_err(ProvingServiceError::BackendCreationFailed)?;
+
         let health_check_client =
-            create_health_check_client(worker.addr.to_string(), connection_timeout, total_timeout)
-                .await?;
+            create_health_check_client(worker_addr, connection_timeout, total_timeout).await?;
 
         Ok(Self {
-            backend: worker,
+            backend,
             is_available: true,
             health_check_client,
             health_status: WorkerHealthStatus::Healthy,


### PR DESCRIPTION
closes #1009

Also addresses an issue that was causing the workers to be locked for more time than needed when health checking.