### PR TITLE
fix: avoid collisions in random numbers

### DIFF
--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -807,7 +807,7 @@ pub enum ProvenTransactionError {
     )]
     ExistingPublicStateAccountRequiresDeltaDetails(AccountId),
     #[error("failed to construct output notes for proven transaction")]
-    OutputNotesError(TransactionOutputError),
+    OutputNotesError(#[source] TransactionOutputError),
     #[error(
         "account update of size {update_size} for account {account_id} exceeds maximum update size of {ACCOUNT_UPDATE_MAX_SIZE}"
     )]

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -529,14 +529,16 @@ fn input_and_output_notes_commitment() -> anyhow::Result<()> {
     // Randomize the note IDs and nullifiers on each test run to make sure the sorting property
     // is tested with various inputs.
     let mut rng = rand::rng();
+    // Generate a single random number and derive other unique numbers from it to avoid collisions.
+    let note_num = rng.random();
 
-    let note0 = mock_output_note(rng.random());
-    let note1 = mock_note(rng.random());
-    let note2 = mock_output_note(rng.random());
-    let note3 = mock_output_note(rng.random());
-    let note4 = mock_note(rng.random());
-    let note5 = mock_note(rng.random());
-    let note6 = mock_note(rng.random());
+    let note0 = mock_output_note(note_num);
+    let note1 = mock_note(note_num.wrapping_add(1));
+    let note2 = mock_output_note(note_num.wrapping_add(2));
+    let note3 = mock_output_note(note_num.wrapping_add(3));
+    let note4 = mock_note(note_num.wrapping_add(4));
+    let note5 = mock_note(note_num.wrapping_add(5));
+    let note6 = mock_note(note_num.wrapping_add(6));
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())


### PR DESCRIPTION
Avoid random `u8` collisions in the test fixed in https://github.com/0xMiden/miden-base/pull/2485/ which lead to test failures.