### PR TITLE
feat: add `StandardNote` constructor from note script

### DIFF
--- a/crates/miden-protocol/src/note/mod.rs
+++ b/crates/miden-protocol/src/note/mod.rs
@@ -37,7 +37,7 @@ mod note_tag;
 pub use note_tag::NoteTag;
 
 mod note_type;
-pub use note_type::{NoteType, PRIVATE, PUBLIC};
+pub use note_type::NoteType;
 
 mod nullifier;
 pub use nullifier::Nullifier;

--- a/crates/miden-protocol/src/note/note_type.rs
+++ b/crates/miden-protocol/src/note/note_type.rs
@@ -11,13 +11,6 @@ use crate::utils::serde::{
     Serializable,
 };
 
-// CONSTANTS
-// ================================================================================================
-
-// Keep these masks in sync with `miden-lib/asm/miden/kernels/tx/tx.masm`
-pub const PUBLIC: u8 = 0b01;
-pub const PRIVATE: u8 = 0b10;
-
 // NOTE TYPE
 // ================================================================================================
 
@@ -25,10 +18,16 @@ pub const PRIVATE: u8 = 0b10;
 #[repr(u8)]
 pub enum NoteType {
     /// Notes with this type have only their hash published to the network.
-    Private = PRIVATE,
+    Private = Self::PRIVATE,
 
     /// Notes with this type are fully shared with the network.
-    Public = PUBLIC,
+    Public = Self::PUBLIC,
+}
+
+impl NoteType {
+    // Keep these masks in sync with `miden-lib/asm/miden/kernels/tx/tx.masm`
+    pub const PUBLIC: u8 = 0b01;
+    pub const PRIVATE: u8 = 0b10;
 }
 
 // CONVERSIONS FROM NOTE TYPE
@@ -48,8 +47,8 @@ impl TryFrom<u8> for NoteType {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            PRIVATE => Ok(NoteType::Private),
-            PUBLIC => Ok(NoteType::Public),
+            Self::PRIVATE => Ok(NoteType::Private),
+            Self::PUBLIC => Ok(NoteType::Public),
             _ => Err(NoteError::UnknownNoteType(format!("0b{value:b}").into())),
         }
     }
@@ -116,8 +115,8 @@ impl Deserializable for NoteType {
         let discriminant = u8::read_from(source)?;
 
         let note_type = match discriminant {
-            PRIVATE => NoteType::Private,
-            PUBLIC => NoteType::Public,
+            NoteType::PRIVATE => NoteType::Private,
+            NoteType::PUBLIC => NoteType::Public,
             discriminant => {
                 return Err(DeserializationError::InvalidValue(format!(
                     "discriminant {discriminant} is not a valid NoteType"

--- a/crates/miden-standards/src/account/interface/extension.rs
+++ b/crates/miden-standards/src/account/interface/extension.rs
@@ -75,7 +75,7 @@ impl AccountInterfaceExt for AccountInterface {
     /// Returns [NoteAccountCompatibility::Maybe] if the provided note is compatible with the
     /// current [AccountInterface], and [NoteAccountCompatibility::No] otherwise.
     fn is_compatible_with(&self, note: &Note) -> NoteAccountCompatibility {
-        if let Some(standard_note) = StandardNote::from_note(note) {
+        if let Some(standard_note) = StandardNote::from_script_root(note.script().root()) {
             if standard_note.is_compatible_with(self) {
                 NoteAccountCompatibility::Maybe
             } else {

--- a/crates/miden-standards/src/note/mod.rs
+++ b/crates/miden-standards/src/note/mod.rs
@@ -51,10 +51,10 @@ impl StandardNote {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a [`StandardNote`] instance based on the note script of the provided [`Note`].
-    /// Returns `None` if the provided note is not a standard note.
-    pub fn from_note(note: &Note) -> Option<Self> {
-        Self::from_script_root(note.script().root())
+    /// Returns a [`StandardNote`] instance based on the provided [`NoteScript`]. Returns `None`
+    /// if the provided script does not match any standard note script.
+    pub fn from_script(script: &NoteScript) -> Option<Self> {
+        Self::from_script_root(script.root())
     }
 
     /// Returns a [`StandardNote`] instance based on the provided script root. Returns `None` if
@@ -83,13 +83,13 @@ impl StandardNote {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the name of this [`StandardNote`] variant as a string.
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &'static str {
         match self {
-            Self::P2ID => "P2ID".to_string(),
-            Self::P2IDE => "P2IDE".to_string(),
-            Self::SWAP => "SWAP".to_string(),
-            Self::MINT => "MINT".to_string(),
-            Self::BURN => "BURN".to_string(),
+            Self::P2ID => "P2ID",
+            Self::P2IDE => "P2IDE",
+            Self::SWAP => "SWAP",
+            Self::MINT => "MINT",
+            Self::BURN => "BURN",
         }
     }
 

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -121,7 +121,9 @@ where
             return Err(NoteCheckerError::InputNoteCountOutOfRange(num_notes));
         }
         // Ensure standard notes are ordered first.
-        notes.sort_unstable_by_key(|note| StandardNote::from_note(note).is_none());
+        notes.sort_unstable_by_key(|note| {
+            StandardNote::from_script_root(note.script().root()).is_none()
+        });
 
         let notes = InputNotes::from(notes);
         let tx_inputs = self
@@ -153,7 +155,7 @@ where
         tx_args: TransactionArgs,
     ) -> Result<NoteConsumptionStatus, NoteCheckerError> {
         // Return the consumption status if we manage to determine it from the standard note
-        if let Some(standard_note) = StandardNote::from_note(note.note())
+        if let Some(standard_note) = StandardNote::from_script_root(note.note().script().root())
             && let Some(consumption_status) =
                 standard_note.is_consumable(note.note(), target_account_id, block_ref)
         {


### PR DESCRIPTION
This PR:
  - Adds `StandardNote::from_script_root(root: Word)` to identify standard notes directly from a script root, and refactors `from_note` to delegate to it
  - Adds `StandardNote::name(&self)` to return the variant name as a string
  - Makes `NoteType` masks (`PUBLIC`, `PRIVATE`) public and re-exports them from `miden_protocol::note`