### PR TITLE
refactor: namespace transaction events under miden::protocol

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
@@ -139,45 +139,45 @@ const ACCOUNT_SLOT_VALUE_OFFSET=4
 # =================================================================================================
 
 # Event emitted before a foreign account is loaded from the advice inputs.
-const ACCOUNT_BEFORE_FOREIGN_LOAD_EVENT=event("miden::account::before_foreign_load")
+const ACCOUNT_BEFORE_FOREIGN_LOAD_EVENT=event("miden::protocol::account::before_foreign_load")
 
 # Event emitted before an asset is added to the account vault.
-const ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=event("miden::account::vault_before_add_asset")
+const ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=event("miden::protocol::account::vault_before_add_asset")
 # Event emitted after an asset is added to the account vault.
-const ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT=event("miden::account::vault_after_add_asset")
+const ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT=event("miden::protocol::account::vault_after_add_asset")
 
 # Event emitted before an asset is removed from the account vault.
-const ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT=event("miden::account::vault_before_remove_asset")
+const ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT=event("miden::protocol::account::vault_before_remove_asset")
 # Event emitted after an asset is removed from the account vault.
-const ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT=event("miden::account::vault_after_remove_asset")
+const ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT=event("miden::protocol::account::vault_after_remove_asset")
 
 # Event emitted before a fungible asset's balance is fetched from the account vault.
-const ACCOUNT_VAULT_BEFORE_GET_BALANCE_EVENT=event("miden::account::vault_before_get_balance")
+const ACCOUNT_VAULT_BEFORE_GET_BALANCE_EVENT=event("miden::protocol::account::vault_before_get_balance")
 
 # Event emitted before it is checked whether a non-fungible asset exists in the account vault.
-const ACCOUNT_VAULT_BEFORE_HAS_NON_FUNGIBLE_ASSET_EVENT=event("miden::account::vault_before_has_non_fungible_asset")
+const ACCOUNT_VAULT_BEFORE_HAS_NON_FUNGIBLE_ASSET_EVENT=event("miden::protocol::account::vault_before_has_non_fungible_asset")
 
 # Event emitted before an account storage item is updated.
-const ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT=event("miden::account::storage_before_set_item")
+const ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT=event("miden::protocol::account::storage_before_set_item")
 # Event emitted after an account storage item is updated.
-const ACCOUNT_STORAGE_AFTER_SET_ITEM_EVENT=event("miden::account::storage_after_set_item")
+const ACCOUNT_STORAGE_AFTER_SET_ITEM_EVENT=event("miden::protocol::account::storage_after_set_item")
 
 # Event emitted before an account storage map item is accessed.
-const ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT=event("miden::account::storage_before_get_map_item")
+const ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT=event("miden::protocol::account::storage_before_get_map_item")
 
 # Event emitted before an account storage map item is updated.
-const ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_EVENT=event("miden::account::storage_before_set_map_item")
+const ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_EVENT=event("miden::protocol::account::storage_before_set_map_item")
 # Event emitted after an account storage map item is updated.
-const ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_EVENT=event("miden::account::storage_after_set_map_item")
+const ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_EVENT=event("miden::protocol::account::storage_after_set_map_item")
 
 # Event emitted before an account nonce is incremented.
-const ACCOUNT_BEFORE_INCREMENT_NONCE_EVENT=event("miden::account::before_increment_nonce")
+const ACCOUNT_BEFORE_INCREMENT_NONCE_EVENT=event("miden::protocol::account::before_increment_nonce")
 # Event emitted after an account nonce is incremented.
-const ACCOUNT_AFTER_INCREMENT_NONCE_EVENT=event("miden::account::after_increment_nonce")
+const ACCOUNT_AFTER_INCREMENT_NONCE_EVENT=event("miden::protocol::account::after_increment_nonce")
 
 # Event emitted to push the index of the account procedure at the top of the operand stack onto
 # the advice stack.
-const ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT=event("miden::account::push_procedure_index")
+const ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT=event("miden::protocol::account::push_procedure_index")
 
 # CONSTANT ACCESSORS
 # =================================================================================================

--- a/crates/miden-protocol/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/epilogue.masm
@@ -22,16 +22,16 @@ const ERR_EPILOGUE_NONCE_CANNOT_BE_0="nonce cannot be 0 after an account-creatin
 # =================================================================================================
 
 # Event emitted to signal that the compute_fee procedure has obtained the current number of cycles.
-const EPILOGUE_AFTER_TX_CYCLES_OBTAINED_EVENT=event("miden::epilogue::after_tx_cycles_obtained")
+const EPILOGUE_AFTER_TX_CYCLES_OBTAINED_EVENT=event("miden::protocol::epilogue::after_tx_cycles_obtained")
 
 # Event emitted to signal that the fee was computed.
-const EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_EVENT=event("miden::epilogue::before_tx_fee_removed_from_account")
+const EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_EVENT=event("miden::protocol::epilogue::before_tx_fee_removed_from_account")
 
 # Event emitted to signal that an execution of the authentication procedure has started.
-const EPILOGUE_AUTH_PROC_START_EVENT=event("miden::epilogue::auth_proc_start")
+const EPILOGUE_AUTH_PROC_START_EVENT=event("miden::protocol::epilogue::auth_proc_start")
 
 # Event emitted to signal that an execution of the authentication procedure has ended.
-const EPILOGUE_AUTH_PROC_END_EVENT=event("miden::epilogue::auth_proc_end")
+const EPILOGUE_AUTH_PROC_END_EVENT=event("miden::protocol::epilogue::auth_proc_end")
 
 # An additional number of cyclces to account for the number of cycles that smt::set will take when
 # removing the computed fee from the asset vault.

--- a/crates/miden-protocol/asm/kernels/transaction/lib/link_map.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/link_map.masm
@@ -167,10 +167,10 @@ const GET_OPERATION_ABSENT_AT_HEAD=1
 # =================================================================================================
 
 # Event emitted when an entry is set.
-const LINK_MAP_SET_EVENT=event("miden::link_map::set")
+const LINK_MAP_SET_EVENT=event("miden::protocol::link_map::set")
 
 # Event emitted when an entry is fetched.
-const LINK_MAP_GET_EVENT=event("miden::link_map::get")
+const LINK_MAP_GET_EVENT=event("miden::protocol::link_map::get")
 
 # LINK MAP PROCEDURES
 # =================================================================================================

--- a/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
@@ -59,14 +59,14 @@ const ERR_NOTE_TAG_MUST_BE_U32="the note's tag must fit into a u32 so the 32 mos
 # =================================================================================================
 
 # Event emitted before a new note is created.
-const NOTE_BEFORE_CREATED_EVENT=event("miden::note::before_created")
+const NOTE_BEFORE_CREATED_EVENT=event("miden::protocol::note::before_created")
 # Event emitted after a new note is created.
-const NOTE_AFTER_CREATED_EVENT=event("miden::note::after_created")
+const NOTE_AFTER_CREATED_EVENT=event("miden::protocol::note::after_created")
 
 # Event emitted before an ASSET is added to a note
-const NOTE_BEFORE_ADD_ASSET_EVENT=event("miden::note::before_add_asset")
+const NOTE_BEFORE_ADD_ASSET_EVENT=event("miden::protocol::note::before_add_asset")
 # Event emitted after an ASSET is added to a note
-const NOTE_AFTER_ADD_ASSET_EVENT=event("miden::note::after_add_asset")
+const NOTE_AFTER_ADD_ASSET_EVENT=event("miden::protocol::note::after_add_asset")
 
 # OUTPUT NOTE PROCEDURES
 # =================================================================================================

--- a/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
@@ -20,7 +20,7 @@ const MAX_BLOCK_NUM=0xFFFFFFFF
 #=================================================================================================
 
 # Emission of an equivalent to `ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT`, use in `add_input_note_assets_to_vault`
-const ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=event("miden::account::vault_before_add_asset")
+const ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=event("miden::protocol::account::vault_before_add_asset")
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-protocol/asm/kernels/transaction/main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/main.masm
@@ -9,29 +9,29 @@ use $kernel::prologue
 # =================================================================================================
 
 # Event emitted to signal that an execution of the transaction prologue has started.
-const PROLOGUE_START_EVENT=event("miden::tx::prologue_start")
+const PROLOGUE_START_EVENT=event("miden::protocol::tx::prologue_start")
 # Event emitted to signal that an execution of the transaction prologue has ended.
-const PROLOGUE_END_EVENT=event("miden::tx::prologue_end")
+const PROLOGUE_END_EVENT=event("miden::protocol::tx::prologue_end")
 
 # Event emitted to signal that the notes processing has started.
-const NOTES_PROCESSING_START_EVENT=event("miden::tx::notes_processing_start")
+const NOTES_PROCESSING_START_EVENT=event("miden::protocol::tx::notes_processing_start")
 # Event emitted to signal that the notes processing has ended.
-const NOTES_PROCESSING_END_EVENT=event("miden::tx::notes_processing_end")
+const NOTES_PROCESSING_END_EVENT=event("miden::protocol::tx::notes_processing_end")
 
 # Event emitted to signal that the note consuming has started.
-const NOTE_EXECUTION_START_EVENT=event("miden::tx::note_execution_start")
+const NOTE_EXECUTION_START_EVENT=event("miden::protocol::tx::note_execution_start")
 # Event emitted to signal that the note consuming has ended.
-const NOTE_EXECUTION_END_EVENT=event("miden::tx::note_execution_end")
+const NOTE_EXECUTION_END_EVENT=event("miden::protocol::tx::note_execution_end")
 
 # Event emitted to signal that the transaction script processing has started.
-const TX_SCRIPT_PROCESSING_START_EVENT=event("miden::tx::tx_script_processing_start")
+const TX_SCRIPT_PROCESSING_START_EVENT=event("miden::protocol::tx::tx_script_processing_start")
 # Event emitted to signal that the transaction script processing has ended.
-const TX_SCRIPT_PROCESSING_END_EVENT=event("miden::tx::tx_script_processing_end")
+const TX_SCRIPT_PROCESSING_END_EVENT=event("miden::protocol::tx::tx_script_processing_end")
 
 # Event emitted to signal that an execution of the transaction epilogue has started.
-const EPILOGUE_START_EVENT=event("miden::tx::epilogue_start")
+const EPILOGUE_START_EVENT=event("miden::protocol::tx::epilogue_start")
 # Event emitted to signal that an execution of the transaction epilogue has ended.
-const EPILOGUE_END_EVENT=event("miden::tx::epilogue_end")
+const EPILOGUE_END_EVENT=event("miden::protocol::tx::epilogue_end")
 
 # MAIN
 # =================================================================================================

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -425,8 +425,8 @@ fn generate_event_constants(asm_source_dir: &Path, target_dir: &Path) -> Result<
 
     // Add two additional events we want in `TransactionEventId` that do not appear in kernel or
     // protocol lib modules.
-    events.insert("miden::auth::request".to_owned(), "AUTH_REQUEST".to_owned());
-    events.insert("miden::auth::unauthorized".to_owned(), "AUTH_UNAUTHORIZED".to_owned());
+    events.insert("miden::protocol::auth::request".to_owned(), "AUTH_REQUEST".to_owned());
+    events.insert("miden::protocol::auth::unauthorized".to_owned(), "AUTH_UNAUTHORIZED".to_owned());
 
     // Generate the events file in OUT_DIR
     let event_file_content = generate_event_file_content(&events).into_diagnostic()?;


### PR DESCRIPTION
Standardize transaction kernel event names to use the miden::protocol:: prefix so they are clearly scoped at the protocol layer and consistent with other protocol events. This updates MASM events in crates/miden-protocol/asm/kernels/transaction while keeping the stdlib smt_peek event unchanged so it stays in sync with miden-stdlib.

Also update the manually registered auth events in crates/miden-protocol/build.rs from miden::auth::{request, unauthorized} to miden::protocol::auth::{request, unauthorized} so TransactionEventId is generated with the new namespace.

Fix #2198 