### PR TITLE
ci: fix check-msrv job

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -30,7 +30,8 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-msrv
-        run: cargo binstall --no-confirm cargo-msrv
+        run: cargo binstall --no-confirm --force cargo-msrv
       - name: Check MSRV for each workspace member
         run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
           ./scripts/check-msrv.sh


### PR DESCRIPTION
The MSRV CI job was failing for two reasons:
1. `~/.cargo/bin` wasn't in PATH when `check-msrv.sh` ran as a subprocess
2. Cached `cargo-msrv` from rust-cache was stale/broken

Fix: add PATH export and force-reinstall cargo-msrv.