### PR TITLE
chore: Add serde for StorageMapWitness

### DIFF
--- a/crates/miden-protocol/src/account/storage/map/witness.rs
+++ b/crates/miden-protocol/src/account/storage/map/witness.rs
@@ -1,5 +1,12 @@
 use alloc::collections::BTreeMap;
 
+use miden_core::utils::{
+    ByteReader,
+    ByteWriter,
+    Deserializable,
+    DeserializationError,
+    Serializable,
+};
 use miden_crypto::merkle::InnerNodeInfo;
 use miden_crypto::merkle::smt::SmtProof;
 
@@ -107,6 +114,21 @@ impl StorageMapWitness {
 impl From<StorageMapWitness> for SmtProof {
     fn from(witness: StorageMapWitness) -> Self {
         witness.proof
+    }
+}
+
+impl Serializable for StorageMapWitness {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.proof.write_into(target);
+        self.entries.write_into(target);
+    }
+}
+
+impl Deserializable for StorageMapWitness {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let proof = SmtProof::read_from(source)?;
+        let entries = BTreeMap::<Word, Word>::read_from(source)?;
+        Ok(Self { proof, entries })
     }
 }
 


### PR DESCRIPTION
Required for upcoming [PR](https://github.com/0xMiden/miden-node/pull/1529) in miden-node which adds a gRPC endpoint to the store to retrieve storage map witnesses.

See [comment](https://github.com/0xMiden/miden-node/pull/1521#discussion_r2702717623).