### PR TITLE
feat: add mapping to aggfaucet to track claim proof nullifiers

### DIFF
--- a/crates/miden-agglayer/asm/bridge/agglayer_faucet.masm
+++ b/crates/miden-agglayer/asm/bridge/agglayer_faucet.masm
@@ -4,6 +4,7 @@ use miden::agglayer::utils
 use miden::agglayer::asset_conversion
 use miden::agglayer::eth_address
 use miden::protocol::active_account
+use miden::protocol::native_account
 use miden::protocol::active_note
 use miden::standards::faucets
 use miden::protocol::note
@@ -23,6 +24,9 @@ const BRIDGE_ID_SLOT = word("miden::agglayer::faucet")
 const CONVERSION_INFO_1_SLOT = word("miden::agglayer::faucet::conversion_info_1")
 # Slot 2: [addr_felt4, origin_network, scale, 0] — remaining address felt + origin network + scale
 const CONVERSION_INFO_2_SLOT = word("miden::agglayer::faucet::conversion_info_2")
+
+# Storage slot for claim nullifier mapping to prevent double-spending
+const CLAIM_NULLIFIER_SLOT = word("miden::agglayer::faucet::claim_nullifier")
 
 const PROOF_DATA_WORD_LEN = 134
 const LEAF_DATA_WORD_LEN = 8
@@ -73,11 +77,12 @@ const EXECUTION_HINT_ALWAYS = 1
 const OUTPUT_NOTE_AUX = 0
 
 const P2ID_OUTPUT_NOTE_AMOUNT_MEM_PTR = 611
+
 # ERRORS
 # =================================================================================================
 
 const ERR_INVALID_CLAIM_PROOF = "invalid claim proof"
-
+const ERR_CLAIM_NOTE_ALREADY_SPENT = "CLAIM note already spent"
 # CONVERSION METADATA HELPERS
 # =================================================================================================
 
@@ -234,10 +239,40 @@ proc get_raw_claim_amount
     mem_load.OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_7
 end
 
-# Inputs: [U256[0], U256[1]]
-# Outputs: [amount]
-proc scale_down_amount
-    repeat.7 drop end
+# Inputs: [PROOF_DATA_KEY]
+# Outputs: []
+proc set_and_check_claimed
+    dupw
+    # => [PROOF_DATA_KEY, PROOF_DATA_KEY]
+
+    # Check if this claim has already been processed (nullifier already exists)
+    # Get the current value from the nullifier mapping
+    push.CLAIM_NULLIFIER_SLOT[0..2]
+    # => [claim_nullifier_slot_idx, PROOF_DATA_KEY, PROOF_DATA_KEY]
+    
+    exec.active_account::get_map_item
+    # => [VALUE, PROOF_DATA_KEY]
+
+    # Assert that the value is empty (all zeros), meaning this claim hasn't been processed yet
+    padw
+    # => [0, 0, 0, 0, VALUE, PROOF_DATA_KEY]
+    
+    assert_eqw.err=ERR_CLAIM_NOTE_ALREADY_SPENT
+    # => [PROOF_DATA_KEY]
+    
+    # Set the nullifier to mark this claim as processed
+    # We'll set it to a non-zero value (e.g., [0, 0, 0, 1])
+    push.1.0.0.0
+    # => [TRUE, PROOF_DATA_KEY]
+
+    swapw 
+    # => [PROOF_DATA_KEY, TRUE]
+    
+    push.CLAIM_NULLIFIER_SLOT[0..2]
+    # => [claim_nullifier_slot_idx, PROOF_DATA_KEY, TRUE]
+    
+    exec.native_account::set_map_item
+    # => []
 end
 
 # Inputs: [PROOF_DATA_KEY, LEAF_DATA_KEY, OUTPUT_NOTE_DATA_KEY]
@@ -393,6 +428,8 @@ pub proc claim
     # validate_claim will overwrite memory in-place, so we need to load the account and amount
     # before calling validate_claim and store it in memory locals
     exec.get_destination_account_id_data
+    # => [prefix, suffix]
+    
     loc_store.CLAIM_PREFIX_MEM_LOC loc_store.CLAIM_SUFFIX_MEM_LOC
     # => [pad(16)]
 
@@ -403,19 +440,28 @@ pub proc claim
     # VALIDATE CLAIM 
     mem_loadw_be.PROOF_DATA_KEY_MEM_ADDR 
     # => [PROOF_DATA_KEY, pad(12)]
-    swapw
-    mem_loadw_be.LEAF_DATA_KEY_MEM_ADDR
+    
+    swapw mem_loadw_be.LEAF_DATA_KEY_MEM_ADDR
     # => [LEAF_DATA_KEY, PROOF_DATA_KEY, pad(8)]
 
     # Errors on invalid proof
     exec.validate_claim
     # => [pad(16)]
 
+    # add CLAIM note nullifier to mapping
+    mem_loadw_be.PROOF_DATA_KEY_MEM_ADDR
+    # => [PROOF_DATA_KEY, pad(12)]
+
+    exec.set_and_check_claimed
+    # => [pad(16)] 
+
     # Create P2ID output note
     loc_loadw_be.CLAIM_AMOUNT_MEM_LOC_1 swapw loc_loadw_be.CLAIM_AMOUNT_MEM_LOC_0
     # => [AMOUNT[0], AMOUNT[1], pad(8)]
+    
     loc_load.CLAIM_SUFFIX_MEM_LOC loc_load.CLAIM_PREFIX_MEM_LOC
     # => [prefix, suffix, AMOUNT[0], AMOUNT[1], pad(8)]
+    
     exec.build_p2id_output_note
     # => [pad(16)] 
 end

--- a/crates/miden-agglayer/src/errors/agglayer.rs
+++ b/crates/miden-agglayer/src/errors/agglayer.rs
@@ -19,6 +19,8 @@ pub const ERR_B2AGG_WRONG_NUMBER_OF_ASSETS: MasmError = MasmError::from_static_s
 /// Error Message: "bridge not mainnet"
 pub const ERR_BRIDGE_NOT_MAINNET: MasmError = MasmError::from_static_str("bridge not mainnet");
 
+/// Error Message: "CLAIM note already spent"
+pub const ERR_CLAIM_NOTE_ALREADY_SPENT: MasmError = MasmError::from_static_str("CLAIM note already spent");
 /// Error Message: "CLAIM's target account address and transaction address do not match"
 pub const ERR_CLAIM_TARGET_ACCT_MISMATCH: MasmError = MasmError::from_static_str("CLAIM's target account address and transaction address do not match");
 

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -327,9 +327,20 @@ pub fn create_agglayer_faucet_component(
         .expect("Conversion info 2 storage slot name should be valid");
     let conversion_slot2 = StorageSlot::with_value(conversion_info_2_name, conversion_slot2_word);
 
+    // Create claim nullifier mapping slot to prevent double-spending
+    let claim_nullifier_slot_name =
+        StorageSlotName::new("miden::agglayer::faucet::claim_nullifier")
+            .expect("Claim nullifier storage slot name should be valid");
+    let claim_nullifier_slot = StorageSlot::with_empty_map(claim_nullifier_slot_name);
+
     // Combine all storage slots for the agglayer faucet component
-    let agglayer_storage_slots =
-        vec![metadata_slot, bridge_slot, conversion_slot1, conversion_slot2];
+    let agglayer_storage_slots = vec![
+        metadata_slot,
+        bridge_slot,
+        conversion_slot1,
+        conversion_slot2,
+        claim_nullifier_slot,
+    ];
     agglayer_faucet_component(agglayer_storage_slots)
 }
 

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 
+use miden_agglayer::errors::ERR_CLAIM_NOTE_ALREADY_SPENT;
 use miden_agglayer::{
     ClaimNoteStorage,
     EthAddressFormat,
@@ -16,7 +17,7 @@ use miden_protocol::note::{NoteTag, NoteType};
 use miden_protocol::transaction::OutputNote;
 use miden_protocol::{Felt, FieldElement};
 use miden_standards::account::wallets::BasicWallet;
-use miden_testing::{AccountState, Auth, MockChain};
+use miden_testing::{AccountState, Auth, MockChain, assert_transaction_executor_error};
 use rand::Rng;
 
 use super::test_utils::real_claim_data;
@@ -157,6 +158,47 @@ async fn test_bridge_in_claim_to_p2id() -> anyhow::Result<()> {
     // - Verification that the minted amount matches the expected scaled value
     // - Full note ID comparison with the expected P2ID note
     // - Asset content verification
+
+    // Add the executed transaction to the chain and prove the block
+    mock_chain.add_pending_executed_transaction(&executed_transaction)?;
+    mock_chain.prove_next_block()?;
+
+    // TEST DOUBLE-SPEND PROTECTION: TRY TO CLAIM THE SAME PROOF AGAIN
+    // --------------------------------------------------------------------------------------------
+    // Create a second CLAIM note with the same proof_data and leaf_data but different RNG
+    // This should fail because the nullifier mapping should prevent double-spending
+
+    // Generate a different serial number for the second P2ID note
+    let serial_num_2 = builder.rng_mut().draw_word();
+
+    let output_note_data_2 = OutputNoteData {
+        output_p2id_serial_num: serial_num_2,
+        target_faucet_account_id: agglayer_faucet.id(),
+        output_note_tag: NoteTag::with_account_target(destination_account_id),
+    };
+
+    // Reuse the same proof_data and leaf_data from the first claim
+    let (proof_data_2, leaf_data_2, _) = real_claim_data();
+    let claim_inputs_2 = ClaimNoteStorage {
+        proof_data: proof_data_2,
+        leaf_data: leaf_data_2,
+        output_note_data: output_note_data_2,
+    };
+
+    let claim_note_2 = create_claim_note(claim_inputs_2, sender_account.id(), builder.rng_mut())?;
+
+    // Get updated foreign account inputs after the first transaction
+    let foreign_account_inputs_2 = mock_chain.get_foreign_account_inputs(bridge_account.id())?;
+
+    let tx_context_2 = mock_chain
+        .build_tx_context(agglayer_faucet.id(), &[], &[claim_note_2])?
+        .foreign_accounts(vec![foreign_account_inputs_2])
+        .build()?;
+
+    // Execute the second claim transaction - this should fail due to the nullifier check
+    let result = tx_context_2.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_CLAIM_NOTE_ALREADY_SPENT);
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds a mapping to the agglayer faucet to prevent double spend of `CLAIM` notes. This approach is a slightly more simplistic approach to the 1st PR I outlined [here](https://github.com/0xMiden/miden-base/issues/2416#issuecomment-3925831085).

Instead of storing the `leafIndex => bool` in a mapping, instead this PR stores `PROOF_DATA_KEY => bool`. Since `PROOF_DATA_KEY` is a hash of the underlying `PROOF_DATA`, this seems like a simple first approach to tracking nullifiers of `CLAIM` notes. 

However, I can still update this PR to store `[0,0,0,leafIndex] => [0,0,0,1]` in the mapping for this first approach. I do think that if we have a follow up PR which refactors the internals of the `set_and_check_claimed` procedure, it might be ok for now to just keep the approach of storing `PROOF_DATA_KEY => [0,0,0,1]` in the mapping.

Resolves https://github.com/0xMiden/miden-base/issues/2416