### PR TITLE
chore: re-export `NetworkIdError`

### DIFF
--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -25,9 +25,9 @@ mod errors;
 pub use constants::*;
 pub use errors::{
     AccountDeltaError, AccountError, AccountIdError, AssetError, AssetVaultError,
-    BatchAccountUpdateError, ChainMmrError, NoteError, NullifierTreeError, ProposedBatchError,
-    ProposedBlockError, ProvenBatchError, ProvenTransactionError, TransactionInputError,
-    TransactionOutputError, TransactionScriptError,
+    BatchAccountUpdateError, ChainMmrError, NetworkIdError, NoteError, NullifierTreeError,
+    ProposedBatchError, ProposedBlockError, ProvenBatchError, ProvenTransactionError,
+    TransactionInputError, TransactionOutputError, TransactionScriptError,
 };
 pub use miden_crypto::hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest};
 pub use vm_core::{


### PR DESCRIPTION
This PR re-exports `NetworkIdError` so that it can be used in the client, specifically in https://github.com/0xPolygonMiden/miden-client/pull/840.