### PR TITLE
chore: Fix release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,6 +18,22 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+      # Ensure the release tag refers to the latest commit on main.
+      # Compare the commit SHA that triggered the workflow with the HEAD of the branch we just
+      # checked out (main).
+      - name: Verify release was triggered from main HEAD
+        run: |
+          tag_sha="${{ github.sha }}"
+          main_sha="$(git rev-parse HEAD)"
+
+          echo "Tag points to:        $tag_sha"
+          echo "Current main HEAD is: $main_sha"
+
+          if [ "$tag_sha" != "$main_sha" ]; then
+            echo "::error::The release tag was not created from the latest commit on main. Aborting."
+            exit 1
+          fi
+          echo "Release tag matches main HEAD — continuing."
       - name: Update Rust toolchain
         run: |
           rustup update --no-self-update


### PR DESCRIPTION
Since our workflow is a little different from the standard `release-plz` workflow, and we publish crates upon a GitHub release rather than upon merging to `main`, we need to first check out the `main` branch, or else we get:
```
fatal: HEAD does not point to a branch
```

Note: by adding `ref: main` to the checkout action, every time a GitHub release is published, the workflow will try to trigger a `release-plz` release (i.e. publish to crates.io) **from the `main` branch**. GitHub releases are based on tags rather than branches, and to ensure the commit associated with the release tag matches the HEAD from `main`, I've added an extra guard step.

This means, our workflow will NOT publish to crates.io:
- if the GitHub release was made from another branch other than `main`;
- if the GitHub release is stale (fresh commits made it to `main` before it's been published)


Failed run: https://github.com/0xMiden/miden-base/actions/runs/16161498637/job/45613907739