### PR TITLE
chore(AI): add MASM skill files

### DIFF
--- a/.ai/skills/masm-comments/SKILL.md
+++ b/.ai/skills/masm-comments/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: masm-comments
+description: Enforce commenting conventions for Miden Assembly (.masm) files. Use when editing, reviewing, or creating .masm files.
+---
+
+# MASM Commenting Conventions
+
+## Rules
+
+### 1. Inline comments start lowercase
+
+Inline comments (single `#`) should begin with a lowercase letter.
+
+```masm
+# good: lowercase start
+exec.native_account::remove_asset
+# => [ASSET, note_idx, pad(11)]
+
+# Bad: uppercase start (avoid)
+# Remove the asset from the account
+```
+
+### 2. Don't over-comment obvious operations
+
+Only add comments that provide value. Skip comments for self-explanatory operations.
+
+**Skip comments for:**
+- Simple arithmetic: `add`, `sub`, `mul`, `div`
+- Basic stack ops when context is clear: `drop`, `swap`, `dup`
+- Standard control flow: `if.true`, `while.true`, `end`
+
+**Do comment:**
+- Stack state after complex operations: `# => [ptr, ASSET, end_ptr]`
+- Purpose of a code block: `# compute the pointer at which we should stop iterating`
+- Non-obvious logic or business rules
+- TODO items and references to external specs
+
+## Examples
+
+**Good:**
+
+```masm
+# remove the asset from the account
+exec.native_account::remove_asset
+# => [ASSET, note_idx, pad(11)]
+
+dupw dup.8 movdn.4
+# => [ASSET, note_idx, ASSET, note_idx, pad(11)]
+
+exec.output_note::add_asset
+# => [ASSET, note_idx, pad(11)]
+```
+
+**Avoid:**
+
+```masm
+# Swap the top two elements
+swap  # swap
+
+# Drop the word
+dropw  # drops 4 elements
+```
+
+## Doc comments
+
+Procedure documentation uses `#!` prefix (this rule only applies to inline `#` comments):
+
+```masm
+#! Adds the provided asset to the active account.
+#!
+#! Inputs:  [ASSET, pad(12)]
+#! Outputs: [pad(16)]
+pub proc receive_asset
+    ...
+end
+```

--- a/.ai/skills/masm-doc-comments/SKILL.md
+++ b/.ai/skills/masm-doc-comments/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: masm-doc-comments
+description: Enforce doc comment conventions for Miden Assembly (.masm) procedures. Use when editing, reviewing, or creating .masm procedures, especially when documenting inputs, outputs, panic conditions, or invocation types.
+---
+
+# MASM Procedure Doc Comments
+
+## Overview
+
+Every public MASM procedure should have a doc comment block using `#!` prefix with these sections in order:
+
+1. **Description** - What the procedure does
+2. **Inputs/Outputs** - Stack state before/after
+3. **Where** - Explanation of each stack item
+4. **Panics if** - Error conditions (when applicable)
+5. **Invocation** - How the procedure is called (`exec` or `call`)
+
+## Required Format
+
+```masm
+#! Brief description of what the procedure does.
+#!
+#! Additional context if needed.
+#!
+#! Inputs:  [item1, item2, WORD_ITEM]
+#! Outputs: [result1, RESULT_WORD]
+#!
+#! Where:
+#! - item1 is the description of item1.
+#! - item2 is the description of item2.
+#! - WORD_ITEM is a 4-element word representing X.
+#! - result1 is the description of result1.
+#! - RESULT_WORD is the resulting word.
+#!
+#! Panics if:
+#! - condition that causes the procedure to fail.
+#! - another error condition.
+#!
+#! Invocation: exec
+pub proc my_procedure
+```
+
+## Stack Notation
+
+### Naming Conventions
+
+| Type | Style | Example |
+|------|-------|---------|
+| Single felt | lowercase with underscores | `note_index`, `amount`, `balance` |
+| Word (4 felts) | UPPERCASE with underscores | `ASSET`, `RECIPIENT`, `SCRIPT_ROOT` |
+| Multi-felt (2-3) | lowercase with `{parts}` suffix | `account_id_{prefix,suffix}` |
+
+### Stack Order
+
+Items are listed left-to-right, with the **top of stack first**:
+
+```masm
+#! Inputs:  [top_item, second_item, THIRD_WORD]
+```
+
+### Empty Stack
+
+Use empty brackets for no inputs or outputs:
+
+```masm
+#! Inputs:  []
+#! Outputs: [result]
+```
+
+### Padding (for `call` procedures only)
+
+Include explicit padding for `call` procedures (see masm-padding skill):
+
+```masm
+#! Inputs:  [ASSET, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+```
+
+## Where Section
+
+Define every item from Inputs and Outputs:
+
+```masm
+#! Where:
+#! - note_index is the index of the input note.
+#! - sender_{prefix,suffix} are the prefix and suffix felts of the sender ID.
+#! - ASSET is the asset word [faucet_id_prefix, faucet_id_suffix, 0, amount].
+#! - balance is the fungible asset balance in the vault.
+```
+
+**Rules:**
+- Use "is" for single items, "are" for multi-part items
+- Start descriptions lowercase (continues the sentence)
+- End each line with a period
+- Group related items (e.g., all inputs, then all outputs)
+
+## Panics Section
+
+### Direct Panics
+
+List conditions from `assert*` statements in the procedure:
+
+```masm
+#! Panics if:
+#! - flag is false.
+proc sample_procedure
+    # => [flag]
+    assert.err=ERR_FLAG_IS_FALSE
+```
+
+### Propagated Panics
+
+When calling other procedures that may panic:
+
+**Simple case (< 4 conditions):** List the specific conditions:
+
+```masm
+#! Description, inputs, etc.
+#! Panics if:
+#! - flag is false.
+proc sample_procedure
+    # => [flag]
+    exec.another_procedure # this procedure may panic
+end
+
+proc another_procedure
+    # => [flag]
+    assert.err=ERR_FLAG_IS_FALSE
+end
+```
+
+**Complex case (4+ conditions):** Reference the subprocedure:
+
+```masm
+#! Description, inputs, etc.
+#! Panics if:
+#! - another_procedure fails to verify.
+proc sample_procedure
+    # => [flag_1, flag_2, flag_3, flag_4]
+    exec.another_procedure # this procedure may panic
+end
+
+#! Description, inputs, etc.
+#! Panics if:
+#! - flag_1 is false.
+#! - flag_2 is false.
+#! - flag_3 is false.
+#! - flag_4 is false.
+proc another_procedure
+    # => [flag_1, flag_2, flag_3, flag_4]
+    assert.err=ERR_FLAG_1_IS_FALSE
+    assert.err=ERR_FLAG_2_IS_FALSE
+    assert.err=ERR_FLAG_3_IS_FALSE
+    assert.err=ERR_FLAG_4_IS_FALSE
+end
+```
+
+### No Panics
+
+Omit the "Panics if:" section entirely if the procedure cannot panic.
+
+## Invocation Types
+
+Always specify how the procedure should be invoked:
+
+```masm
+#! Invocation: exec
+```
+
+or
+
+```masm
+#! Invocation: call
+```
+
+For existing procedures, a good rule of thumb is to use `call` when other procedures invoke this procedure via `call.<procedure_name>`, and `exec` if the procedure is invoked via `exec.<procedure_name>`.
+There is also `dyncall` or `syscall` but they are not commonly used and should be handled by the programmer.
+
+## Validation Checklist
+
+- [ ] Description starts with verb (Returns, Gets, Computes, Burns, etc.)
+- [ ] Inputs and Outputs use correct stack notation
+- [ ] All stack items defined in Where section
+- [ ] Words are UPPERCASE, felts are lowercase
+- [ ] Panics section lists direct asserts and propagated errors
+- [ ] Complex panic propagation uses "if <procedure> fails to verify" shorthand
+- [ ] Invocation type specified (exec or call)
+- [ ] For `call`: padding shown in Inputs/Outputs (see masm-padding skill)

--- a/.ai/skills/masm-padding/SKILL.md
+++ b/.ai/skills/masm-padding/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: masm-padding
+description: Enforce stack padding conventions for Miden Assembly (.masm) procedures based on invocation type (call vs exec). Use when editing, reviewing, or creating .masm procedures, especially those with Invocation annotations.
+---
+
+# MASM Padding Conventions
+
+## Overview
+
+Padding requirements differ based on procedure invocation type:
+
+| Invocation | Padding Required | Input/Output Elements |
+|------------|------------------|----------------------|
+| `call`     | Explicit padding in comments | Exactly 16 |
+| `exec`     | No explicit padding | No requirement |
+
+## Call Procedures
+
+Procedures invoked with `call` must have explicit padding in:
+1. **Doc comments** (`#!`) for Inputs/Outputs
+2. **Inline comments** (`#`) showing stack state
+
+### Doc Comment Format
+
+Use `pad(N)` notation where N + other elements = 16:
+
+```masm
+#! Inputs:  [ASSET, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+pub proc receive_asset
+```
+
+### Inline Comment Format
+
+Track padding through the procedure:
+
+```masm
+exec.native_account::set_item
+# => [OLD_VALUE, pad(12)]
+
+dropw
+# => [pad(16)] auto-padded to 16 elements    
+```
+
+### Auto-Padding Behavior
+
+If the stack falls below 16 elements for a `call` procedure, Miden auto-pads to 16. This is acceptable and should be documented in the output as the padded result.
+
+## Exec Procedures
+
+Procedures invoked with `exec` should NOT have explicit padding:
+
+```masm
+#! Inputs:  [PUB_KEY]
+#! Outputs: []
+#!
+#! Invocation: exec
+pub proc authenticate_transaction
+```
+
+### Why No Padding for Exec
+
+`exec` procedures share the caller's stack directly. Explicit padding would be misleading because:
+- The actual stack may have additional elements from the caller
+- The procedure may consume caller's stack elements
+
+### Danger Zone
+
+If an `exec` procedure's stack falls below the specified stack elements, it will consume stack items from its caller, potentially leading to unexpected behavior. This is a bug and should be fixed by ensuring the procedure maintains sufficient stack depth and avoiding dropping more stack elements than available.
+
+### Example of Dangerous Behavior
+
+```masm
+# => [num_approvers, threshold]
+dropw # dropw drops 4 elements, which will result in "negative" stack consumption (consuming 2 elements from the caller's stack)
+```
+
+
+## Intermediate States
+
+Inside a procedure, the stack may temporarily exceed 16 elements:
+
+```masm
+# => [num_approvers, threshold, MULTISIG_CONFIG, pad(12)]
+#     ^--- 18 elements total, must be reduced before return
+```
+
+These extra elements must be explicitly dropped before the procedure returns (directly or via called procedures).
+
+## Validation Checklist
+
+For `call` procedures:
+- [ ] Inputs doc comment shows exactly 16 elements with `pad(N)`
+- [ ] Outputs doc comment shows exactly 16 elements with `pad(N)`
+- [ ] Inline comments use `# =>` format with `pad(N)` notation
+- [ ] All intermediate states track the full stack including padding
+
+For `exec` procedures:
+- [ ] No `pad(N)` in Inputs/Outputs doc comments
+- [ ] No explicit padding in inline stack state comments
+- [ ] Verify stack never drops below safe depth


### PR DESCRIPTION
I think it'd be good to share this. Cursor is really good at applying these skills actually, I imagine other tools ppl use would do a similarly better job with the skills.

The idea is that we share an `.ai/skills` directory, and everyone copies/symlinks/etc. wherever they want. For example, I'd copy them over to my `~/.cursor/skills` dir.