### PR TITLE
chore: fix `miden-objects` standalone compilation

### DIFF
--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -82,6 +82,13 @@ impl AccountVaultDelta {
         self.non_fungible.merge(other.non_fungible)?;
         self.fungible.merge(other.fungible)
     }
+
+    /// Appends the vault delta to the given `elements` from which the delta commitment will be
+    /// computed.
+    pub(super) fn append_delta_elements(&self, elements: &mut Vec<Felt>) {
+        self.fungible().append_delta_elements(elements);
+        self.non_fungible().append_delta_elements(elements);
+    }
 }
 
 #[cfg(any(feature = "testing", test))]
@@ -149,13 +156,6 @@ impl AccountVaultDelta {
             .chain(self.non_fungible.filter_by_action(NonFungibleDeltaAction::Remove).map(|key| {
                 Asset::NonFungible(unsafe { NonFungibleAsset::new_unchecked(key.into()) })
             }))
-    }
-
-    /// Appends the vault delta to the given `elements` from which the delta commitment will be
-    /// computed.
-    pub(super) fn append_delta_elements(&self, elements: &mut Vec<Felt>) {
-        self.fungible().append_delta_elements(elements);
-        self.non_fungible().append_delta_elements(elements);
     }
 }
 


### PR DESCRIPTION
Fixes #1487.

The issue was that `AccountVaultDelta::append_delta_elements` was feature gated behind `testing/test`. However it was being used from outside the feature gate.

This meant `miden-objects` would fail to compile if feature resolution resolved without `testing` feature active. i.e.

```
cargo check -p miden-objects                    # fails
cargo check -p miden-objects --features testing # works
```

This PR removes the `append_delta_elements` feature gatedness.

In general it might be a good idea to evaluate what methods are actually kept behind a `testing` feature. Is there really any harm in letting users have access to these methods always?