### PR TITLE
fix: clippy 1.90 lints

### DIFF
--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -449,11 +449,11 @@ pub const LINK_MAP_USED_MEMORY_SIZE: MemoryAddress = 33_554_432;
 pub const LINK_MAP_ENTRY_SIZE: MemoryOffset = 16;
 
 const _: () = assert!(
-    LINK_MAP_REGION_START_PTR % LINK_MAP_ENTRY_SIZE == 0,
+    LINK_MAP_REGION_START_PTR.is_multiple_of(LINK_MAP_ENTRY_SIZE),
     "link map region start ptr should be aligned to entry size"
 );
 
 const _: () = assert!(
-    (LINK_MAP_REGION_END_PTR - LINK_MAP_REGION_START_PTR) % LINK_MAP_ENTRY_SIZE == 0,
+    (LINK_MAP_REGION_END_PTR - LINK_MAP_REGION_START_PTR).is_multiple_of(LINK_MAP_ENTRY_SIZE),
     "the link map memory range should cleanly contain a multiple of the entry size"
 );

--- a/crates/miden-objects/src/note/assets.rs
+++ b/crates/miden-objects/src/note/assets.rs
@@ -93,7 +93,7 @@ impl NoteAssets {
     /// because hashing the returned elements results in the note asset commitment.
     pub fn to_padded_assets(&self) -> Vec<Felt> {
         // if we have an odd number of assets with pad with a single word.
-        let padded_len = if self.assets.len() % 2 == 0 {
+        let padded_len = if self.assets.len().is_multiple_of(2) {
             self.assets.len() * WORD_SIZE
         } else {
             (self.assets.len() + 1) * WORD_SIZE
@@ -192,7 +192,7 @@ fn compute_asset_commitment(assets: &[Asset]) -> Word {
 
     // If we have an odd number of assets we pad the vector with 4 zero elements. This is to
     // ensure the number of elements is a multiple of 8 - the size of the hasher rate.
-    let word_capacity = if assets.len() % 2 == 0 {
+    let word_capacity = if assets.len().is_multiple_of(2) {
         assets.len()
     } else {
         assets.len() + 1

--- a/crates/miden-objects/src/note/script.rs
+++ b/crates/miden-objects/src/note/script.rs
@@ -84,7 +84,7 @@ impl From<&NoteScript> for Vec<Felt> {
         let len = bytes.len();
 
         // Pad the data so that it can be encoded with u32
-        let missing = if len % 4 > 0 { 4 - (len % 4) } else { 0 };
+        let missing = if !len.is_multiple_of(4) { 4 - (len % 4) } else { 0 };
         bytes.resize(bytes.len() + missing, 0);
 
         let final_size = 2 + bytes.len();


### PR DESCRIPTION
Fixes the lints introduced with clippy 1.90 due to the newly released Rust version (https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/).