### PR TITLE
feat: add proof security level getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.0 (TBD)
 
 - [BREAKING] Hash keys in storage maps before insertion into the SMT (#1250).
+- Added getter for proof security level in `ProvenBatch` and `ProvenBlock` (#1259).
 
 ## 0.8.1 (2025-03-26)
 

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -1,7 +1,7 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
 use crate::{
-    Digest,
+    Digest, MIN_PROOF_SECURITY_LEVEL,
     account::AccountId,
     batch::{BatchAccountUpdate, BatchId},
     block::BlockNumber,
@@ -74,6 +74,11 @@ impl ProvenBatch {
     /// Returns an iterator over the IDs of all accounts updated in this batch.
     pub fn updated_accounts(&self) -> impl Iterator<Item = AccountId> + use<'_> {
         self.account_updates.keys().copied()
+    }
+
+    /// Returns the proof security level of the batch.
+    pub fn proof_security_level(&self) -> u32 {
+        MIN_PROOF_SECURITY_LEVEL
     }
 
     /// Returns the map of account IDs mapped to their [`BatchAccountUpdate`]s.

--- a/crates/miden-objects/src/block/proven_block.rs
+++ b/crates/miden-objects/src/block/proven_block.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use crate::{
-    Digest,
+    Digest, MIN_PROOF_SECURITY_LEVEL,
     account::AccountId,
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree, OutputNoteBatch},
     note::Nullifier,
@@ -83,6 +83,11 @@ impl ProvenBlock {
     /// Returns the slice of [`OutputNoteBatch`]es for all output notes created in this block.
     pub fn output_note_batches(&self) -> &[OutputNoteBatch] {
         &self.output_note_batches
+    }
+
+    /// Returns the proof security level of the block.
+    pub fn proof_security_level(&self) -> u32 {
+        MIN_PROOF_SECURITY_LEVEL
     }
 
     /// Returns an iterator over all [`OutputNote`]s created in this block.


### PR DESCRIPTION
Adds a getter to `ProvenBatch` and `ProvenBlock` that returns the security level of the proof.

Currently, it only returns the value of the `MIN_PROOF_SECURITY_LEVEL` constant.

This PR is part of: https://github.com/0xPolygonMiden/miden-node/issues/744