### PR TITLE
Protocol symbol resolution

### DIFF
--- a/crates/miden-standards/asm/account_components/auth/ecdsa_k256_keccak_multisig.masm
+++ b/crates/miden-standards/asm/account_components/auth/ecdsa_k256_keccak_multisig.masm
@@ -3,7 +3,6 @@
 # See the `AuthEcdsaK256KeccakMultisig` Rust type's documentation for more details.
 
 use miden::protocol::active_account
-use miden::protocol::auth::AUTH_UNAUTHORIZED_EVENT
 use miden::protocol::native_account
 use miden::standards::auth
 
@@ -11,6 +10,8 @@ type BeWord = struct @bigendian { a: felt, b: felt, c: felt, d: felt }
 
 # CONSTANTS
 # =================================================================================================
+
+const AUTH_UNAUTHORIZED_EVENT = event("miden::protocol::auth::unauthorized")
 
 # Storage Layout Constants
 #

--- a/crates/miden-standards/asm/account_components/auth/falcon_512_rpo_multisig.masm
+++ b/crates/miden-standards/asm/account_components/auth/falcon_512_rpo_multisig.masm
@@ -3,7 +3,6 @@
 # See the `AuthFalcon512RpoMultisig` Rust type's documentation for more details.
 
 use miden::protocol::active_account
-use miden::protocol::auth::AUTH_UNAUTHORIZED_EVENT
 use miden::protocol::native_account
 use miden::standards::auth
 
@@ -11,6 +10,8 @@ type BeWord = struct @bigendian { a: felt, b: felt, c: felt, d: felt }
 
 # CONSTANTS
 # =================================================================================================
+
+const AUTH_UNAUTHORIZED_EVENT = event("miden::protocol::auth::unauthorized")
 
 # Storage Layout Constants
 #

--- a/crates/miden-standards/asm/standards/auth/ecdsa_k256_keccak.masm
+++ b/crates/miden-standards/asm/standards/auth/ecdsa_k256_keccak.masm
@@ -1,7 +1,6 @@
 use miden::core::crypto::dsa::ecdsa_k256_keccak
 use miden::core::crypto::hashes::rpo256
 use miden::protocol::active_account
-use miden::protocol::auth::AUTH_REQUEST_EVENT
 use miden::protocol::native_account
 use miden::protocol::tx
 use miden::standards::auth
@@ -10,6 +9,7 @@ use miden::standards::auth
 # =================================================================================================
 
 # Local Memory Addresses for multisig operations
+const AUTH_REQUEST_EVENT = event("miden::protocol::auth::request")
 const NUM_OF_APPROVERS_LOC=0
 const PUB_KEY_SLOT_SUFFIX_LOC=4
 const PUB_KEY_SLOT_PREFIX_LOC=5

--- a/crates/miden-standards/asm/standards/auth/falcon512_rpo.masm
+++ b/crates/miden-standards/asm/standards/auth/falcon512_rpo.masm
@@ -1,7 +1,6 @@
 use miden::core::crypto::dsa::falcon512rpo
 use miden::core::crypto::hashes::rpo256
 use miden::protocol::active_account
-use miden::protocol::auth::AUTH_REQUEST_EVENT
 use miden::protocol::native_account
 use miden::protocol::tx
 use miden::standards::auth
@@ -10,6 +9,7 @@ use miden::standards::auth
 # =================================================================================================
 
 # Local Memory Addresses for multisig operations
+const AUTH_REQUEST_EVENT = event("miden::protocol::auth::request")
 const NUM_OF_APPROVERS_LOC=0
 const PUB_KEY_SLOT_SUFFIX_LOC=4
 const PUB_KEY_SLOT_PREFIX_LOC=5


### PR DESCRIPTION
Localize auth event constants in `miden-standards` ASM to fix undefined symbol errors when used with older `miden-assembly` versions.

The `miden-node` project, when updated to a newer `miden-protocol` (which pulls a newer `miden-base`), failed to build `miden-standards` due to an "undefined symbol reference" for `miden::protocol::auth::AUTH_REQUEST_EVENT`. This was traced to an incompatibility with the older `miden-assembly` version used by `miden-node`, which did not reliably resolve `event(...)` constants imported across library boundaries. Defining these constants locally in `miden-standards` resolves this issue.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-beb19331-b145-4955-aced-3188e95aa07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-beb19331-b145-4955-aced-3188e95aa07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

