### PR TITLE
feat: add `Clone` to `NoteConsumptionStatus`

### DIFF
--- a/crates/miden-standards/src/note/well_known_note.rs
+++ b/crates/miden-standards/src/note/well_known_note.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use core::error::Error;
 
 use miden_protocol::account::AccountId;
@@ -427,6 +427,27 @@ pub enum NoteConsumptionStatus {
     UnconsumableConditions,
     /// The note cannot be consumed by the specified account under any conditions.
     NeverConsumable(Box<dyn Error + Send + Sync + 'static>),
+}
+
+impl Clone for NoteConsumptionStatus {
+    fn clone(&self) -> Self {
+        match self {
+            NoteConsumptionStatus::Consumable => NoteConsumptionStatus::Consumable,
+            NoteConsumptionStatus::ConsumableAfter(block_height) => {
+                NoteConsumptionStatus::ConsumableAfter(*block_height)
+            },
+            NoteConsumptionStatus::ConsumableWithAuthorization => {
+                NoteConsumptionStatus::ConsumableWithAuthorization
+            },
+            NoteConsumptionStatus::UnconsumableConditions => {
+                NoteConsumptionStatus::UnconsumableConditions
+            },
+            NoteConsumptionStatus::NeverConsumable(error) => {
+                let err = error.to_string();
+                NoteConsumptionStatus::NeverConsumable(err.into())
+            },
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Working on https://github.com/0xmiden/miden-client/issues/1381, I've faced the issue that `NoteConsumptionStatus` needs to be `Clone`able in order to be used alongs various parts of the client, for example being a new field of [`NoteConsumability`](https://github.com/0xMiden/miden-client/blob/316fadd305191ca624be44fc07c02b6bffdfbec6/crates/web-client/src/models/consumable_note_record.rs#L16-L19) mandates the `Clone` implementation (`Copy` is needless and can be removed).

Note: `Clone` needs to be implemented manually as `NoteConsumptionStatus::NeverConsumable` wraps a `Box` inside which cannot be cloned.