### PR TITLE
Add `ExecutedTransaction` to `TransactionHeader` conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [BREAKING] Refactored storage slots to be accessed by names instead of indices ([#1987](https://github.com/0xMiden/miden-base/pull/1987), [#2025](https://github.com/0xMiden/miden-base/pull/2025), [#2149](https://github.com/0xMiden/miden-base/pull/2149), [#2150](https://github.com/0xMiden/miden-base/pull/2150), [#2153](https://github.com/0xMiden/miden-base/pull/2153), [#2154](https://github.com/0xMiden/miden-base/pull/2154), [#2161](https://github.com/0xMiden/miden-base/pull/2161), [#2170](https://github.com/0xMiden/miden-base/pull/2170)).
 - [BREAKING] Allowed account components to share identical account code procedures ([#2164](https://github.com/0xMiden/miden-base/pull/2164)).
+- Add `From<&ExecutedTransaction> for TransactionHeader` implementation ([#2178](https://github.com/0xMiden/miden-base/pull/2178)).
 
 ### Changes
 

--- a/crates/miden-objects/src/transaction/inputs/notes.rs
+++ b/crates/miden-objects/src/transaction/inputs/notes.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use super::TransactionInputError;
 use crate::note::{Note, NoteId, NoteInclusionProof, NoteLocation, Nullifier};
+use crate::transaction::InputNoteCommitment;
 use crate::utils::serde::{
     ByteReader,
     ByteWriter,
@@ -144,6 +145,12 @@ impl InputNotes<InputNote> {
             notes.into_iter().map(|note| InputNote::Unauthenticated { note }).collect();
 
         Self::new(input_note_vec)
+    }
+
+    /// Returns a vector of input note commitments based on the input notes.
+    pub fn to_commitments(&self) -> InputNotes<InputNoteCommitment> {
+        let notes = self.notes.iter().map(InputNoteCommitment::from).collect();
+        InputNotes::<InputNoteCommitment>::new_unchecked(notes)
     }
 }
 

--- a/crates/miden-objects/src/transaction/tx_header.rs
+++ b/crates/miden-objects/src/transaction/tx_header.rs
@@ -7,6 +7,7 @@ use crate::asset::FungibleAsset;
 use crate::note::NoteHeader;
 use crate::transaction::{
     AccountId,
+    ExecutedTransaction,
     InputNoteCommitment,
     InputNotes,
     OutputNotes,
@@ -171,6 +172,21 @@ impl From<&ProvenTransaction> for TransactionHeader {
     }
 }
 
+impl From<&ExecutedTransaction> for TransactionHeader {
+    /// Constructs a [`TransactionHeader`] from a [`ExecutedTransaction`].
+    fn from(tx: &ExecutedTransaction) -> Self {
+        TransactionHeader::new_unchecked(
+            tx.id(),
+            tx.account_id(),
+            tx.initial_account().initial_commitment(),
+            tx.final_account().commitment(),
+            tx.input_notes().to_commitments(),
+            tx.output_notes().iter().map(NoteHeader::from).collect(),
+            tx.fee(),
+        )
+    }
+}
+
 // SERIALIZATION
 // ================================================================================================
 
@@ -214,5 +230,81 @@ impl Deserializable for TransactionHeader {
         );
 
         Ok(tx_header)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_verifier::ExecutionProof;
+
+    use super::*;
+    use crate::asset::FungibleAsset;
+    use crate::transaction::ProvenTransactionBuilder;
+
+    #[test]
+    fn from_proven_transaction() {
+        // Build proven transaction.
+        let account_id = crate::account::AccountId::dummy(
+            [1; 15],
+            crate::account::AccountIdVersion::Version0,
+            crate::account::AccountType::FungibleFaucet,
+            crate::account::AccountStorageMode::Private,
+        );
+        let initial_commitment =
+            [2; 32].try_into().expect("failed to create initial account commitment");
+        let final_commitment =
+            [3; 32].try_into().expect("failed to create final account commitment");
+        let account_delta_commitment =
+            [4; 32].try_into().expect("failed to create account delta commitment");
+        let block_num = crate::block::BlockNumber::from(1);
+        let block_ref = Word::empty();
+        let fee = FungibleAsset::mock(42).unwrap_fungible();
+        let expiration_block_num = crate::block::BlockNumber::from(2);
+        let proof = ExecutionProof::new_dummy();
+
+        let proven_tx = ProvenTransactionBuilder::new(
+            account_id,
+            initial_commitment,
+            final_commitment,
+            account_delta_commitment,
+            block_num,
+            block_ref,
+            fee,
+            expiration_block_num,
+            proof,
+        )
+        .build()
+        .unwrap();
+
+        // Create header from proven transaction.
+        let header = TransactionHeader::from(&proven_tx);
+
+        // Verify the header data matches the proven transaction.
+        assert_eq!(header.id(), proven_tx.id());
+        assert_eq!(header.account_id(), proven_tx.account_id());
+        assert_eq!(
+            header.initial_state_commitment(),
+            proven_tx.account_update().initial_state_commitment()
+        );
+        assert_eq!(
+            header.final_state_commitment(),
+            proven_tx.account_update().final_state_commitment()
+        );
+        assert_eq!(header.fee(), proven_tx.fee());
+
+        assert_eq!(header.input_notes().iter().count(), proven_tx.input_notes().iter().count());
+
+        for (header_note, tx_note) in
+            header.input_notes().iter().zip(proven_tx.input_notes().iter())
+        {
+            assert_eq!(header_note, tx_note);
+        }
+
+        assert_eq!(header.output_notes().len(), proven_tx.output_notes().iter().count());
+        for (header_note, tx_note) in
+            header.output_notes().iter().zip(proven_tx.output_notes().iter())
+        {
+            assert_eq!(*header_note, crate::note::NoteHeader::from(tx_note));
+        }
     }
 }


### PR DESCRIPTION
Unblocks validator ability to compare re-executed transactions with provided proven transactions.