### PR TITLE
feat: pretty print account code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added getter for proof security level in `ProvenBatch` and `ProvenBlock` (#1259).
 - [BREAKING] Replaced the `ProvenBatch::new_unchecked` with the `ProvenBatch::new` method to initialize the struct with validations (#1260).
 - Added a retry strategy for worker's health check (#1255).
+- Added pretty print for `AccountCode` (#1273).
 
 ## 0.8.1 (2025-03-26) - `miden-objects` and `miden-tx` crates only.
 

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -356,9 +356,11 @@ fn build_procedure_commitment(procedures: &[AccountProcedureInfo]) -> Digest {
 
 #[cfg(test)]
 mod tests {
+    use std::println;
+
     use assembly::Assembler;
     use assert_matches::assert_matches;
-    use vm_core::Word;
+    use vm_core::{Word, prettier::PrettyPrint};
 
     use super::{AccountCode, Deserializable, Serializable};
     use crate::{
@@ -398,12 +400,14 @@ mod tests {
                 .with_supports_all_types();
 
         // This is fine as the offset+size for component 2 is <= 255.
-        AccountCode::from_components(
+        let account_code = AccountCode::from_components(
             &[component1.clone(), component2.clone()],
             AccountType::RegularAccountUpdatableCode,
         )
         .unwrap();
 
+        println!("{}", account_code.to_pretty_string());
+        assert!(false);
         // Push one more slot so offset+size exceeds 255.
         component2.storage_slots.push(StorageSlot::Value(Word::default()));
 

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -247,9 +247,8 @@ impl AccountCode {
             .mast
             .find_procedure_root(*proc_info.mast_root())
             .expect("procedure root should be present in the mast forest");
-        let node_raw = self.mast[node_id].clone();
 
-        Ok(PrintableProcedure::new(self.mast.clone(), *proc_info, node_raw))
+        Ok(PrintableProcedure::new(self.mast.clone(), *proc_info, node_id))
     }
 }
 

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -306,31 +306,26 @@ impl PrettyPrint for AccountCode {
             let node_raw = self.mast[node_id].clone();
 
             partial = partial
-                + const_text("Procedure:")
-                + nl()
                 + indent(
                     4,
-                    text(&format!("export.{}", procedure_root))
+                    text(format!("Procedure: {}", procedure_root))
+                        + nl()
+                        + text("Storage:")
                         + nl()
                         + indent(
                             4,
-                            text("Storage:")
+                            text(&format!("offset: {}", storage_offset))
                                 + nl()
-                                + indent(
-                                    4,
-                                    text(&format!("offset: {}", storage_offset))
-                                        + nl()
-                                        + text(&format!("size: {}", storage_size)),
-                                )
-                                + nl()
-                                + nl()
-                                + text("Body:")
-                                + nl()
-                                + indent(4, node_raw.to_pretty_print(&self.mast).render()),
-                        ),
-                )
-                + nl()
-                + const_text("end");
+                                + text(&format!("size: {}", storage_size)),
+                        )
+                        + nl()
+                        + text("Body:")
+                        + nl()
+                        + indent(4, node_raw.to_pretty_print(&self.mast).render())
+                        + nl()
+                        + const_text("end"),
+                );
+
             if index < len_procedures - 1 {
                 partial += nl();
             }

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -52,8 +52,7 @@ impl PrettyPrint for PrintableProcedure {
                         )
                         + nl()
                         + const_text("end"),
-                )
-                + nl(),
+                ),
         )
     }
 }

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -309,7 +309,14 @@ impl PrettyPrint for AccountCode {
                 + nl()
                 + text(&format!("Storage size: {}", storage_size))
                 + nl()
-                + indent(4, node_raw.to_pretty_print(&self.mast).render())
+                + const_text("Procedure:")
+                + nl()
+                + indent(
+                    4,
+                    text(&format!("export.{}", procedure_root))
+                        + nl()
+                        + node_raw.to_pretty_print(&self.mast).render(),
+                )
                 + nl()
                 + const_text("end");
             if index < len_procedures - 1 {

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -328,7 +328,22 @@ impl PrettyPrint for AccountCode {
         let len_procedures = self.num_procedures();
 
         for (index, printable_procedure) in self.printable_procedures().enumerate() {
-            partial += printable_procedure.render();
+            partial += indent(
+                0,
+                indent(
+                    4,
+                    text(format!("proc.{}", printable_procedure.mast_root()))
+                        + nl()
+                        + text(format!(
+                            "storage.{}.{}",
+                            printable_procedure.storage_offset(),
+                            printable_procedure.storage_size()
+                        ))
+                        + nl()
+                        + printable_procedure.render(),
+                ) + nl()
+                    + const_text("end"),
+            );
             if index < len_procedures - 1 {
                 partial += nl();
             }

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -310,23 +310,29 @@ impl PrettyPrint for AccountCode {
                     4,
                     text(format!("Procedure: {}", procedure_root))
                         + nl()
-                        + text("Storage:")
                         + indent(
                             4,
-                            nl() + text(&format!("offset: {}", storage_offset))
+                            const_text("Storage:")
+                                + nl()
+                                + text(&format!("offset: {}", storage_offset))
                                 + nl()
                                 + text(&format!("size: {}", storage_size)),
                         )
                         + nl()
-                        + text("Body:")
                         + indent(
                             4,
-                            text(format!("export.{}", procedure_root))
+                            const_text("Body:")
                                 + nl()
-                                + node_raw.to_pretty_print(&self.mast).render(),
+                                + indent(
+                                    8,
+                                    text(format!("export.{}", procedure_root))
+                                        + nl()
+                                        + node_raw.to_pretty_print(&self.mast).render(),
+                                )
+                                + nl()
+                                + const_text("end"),
                         )
-                        + nl()
-                        + const_text("end"),
+                        + nl(),
                 );
 
             if index < len_procedures - 1 {

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -293,18 +293,23 @@ impl PrettyPrint for AccountCode {
         use vm_core::prettier::*;
         let mut partial = Document::Empty;
         let len_procedures = self.procedures().len();
-        for (index, procedure_root) in self.procedure_roots().enumerate() {
+        for (index, procedure_info) in self.procedures().iter().enumerate() {
+            let procedure_root = procedure_info.mast_root();
+            let storage_offset = procedure_info.storage_offset();
+            let storage_size = procedure_info.storage_size();
+
             let node_id = self
                 .mast
-                .find_procedure_root(procedure_root)
+                .find_procedure_root(*procedure_root)
                 .expect("procedure root should be present in the mast forest");
             let node_raw = self.mast[node_id].clone();
 
             partial = partial
-                + indent(
-                    4,
-                    const_text("begin") + nl() + node_raw.to_pretty_print(&self.mast).render(),
-                )
+                + text(&format!("Storage offset: {}", storage_offset))
+                + nl()
+                + text(&format!("Storage size: {}", storage_size))
+                + nl()
+                + indent(4, node_raw.to_pretty_print(&self.mast).render())
                 + nl()
                 + const_text("end");
             if index < len_procedures - 1 {

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -311,17 +311,20 @@ impl PrettyPrint for AccountCode {
                     text(format!("Procedure: {}", procedure_root))
                         + nl()
                         + text("Storage:")
-                        + nl()
                         + indent(
                             4,
-                            text(&format!("offset: {}", storage_offset))
+                            nl() + text(&format!("offset: {}", storage_offset))
                                 + nl()
                                 + text(&format!("size: {}", storage_size)),
                         )
                         + nl()
                         + text("Body:")
-                        + nl()
-                        + indent(4, node_raw.to_pretty_print(&self.mast).render())
+                        + indent(
+                            4,
+                            text(format!("export.{}", procedure_root))
+                                + nl()
+                                + node_raw.to_pretty_print(&self.mast).render(),
+                        )
                         + nl()
                         + const_text("end"),
                 );

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -356,11 +356,10 @@ fn build_procedure_commitment(procedures: &[AccountProcedureInfo]) -> Digest {
 
 #[cfg(test)]
 mod tests {
-    use std::println;
 
     use assembly::Assembler;
     use assert_matches::assert_matches;
-    use vm_core::{Word, prettier::PrettyPrint};
+    use vm_core::Word;
 
     use super::{AccountCode, Deserializable, Serializable};
     use crate::{
@@ -400,14 +399,12 @@ mod tests {
                 .with_supports_all_types();
 
         // This is fine as the offset+size for component 2 is <= 255.
-        let account_code = AccountCode::from_components(
+        AccountCode::from_components(
             &[component1.clone(), component2.clone()],
             AccountType::RegularAccountUpdatableCode,
         )
         .unwrap();
 
-        println!("{}", account_code.to_pretty_string());
-        assert!(false);
         // Push one more slot so offset+size exceeds 255.
         component2.storage_slots.push(StorageSlot::Value(Word::default()));
 

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -227,10 +227,9 @@ impl AccountCode {
     /// An iterator yielding [`PrintableProcedure`] instances for all procedures in this account
     /// code.
     pub fn printable_procedures(&self) -> impl Iterator<Item = PrintableProcedure> {
-        self.procedures().iter().filter_map(move |procedure_info| {
-            let root = *procedure_info.mast_root();
-            self.printable_procedure(root).ok()
-        })
+        self.procedures()
+            .iter()
+            .filter_map(move |procedure_info| self.printable_procedure(procedure_info).ok())
     }
 
     // HELPER FUNCTIONS
@@ -240,18 +239,17 @@ impl AccountCode {
     ///
     /// # Errors
     /// Returns an error if no procedure with the specified root exists in this account code.
-    fn printable_procedure(&self, root: Digest) -> Result<PrintableProcedure, AccountError> {
-        let procedure_info = self.procedures.iter().find(|p| p.mast_root() == &root).ok_or(
-            AccountError::AssumptionViolated(format!("procedure with root {} not found", root)),
-        )?;
-
+    fn printable_procedure(
+        &self,
+        proc_info: &AccountProcedureInfo,
+    ) -> Result<PrintableProcedure, AccountError> {
         let node_id = self
             .mast
-            .find_procedure_root(root)
+            .find_procedure_root(*proc_info.mast_root())
             .expect("procedure root should be present in the mast forest");
         let node_raw = self.mast[node_id].clone();
 
-        Ok(PrintableProcedure::new(self.mast.clone(), *procedure_info, node_raw))
+        Ok(PrintableProcedure::new(self.mast.clone(), *proc_info, node_raw))
     }
 }
 

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -1,5 +1,6 @@
 use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
 
+use assembly::KernelLibrary;
 use vm_core::{mast::MastForest, prettier::PrettyPrint};
 
 use super::{
@@ -305,17 +306,28 @@ impl PrettyPrint for AccountCode {
             let node_raw = self.mast[node_id].clone();
 
             partial = partial
-                + text(&format!("Storage offset: {}", storage_offset))
-                + nl()
-                + text(&format!("Storage size: {}", storage_size))
-                + nl()
                 + const_text("Procedure:")
                 + nl()
                 + indent(
                     4,
                     text(&format!("export.{}", procedure_root))
                         + nl()
-                        + node_raw.to_pretty_print(&self.mast).render(),
+                        + indent(
+                            4,
+                            text("Storage:")
+                                + nl()
+                                + indent(
+                                    4,
+                                    text(&format!("offset: {}", storage_offset))
+                                        + nl()
+                                        + text(&format!("size: {}", storage_size)),
+                                )
+                                + nl()
+                                + nl()
+                                + text("Body:")
+                                + nl()
+                                + indent(4, node_raw.to_pretty_print(&self.mast).render()),
+                        ),
                 )
                 + nl()
                 + const_text("end");

--- a/crates/miden-objects/src/account/code/procedure.rs
+++ b/crates/miden-objects/src/account/code/procedure.rs
@@ -153,6 +153,7 @@ impl Deserializable for AccountProcedureInfo {
 }
 
 // PRINTABLE PROCEDURE
+// ================================================================================================
 
 /// A printable representation of a single account procedure.
 #[derive(Debug, Clone)]

--- a/crates/miden-objects/src/account/code/procedure.rs
+++ b/crates/miden-objects/src/account/code/procedure.rs
@@ -1,7 +1,7 @@
 use alloc::{string::ToString, sync::Arc};
 
 use vm_core::{mast::MastForest, prettier::PrettyPrint};
-use vm_processor::MastNode;
+use vm_processor::{MastNode, MastNodeId};
 
 use super::{Digest, Felt};
 use crate::{
@@ -160,7 +160,7 @@ impl Deserializable for AccountProcedureInfo {
 pub struct PrintableProcedure {
     mast: Arc<MastForest>,
     procedure_info: AccountProcedureInfo,
-    entrypoint: MastNode,
+    entrypoint: MastNodeId,
 }
 
 impl PrintableProcedure {
@@ -168,13 +168,13 @@ impl PrintableProcedure {
     pub(crate) fn new(
         mast: Arc<MastForest>,
         procedure_info: AccountProcedureInfo,
-        entrypoint: MastNode,
+        entrypoint: MastNodeId,
     ) -> Self {
         Self { mast, procedure_info, entrypoint }
     }
 
     fn entrypoint(&self) -> &MastNode {
-        &self.entrypoint
+        &self.mast[self.entrypoint]
     }
 
     pub(crate) fn storage_offset(&self) -> u8 {

--- a/crates/miden-objects/src/account/code/procedure.rs
+++ b/crates/miden-objects/src/account/code/procedure.rs
@@ -199,22 +199,21 @@ impl PrettyPrint for PrintableProcedure {
 
         indent(
             0,
-            text(format!("proc.{}", procedure_root))
-                + nl()
-                + indent(
-                    4,
-                    text(format!("storage.{}.{}", storage_offset, storage_size))
-                        + nl()
-                        + indent(
-                            4,
-                            const_text("begin")
-                                + nl()
-                                + self.entrypoint().to_pretty_print(&self.mast).render(),
-                        )
-                        + nl()
-                        + const_text("end"),
-                )
-                + nl()
+            indent(
+                4,
+                text(format!("proc.{}", procedure_root))
+                    + nl()
+                    + text(format!("storage.{}.{}", storage_offset, storage_size))
+                    + nl()
+                    + indent(
+                        4,
+                        const_text("begin")
+                            + nl()
+                            + self.entrypoint().to_pretty_print(&self.mast).render(),
+                    )
+                    + nl()
+                    + const_text("end"),
+            ) + nl()
                 + const_text("end"),
         )
     }

--- a/crates/miden-objects/src/account/code/procedure.rs
+++ b/crates/miden-objects/src/account/code/procedure.rs
@@ -177,15 +177,15 @@ impl PrintableProcedure {
         &self.entrypoint
     }
 
-    fn storage_offset(&self) -> u8 {
+    pub(crate) fn storage_offset(&self) -> u8 {
         self.procedure_info.storage_offset()
     }
 
-    fn storage_size(&self) -> u8 {
+    pub(crate) fn storage_size(&self) -> u8 {
         self.procedure_info.storage_size()
     }
 
-    fn mast_root(&self) -> &Digest {
+    pub(crate) fn mast_root(&self) -> &Digest {
         self.procedure_info.mast_root()
     }
 }
@@ -193,29 +193,12 @@ impl PrintableProcedure {
 impl PrettyPrint for PrintableProcedure {
     fn render(&self) -> vm_core::prettier::Document {
         use vm_core::prettier::*;
-        let procedure_root = self.mast_root();
-        let storage_offset = self.storage_offset();
-        let storage_size = self.storage_size();
 
         indent(
-            0,
-            indent(
-                4,
-                text(format!("proc.{}", procedure_root))
-                    + nl()
-                    + text(format!("storage.{}.{}", storage_offset, storage_size))
-                    + nl()
-                    + indent(
-                        4,
-                        const_text("begin")
-                            + nl()
-                            + self.entrypoint().to_pretty_print(&self.mast).render(),
-                    )
-                    + nl()
-                    + const_text("end"),
-            ) + nl()
-                + const_text("end"),
-        )
+            4,
+            const_text("begin") + nl() + self.entrypoint().to_pretty_print(&self.mast).render(),
+        ) + nl()
+            + const_text("end")
     }
 }
 


### PR DESCRIPTION
Adds pretty print to `AccountCode`.

Since procedures are external, they are printed as:
```
begin
  external.<digest>
 end
 ```

Closes #1228 