### PR TITLE
Introduced `cargo binstall` for installing `cargo-msrv`

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-msrv
-        run: cargo binstall cargo-msrv
+        run: cargo binstall --no-confirm cargo-msrv
       - name: Check MSRV for each workspace member
         run: |
           ./scripts/check-msrv.sh


### PR DESCRIPTION
Closes #2082 

PR introduced binstall into CI when installing `cargo-msrv`, to cut CI run-time