### PR TITLE
fix: load foreign accounts in `LocalTransactionProver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.2 (2025-09-08)
+
+- Fixed foreign account inputs not being loaded in `LocalTransactionProver` ([#1866](https://github.com/0xMiden/miden-base/pull/#1866)).
+
 ## 0.11.1 (2025-08-28)
 
 - Added `AddressInterface::Unspecified` to represent default addresses ([#1801](https://github.com/0xMiden/miden-base/pull/#1801)).

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -37,6 +37,7 @@ use miden_objects::assembly::DefaultSourceManager;
 use miden_objects::testing::storage::STORAGE_LEAVES_2;
 use miden_objects::transaction::AccountInputs;
 use miden_processor::{AdviceInputs, Felt};
+use miden_tx::LocalTransactionProver;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
@@ -848,7 +849,11 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    let _executed_transaction = tx_context.execute_blocking()?;
+    let executed_transaction = tx_context.execute_blocking()?;
+
+    // TODO: Remove later and add a integration test using FPI.
+    LocalTransactionProver::default().prove(executed_transaction.into())?;
+
     Ok(())
 }
 

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -72,6 +72,9 @@ impl LocalTransactionProver {
 
         // load the store with account/note/tx_script MASTs
         self.mast_store.load_account_code(account.code());
+        for account_inputs in tx_args.foreign_account_inputs() {
+            self.mast_store.load_account_code(account_inputs.code());
+        }
 
         let script_mast_store = ScriptMastForestStore::new(
             tx_args.tx_script(),


### PR DESCRIPTION
Load foreign accounts in `LocalTransactionProver`.

addresses #1865

To close that issue, I'd add a proper FPI integration test.