### PR TITLE
fix: u64 limb ordering

### DIFF
--- a/crates/miden-standards/asm/standards/note_tag/mod.masm
+++ b/crates/miden-standards/asm/standards/note_tag/mod.masm
@@ -67,19 +67,19 @@ pub proc create_custom_account_target
     # create a bit mask that zeros out the lower (32 - tag_len) bits.
     # since u32shl panics for a 32 shift, we need to use u64::shl in case tag_len is 0
 
-    # push u32::MAX as a u64
-    push.0 push.0xffffffff
-    # => [u32::MAX, 0, tag_len, account_id_prefix]
+    # push u32::MAX as a u64 (hi limb set to zero)
+    push.0xffffffff push.0
+    # => [0, u32::MAX, tag_len, account_id_prefix]
 
     # compute "number of bits in u32" - tag_len
     push.32 movup.3 sub
-    # => [shift_by, u32::MAX, 0, account_id_prefix]
+    # => [shift_by, 0, u32::MAX, account_id_prefix]
 
     exec.u64::shl
     # => [bit_mask_hi, bit_mask_lo, account_id_prefix]
 
-    # discard the lo part
-    swap drop
+    # the mask we need is the lo limb so discard the hi limb
+    drop
     # => [bit_mask, account_id_prefix]
 
     swap u32split


### PR DESCRIPTION
Fixes the u64 limb ordering in `note_tag::create_custom_account_target` where the comment suggests it pushes `u32::MAX as u64`, but it actually pushes `0xffff_ffff_0000_0000`. The code accidentally worked anyway, but for consistency this change seems better as it was confusing during the BE -> LE migration.