### PR TITLE
fix: lowercase `.expect()` messages in `miden-agglayer` code

### DIFF
--- a/crates/miden-agglayer/src/b2agg_note.rs
+++ b/crates/miden-agglayer/src/b2agg_note.rs
@@ -32,7 +32,7 @@ use crate::EthAddressFormat;
 // Initialize the B2AGG note script only once
 static B2AGG_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/B2AGG.masb"));
-    let program = Program::read_from_bytes(bytes).expect("Shipped B2AGG script is well-formed");
+    let program = Program::read_from_bytes(bytes).expect("shipped B2AGG script is well-formed");
     NoteScript::new(program)
 });
 

--- a/crates/miden-agglayer/src/config_note.rs
+++ b/crates/miden-agglayer/src/config_note.rs
@@ -34,7 +34,7 @@ static CONFIG_AGG_BRIDGE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes =
         include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CONFIG_AGG_BRIDGE.masb"));
     let program =
-        Program::read_from_bytes(bytes).expect("Shipped CONFIG_AGG_BRIDGE script is well-formed");
+        Program::read_from_bytes(bytes).expect("shipped CONFIG_AGG_BRIDGE script is well-formed");
     NoteScript::new(program)
 });
 

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -60,7 +60,7 @@ pub use update_ger_note::UpdateGerNote;
 // Initialize the CLAIM note script only once
 static CLAIM_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CLAIM.masb"));
-    let program = Program::read_from_bytes(bytes).expect("Shipped CLAIM script is well-formed");
+    let program = Program::read_from_bytes(bytes).expect("shipped CLAIM script is well-formed");
     NoteScript::new(program)
 });
 
@@ -75,7 +75,7 @@ pub fn claim_script() -> NoteScript {
 // Initialize the unified AggLayer library only once
 static AGGLAYER_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/agglayer.masl"));
-    Library::read_from_bytes(bytes).expect("Shipped AggLayer library is well-formed")
+    Library::read_from_bytes(bytes).expect("shipped AggLayer library is well-formed")
 });
 
 /// Returns the unified AggLayer Library containing all agglayer modules.
@@ -265,7 +265,7 @@ pub fn faucet_registry_key(faucet_id: AccountId) -> Word {
 /// Returns an [`AccountComponent`] configured for bridge operations with MMR validation.
 pub fn create_bridge_account_component() -> AccountComponent {
     let bridge_storage_slot_name = StorageSlotName::new("miden::agglayer::bridge")
-        .expect("Bridge storage slot name should be valid");
+        .expect("bridge storage slot name should be valid");
     let bridge_storage_slots = vec![StorageSlot::with_empty_map(bridge_storage_slot_name)];
     bridge_out_component(bridge_storage_slots)
 }
@@ -304,7 +304,7 @@ pub fn create_agglayer_faucet_component(
     scale: u8,
 ) -> AccountComponent {
     // Create network faucet metadata slot: [token_supply, max_supply, decimals, token_symbol]
-    let token_symbol = TokenSymbol::new(token_symbol).expect("Token symbol should be valid");
+    let token_symbol = TokenSymbol::new(token_symbol).expect("token symbol should be valid");
     let metadata_word =
         Word::new([token_supply, max_supply, Felt::from(decimals), token_symbol.into()]);
     let metadata_slot =
@@ -318,7 +318,7 @@ pub fn create_agglayer_faucet_component(
         bridge_account_id.prefix().as_felt(),
     ]);
     let agglayer_storage_slot_name = StorageSlotName::new("miden::agglayer::faucet")
-        .expect("Agglayer faucet storage slot name should be valid");
+        .expect("agglayer faucet storage slot name should be valid");
     let bridge_slot = StorageSlot::with_value(agglayer_storage_slot_name, bridge_account_id_word);
 
     // Create conversion metadata storage slots
@@ -326,11 +326,11 @@ pub fn create_agglayer_faucet_component(
         agglayer_faucet_conversion_slots(origin_token_address, origin_network, scale);
 
     let conversion_info_1_name = StorageSlotName::new("miden::agglayer::faucet::conversion_info_1")
-        .expect("Conversion info 1 storage slot name should be valid");
+        .expect("conversion info 1 storage slot name should be valid");
     let conversion_slot1 = StorageSlot::with_value(conversion_info_1_name, conversion_slot1_word);
 
     let conversion_info_2_name = StorageSlotName::new("miden::agglayer::faucet::conversion_info_2")
-        .expect("Conversion info 2 storage slot name should be valid");
+        .expect("conversion info 2 storage slot name should be valid");
     let conversion_slot2 = StorageSlot::with_value(conversion_info_2_name, conversion_slot2_word);
 
     // Combine all storage slots for the agglayer faucet component
@@ -356,7 +356,7 @@ pub fn create_bridge_account_builder(
     ger_manager_id: AccountId,
 ) -> AccountBuilder {
     let ger_storage_slot_name = StorageSlotName::new("miden::agglayer::bridge::ger")
-        .expect("Bridge storage slot name should be valid");
+        .expect("bridge storage slot name should be valid");
     let bridge_in_storage_slots = vec![StorageSlot::with_empty_map(ger_storage_slot_name)];
 
     let bridge_in_component = bridge_in_component(bridge_in_storage_slots);
@@ -375,10 +375,10 @@ pub fn create_bridge_account_builder(
         .expect("LET num_leaves storage slot name should be valid");
     let faucet_registry_slot_name =
         StorageSlotName::new("miden::agglayer::bridge::faucet_registry")
-            .expect("Faucet registry storage slot name should be valid");
+            .expect("faucet registry storage slot name should be valid");
 
     let bridge_admin_slot_name = StorageSlotName::new(BRIDGE_ADMIN_SLOT_NAME)
-        .expect("Bridge admin storage slot name should be valid");
+        .expect("bridge admin storage slot name should be valid");
     let bridge_admin_word = Word::new([
         Felt::ZERO,
         Felt::ZERO,
@@ -426,7 +426,7 @@ pub fn create_bridge_account(
     create_bridge_account_builder(seed, bridge_admin_id, ger_manager_id)
         .with_auth_component(AccountComponent::from(NoAuth))
         .build()
-        .expect("Bridge account should be valid")
+        .expect("bridge account should be valid")
 }
 
 /// Creates an existing bridge account with the standard configuration.
@@ -441,7 +441,7 @@ pub fn create_existing_bridge_account(
     create_bridge_account_builder(seed, bridge_admin_id, ger_manager_id)
         .with_auth_component(AccountComponent::from(NoAuth))
         .build_existing()
-        .expect("Bridge account should be valid")
+        .expect("bridge account should be valid")
 }
 
 /// Creates a complete agglayer faucet account builder with the specified configuration.
@@ -500,7 +500,7 @@ pub fn create_agglayer_faucet(
     )
     .with_auth_component(AccountComponent::from(NoAuth))
     .build()
-    .expect("Agglayer faucet account should be valid")
+    .expect("agglayer faucet account should be valid")
 }
 
 /// Creates an existing agglayer faucet account with the specified configuration.
@@ -532,5 +532,5 @@ pub fn create_existing_agglayer_faucet(
     )
     .with_auth_component(AccountComponent::from(NoAuth))
     .build_existing()
-    .expect("Agglayer faucet account should be valid")
+    .expect("agglayer faucet account should be valid")
 }

--- a/crates/miden-agglayer/src/update_ger_note.rs
+++ b/crates/miden-agglayer/src/update_ger_note.rs
@@ -35,7 +35,7 @@ use crate::ExitRoot;
 static UPDATE_GER_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/UPDATE_GER.masb"));
     let program =
-        Program::read_from_bytes(bytes).expect("Shipped UPDATE_GER script is well-formed");
+        Program::read_from_bytes(bytes).expect("shipped UPDATE_GER script is well-formed");
     NoteScript::new(program)
 });
 

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -343,7 +343,7 @@ async fn test_bridge_out_fails_with_unregistered_faucet() -> anyhow::Result<()> 
 
     let destination_address = "0x1234567890abcdef1122334455667788990011aa";
     let eth_address =
-        EthAddressFormat::from_hex(destination_address).expect("Valid Ethereum address");
+        EthAddressFormat::from_hex(destination_address).expect("valid Ethereum address");
 
     let b2agg_note = B2AggNote::create(
         1u32, // destination_network
@@ -426,7 +426,7 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
     let destination_network = 1u32;
     let destination_address = "0x1234567890abcdef1122334455667788990011aa";
     let eth_address =
-        EthAddressFormat::from_hex(destination_address).expect("Valid Ethereum address");
+        EthAddressFormat::from_hex(destination_address).expect("valid Ethereum address");
 
     let assets = NoteAssets::new(vec![bridge_asset])?;
 
@@ -542,7 +542,7 @@ async fn b2agg_note_non_target_account_cannot_consume() -> anyhow::Result<()> {
     let destination_network = 1u32;
     let destination_address = "0x1234567890abcdef1122334455667788990011aa";
     let eth_address =
-        EthAddressFormat::from_hex(destination_address).expect("Valid Ethereum address");
+        EthAddressFormat::from_hex(destination_address).expect("valid Ethereum address");
 
     let assets = NoteAssets::new(vec![bridge_asset])?;
 

--- a/crates/miden-testing/tests/agglayer/crypto_utils.rs
+++ b/crates/miden-testing/tests/agglayer/crypto_utils.rs
@@ -111,7 +111,7 @@ fn merkle_proof_verification_code(
 #[tokio::test]
 async fn pack_leaf_data() -> anyhow::Result<()> {
     let vector: LeafValueVector =
-        serde_json::from_str(LEAF_VALUE_VECTORS_JSON).expect("Failed to parse leaf value vector");
+        serde_json::from_str(LEAF_VALUE_VECTORS_JSON).expect("failed to parse leaf value vector");
 
     let leaf_data = vector.to_leaf_data();
 
@@ -233,7 +233,7 @@ async fn pack_leaf_data() -> anyhow::Result<()> {
 #[tokio::test]
 async fn get_leaf_value() -> anyhow::Result<()> {
     let vector: LeafValueVector =
-        serde_json::from_str(LEAF_VALUE_VECTORS_JSON).expect("Failed to parse leaf value vector");
+        serde_json::from_str(LEAF_VALUE_VECTORS_JSON).expect("failed to parse leaf value vector");
 
     let leaf_data = vector.to_leaf_data();
     let key: Word = leaf_data.to_commitment();

--- a/crates/miden-testing/tests/agglayer/test_utils.rs
+++ b/crates/miden-testing/tests/agglayer/test_utils.rs
@@ -245,7 +245,7 @@ pub static SOLIDITY_MERKLE_PROOF_VECTORS: LazyLock<MerkleProofVerificationFile> 
 
 /// Lazily parsed canonical zeros from the JSON file.
 pub static SOLIDITY_CANONICAL_ZEROS: LazyLock<CanonicalZerosFile> = LazyLock::new(|| {
-    serde_json::from_str(CANONICAL_ZEROS_JSON).expect("Failed to parse canonical zeros JSON")
+    serde_json::from_str(CANONICAL_ZEROS_JSON).expect("failed to parse canonical zeros JSON")
 });
 
 /// Lazily parsed MMR frontier vectors from the JSON file.

--- a/crates/miden-testing/tests/agglayer/update_ger.rs
+++ b/crates/miden-testing/tests/agglayer/update_ger.rs
@@ -42,7 +42,7 @@ struct ExitRootsFile {
 
 /// Lazily parsed exit root vectors from the JSON file.
 static EXIT_ROOTS_VECTORS: LazyLock<ExitRootsFile> = LazyLock::new(|| {
-    serde_json::from_str(EXIT_ROOTS_JSON).expect("Failed to parse exit roots JSON")
+    serde_json::from_str(EXIT_ROOTS_JSON).expect("failed to parse exit roots JSON")
 });
 
 #[tokio::test]
@@ -128,11 +128,11 @@ async fn compute_ger() -> anyhow::Result<()> {
 
     for i in 0..vectors.mainnet_exit_roots.len() {
         let mainnet_exit_root_bytes =
-            hex_to_bytes(vectors.mainnet_exit_roots[i].as_str()).expect("Invalid hex string");
+            hex_to_bytes(vectors.mainnet_exit_roots[i].as_str()).expect("invalid hex string");
         let rollup_exit_root_bytes =
-            hex_to_bytes(vectors.rollup_exit_roots[i].as_str()).expect("Invalid hex string");
+            hex_to_bytes(vectors.rollup_exit_roots[i].as_str()).expect("invalid hex string");
         let expected_ger_bytes =
-            hex_to_bytes(vectors.global_exit_roots[i].as_str()).expect("Invalid hex string");
+            hex_to_bytes(vectors.global_exit_roots[i].as_str()).expect("invalid hex string");
 
         // Convert expected GER to felts for comparison
         let expected_ger_exit_root = ExitRoot::from(expected_ger_bytes);


### PR DESCRIPTION
## Summary

- Lowercases the first letter of all `.expect(\"...\")` messages in `crates/miden-agglayer/` and `crates/miden-testing/tests/agglayer/` to match the style convention used elsewhere in `miden-base`
- Messages starting with all-caps acronyms (LET, GER) are left unchanged

Follows the style suggestion in https://github.com/0xMiden/miden-base/pull/2479/changes#r2834139772.

## Test plan

- [ ] CI passes (no logic changes, purely cosmetic string updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)