### PR TITLE
Update documentation based on issue 1623

### DIFF
--- a/crates/miden-lib/src/account/auth/mod.rs
+++ b/crates/miden-lib/src/account/auth/mod.rs
@@ -143,10 +143,12 @@ impl Default for AuthRpoFalcon512AclConfig {
 /// ## Important Note on Procedure Detection
 /// The procedure-based authentication relies on the `was_procedure_called` kernel function,
 /// which only returns `true` if the procedure in question called into a kernel account API
-/// that is restricted to the account context. Procedures that don't interact with account
-/// state or kernel APIs may not be detected as "called" even if they were executed during
-/// the transaction. This is an important limitation to consider when designing trigger
-/// procedures for authentication.
+/// that is restricted to the account context (e.g., via `tx::authenticate_account_origin`
+/// which executes `account::authenticate_and_track_procedure`, or via
+/// `tx::assert_auth_procedure_origin`). Procedures that don't interact with account state
+/// or account-restricted kernel APIs may not be detected as "called" even if they were
+/// executed during the transaction. This is an important limitation to consider when
+/// designing trigger procedures for authentication.
 ///
 /// This component supports all account types.
 pub struct AuthRpoFalcon512Acl {

--- a/docs/src/account/code.md
+++ b/docs/src/account/code.md
@@ -25,3 +25,25 @@ Such an authentication procedure typically inspects the transaction and then dec
 - checking whether notes have been created.
 
 Recall that an [account's nonce](overview.md#nonce) must be incremented whenever its state changes. Only authentication procedures are allowed to do so, to prevent accidental or unintended authorization of state changes.
+
+## Procedure tracking
+
+> [!Warning]
+> Procedure tracking is edge-triggered via kernel account APIs. Merely executing an account procedure does not guarantee it will be marked as "called".
+
+Miden tracks whether an account procedure "was called" during a transaction using kernel support. A procedure is marked as called only when it invokes an authenticateable kernel account API that asserts the account context. Concretely, tracking is engaged when the call stack passes through:
+
+- `tx::authenticate_account_origin` (which internally executes `account::authenticate_and_track_procedure`), or
+- `tx::assert_auth_procedure_origin` (which internally executes `account::assert_auth_procedure`).
+
+If a procedure executes only local MASM instructions and never calls into account-restricted kernel APIs (e.g., it just does `push.0 drop`), it will not be tracked, even though it was executed.
+
+- Example: An authentication procedure like `auth__basic` verifies a signature and uses account APIs (e.g., `account::incr_nonce`), so it will be tracked and visible to `was_procedure_called`-based logic.
+- Counter-example: A noop variant like `auth__noop` which only contains local instructions (e.g., `push.0 drop`) will not trigger tracking, thus `was_procedure_called` will remain false even if the procedure ran.
+
+Implications:
+- **ACLs keyed off tracked procedures** must ensure that the relevant procedures interact with account-restricted kernel APIs so that tracking is triggered.
+- Current tracking records a boolean "was_called" per procedure. Counting the number of invocations is not yet recorded.
+
+Rationale and future direction:
+- Today’s approach is lightweight and implemented at the kernel level via `account::authenticate_and_track_procedure` and `account::assert_auth_procedure`. A future enhancement may introduce VM-level native tracking to unambiguously track account procedure calls and to enable per-procedure invocation counts.

--- a/docs/src/transaction.md
+++ b/docs/src/transaction.md
@@ -47,6 +47,9 @@ A `Transaction` requires several inputs:
 4. **Epilogue**
    Completes the execution, resulting in an updated account state and a generated zero-knowledge proof. The validity of the resulting transaction is checked. The account's state must have changed or at least one input note must have been consumed to make the transaction non-empty. This check ensures that a transaction can only be submitted once to the network. If the account's state has changed, the `nonce` must have been incremented, which is how the entire transaction is authenticated. Additionally, the net sum of all involved assets must be `0` (if the account is not a faucet).
 
+   > [!Note]
+   > Authentication procedures can base their decision on whether specific account procedures were called during the transaction. A procedure is considered "tracked" only if it invokes account-restricted kernel APIs (e.g., via `tx::authenticate_account_origin` → `account::authenticate_and_track_procedure`). Procedures that execute only local instructions (e.g., a noop `push.0 drop`) will not be marked as called.
+
 The proof together with the corresponding data needed for verification and updates of the global state can then be submitted and processed by the network.
 
 ## Examples


### PR DESCRIPTION
Clarify when account procedures are tracked to resolve ambiguity from issue #1623.

The previous documentation implied that any executed account procedure would be tracked, leading to confusion. This PR clarifies that tracking is "edge-triggered" only when specific kernel account APIs are called, providing examples and implications for ACLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e2c31cc-3598-454d-976b-5982d15e02d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e2c31cc-3598-454d-976b-5982d15e02d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

