### PR TITLE
refactor: Remove short flags on miden-proving-service

### DIFF
--- a/bin/proving-service/src/commands/worker.rs
+++ b/bin/proving-service/src/commands/worker.rs
@@ -11,13 +11,13 @@ use crate::{api::RpcListener, generated::api_server::ApiServer, utils::MIDEN_PRO
 #[derive(Debug, Parser, Clone, Copy, Default)]
 pub struct ProverTypeSupport {
     /// Enables transaction proving.
-    #[clap(short, long, default_value = "false")]
+    #[clap(long, default_value = "false")]
     tx_prover: bool,
     /// Enables batch proving.
-    #[clap(short, long, default_value = "false")]
+    #[clap(long, default_value = "false")]
     batch_prover: bool,
     /// Enables block proving.
-    #[clap(short, long, default_value = "false")]
+    #[clap(long, default_value = "false")]
     block_prover: bool,
 }
 
@@ -60,10 +60,10 @@ impl ProverTypeSupport {
 #[derive(Debug, Parser)]
 pub struct StartWorker {
     /// The host of the worker
-    #[clap(short, long, default_value = "0.0.0.0")]
+    #[clap(long, default_value = "0.0.0.0")]
     host: String,
     /// The port of the worker
-    #[clap(short, long, default_value = "50051")]
+    #[clap(long, default_value = "50051")]
     port: u16,
     /// The type of prover that the worker will be
     #[clap(flatten)]


### PR DESCRIPTION
Fixes #1265.

I was not able to reproduce this problem on `main` when compiling on release; it only seemed to happen on debug builds. 

This PR removes the short flags so that there are no collisions. The batch prover and block prover flags were also conflicting on `-b` so I removed them as well (and the others for consistency).

For testing these changes you can see that both these commands succeed:

- `cargo run --release -- start-worker --host 0.0.0.0 --port 12324` 
- `cargo run -- start-worker --host 0.0.0.0 --port 12324`
