### PR TITLE
 refactor: Move advice inputs to executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [BREAKING] Make the naming of the transaction script arguments consistent ([#1632](https://github.com/0xMiden/miden-base/pull/1632)).
 - [BREAKING] Move `TransactionProverHost` and `TransactionExecutorHost` from dynamic dispatch to generics ([#1037](https://github.com/0xMiden/miden-node/issues/1037))
 - [BREAKING] Changed `PartialStorage` and `PartialVault` to use `PartialSmt` instead of separate merkle proofs ([#1590](https://github.com/0xMiden/miden-base/pull/1590)).
+- [BREAKING] Move transaction inputs insertion out of transaction hosts ([#1639](https://github.com/0xMiden/miden-node/issues/1639))
 - Implemented serialization for `MockChain` ([#1642](https://github.com/0xMiden/miden-base/pull/1642)).
 
 ## 0.10.0 (2025-07-08)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8e112548b2d316598c2258326b5f8d8d018f37df8a190d2cd7f9d2e11a4921"
+checksum = "8b3d8fb95de53071a391767549a5d6ef7113e121a33f9a63d91e6ae7b2ecfe6e"
 dependencies = [
  "miden-air",
  "miden-core",

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -22,7 +22,7 @@ mod events;
 pub use events::TransactionEvent;
 
 mod inputs;
-pub use inputs::TransactionAdviceInputs;
+pub use inputs::{TransactionAdviceInputs, TransactionAdviceMapMismatch};
 
 mod outputs;
 pub use outputs::{
@@ -116,7 +116,7 @@ impl TransactionKernel {
         tx_inputs: &TransactionInputs,
         tx_args: &TransactionArgs,
         init_advice_inputs: Option<AdviceInputs>,
-    ) -> (StackInputs, TransactionAdviceInputs) {
+    ) -> Result<(StackInputs, TransactionAdviceInputs), TransactionAdviceMapMismatch> {
         let account = tx_inputs.account();
 
         let stack_inputs = TransactionKernel::build_input_stack(
@@ -127,12 +127,12 @@ impl TransactionKernel {
             tx_inputs.block_header().block_num(),
         );
 
-        let mut tx_advice_inputs = TransactionAdviceInputs::new(tx_inputs, tx_args);
+        let mut tx_advice_inputs = TransactionAdviceInputs::new(tx_inputs, tx_args)?;
         if let Some(init_advice_inputs) = init_advice_inputs {
             tx_advice_inputs.extend(init_advice_inputs);
         }
 
-        (stack_inputs, tx_advice_inputs)
+        Ok((stack_inputs, tx_advice_inputs))
     }
 
     // ASSEMBLER CONSTRUCTOR

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -141,7 +141,7 @@ impl TransactionArgs {
     }
 
     /// Collects and returns a set containing all code commitments from foreign accounts.
-    pub fn foreign_account_code_commitments(&self) -> BTreeSet<Word> {
+    pub fn to_foreign_account_code_commitments(&self) -> BTreeSet<Word> {
         self.foreign_account_inputs()
             .iter()
             .map(|acc| acc.code().commitment())

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -71,7 +71,8 @@ impl TransactionContext {
             &self.tx_inputs,
             &self.tx_args,
             Some(self.advice_inputs.clone()),
-        );
+        )
+        .expect("error initializing transaction inputs");
 
         let test_lib = TransactionKernel::kernel_as_library();
 
@@ -103,7 +104,7 @@ impl TransactionContext {
             self.tx_inputs.account().into(),
             &advice_inputs,
             mast_store,
-            self.tx_args.foreign_account_code_commitments(),
+            self.tx_args.to_foreign_account_code_commitments(),
         ))
         .stack_inputs(stack_inputs)
         .extend_advice_inputs(advice_inputs)

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -1,6 +1,7 @@
 use alloc::{boxed::Box, string::String};
 use core::error::Error;
 
+use miden_lib::transaction::TransactionAdviceMapMismatch;
 use miden_objects::{
     AccountError, Felt, ProvenTransactionError, TransactionInputError, TransactionOutputError,
     Word, account::AccountId, assembly::diagnostics::reporting::PrintDiagnostic,
@@ -16,6 +17,8 @@ use vm_processor::ExecutionError;
 
 #[derive(Debug, Error)]
 pub enum TransactionExecutorError {
+    #[error("the advice map contains conflicting map entries")]
+    ConflictingAdviceMapEntry(#[source] TransactionAdviceMapMismatch),
     #[error("failed to fetch transaction inputs from the data store")]
     FetchTransactionInputsFailed(#[source] DataStoreError),
     #[error("foreign account inputs for ID {0} are not anchored on reference block")]
@@ -79,6 +82,8 @@ pub enum TransactionProverError {
     TransactionOutputConstructionFailed(#[source] TransactionOutputError),
     #[error("failed to build proven transaction")]
     ProvenTransactionBuildFailed(#[source] ProvenTransactionError),
+    #[error("the advice map contains conflicting map entries")]
+    ConflictingAdviceMapEntry(#[source] TransactionAdviceMapMismatch),
     // Print the diagnostic directly instead of returning the source error. In the source error
     // case, the diagnostic is lost if the execution error is not explicitly unwrapped.
     #[error("failed to execute transaction kernel program:\n{}", PrintDiagnostic::new(.0))]

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -1,9 +1,4 @@
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
 use miden_lib::{errors::TransactionKernelError, transaction::TransactionEvent};
 use miden_objects::{
@@ -12,13 +7,12 @@ use miden_objects::{
     transaction::{InputNote, InputNotes, OutputNote},
 };
 use vm_processor::{
-    AdviceInputs, BaseHost, ErrorContext, ExecutionError, MastForest, MastForestStore,
-    ProcessState, SyncHost,
+    BaseHost, ErrorContext, ExecutionError, MastForest, MastForestStore, ProcessState, SyncHost,
 };
 
 use crate::{
+    AccountProcedureIndexMap,
     auth::{SigningInputs, TransactionAuthenticator},
-    errors::TransactionHostError,
     host::{ScriptMastForestStore, TransactionBaseHost, TransactionProgress},
 };
 
@@ -61,26 +55,24 @@ where
     pub fn new(
         account: &PartialAccount,
         input_notes: InputNotes<InputNote>,
-        advice_inputs: &mut AdviceInputs,
         mast_store: &'store STORE,
         scripts_mast_store: ScriptMastForestStore,
+        acct_procedure_index_map: AccountProcedureIndexMap,
         authenticator: Option<&'auth AUTH>,
-        foreign_account_code_commitments: BTreeSet<Word>,
-    ) -> Result<Self, TransactionHostError> {
+    ) -> Self {
         let base_host = TransactionBaseHost::new(
             account,
             input_notes,
-            advice_inputs,
             mast_store,
             scripts_mast_store,
-            foreign_account_code_commitments,
-        )?;
+            acct_procedure_index_map,
+        );
 
-        Ok(Self {
+        Self {
             base_host,
             authenticator,
             generated_signatures: BTreeMap::new(),
-        })
+        }
     }
 
     // PUBLIC ACCESSORS

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -16,12 +16,7 @@ mod script_mast_forest_store;
 pub use script_mast_forest_store::ScriptMastForestStore;
 
 mod tx_progress;
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::{
     TransactionEvent, TransactionEventError, TransactionKernelError,
@@ -37,11 +32,9 @@ use miden_objects::{
 };
 pub use tx_progress::TransactionProgress;
 use vm_processor::{
-    AdviceInputs, ContextId, ErrorContext, ExecutionError, Felt, KvMap, MastForest,
-    MastForestStore, MemoryError, ProcessState,
+    ContextId, ErrorContext, ExecutionError, Felt, MastForest, MastForestStore, MemoryError,
+    ProcessState,
 };
-
-use crate::errors::TransactionHostError;
 
 // TRANSACTION BASE HOST
 // ================================================================================================
@@ -89,54 +82,22 @@ where
     pub fn new(
         account: &PartialAccount,
         input_notes: InputNotes<InputNote>,
-        advice_inputs: &mut AdviceInputs,
         mast_store: &'store STORE,
         scripts_mast_store: ScriptMastForestStore,
-        mut foreign_account_code_commitments: BTreeSet<Word>,
-    ) -> Result<Self, TransactionHostError> {
-        // currently, the executor/prover do not keep track of the code commitment of the native
-        // account, so we add it to the set here
-        foreign_account_code_commitments.insert(account.code().commitment());
-
-        // Insert the account advice map into the advice recorder.
-        // This ensures that the advice map is available during the note script execution when it
-        // calls the account's code that relies on the it's advice map data (data segments) loaded
-        // into the advice provider
-        advice_inputs.extend_map(
-            account
-                .code()
-                .mast()
-                .advice_map()
-                .iter()
-                .map(|(key, values)| (*key, values.clone())),
-        );
-
-        // Add all advice data from scripts_mast_store to the adv_provider. This ensures the
-        // advice provider has all the necessary data for script execution
-        advice_inputs.extend_map(
-            scripts_mast_store
-                .advice_map()
-                .iter()
-                .map(|(key, values)| (*key, values.clone())),
-        );
-
-        let proc_index_map =
-            AccountProcedureIndexMap::new(foreign_account_code_commitments, advice_inputs)?;
-
-        let base = Self {
+        acct_procedure_index_map: AccountProcedureIndexMap,
+    ) -> Self {
+        Self {
             mast_store,
             scripts_mast_store,
             account_delta: AccountDeltaTracker::new(
                 account.id(),
                 account.storage().header().clone(),
             ),
-            acct_procedure_index_map: proc_index_map,
+            acct_procedure_index_map,
             output_notes: BTreeMap::default(),
             input_notes,
             tx_progress: TransactionProgress::default(),
-        };
-
-        Ok(base)
+        }
     }
 
     // PUBLIC ACCESSORS

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, collections::BTreeSet, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionEvent;
 use miden_objects::{
@@ -7,12 +7,11 @@ use miden_objects::{
     transaction::{InputNote, InputNotes, OutputNote},
 };
 use vm_processor::{
-    AdviceInputs, BaseHost, ErrorContext, ExecutionError, MastForest, MastForestStore,
-    ProcessState, SyncHost,
+    BaseHost, ErrorContext, ExecutionError, MastForest, MastForestStore, ProcessState, SyncHost,
 };
 
 use crate::{
-    errors::TransactionHostError,
+    AccountProcedureIndexMap,
     host::{ScriptMastForestStore, TransactionBaseHost, TransactionProgress},
 };
 
@@ -37,21 +36,19 @@ where
     pub fn new(
         account: &PartialAccount,
         input_notes: InputNotes<InputNote>,
-        advice_inputs: &mut AdviceInputs,
         mast_store: &'store STORE,
         scripts_mast_store: ScriptMastForestStore,
-        foreign_account_code_commitments: BTreeSet<Word>,
-    ) -> Result<Self, TransactionHostError> {
+        acct_procedure_index_map: AccountProcedureIndexMap,
+    ) -> Self {
         let base_host = TransactionBaseHost::new(
             account,
             input_notes,
-            advice_inputs,
             mast_store,
             scripts_mast_store,
-            foreign_account_code_commitments,
-        )?;
+            acct_procedure_index_map,
+        );
 
-        Ok(Self { base_host })
+        Self { base_host }
     }
 
     // PUBLIC ACCESSORS


### PR DESCRIPTION
Closes #1567 

## Changes

- Removes the `&mut AdviceInputs` parameters from the host. Extra inputs are now inserted at the moment of `TransactionAdviceInputs` instantiation
- As a consequence of the above, the creation of `AccountProcedureIndexMap` was also modified a bit to happen within the executor