### PR TITLE
docs: add comment about transitive dependency error

### DIFF
--- a/bin/proving-service/README.md
+++ b/bin/proving-service/README.md
@@ -1,5 +1,8 @@
 # Miden proving service
 
+> [!IMPORTANT]  
+> **Due to a transitive dependency compilation error, the only way to install the binary is using `--locked`.**
+
 A service for generating Miden proofs on-demand. The binary enables spawning workers and a proxy for Miden's remote proving service. It currently supports proving individual transactions, transaction batches, and blocks.
 
 The worker is a gRPC service that can receive transaction witnesses or proposed batches and returns the proof. It can only handle one request at a time and returns an error if it is already in use.


### PR DESCRIPTION
Due to a compilation error in Pingora, updating the transitive dependencies makes the whole binary to fail when compiling. This issue is being address in Pingora, but for the moment using `cargo install miden-proving-service` fails.

Using `cargo install miden-proving-service --locked` is the only way to make the binary work when downloading through crates.io.