### PR TITLE
feat: add BlockNumber::MAX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Enable `CodeBuilder` to add advice map entries to compiled scripts ([#2275](https://github.com/0xMiden/miden-base/pull/2275)).
+- Added `BlockNumber::MAX` constant to represent the maximum block number ([#2324](https://github.com/0xMiden/miden-base/pull/2324)).
 
 ### Changes
 

--- a/crates/miden-protocol/src/block/block_number.rs
+++ b/crates/miden-protocol/src/block/block_number.rs
@@ -30,6 +30,9 @@ impl BlockNumber {
     /// The block height of the genesis block.
     pub const GENESIS: Self = Self(0);
 
+    /// The maximum block number.
+    pub const MAX: Self = Self(u32::MAX);
+
     /// Returns the previous block number
     pub fn parent(self) -> Option<BlockNumber> {
         self.checked_sub(1)


### PR DESCRIPTION
In the node I found myself doing `BlockNumber::from(u32::MAX)`  a couple times.