### PR TITLE
Account Tree follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - [BREAKING] Replaced the `ProvenBatch::new_unchecked` with the `ProvenBatch::new` method to initialize the struct with validations (#1260).
 - Added pretty print for `AccountCode` (#1273).
 - [BREAKING] Add `NetworkAccount` configuration (#1275).
-- [BREAKING] Add `NetworkAccount` configuration (#1275).
 - Added support for environment variables to set up the `miden-proving-service` worker (#1281).
 
 ## 0.8.2 (2025-04-18) - `miden-proving-service` crate only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added getter for proof security level in `ProvenBatch` and `ProvenBlock` (#1259).
 - [BREAKING] Replaced the `ProvenBatch::new_unchecked` with the `ProvenBatch::new` method to initialize the struct with validations (#1260).
 - Added pretty print for `AccountCode` (#1273).
-- [BREAKING] Add `NetworkAccount` configuration (#1275).
+- [BREAKING] Add `NetworkAccount` configuration (#1275, #1301).
 
 ## 0.8.2 (2025-04-18) - `miden-proving-service` crate only
 

--- a/crates/miden-lib/asm/shared/util/account_id.masm
+++ b/crates/miden-lib/asm/shared/util/account_id.masm
@@ -13,7 +13,7 @@ const.ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE=0x00020145
 # Least significant byte of the account ID suffix must be zero.
 const.ERR_ACCOUNT_ID_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO=0x00020144
 
-# Provided storage slot index is out of bounds.
+# Provided storage slot index is out of bounds
 const.ERR_ACCOUNT_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS=0x00020152
 
 # The account ID must have storage mode public if the network flag is set.


### PR DESCRIPTION
Small follow-up for the `AccountTree`, addressing this comment: https://github.com/0xPolygonMiden/miden-base/pull/1254#discussion_r2049900789.

Also fixes `compute_mutations` not checking for account ID prefix uniqueness.

In miden-node, this breaks test code in `crates/block-producer/src/test_utils/store.rs` but the fix should be relatively easy cc @Mirko-von-Leipzig.