### PR TITLE
chore: Remove unnecessary `cdropw` logic in `account_delta::compute_commitment`

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -176,31 +176,15 @@ proc.update_value_slot_delta
     dup.4 exec.account::get_initial_item
     # => [INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
-    # if account is new, replace INIT_VALUE with EMPTY_WORD
-    # we need to do this specifically for new accounts because for those, get_initial_item returns
-    # the same as get_item but we want the delta for value slots to be from an empty value to the
-    # final value
-    # use get_init_nonce so the delta is still correctly computed when the nonce has already been
-    # incremented
-    padw exec.memory::get_init_nonce eq.0
-    # => [is_account_new, EMPTY_WORD, INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
-
-    # If is_account_new EMPTY_WORD remains.
-    # If !is_account_new INIT_VALUE remains.
-    cdropw
-    # => [INIT_VALUE', CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
-
     exec.word::test_eq not
-    # => [was_changed, INIT_VALUE', CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
+    # => [was_changed, INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
     # set was_changed to true if the account is new
-    # this means a storage slot initialized with an empty word is included in the commitment for
-    # new accounts
-    # more generally, we want the delta for a new account to include all its newly added values,
-    # regardless of the exact value, because the initial delta for an account must represent its
-    # full state
-    exec.memory::get_init_nonce eq.0 or
-    # => [was_changed, INIT_VALUE', CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
+    # generally, the delta for a new account must include all its storage slots, regardless of the
+    # initial value and even if it is an empty word, because the initial delta for an account must
+    # represent its full state
+    exec.memory::is_new_account or
+    # => [was_changed, INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
     # only include in delta if the slot's value has changed or the account is new
     if.true
@@ -320,7 +304,7 @@ proc.update_map_slot_delta.4
 
     # if the account is new (nonce == 0) include the map header even if it is an empty map
     # in order to have the delta commit to this initial storage slot.
-    exec.memory::get_init_nonce eq.0 or
+    exec.memory::is_new_account or
     # => [should_include_map_header, RATE, RATE, PERM]
 
     if.true

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -987,6 +987,17 @@ export.is_native_account
     # => [is_native_account]
 end
 
+#! Returns 1 if the native account is new, i.e. its nonce is zero, 0 otherwise.
+#!
+#! Inputs:  []
+#! Outputs: [is_new_account]
+export.is_new_account
+    # the account is new if its nonce is zero
+    # use get_init_nonce so this procedure works correctly even after the account's nonce was
+    # incremented
+    exec.get_init_nonce eq.0
+end
+
 #! Returns a pointer to the end of the core account data section.
 #!
 #! Inputs:  []

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -50,7 +50,7 @@ pub const KERNEL_PROCEDURES: [Word; 52] = [
     // account_has_non_fungible_asset
     word!("0xfaad11de0c026551df15231790c2364cc598e891444bf826da01b524b1a8ca8f"),
     // account_compute_delta_commitment
-    word!("0xbb3ff91c5791cf0062df00954ebea8d97a79084d053e7c3a4555391faebdc819"),
+    word!("0xa19790f217a166fa3918118f75eb234436fe5dd513274b625757eab83d67a37c"),
     // account_get_num_procedures
     word!("0x53b5ec38b7841948762c258010e6e07ad93963bcaac2d83813f8edb6710dc720"),
     // account_get_procedure_root


### PR DESCRIPTION
Small follow-up to #2075.

Removes unnecessary `cdropw` logic in `account_delta::compute_commitment` since this logic is specifically for new accounts, and this is already covered by the "is new account" logic introduced in #2075.

Also introduces a `memory::is_new_account` helper procedure.