### PR TITLE
chore: change import to not use contracts

### DIFF
--- a/crates/miden-lib/asm/miden/active_note.masm
+++ b/crates/miden-lib/asm/miden/active_note.masm
@@ -2,8 +2,8 @@ use.std::mem
 
 use.miden::kernel_proc_offsets
 use.miden::note
+use.miden::account
 use.miden::account_id
-use.miden::contracts::wallets::basic->wallet
 
 # ERRORS
 # =================================================================================================
@@ -268,8 +268,8 @@ export.add_assets_to_account.1024
         # => [ASSET, pad(12), ptr, end_ptr]
 
         # add asset to the account
-        call.wallet::receive_asset
-        # => [pad(16), ptr, end_ptr]
+        call.account::add_asset
+        # => [ASSET', pad(12), ptr, end_ptr]
 
         # clean the stack after call
         dropw dropw dropw


### PR DESCRIPTION
in preparation for https://github.com/0xMiden/miden-base/issues/1563:
- if we move the `contracts` directory to a new crate (which would depend on `miden-lib` to not re-build the kernel assembler), we can't have a cyclic dependency