### PR TITLE
chore: migrate to anyhow + ExecError and unify error handling

### DIFF
--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use miden_lib::account::wallets::BasicWallet;
 use miden_lib::errors::MasmError;
 use miden_lib::testing::note::NoteBuilder;
@@ -10,7 +10,6 @@ use miden_lib::transaction::memory::ACTIVE_INPUT_NOTE_PTR;
 use miden_lib::utils::ScriptBuilder;
 use miden_objects::account::{AccountBuilder, AccountId, PublicKeyCommitment};
 use miden_objects::assembly::DefaultSourceManager;
-use miden_objects::assembly::diagnostics::miette::{self, miette};
 use miden_objects::asset::FungibleAsset;
 use miden_objects::crypto::dsa::rpo_falcon512::SecretKey;
 use miden_objects::crypto::rand::{FeltRng, RpoRandomCoin};
@@ -88,10 +87,11 @@ async fn test_note_setup() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_note_script_and_note_args() -> miette::Result<()> {
+async fn test_note_script_and_note_args() -> anyhow::Result<()> {
     let mut tx_context = {
         let mut builder = MockChain::builder();
-        let account = builder.add_existing_wallet(Auth::BasicAuth).map_err(|err| miette!(err))?;
+        let account =
+            builder.add_existing_wallet(Auth::BasicAuth).map_err(|err| anyhow!("{err}"))?;
         let p2id_note_1 = builder
             .add_p2id_note(
                 ACCOUNT_ID_SENDER.try_into().unwrap(),
@@ -99,7 +99,7 @@ async fn test_note_script_and_note_args() -> miette::Result<()> {
                 &[FungibleAsset::mock(150)],
                 NoteType::Public,
             )
-            .map_err(|err| miette!(err))?;
+            .map_err(|err| anyhow!("{err}"))?;
         let p2id_note_2 = builder
             .add_p2id_note(
                 ACCOUNT_ID_SENDER.try_into().unwrap(),
@@ -107,8 +107,8 @@ async fn test_note_script_and_note_args() -> miette::Result<()> {
                 &[FungibleAsset::mock(300)],
                 NoteType::Public,
             )
-            .map_err(|err| miette!(err))?;
-        let mut mock_chain = builder.build().map_err(|err| miette!(err))?;
+            .map_err(|err| anyhow!("{err}"))?;
+        let mut mock_chain = builder.build().map_err(|err| anyhow!("{err}"))?;
         mock_chain.prove_next_block().unwrap();
 
         mock_chain
@@ -368,32 +368,32 @@ async fn test_compute_inputs_commitment() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_build_metadata() -> miette::Result<()> {
+async fn test_build_metadata() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
 
     let sender = tx_context.account().id();
     let receiver = AccountId::try_from(ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE)
-        .map_err(|e| miette::miette!("Failed to convert account ID: {}", e))?;
+        .map_err(|e| anyhow!("Failed to convert account ID: {}", e))?;
 
     let test_metadata1 = NoteMetadata::new(
         sender,
         NoteType::Private,
         NoteTag::from_account_id(receiver),
         NoteExecutionHint::after_block(500.into())
-            .map_err(|e| miette::miette!("Failed to create execution hint: {}", e))?,
-        Felt::try_from(1u64 << 63).map_err(|e| miette::miette!("Failed to convert felt: {}", e))?,
+            .map_err(|e| anyhow!("Failed to create execution hint: {}", e))?,
+        Felt::try_from(1u64 << 63).map_err(|e| anyhow!("Failed to convert felt: {}", e))?,
     )
-    .map_err(|e| miette::miette!("Failed to create metadata: {}", e))?;
+    .map_err(|e| anyhow!("Failed to create metadata: {}", e))?;
     let test_metadata2 = NoteMetadata::new(
         sender,
         NoteType::Public,
         // Use largest allowed use_case_id.
         NoteTag::for_public_use_case((1 << 14) - 1, u16::MAX, NoteExecutionMode::Local)
-            .map_err(|e| miette::miette!("Failed to create note tag: {}", e))?,
+            .map_err(|e| anyhow!("Failed to create note tag: {}", e))?,
         NoteExecutionHint::on_block_slot(u8::MAX, u8::MAX, u8::MAX),
-        Felt::try_from(0u64).map_err(|e| miette::miette!("Failed to convert felt: {}", e))?,
+        Felt::try_from(0u64).map_err(|e| anyhow!("Failed to convert felt: {}", e))?,
     )
-    .map_err(|e| miette::miette!("Failed to create metadata: {}", e))?;
+    .map_err(|e| anyhow!("Failed to create metadata: {}", e))?;
 
     for (iteration, test_metadata) in [test_metadata1, test_metadata2].into_iter().enumerate() {
         let code = format!(

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -20,7 +20,7 @@ use miden_objects::transaction::{
     TransactionInputs,
 };
 use miden_processor::fast::ExecutionOutput;
-use miden_processor::{ExecutionError, FutureMaybeSend, MastForest, MastForestStore, Word};
+use miden_processor::{FutureMaybeSend, MastForest, MastForestStore, Word};
 use miden_tx::auth::{BasicAuthenticator, UnreachableAuth};
 use miden_tx::{
     AccountProcedureIndexMap,
@@ -37,6 +37,7 @@ use rand_chacha::ChaCha20Rng;
 use crate::executor::CodeExecutor;
 use crate::mock_host::MockHost;
 use crate::tx_context::builder::MockAuthenticator;
+use crate::tx_context::errors::ExecError;
 
 // TRANSACTION CONTEXT
 // ================================================================================================
@@ -78,7 +79,7 @@ impl TransactionContext {
     /// # Panics
     ///
     /// - If the provided `code` is not a valid program.
-    pub async fn execute_code(&self, code: &str) -> Result<ExecutionOutput, ExecutionError> {
+    pub async fn execute_code(&self, code: &str) -> Result<ExecutionOutput, ExecError> {
         let (stack_inputs, advice_inputs) = TransactionKernel::prepare_inputs(&self.tx_inputs)
             .expect("error initializing transaction inputs");
 
@@ -135,6 +136,7 @@ impl TransactionContext {
             .extend_advice_inputs(advice_inputs)
             .execute_program(program)
             .await
+            .map_err(ExecError)
     }
 
     /// Executes the transaction through a [TransactionExecutor]

--- a/crates/miden-testing/src/tx_context/error.rs
+++ b/crates/miden-testing/src/tx_context/error.rs
@@ -1,0 +1,27 @@
+use alloc::string::ToString;
+use core::fmt::Display;
+
+use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
+use miden_processor::ExecutionError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub struct ExecError(pub ExecutionError);
+
+impl Display for ExecError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&PrintDiagnostic::new(&self.0).to_string())
+    }
+}
+
+impl From<ExecutionError> for ExecError {
+    fn from(err: ExecutionError) -> Self {
+        ExecError(err)
+    }
+}
+
+impl From<ExecError> for ExecutionError {
+    fn from(err: ExecError) -> Self {
+        err.0
+    }
+}

--- a/crates/miden-testing/src/tx_context/mod.rs
+++ b/crates/miden-testing/src/tx_context/mod.rs
@@ -1,5 +1,6 @@
 mod builder;
 mod context;
+pub mod errors;
 
 pub use builder::TransactionContextBuilder;
 pub use context::TransactionContext;

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -20,19 +20,24 @@ use rand::rngs::SmallRng;
 macro_rules! assert_execution_error {
     ($execution_result:expr, $expected_err:expr) => {
         match $execution_result {
-            Err(miden_processor::ExecutionError::FailedAssertion { label: _, source_file: _, clk: _, err_code, err_msg }) => {
-                if let Some(ref msg) = err_msg {
-                  assert_eq!(msg.as_ref(), $expected_err.message(), "error messages did not match");
-                }
+            Err(err) => {
+                let inner: miden_processor::ExecutionError = err.into();
+                match inner {
+                    miden_processor::ExecutionError::FailedAssertion { label: _, source_file: _, clk: _, err_code, err_msg } => {
+                        if let Some(ref msg) = err_msg {
+                            assert_eq!(msg.as_ref(), $expected_err.message(), "error messages did not match");
+                        }
 
-                assert_eq!(
-                    err_code, $expected_err.code(),
-                    "Execution failed on assertion with an unexpected error (Actual code: {}, msg: {}, Expected code: {}).",
-                    err_code, err_msg.as_ref().map(|string| string.as_ref()).unwrap_or("<no message>"), $expected_err,
-                );
-            },
+                        assert_eq!(
+                            err_code, $expected_err.code(),
+                            "Execution failed on assertion with an unexpected error (Actual code: {}, msg: {}, Expected code: {}).",
+                            err_code, err_msg.as_ref().map(|string| string.as_ref()).unwrap_or("<no message>"), $expected_err,
+                        );
+                    },
+                    other => panic!("Execution error was not as expected: {}", $crate::tx_context::ExecError(other)),
+                }
+            }
             Ok(_) => panic!("Execution was unexpectedly successful"),
-            Err(err) => panic!("Execution error was not as expected: {err}"),
         }
     };
 }


### PR DESCRIPTION
Refactor miden-testing to standardize error handling on anyhow and introduce an ExecError wrapper for execution diagnostics. Replace all remaining miette usage with anyhow patterns, removing into_diagnostic and wrap_err, and mapping non-Error diagnostics (Report) into anyhow where needed. Add ExecError(ExecutionError) with Display implemented via PrintDiagnostic and provide From conversions in both directions to keep conversions ergonomic across call sites and macros. Update the assert_execution_error! macro to accept both ExecError and ExecutionError by converting via Into, preserving readable diagnostics while unifying behavior. Adapt affected tests in tx to the new model, ensuring assembler/linker diagnostics are mapped to anyhow and that API methods like with_supports_all_types are called on unwrapped values.

fixes #2040