### PR TITLE
fix: expose `with_backend_from_entries` for `LargeSmt<Backend>` backed `NullifierTree`s

### DIFF
--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -1085,9 +1085,6 @@ pub enum NullifierTreeError {
 
     #[error("failed to compute nullifier tree mutations")]
     ComputeMutations(#[source] MerkleError),
-
-    #[error("storage error {0}")]
-    LargeSmt(String),
 }
 
 // AUTH SCHEME ERROR


### PR DESCRIPTION
Required in nullifier tree construction in the node.