### PR TITLE
fix(swap-script): add explicit check for single asset in SWAP note

### DIFF
--- a/crates/miden-lib/asm/note_scripts/SWAP.masm
+++ b/crates/miden-lib/asm/note_scripts/SWAP.masm
@@ -40,8 +40,7 @@ begin
     push.12 exec.note::get_assets
     # => [num_assets, ptr]
 
-    # make sure the number of inputs is 1
-    assert.err=ERR_SWAP_WRONG_NUMBER_OF_ASSETS
+    eq.1 assert.err=ERR_SWAP_WRONG_NUMBER_OF_ASSETS
     # => [ptr]
 
     # load the ASSET


### PR DESCRIPTION
Added an explicit check to ensure that the SWAP note contains exactly one asset.

Previously, the script only checked that the number of assets was non-zero, which could allow cases with multiple assets to pass through incorrectly. Now, a strict check (eq.1 assert.err) guarantees that the SWAP note contains exactly one asset, as required by the swap logic.

This change prevents potential errors and incorrect behavior when attempting to perform a SWAP with an invalid number of assets, making the script more robust and secure.