### PR TITLE
feat: re-export `PackageKind` & `ProcedureExport`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `BlockNumber::MAX` constant to represent the maximum block number ([#2324](https://github.com/0xMiden/miden-base/pull/2324)).
 - Added single-word `Array` standard ([#2203](https://github.com/0xMiden/miden-base/pull/2203)).
 - Added `SignedBlock` struct ([#2355](https://github.com/0xMiden/miden-base/pull/2235)).
+- Added `PackageKind` and `ProcedureExport` ([#2358](https://github.com/0xMiden/miden-base/pull/2358)).
 
 ### Changes
 

--- a/crates/miden-protocol/src/lib.rs
+++ b/crates/miden-protocol/src/lib.rs
@@ -84,7 +84,9 @@ pub mod vm {
         MastArtifact,
         Package,
         PackageExport,
+        PackageKind,
         PackageManifest,
+        ProcedureExport,
         Section,
         SectionId,
     };


### PR DESCRIPTION
Re export `PackageKind` and `ProcudereExport` since these two structs are used [in the miden client](https://github.com/0xMiden/miden-client/blob/0a5add565d1388f77cd182f3639c16aa8f7ec674/crates/rust-client/src/lib.rs#L261)