### PR TITLE
fix: typos and quotation marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Polygon Miden is currently on release v0.8. This is an early version of the prot
 ### Feature highlights
 
 - **Private accounts**. The Miden Operator tracks only commitments to account data in the public database. The users are responsible for keeping track of the state of their accounts.
-- **Public accounts**. With public accounts users are be able to store the entire state of their accounts on-chain, thus, eliminating the need to keep track of account states locally (albeit by sacrificing privacy and at a higher cost).
+- **Public accounts**. With public accounts users will be able to store the entire state of their accounts on-chain, thus, eliminating the need to keep track of account states locally (albeit by sacrificing privacy and at a higher cost).
 - **Private notes**. Like with private accounts, the Miden Operator tracks only commitments to notes in the public database. Users need to communicate note details to each other via side channels.
-- **Public notes**. With public notes, the users are be able to store all note details on-chain, thus, eliminating the need to communicate note details via side-channels.
+- **Public notes**. With public notes, the users will be able to store all note details on-chain, thus, eliminating the need to communicate note details via side-channels.
 - **Local transactions**. Users can execute and prove transactions locally on their devices. The Miden Operator verifies the proofs and if the proofs are valid, updates the state of the rollup accordingly.
 - **Standard account**. Users can create accounts using a small number of standard account interfaces (e.g., basic wallet). In the future, the set of standard smart contracts will be expanded.
 - **Standard notes**. Can create notes using standardized note scripts such as Pay-to-ID (`P2ID`) and atomic swap (`SWAP`). In the future, the set of standardized notes will be expanded.
@@ -40,7 +40,7 @@ Polygon Miden is currently on release v0.8. This is an early version of the prot
 ### Planned features
 
 - **Network transactions**. Users will be able to create notes intended for network execution. Such notes will be included into transactions executed and proven by the Miden operator.
-- **Encrypted notes**. With encrypted notes users will be able to put all note details on-chain, but the data contained withing the notes would be encrypted with the recipients key.
+- **Encrypted notes**. With encrypted notes users will be able to put all note details on-chain, but the data contained within the notes would be encrypted with the recipient's key.
 
 ## Project structure
 

--- a/crates/miden-objects/src/note/metadata.rs
+++ b/crates/miden-objects/src/note/metadata.rs
@@ -229,7 +229,7 @@ fn unmerge_id_type_and_hint_tag(element: Felt) -> Result<(Felt, NoteType, u8), N
     // Set least significant byte to zero.
     let element = element & 0xffff_ffff_ffff_ff00;
 
-    // SAFETY: The input was a valid felt and and we cleared additional bits and did not set any
+    // SAFETY: The input was a valid felt and we cleared additional bits and did not set any
     // bits, so it must still be a valid felt.
     let sender_id_suffix = Felt::try_from(element).expect("element should still be valid");
 

--- a/docs/src/blockchain.md
+++ b/docs/src/blockchain.md
@@ -37,7 +37,7 @@ The block producer ensures:
 3. **Block hash references**: Check that all block hashes references by batches are in the chain.
 4. **Double-spend prevention**: Each consumed note’s nullifier is checked against prior consumption. The Block `N` Nullifier DB commitment is authenticated against all provided nullifiers for consumed notes, ensuring no nullifier is reused.
 5. **Global note uniqueness**: All created and consumed notes must be unique across batches.
-6. **Batch expiration**: The block height of the created block must be smaller or equal than the lowest batch expiration.
+6. **Batch expiration**: The block height of the created block must be smaller than or equal to the lowest batch expiration.
 7. **Block time increase**: The block timestamp must increase monotonically from the previous block.
 8. **Note erasure of erasable notes**: If an erasable note is created and consumed in different batches, it is erased now. If, however, an erasable note is consumed but not created within the block, the batch it contains is rejected. The Miden operator's mempool should preemptively filter such transactions.
 

--- a/docs/src/note.md
+++ b/docs/src/note.md
@@ -83,7 +83,7 @@ As with [accounts](account.md), `Note`s can be stored either publicly or private
 
 Once created, a `Note` must be validated by a Miden operator. Validation involves checking the transaction proof that produced the `Note` to ensure it meets all protocol requirements.
 
-After validation `Note`s become “live” and eligible for consumption. If creation and consumption happens within the same block, there is no entry in the Notes DB. All other notes, are being added either as a commitment or fully public.
+After validation `Note`s become "live" and eligible for consumption. If creation and consumption happens within the same block, there is no entry in the Notes DB. All other notes, are being added either as a commitment or fully public.
 
 ### Note discovery
 
@@ -97,7 +97,7 @@ To consume a `Note`, the consumer must know its data, including the inputs neede
 
 Upon successful verification of the transaction:
 
-1. The Miden operator records the `Note`’s nullifier as “consumed” in the nullifier database.
+1. The Miden operator records the `Note`’s nullifier as "consumed" in the nullifier database.
 2. The `Note`’s one-time claim is thus extinguished, preventing reuse.
 
 #### Note recipient restricting consumption

--- a/docs/src/state.md
+++ b/docs/src/state.md
@@ -1,6 +1,6 @@
 # State
 
-The `State` describes the current condition of all accounts, notes, nullifiers and their statuses. Reflecting the “current reality” of the protocol at any given time.
+The `State` describes the current condition of all accounts, notes, nullifiers and their statuses. Reflecting the "current reality" of the protocol at any given time.
 
 ## What is the purpose of the Miden state model?
 
@@ -78,7 +78,7 @@ Both of these properties are needed for supporting local transactions using clie
 
 ### Nullifier database
 
-Each [note](note.md) has an associated nullifier which enables the tracking of whether it's associated note has been consumed or not, preventing double-spending.
+Each [note](note.md) has an associated nullifier which enables the tracking of whether its associated note has been consumed or not, preventing double-spending.
 
 To prove that a note has not been consumed, the operator must provide a Merkle path to the corresponding node and show that the node’s value is 0. Since nullifiers are 32 bytes each, the sparse Merkle tree height must be sufficient to represent all possible nullifiers. Operators must maintain the entire nullifier set to compute the new tree root after inserting new nullifiers. For each nullifier we also record the block in which it was created. This way "unconsumed" nullifiers have block 0, but all consumed nullifiers have a non-zero block.
 


### PR DESCRIPTION
Some editors may not accurately render unexpected characters, appearing as gibberish or causing formatting problems.