### PR TITLE
fix: `InitStorageData::map_entries` should be public

### DIFF
--- a/crates/miden-objects/src/account/component/template/storage/init_storage_data.rs
+++ b/crates/miden-objects/src/account/component/template/storage/init_storage_data.rs
@@ -57,7 +57,7 @@ impl InitStorageData {
     }
 
     /// Returns the map entries associated with the given placeholder name, if any.
-    pub(crate) fn map_entries(&self, key: &StorageValueName) -> Option<&Vec<(Word, Word)>> {
+    pub fn map_entries(&self, key: &StorageValueName) -> Option<&Vec<(Word, Word)>> {
         self.map_entries.get(key)
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/0xMiden/miden-base/pull/2053

Testing of the functionality done in:

https://github.com/0xMiden/miden-client/compare/mmagician-test-init-storage-maps