### PR TITLE
refactor: add miden::protocol::auth module with public auth event constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 - Removed redundant note storage item count from advice map ([#2376](https://github.com/0xMiden/miden-base/pull/2376)).
+- Added `miden::protocol::auth` module with public auth event constants ([#2377](https://github.com/0xMiden/miden-base/pull/2377)).
 - [BREAKING] Prefixed transaction kernel events with `miden::protocol` ([#2364](https://github.com/0xMiden/miden-base/pull/2364)).
 - [BREAKING] Simplified `NoteMetadata::new()` constructor to not require tag parameter; tag defaults to zero and can be set via `with_tag()` builder method ([#2384](https://github.com/0xMiden/miden-base/pull/2384)).
 - [BREAKING] Renamed `WellKnownComponent` to `StandardAccountComponent`, `WellKnownNote` to `StandardNote`, and `WellKnownNoteAttachment` to `StandardNoteAttachment` ([#2332](https://github.com/0xMiden/miden-base/pull/2332)).

--- a/crates/miden-protocol/asm/protocol/auth.masm
+++ b/crates/miden-protocol/asm/protocol/auth.masm
@@ -1,0 +1,8 @@
+# EVENTS
+# =================================================================================================
+
+#! The event to request an authentication signature.
+pub const AUTH_REQUEST_EVENT = event("miden::protocol::auth::request")
+
+#! The event emitted when authentication is unauthorized.
+pub const AUTH_UNAUTHORIZED_EVENT = event("miden::protocol::auth::unauthorized")

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -421,12 +421,7 @@ fn validate_tx_kernel_category(errors: &[shared::NamedError]) -> Result<()> {
 /// then generates the transaction_events.rs file with constants.
 fn generate_event_constants(asm_source_dir: &Path, target_dir: &Path) -> Result<()> {
     // Extract all event definitions from MASM files
-    let mut events = extract_all_event_definitions(asm_source_dir)?;
-
-    // Add two additional events we want in `TransactionEventId` that do not appear in kernel or
-    // protocol lib modules.
-    events.insert("miden::protocol::auth::request".to_owned(), "AUTH_REQUEST".to_owned());
-    events.insert("miden::protocol::auth::unauthorized".to_owned(), "AUTH_UNAUTHORIZED".to_owned());
+    let events = extract_all_event_definitions(asm_source_dir)?;
 
     // Generate the events file in OUT_DIR
     let event_file_content = generate_event_file_content(&events).into_diagnostic()?;

--- a/crates/miden-standards/asm/account_components/auth/ecdsa_k256_keccak_multisig.masm
+++ b/crates/miden-standards/asm/account_components/auth/ecdsa_k256_keccak_multisig.masm
@@ -11,10 +11,8 @@ type BeWord = struct @bigendian { a: felt, b: felt, c: felt, d: felt }
 # CONSTANTS
 # =================================================================================================
 
-# Auth Request Constants
-
-# The event emitted when a signature is not found for a required signer.
-const AUTH_UNAUTHORIZED_EVENT = event("miden::protocol::auth::unauthorized")
+# Auth event constant (workaround for linker bug - see https://github.com/0xMiden/miden-base/pull/2377)
+const AUTH_UNAUTHORIZED_EVENT = ::miden::protocol::auth::AUTH_UNAUTHORIZED_EVENT
 
 # Storage Layout Constants
 #

--- a/crates/miden-standards/asm/account_components/auth/falcon_512_rpo_multisig.masm
+++ b/crates/miden-standards/asm/account_components/auth/falcon_512_rpo_multisig.masm
@@ -11,10 +11,8 @@ type BeWord = struct @bigendian { a: felt, b: felt, c: felt, d: felt }
 # CONSTANTS
 # =================================================================================================
 
-# Auth Request Constants
-
-# The event emitted when a signature is not found for a required signer.
-const AUTH_UNAUTHORIZED_EVENT = event("miden::protocol::auth::unauthorized")
+# Auth event constant (workaround for linker bug - see https://github.com/0xMiden/miden-base/pull/2377)
+const AUTH_UNAUTHORIZED_EVENT = ::miden::protocol::auth::AUTH_UNAUTHORIZED_EVENT
 
 # Storage Layout Constants
 #

--- a/crates/miden-standards/asm/standards/auth/ecdsa_k256_keccak.masm
+++ b/crates/miden-standards/asm/standards/auth/ecdsa_k256_keccak.masm
@@ -8,8 +8,8 @@ use miden::standards::auth
 # CONSTANTS
 # =================================================================================================
 
-# The event to request an authentication signature.
-const AUTH_REQUEST_EVENT=event("miden::protocol::auth::request")
+# Auth event constant (workaround for linker bug - see https://github.com/0xMiden/miden-base/pull/2377)
+const AUTH_REQUEST_EVENT = ::miden::protocol::auth::AUTH_REQUEST_EVENT
 
 # Local Memory Addresses for multisig operations
 const NUM_OF_APPROVERS_LOC=0

--- a/crates/miden-standards/asm/standards/auth/falcon512_rpo.masm
+++ b/crates/miden-standards/asm/standards/auth/falcon512_rpo.masm
@@ -8,8 +8,8 @@ use miden::standards::auth
 # CONSTANTS
 # =================================================================================================
 
-# The event to request an authentication signature.
-const AUTH_REQUEST_EVENT=event("miden::protocol::auth::request")
+# Auth event constant (workaround for linker bug - see https://github.com/0xMiden/miden-base/pull/2377)
+const AUTH_REQUEST_EVENT = ::miden::protocol::auth::AUTH_REQUEST_EVENT
 
 # Local Memory Addresses for multisig operations
 const NUM_OF_APPROVERS_LOC=0


### PR DESCRIPTION
## Summary

- Created `crates/miden-protocol/asm/protocol/auth.masm` with public constants:
  - `AUTH_REQUEST_EVENT`
  - `AUTH_UNAUTHORIZED_EVENT`
- Updated 4 auth modules in miden-standards to import these constants instead of defining them locally
- Removed custom event handling from `build.rs` since events are now defined in the protocol module

Closes #2370