### PR TITLE
chore: rename `SchemaTypeId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [BREAKING] Renamed `AccountHeader::commitment`, `Account::commitment` and `PartialAccount::commitment` to `to_commitment` ([#2442](https://github.com/0xMiden/miden-base/pull/2442)).
 - [BREAKING] Remove `BlockSigner` trait ([#2447](https://github.com/0xMiden/miden-base/pull/2447)).
 - Updated account schema commitment construction to accept borrowed schema iterators; added extension trait to enable `AccountBuilder::with_schema_commitment()` helper ([#2419](https://github.com/0xMiden/miden-base/pull/2419)).
+- [BREAKING] Renamed `SchemaTypeId` to `SchemaType` ([#2494](https://github.com/0xMiden/miden-base/pull/2494)).
 - Updated stale `miden-base` references to `protocol` across docs, READMEs, code comments, and Cargo.toml repository URL ([#2503](https://github.com/0xMiden/protocol/pull/2503)).
 
 ## 0.13.3 (2026-01-27)

--- a/crates/miden-protocol/src/account/component/metadata/mod.rs
+++ b/crates/miden-protocol/src/account/component/metadata/mod.rs
@@ -41,7 +41,7 @@ use crate::errors::AccountError;
 ///     AccountComponentMetadata,
 ///     FeltSchema,
 ///     InitStorageData,
-///     SchemaTypeId,
+///     SchemaType,
 ///     StorageSchema,
 ///     StorageSlotSchema,
 ///     StorageValueName,

--- a/crates/miden-protocol/src/account/component/storage/mod.rs
+++ b/crates/miden-protocol/src/account/component/storage/mod.rs
@@ -5,7 +5,7 @@ mod value_name;
 pub use value_name::{StorageValueName, StorageValueNameError};
 
 mod type_registry;
-pub use type_registry::{SchemaRequirement, SchemaTypeError, SchemaTypeId};
+pub use type_registry::{SchemaRequirement, SchemaType, SchemaTypeError};
 
 mod init_storage_data;
 pub use init_storage_data::{InitStorageData, InitStorageDataError, WordValue};

--- a/crates/miden-protocol/src/account/component/storage/schema/felt.rs
+++ b/crates/miden-protocol/src/account/component/storage/schema/felt.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use miden_processor::DeserializationError;
 
-use super::super::type_registry::{SCHEMA_TYPE_REGISTRY, SchemaRequirement, SchemaTypeId};
+use super::super::type_registry::{SCHEMA_TYPE_REGISTRY, SchemaRequirement, SchemaType};
 use super::super::{InitStorageData, StorageValueName, WordValue};
 use super::validate_description_ascii;
 use crate::account::StorageSlotName;
@@ -25,13 +25,13 @@ use crate::{Felt, FieldElement};
 pub struct FeltSchema {
     name: Option<String>,
     description: Option<String>,
-    r#type: SchemaTypeId,
+    r#type: SchemaType,
     default_value: Option<Felt>,
 }
 
 impl FeltSchema {
     /// Creates a new required typed felt field.
-    pub fn new_typed(r#type: SchemaTypeId, name: impl Into<String>) -> Self {
+    pub fn new_typed(r#type: SchemaType, name: impl Into<String>) -> Self {
         FeltSchema {
             name: Some(name.into()),
             description: None,
@@ -42,7 +42,7 @@ impl FeltSchema {
 
     /// Creates a new typed felt field with a default value.
     pub fn new_typed_with_default(
-        r#type: SchemaTypeId,
+        r#type: SchemaType,
         name: impl Into<String>,
         default_value: Felt,
     ) -> Self {
@@ -59,34 +59,34 @@ impl FeltSchema {
         FeltSchema {
             name: None,
             description: None,
-            r#type: SchemaTypeId::void(),
+            r#type: SchemaType::void(),
             default_value: None,
         }
     }
 
-    /// Creates a new required felt field typed as [`SchemaTypeId::native_felt()`].
+    /// Creates a new required felt field typed as [`SchemaType::native_felt()`].
     pub fn felt(name: impl Into<String>) -> Self {
-        Self::new_typed(SchemaTypeId::native_felt(), name)
+        Self::new_typed(SchemaType::native_felt(), name)
     }
 
-    /// Creates a new required felt field typed as [`SchemaTypeId::native_word()`].
+    /// Creates a new required felt field typed as [`SchemaType::native_word()`].
     pub fn word(name: impl Into<String>) -> Self {
-        Self::new_typed(SchemaTypeId::native_word(), name)
+        Self::new_typed(SchemaType::native_word(), name)
     }
 
-    /// Creates a new required felt field typed as [`SchemaTypeId::u8()`].
+    /// Creates a new required felt field typed as [`SchemaType::u8()`].
     pub fn u8(name: impl Into<String>) -> Self {
-        Self::new_typed(SchemaTypeId::u8(), name)
+        Self::new_typed(SchemaType::u8(), name)
     }
 
-    /// Creates a new required felt field typed as [`SchemaTypeId::u16()`].
+    /// Creates a new required felt field typed as [`SchemaType::u16()`].
     pub fn u16(name: impl Into<String>) -> Self {
-        Self::new_typed(SchemaTypeId::u16(), name)
+        Self::new_typed(SchemaType::u16(), name)
     }
 
-    /// Creates a new required felt field typed as [`SchemaTypeId::u32()`].
+    /// Creates a new required felt field typed as [`SchemaType::u32()`].
     pub fn u32(name: impl Into<String>) -> Self {
-        Self::new_typed(SchemaTypeId::u32(), name)
+        Self::new_typed(SchemaType::u32(), name)
     }
 
     /// Sets the default value of the [`FeltSchema`] and returns `self`.
@@ -106,7 +106,7 @@ impl FeltSchema {
     }
 
     /// Returns the felt type.
-    pub fn felt_type(&self) -> SchemaTypeId {
+    pub fn felt_type(&self) -> SchemaType {
         self.r#type.clone()
     }
 
@@ -127,7 +127,7 @@ impl FeltSchema {
         slot_prefix: StorageValueName,
         requirements: &mut BTreeMap<StorageValueName, SchemaRequirement>,
     ) -> Result<(), ComponentMetadataError> {
-        if self.r#type == SchemaTypeId::void() {
+        if self.r#type == SchemaType::void() {
             return Ok(());
         }
 
@@ -203,7 +203,7 @@ impl FeltSchema {
             }
         }
 
-        if self.r#type == SchemaTypeId::void() {
+        if self.r#type == SchemaType::void() {
             return Ok(Felt::ZERO);
         }
 
@@ -234,7 +234,7 @@ impl FeltSchema {
             ));
         }
 
-        if self.r#type == SchemaTypeId::void() {
+        if self.r#type == SchemaType::void() {
             if self.name.is_some() {
                 return Err(ComponentMetadataError::InvalidSchema(
                     "void felt elements must be unnamed".into(),
@@ -285,7 +285,7 @@ impl Deserializable for FeltSchema {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let name = Option::<String>::read_from(source)?;
         let description = Option::<String>::read_from(source)?;
-        let r#type = SchemaTypeId::read_from(source)?;
+        let r#type = SchemaType::read_from(source)?;
         let default_value = Option::<Felt>::read_from(source)?;
         Ok(FeltSchema { name, description, r#type, default_value })
     }

--- a/crates/miden-protocol/src/account/component/storage/schema/parse.rs
+++ b/crates/miden-protocol/src/account/component/storage/schema/parse.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use super::super::type_registry::{SCHEMA_TYPE_REGISTRY, SchemaTypeId};
+use super::super::type_registry::{SCHEMA_TYPE_REGISTRY, SchemaType};
 use super::super::{StorageValueName, WordValue};
 use super::{FeltSchema, WordSchema};
 use crate::errors::ComponentMetadataError;
@@ -24,7 +24,7 @@ pub(crate) fn parse_storage_value_with_schema(
             parse_composite_elements(value, elements, slot_prefix)?
         },
         (WordSchema::Composite { .. }, WordValue::Atomic(value)) => SCHEMA_TYPE_REGISTRY
-            .try_parse_word(&SchemaTypeId::native_word(), value)
+            .try_parse_word(&SchemaType::native_word(), value)
             .map_err(|err| {
                 ComponentMetadataError::InvalidInitStorageValue(
                     slot_prefix.clone(),
@@ -38,7 +38,7 @@ pub(crate) fn parse_storage_value_with_schema(
 }
 
 fn parse_simple_word_value(
-    schema_type: &SchemaTypeId,
+    schema_type: &SchemaType,
     raw_value: &WordValue,
     slot_prefix: &StorageValueName,
 ) -> Result<Word, ComponentMetadataError> {
@@ -55,7 +55,7 @@ fn parse_simple_word_value(
             let felts: Vec<Felt> = elements
                 .iter()
                 .map(|element| {
-                    SCHEMA_TYPE_REGISTRY.try_parse_felt(&SchemaTypeId::native_felt(), element)
+                    SCHEMA_TYPE_REGISTRY.try_parse_felt(&SchemaType::native_felt(), element)
                 })
                 .collect::<Result<_, _>>()
                 .map_err(|err| {

--- a/crates/miden-protocol/src/account/component/storage/schema/slot.rs
+++ b/crates/miden-protocol/src/account/component/storage/schema/slot.rs
@@ -4,7 +4,7 @@ use alloc::string::String;
 use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use miden_processor::DeserializationError;
 
-use super::super::type_registry::{SchemaRequirement, SchemaTypeId};
+use super::super::type_registry::{SchemaRequirement, SchemaType};
 use super::super::{InitStorageData, StorageValueName};
 use super::{MapSlotSchema, ValueSlotSchema, WordSchema};
 use crate::account::{StorageSlot, StorageSlotName};
@@ -25,7 +25,7 @@ pub enum StorageSlotSchema {
 impl StorageSlotSchema {
     /// Creates a value slot schema with the given description and word schema.
     ///
-    /// Accepts anything convertible to [`WordSchema`]: a [`SchemaTypeId`] for simple typed slots,
+    /// Accepts anything convertible to [`WordSchema`]: a [`SchemaType`] for simple typed slots,
     /// a `[FeltSchema; 4]` for composite slots, or a [`WordSchema`] directly.
     pub fn value(description: impl Into<String>, word: impl Into<WordSchema>) -> Self {
         Self::Value(ValueSlotSchema::new(Some(description.into()), word.into()))
@@ -34,8 +34,8 @@ impl StorageSlotSchema {
     /// Creates a map slot schema with the given description and simple key/value types.
     pub fn map(
         description: impl Into<String>,
-        key_type: SchemaTypeId,
-        value_type: SchemaTypeId,
+        key_type: SchemaType,
+        value_type: SchemaType,
     ) -> Self {
         Self::Map(MapSlotSchema::new(
             Some(description.into()),

--- a/crates/miden-protocol/src/account/component/storage/schema/tests.rs
+++ b/crates/miden-protocol/src/account/component/storage/schema/tests.rs
@@ -1,13 +1,13 @@
 use alloc::collections::BTreeMap;
 
-use super::super::{InitStorageData, SchemaTypeId};
+use super::super::{InitStorageData, SchemaType};
 use super::{FeltSchema, MapSlotSchema, ValueSlotSchema, WordSchema};
 use crate::account::{StorageMap, StorageSlotName};
 use crate::{Felt, Word};
 
 #[test]
 fn map_slot_schema_default_values_returns_map() {
-    let word_schema = WordSchema::new_simple(SchemaTypeId::native_word());
+    let word_schema = WordSchema::new_simple(SchemaType::native_word());
     let mut default_values = BTreeMap::new();
     default_values.insert(
         Word::from([Felt::new(1), Felt::new(0), Felt::new(0), Felt::new(0)]),
@@ -35,7 +35,7 @@ fn value_slot_schema_exposes_felt_schema_types() {
         FeltSchema::u8("a"),
         FeltSchema::u16("b"),
         FeltSchema::u32("c"),
-        FeltSchema::new_typed(SchemaTypeId::new("felt").unwrap(), "d"),
+        FeltSchema::new_typed(SchemaType::new("felt").unwrap(), "d"),
     ];
 
     let slot = ValueSlotSchema::new(None, WordSchema::new_value(felt_values));
@@ -43,15 +43,15 @@ fn value_slot_schema_exposes_felt_schema_types() {
         panic!("expected composite word schema");
     };
 
-    assert_eq!(value[0].felt_type(), SchemaTypeId::u8());
-    assert_eq!(value[1].felt_type(), SchemaTypeId::u16());
-    assert_eq!(value[2].felt_type(), SchemaTypeId::u32());
-    assert_eq!(value[3].felt_type(), SchemaTypeId::new("felt").unwrap());
+    assert_eq!(value[0].felt_type(), SchemaType::u8());
+    assert_eq!(value[1].felt_type(), SchemaType::u16());
+    assert_eq!(value[2].felt_type(), SchemaType::u32());
+    assert_eq!(value[3].felt_type(), SchemaType::new("felt").unwrap());
 }
 
 #[test]
 fn map_slot_schema_key_and_value_types() {
-    let key_schema = WordSchema::new_simple(SchemaTypeId::new("sampling::Key").unwrap());
+    let key_schema = WordSchema::new_simple(SchemaType::new("sampling::Key").unwrap());
 
     let value_schema = WordSchema::new_value([
         FeltSchema::felt("a"),
@@ -64,20 +64,20 @@ fn map_slot_schema_key_and_value_types() {
 
     assert_eq!(
         slot.key_schema(),
-        &WordSchema::new_simple(SchemaTypeId::new("sampling::Key").unwrap())
+        &WordSchema::new_simple(SchemaType::new("sampling::Key").unwrap())
     );
 
     let WordSchema::Composite { value } = slot.value_schema() else {
         panic!("expected composite word schema for map values");
     };
     for felt in value.iter() {
-        assert_eq!(felt.felt_type(), SchemaTypeId::native_felt());
+        assert_eq!(felt.felt_type(), SchemaType::native_felt());
     }
 }
 
 #[test]
 fn value_slot_schema_accepts_typed_word_init_value() {
-    let slot = ValueSlotSchema::new(None, WordSchema::new_simple(SchemaTypeId::native_word()));
+    let slot = ValueSlotSchema::new(None, WordSchema::new_simple(SchemaType::native_word()));
     let slot_name: StorageSlotName = "demo::slot".parse().unwrap();
 
     let mut init_data = InitStorageData::default();
@@ -90,7 +90,7 @@ fn value_slot_schema_accepts_typed_word_init_value() {
 
 #[test]
 fn value_slot_schema_accepts_felt_typed_word_init_value() {
-    let slot = ValueSlotSchema::new(None, WordSchema::new_simple(SchemaTypeId::u8()));
+    let slot = ValueSlotSchema::new(None, WordSchema::new_simple(SchemaType::u8()));
     let slot_name: StorageSlotName = "demo::u8_word".parse().unwrap();
 
     let mut init_data = InitStorageData::default();
@@ -120,7 +120,7 @@ fn value_slot_schema_accepts_typed_felt_init_value_in_composed_word() {
 
 #[test]
 fn map_slot_schema_accepts_typed_map_init_value() {
-    let word_schema = WordSchema::new_simple(SchemaTypeId::native_word());
+    let word_schema = WordSchema::new_simple(SchemaType::native_word());
     let slot = MapSlotSchema::new(None, None, word_schema.clone(), word_schema);
     let slot_name: StorageSlotName = "demo::map".parse().unwrap();
 
@@ -140,7 +140,7 @@ fn map_slot_schema_accepts_typed_map_init_value() {
 
 #[test]
 fn map_slot_schema_missing_init_value_defaults_to_empty_map() {
-    let word_schema = WordSchema::new_simple(SchemaTypeId::native_word());
+    let word_schema = WordSchema::new_simple(SchemaType::native_word());
     let slot = MapSlotSchema::new(None, None, word_schema.clone(), word_schema);
     let built = slot
         .try_build_map(&InitStorageData::default(), &"demo::map".parse().unwrap())

--- a/crates/miden-protocol/src/account/component/storage/schema/word.rs
+++ b/crates/miden-protocol/src/account/component/storage/schema/word.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use miden_processor::DeserializationError;
 
-use super::super::type_registry::{SCHEMA_TYPE_REGISTRY, SchemaRequirement, SchemaTypeId};
+use super::super::type_registry::{SCHEMA_TYPE_REGISTRY, SchemaRequirement, SchemaType};
 use super::super::{InitStorageData, StorageValueName};
 use super::FeltSchema;
 use crate::account::StorageSlotName;
@@ -23,7 +23,7 @@ use crate::{Felt, FieldElement, Word};
 pub enum WordSchema {
     /// A whole-word typed value supplied at instantiation time.
     Simple {
-        r#type: SchemaTypeId,
+        r#type: SchemaType,
         default_value: Option<Word>,
     },
     /// A composed word that may mix defaults and typed fields.
@@ -31,11 +31,11 @@ pub enum WordSchema {
 }
 
 impl WordSchema {
-    pub fn new_simple(r#type: SchemaTypeId) -> Self {
+    pub fn new_simple(r#type: SchemaType) -> Self {
         WordSchema::Simple { r#type, default_value: None }
     }
 
-    pub fn new_simple_with_default(r#type: SchemaTypeId, default_value: Word) -> Self {
+    pub fn new_simple_with_default(r#type: SchemaType, default_value: Word) -> Self {
         WordSchema::Simple {
             r#type,
             default_value: Some(default_value),
@@ -53,11 +53,11 @@ impl WordSchema {
         }
     }
 
-    /// Returns the schema type identifier associated with whole-word init-supplied values.
-    pub fn word_type(&self) -> SchemaTypeId {
+    /// Returns the schema type associated with whole-word init-supplied values.
+    pub fn word_type(&self) -> SchemaType {
         match self {
             WordSchema::Simple { r#type, .. } => r#type.clone(),
-            WordSchema::Composite { .. } => SchemaTypeId::native_word(),
+            WordSchema::Composite { .. } => SchemaType::native_word(),
         }
     }
 
@@ -69,7 +69,7 @@ impl WordSchema {
     ) -> Result<(), ComponentMetadataError> {
         match self {
             WordSchema::Simple { r#type, default_value } => {
-                if *r#type == SchemaTypeId::void() {
+                if *r#type == SchemaType::void() {
                     return Ok(());
                 }
 
@@ -165,7 +165,7 @@ impl WordSchema {
                         super::parse_storage_value_with_schema(self, value, &slot_prefix)
                     },
                     None => {
-                        if *r#type == SchemaTypeId::void() {
+                        if *r#type == SchemaType::void() {
                             Ok(Word::empty())
                         } else {
                             default_value.as_ref().copied().ok_or_else(|| {
@@ -261,7 +261,7 @@ impl Deserializable for WordSchema {
         let tag = source.read_u8()?;
         match tag {
             0 => {
-                let r#type = SchemaTypeId::read_from(source)?;
+                let r#type = SchemaType::read_from(source)?;
                 let default_value = Option::<Word>::read_from(source)?;
                 Ok(WordSchema::Simple { r#type, default_value })
             },
@@ -276,8 +276,8 @@ impl Deserializable for WordSchema {
     }
 }
 
-impl From<SchemaTypeId> for WordSchema {
-    fn from(r#type: SchemaTypeId) -> Self {
+impl From<SchemaType> for WordSchema {
+    fn from(r#type: SchemaType) -> Self {
         WordSchema::new_simple(r#type)
     }
 }
@@ -290,6 +290,6 @@ impl From<[FeltSchema; 4]> for WordSchema {
 
 impl From<[Felt; 4]> for WordSchema {
     fn from(value: [Felt; 4]) -> Self {
-        WordSchema::new_simple_with_default(SchemaTypeId::native_word(), Word::from(value))
+        WordSchema::new_simple_with_default(SchemaType::native_word(), Word::from(value))
     }
 }

--- a/crates/miden-protocol/src/account/component/storage/toml/mod.rs
+++ b/crates/miden-protocol/src/account/component/storage/toml/mod.rs
@@ -18,7 +18,7 @@ use super::super::{
     WordValue,
 };
 use crate::account::component::storage::type_registry::SCHEMA_TYPE_REGISTRY;
-use crate::account::component::{AccountComponentMetadata, SchemaTypeId};
+use crate::account::component::{AccountComponentMetadata, SchemaType};
 use crate::account::{AccountType, StorageSlotName};
 use crate::errors::ComponentMetadataError;
 
@@ -118,7 +118,7 @@ enum RawSlotType {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 enum RawWordType {
-    TypeIdentifier(SchemaTypeId),
+    TypeIdentifier(SchemaType),
     FeltSchemaArray(Vec<FeltSchema>),
 }
 
@@ -463,7 +463,7 @@ impl RawStorageSlotSchema {
 impl WordValue {
     pub(super) fn try_parse_as_typed_word(
         &self,
-        schema_type: &SchemaTypeId,
+        schema_type: &SchemaType,
         slot_prefix: &StorageValueName,
         label: &str,
     ) -> Result<Word, ComponentMetadataError> {
@@ -476,7 +476,7 @@ impl WordValue {
                 let felts = elements
                     .iter()
                     .map(|element| {
-                        SCHEMA_TYPE_REGISTRY.try_parse_felt(&SchemaTypeId::native_felt(), element)
+                        SCHEMA_TYPE_REGISTRY.try_parse_felt(&SchemaType::native_felt(), element)
                     })
                     .collect::<Result<Vec<Felt>, _>>()
                     .map_err(ComponentMetadataError::StorageValueParsingError)?;
@@ -493,7 +493,7 @@ impl WordValue {
         Ok(word)
     }
 
-    pub(super) fn from_word(schema_type: &SchemaTypeId, word: Word) -> Self {
+    pub(super) fn from_word(schema_type: &SchemaType, word: Word) -> Self {
         WordValue::Atomic(SCHEMA_TYPE_REGISTRY.display_word(schema_type, word).value().to_string())
     }
 }

--- a/crates/miden-protocol/src/account/component/storage/toml/serde_impls.rs
+++ b/crates/miden-protocol/src/account/component/storage/toml/serde_impls.rs
@@ -5,7 +5,7 @@ use serde::ser::{Error as SerError, SerializeStruct};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::super::type_registry::SCHEMA_TYPE_REGISTRY;
-use super::super::{FeltSchema, SchemaTypeId, WordValue};
+use super::super::{FeltSchema, SchemaType, WordValue};
 
 // FELT SCHEMA SERIALIZATION
 // ================================================================================================
@@ -15,9 +15,9 @@ impl Serialize for FeltSchema {
     where
         S: Serializer,
     {
-        if self.felt_type() == SchemaTypeId::void() {
+        if self.felt_type() == SchemaType::void() {
             let mut state = serializer.serialize_struct("FeltSchema", 2)?;
-            state.serialize_field("type", &SchemaTypeId::void())?;
+            state.serialize_field("type", &SchemaType::void())?;
             if let Some(description) = self.description() {
                 state.serialize_field("description", description)?;
             }
@@ -33,7 +33,7 @@ impl Serialize for FeltSchema {
         if let Some(description) = self.description() {
             state.serialize_field("description", description)?;
         }
-        if self.felt_type() != SchemaTypeId::native_felt() {
+        if self.felt_type() != SchemaType::native_felt() {
             state.serialize_field("type", &self.felt_type())?;
         }
         if let Some(default_value) = self.default_value() {
@@ -61,12 +61,12 @@ impl<'de> Deserialize<'de> for FeltSchema {
             #[serde(default, rename = "default-value")]
             default_value: Option<String>,
             #[serde(default, rename = "type")]
-            r#type: Option<SchemaTypeId>,
+            r#type: Option<SchemaType>,
         }
 
         let raw = RawFeltSchema::deserialize(deserializer)?;
 
-        let felt_type = raw.r#type.unwrap_or_else(SchemaTypeId::native_felt);
+        let felt_type = raw.r#type.unwrap_or_else(SchemaType::native_felt);
 
         let description = raw.description.and_then(|description| {
             if description.trim().is_empty() {
@@ -76,7 +76,7 @@ impl<'de> Deserialize<'de> for FeltSchema {
             }
         });
 
-        if felt_type == SchemaTypeId::void() {
+        if felt_type == SchemaType::void() {
             if raw.name.is_some() {
                 return Err(D::Error::custom("`type = \"void\"` elements must omit `name`"));
             }

--- a/crates/miden-protocol/src/account/component/storage/toml/tests.rs
+++ b/crates/miden-protocol/src/account/component/storage/toml/tests.rs
@@ -9,7 +9,7 @@ use crate::account::component::{
     AccountComponentMetadata,
     InitStorageData,
     InitStorageDataError as CoreInitStorageDataError,
-    SchemaTypeId,
+    SchemaType,
     StorageSlotSchema,
     StorageValueName,
     StorageValueNameError,
@@ -498,7 +498,7 @@ fn metadata_toml_round_trip_composed_slot_with_typed_fields() {
             .remove(&"demo::composed.a".parse::<StorageValueName>().unwrap())
             .unwrap()
             .r#type,
-        SchemaTypeId::u16()
+        SchemaType::u16()
     );
 
     let round_trip_toml = original.to_toml().expect("serialize to toml");
@@ -538,7 +538,7 @@ fn metadata_toml_round_trip_typed_slots() {
         _ => panic!("expected value slot"),
     };
 
-    let typed_value = SchemaTypeId::native_word();
+    let typed_value = SchemaType::native_word();
     assert_eq!(value_slot.word(), &WordSchema::new_simple(typed_value.clone()));
 
     let map_slot = schema
@@ -550,7 +550,7 @@ fn metadata_toml_round_trip_typed_slots() {
         _ => panic!("expected map slot"),
     };
 
-    let pub_key_type = SchemaTypeId::new("miden::standards::auth::pub_key").unwrap();
+    let pub_key_type = SchemaType::new("miden::standards::auth::pub_key").unwrap();
     assert_eq!(map_slot.key_schema(), &WordSchema::new_simple(pub_key_type.clone()));
     assert_eq!(map_slot.value_schema(), &WordSchema::new_simple(pub_key_type));
 
@@ -676,8 +676,8 @@ fn extensive_schema_metadata_and_init_toml_example() {
     else {
         panic!("expected map slot schema");
     };
-    assert_eq!(default_map.key_schema(), &WordSchema::new_simple(SchemaTypeId::native_word()));
-    assert_eq!(default_map.value_schema(), &WordSchema::new_simple(SchemaTypeId::native_word()));
+    assert_eq!(default_map.key_schema(), &WordSchema::new_simple(SchemaType::native_word()));
+    assert_eq!(default_map.value_schema(), &WordSchema::new_simple(SchemaType::native_word()));
 
     // `type.key`/`type.value` parse as schema/type descriptors (not literal words).
     let typed_map_new_name = StorageSlotName::new("demo::typed_map_new").unwrap();
@@ -686,7 +686,7 @@ fn extensive_schema_metadata_and_init_toml_example() {
     else {
         panic!("expected map slot schema");
     };
-    assert_eq!(typed_map_new.value_schema(), &WordSchema::new_simple(SchemaTypeId::u16()));
+    assert_eq!(typed_map_new.value_schema(), &WordSchema::new_simple(SchemaType::u16()));
     assert!(matches!(typed_map_new.key_schema(), WordSchema::Composite { .. }));
 
     // used storage slots
@@ -708,7 +708,7 @@ fn extensive_schema_metadata_and_init_toml_example() {
         .expect("symbol should be reported with a default value");
     assert_eq!(
         symbol_requirement.r#type,
-        SchemaTypeId::new("miden::standards::fungible_faucets::metadata::token_symbol").unwrap()
+        SchemaType::new("miden::standards::fungible_faucets::metadata::token_symbol").unwrap()
     );
     assert_eq!(symbol_requirement.default_value.as_deref(), Some("TST"));
     assert!(

--- a/crates/miden-protocol/src/account/component/storage/type_registry.rs
+++ b/crates/miden-protocol/src/account/component/storage/type_registry.rs
@@ -43,24 +43,24 @@ pub enum SchemaTypeError {
     #[error("conversion error: {0}")]
     ConversionError(String),
     #[error("felt type ` {0}` not found in the type registry")]
-    FeltTypeNotFound(SchemaTypeId),
+    FeltTypeNotFound(SchemaType),
     #[error("invalid type name `{0}`: {1}")]
     InvalidTypeName(String, String),
     #[error("failed to parse input `{input}` as `{schema_type}`")]
     ParseError {
         input: String,
-        schema_type: SchemaTypeId,
+        schema_type: SchemaType,
         source: Box<dyn Error + Send + Sync + 'static>,
     },
     #[error("word type ` {0}` not found in the type registry")]
-    WordTypeNotFound(SchemaTypeId),
+    WordTypeNotFound(SchemaType),
 }
 
 impl SchemaTypeError {
     /// Creates a [`SchemaTypeError::ParseError`].
     pub fn parse(
         input: impl Into<String>,
-        schema_type: SchemaTypeId,
+        schema_type: SchemaType,
         source: impl Error + Send + Sync + 'static,
     ) -> Self {
         SchemaTypeError::ParseError {
@@ -74,9 +74,9 @@ impl SchemaTypeError {
 // SCHEMA TYPE
 // ================================================================================================
 
-/// A newtype wrapper around a `String`, representing a schema type identifier.
+/// A newtype wrapper around a `String`, representing a schema type.
 ///
-/// A valid schema identifier is a name in the style of Rust namespaces, composed of one or more
+/// A valid schema type is a name in the style of Rust namespaces, composed of one or more
 /// non-empty segments separated by `::`. Each segment can contain only ASCII alphanumerics or `_`.
 ///
 /// Some examples:
@@ -87,10 +87,10 @@ impl SchemaTypeError {
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 #[cfg_attr(feature = "std", derive(::serde::Deserialize, ::serde::Serialize))]
 #[cfg_attr(feature = "std", serde(transparent))]
-pub struct SchemaTypeId(String);
+pub struct SchemaType(String);
 
-impl SchemaTypeId {
-    /// Creates a new [`SchemaTypeId`] from a `String`.
+impl SchemaType {
+    /// Creates a new [`SchemaType`] from a `String`.
     ///
     /// The name must follow a Rust-style namespace format, consisting of one or more segments
     /// (non-empty, and alphanumerical) separated by double-colon (`::`) delimiters.
@@ -105,14 +105,14 @@ impl SchemaTypeId {
         if s.is_empty() {
             return Err(SchemaTypeError::InvalidTypeName(
                 s.clone(),
-                "schema type identifier is empty".to_string(),
+                "schema type is empty".to_string(),
             ));
         }
         for segment in s.split("::") {
             if segment.is_empty() {
                 return Err(SchemaTypeError::InvalidTypeName(
                     s.clone(),
-                    "empty segment in schema type identifier".to_string(),
+                    "empty segment in schema type".to_string(),
                 ));
             }
             if !segment.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
@@ -125,51 +125,51 @@ impl SchemaTypeId {
         Ok(Self(s))
     }
 
-    /// Returns the schema type identifier for the `void` type.
+    /// Returns the schema type for the `void` type.
     ///
     /// The `void` type always parses to `0` and is intended to model reserved or padding felts.
-    pub fn void() -> SchemaTypeId {
-        SchemaTypeId::new("void").expect("type is well formed")
+    pub fn void() -> SchemaType {
+        SchemaType::new("void").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for the native [`Felt`] type.
-    pub fn native_felt() -> SchemaTypeId {
-        SchemaTypeId::new("felt").expect("type is well formed")
+    /// Returns the schema type for the native [`Felt`] type.
+    pub fn native_felt() -> SchemaType {
+        SchemaType::new("felt").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for the native [`Word`] type.
-    pub fn native_word() -> SchemaTypeId {
-        SchemaTypeId::new("word").expect("type is well formed")
+    /// Returns the schema type for the native [`Word`] type.
+    pub fn native_word() -> SchemaType {
+        SchemaType::new("word").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for the native `u8` type.
-    pub fn u8() -> SchemaTypeId {
-        SchemaTypeId::new("u8").expect("type is well formed")
+    /// Returns the schema type for the native `u8` type.
+    pub fn u8() -> SchemaType {
+        SchemaType::new("u8").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for the native `u16` type.
-    pub fn u16() -> SchemaTypeId {
-        SchemaTypeId::new("u16").expect("type is well formed")
+    /// Returns the schema type for the native `u16` type.
+    pub fn u16() -> SchemaType {
+        SchemaType::new("u16").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for the native `u32` type.
-    pub fn u32() -> SchemaTypeId {
-        SchemaTypeId::new("u32").expect("type is well formed")
+    /// Returns the schema type for the native `u32` type.
+    pub fn u32() -> SchemaType {
+        SchemaType::new("u32").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for auth scheme identifiers.
-    pub fn auth_scheme() -> SchemaTypeId {
-        SchemaTypeId::new("miden::standards::auth::scheme").expect("type is well formed")
+    /// Returns the schema type for auth scheme identifiers.
+    pub fn auth_scheme() -> SchemaType {
+        SchemaType::new("miden::standards::auth::scheme").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for public key commitments.
-    pub fn pub_key() -> SchemaTypeId {
-        SchemaTypeId::new("miden::standards::auth::pub_key").expect("type is well formed")
+    /// Returns the schema type for public key commitments.
+    pub fn pub_key() -> SchemaType {
+        SchemaType::new("miden::standards::auth::pub_key").expect("type is well formed")
     }
 
-    /// Returns the schema type identifier for fungible faucet token symbols.
-    pub fn token_symbol() -> SchemaTypeId {
-        SchemaTypeId::new("miden::standards::fungible_faucets::metadata::token_symbol")
+    /// Returns the schema type for fungible faucet token symbols.
+    pub fn token_symbol() -> SchemaType {
+        SchemaType::new("miden::standards::fungible_faucets::metadata::token_symbol")
             .expect("type is well formed")
     }
 
@@ -179,23 +179,23 @@ impl SchemaTypeId {
     }
 }
 
-impl Display for SchemaTypeId {
+impl Display for SchemaType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl Serializable for SchemaTypeId {
+impl Serializable for SchemaType {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write(self.0.clone())
     }
 }
 
-impl Deserializable for SchemaTypeId {
+impl Deserializable for SchemaType {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let id: String = source.read()?;
 
-        SchemaTypeId::new(id).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
+        SchemaType::new(id).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 
@@ -212,7 +212,7 @@ impl Deserializable for SchemaTypeId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaRequirement {
     /// The expected type identifier.
-    pub r#type: SchemaTypeId,
+    pub r#type: SchemaType,
     /// An optional description providing additional context.
     pub description: Option<String>,
     /// An optional default value, which can be overridden at component instantiation time.
@@ -225,7 +225,7 @@ pub struct SchemaRequirement {
 /// Trait for converting a string into a single `Felt`.
 pub trait FeltType: Send + Sync {
     /// Returns the type identifier.
-    fn type_name() -> SchemaTypeId
+    fn type_name() -> SchemaType
     where
         Self: Sized;
 
@@ -243,7 +243,7 @@ pub trait FeltType: Send + Sync {
 /// Trait for converting a string into a single `Word`.
 pub trait WordType: Send + Sync {
     /// Returns the type identifier.
-    fn type_name() -> SchemaTypeId
+    fn type_name() -> SchemaType
     where
         Self: Sized;
 
@@ -262,7 +262,7 @@ impl<T> WordType for T
 where
     T: FeltType,
 {
-    fn type_name() -> SchemaTypeId {
+    fn type_name() -> SchemaType {
         <T as FeltType>::type_name()
     }
 
@@ -289,8 +289,8 @@ where
 struct Void;
 
 impl FeltType for Void {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::void()
+    fn type_name() -> SchemaType {
+        SchemaType::void()
     }
 
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
@@ -310,8 +310,8 @@ impl FeltType for Void {
 }
 
 impl FeltType for u8 {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::u8()
+    fn type_name() -> SchemaType {
+        SchemaType::u8()
     }
 
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
@@ -330,8 +330,8 @@ impl FeltType for u8 {
 }
 
 impl FeltType for AuthScheme {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::auth_scheme()
+    fn type_name() -> SchemaType {
+        SchemaType::auth_scheme()
     }
 
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
@@ -372,8 +372,8 @@ impl FeltType for AuthScheme {
 }
 
 impl FeltType for u16 {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::u16()
+    fn type_name() -> SchemaType {
+        SchemaType::u16()
     }
 
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
@@ -392,8 +392,8 @@ impl FeltType for u16 {
 }
 
 impl FeltType for u32 {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::u32()
+    fn type_name() -> SchemaType {
+        SchemaType::u32()
     }
 
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
@@ -412,8 +412,8 @@ impl FeltType for u32 {
 }
 
 impl FeltType for Felt {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::native_felt()
+    fn type_name() -> SchemaType {
+        SchemaType::native_felt()
     }
 
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
@@ -434,8 +434,8 @@ impl FeltType for Felt {
 }
 
 impl FeltType for TokenSymbol {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::token_symbol()
+    fn type_name() -> SchemaType {
+        SchemaType::token_symbol()
     }
     fn parse_str(input: &str) -> Result<Felt, SchemaTypeError> {
         let token = TokenSymbol::new(input).map_err(|err| {
@@ -483,8 +483,8 @@ fn pad_hex_string(input: &str) -> String {
 }
 
 impl WordType for Word {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::native_word()
+    fn type_name() -> SchemaType {
+        SchemaType::native_word()
     }
     fn parse_str(input: &str) -> Result<Word, SchemaTypeError> {
         Word::parse(input).map_err(|err| {
@@ -502,8 +502,8 @@ impl WordType for Word {
 }
 
 impl WordType for PublicKey {
-    fn type_name() -> SchemaTypeId {
-        SchemaTypeId::pub_key()
+    fn type_name() -> SchemaType {
+        SchemaType::pub_key()
     }
     fn parse_str(input: &str) -> Result<Word, SchemaTypeError> {
         let padded_input = pad_hex_string(input);
@@ -571,10 +571,10 @@ enum TypeKind {
 /// corresponding storage values.
 #[derive(Clone, Debug, Default)]
 pub struct SchemaTypeRegistry {
-    felt: BTreeMap<SchemaTypeId, FeltFromStrConverter>,
-    word: BTreeMap<SchemaTypeId, WordFromStrConverter>,
-    felt_display: BTreeMap<SchemaTypeId, FeltTypeDisplayer>,
-    word_display: BTreeMap<SchemaTypeId, WordTypeDisplayer>,
+    felt: BTreeMap<SchemaType, FeltFromStrConverter>,
+    word: BTreeMap<SchemaType, WordFromStrConverter>,
+    felt_display: BTreeMap<SchemaType, FeltTypeDisplayer>,
+    word_display: BTreeMap<SchemaType, WordTypeDisplayer>,
 }
 
 impl SchemaTypeRegistry {
@@ -613,7 +613,7 @@ impl SchemaTypeRegistry {
     /// - If the type is not registered or if the conversion fails.
     pub fn try_parse_felt(
         &self,
-        type_name: &SchemaTypeId,
+        type_name: &SchemaType,
         value: &str,
     ) -> Result<Felt, SchemaTypeError> {
         let converter = self
@@ -626,7 +626,7 @@ impl SchemaTypeRegistry {
     /// Validates that the given [`Felt`] conforms to the specified schema type.
     pub fn validate_felt_value(
         &self,
-        type_name: &SchemaTypeId,
+        type_name: &SchemaType,
         felt: Felt,
     ) -> Result<(), SchemaTypeError> {
         let display = self
@@ -642,7 +642,7 @@ impl SchemaTypeRegistry {
     /// Validates that the given [`Word`] conforms to the specified schema type.
     pub fn validate_word_value(
         &self,
-        type_name: &SchemaTypeId,
+        type_name: &SchemaType,
         word: Word,
     ) -> Result<(), SchemaTypeError> {
         match self.type_kind(type_name) {
@@ -663,7 +663,7 @@ impl SchemaTypeRegistry {
     ///
     /// This is intended for serializing schemas to TOML (e.g. default values).
     #[allow(dead_code)]
-    pub fn display_felt(&self, type_name: &SchemaTypeId, felt: Felt) -> String {
+    pub fn display_felt(&self, type_name: &SchemaType, felt: Felt) -> String {
         self.felt_display
             .get(type_name)
             .and_then(|display| display(felt).ok())
@@ -671,7 +671,7 @@ impl SchemaTypeRegistry {
     }
 
     /// Converts a [`Word`] into a canonical string representation and reports how it was produced.
-    pub fn display_word(&self, type_name: &SchemaTypeId, word: Word) -> WordDisplay {
+    pub fn display_word(&self, type_name: &SchemaType, word: Word) -> WordDisplay {
         if let Some(display) = self.word_display.get(type_name) {
             let value = display(word).unwrap_or_else(|_| word.to_string());
             return WordDisplay::Word(value);
@@ -699,7 +699,7 @@ impl SchemaTypeRegistry {
     /// - If the type is not registered or if the conversion fails.
     pub fn try_parse_word(
         &self,
-        type_name: &SchemaTypeId,
+        type_name: &SchemaType,
         value: &str,
     ) -> Result<Word, SchemaTypeError> {
         if let Some(converter) = self.word.get(type_name) {
@@ -716,11 +716,11 @@ impl SchemaTypeRegistry {
     }
 
     /// Returns `true` if a `FeltType` is registered for the given type.
-    pub fn contains_felt_type(&self, type_name: &SchemaTypeId) -> bool {
+    pub fn contains_felt_type(&self, type_name: &SchemaType) -> bool {
         self.felt.contains_key(type_name)
     }
 
-    fn type_kind(&self, type_name: &SchemaTypeId) -> TypeKind {
+    fn type_kind(&self, type_name: &SchemaType) -> TypeKind {
         if self.contains_felt_type(type_name) {
             TypeKind::Felt
         } else {
@@ -732,7 +732,7 @@ impl SchemaTypeRegistry {
     ///
     /// This also returns `true` for any registered felt type (as those can be embedded into a word
     /// with zero-padding).
-    pub fn contains_word_type(&self, type_name: &SchemaTypeId) -> bool {
+    pub fn contains_word_type(&self, type_name: &SchemaType) -> bool {
         self.word.contains_key(type_name) || self.felt.contains_key(type_name)
     }
 }
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn auth_scheme_type_supports_named_and_numeric_values() {
-        let auth_scheme_type = SchemaTypeId::auth_scheme();
+        let auth_scheme_type = SchemaType::auth_scheme();
 
         let numeric_word = SCHEMA_TYPE_REGISTRY
             .try_parse_word(&auth_scheme_type, "2")
@@ -764,7 +764,7 @@ mod tests {
 
     #[test]
     fn auth_scheme_type_rejects_invalid_values() {
-        let auth_scheme_type = SchemaTypeId::auth_scheme();
+        let auth_scheme_type = SchemaType::auth_scheme();
 
         assert!(SCHEMA_TYPE_REGISTRY.try_parse_word(&auth_scheme_type, "9").is_err());
         assert!(SCHEMA_TYPE_REGISTRY.try_parse_word(&auth_scheme_type, "invalid").is_err());

--- a/crates/miden-standards/src/account/auth/multisig.rs
+++ b/crates/miden-standards/src/account/auth/multisig.rs
@@ -6,7 +6,7 @@ use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
 use miden_protocol::account::component::{
     AccountComponentMetadata,
     FeltSchema,
-    SchemaTypeId,
+    SchemaType,
     StorageSchema,
     StorageSlotSchema,
 };
@@ -192,8 +192,8 @@ impl AuthMultisig {
             Self::approver_public_keys_slot().clone(),
             StorageSlotSchema::map(
                 "Approver public keys",
-                SchemaTypeId::u32(),
-                SchemaTypeId::pub_key(),
+                SchemaType::u32(),
+                SchemaType::pub_key(),
             ),
         )
     }
@@ -204,8 +204,8 @@ impl AuthMultisig {
             Self::approver_scheme_ids_slot().clone(),
             StorageSlotSchema::map(
                 "Approver scheme IDs",
-                SchemaTypeId::u32(),
-                SchemaTypeId::auth_scheme(),
+                SchemaType::u32(),
+                SchemaType::auth_scheme(),
             ),
         )
     }
@@ -216,8 +216,8 @@ impl AuthMultisig {
             Self::executed_transactions_slot().clone(),
             StorageSlotSchema::map(
                 "Executed transactions",
-                SchemaTypeId::native_word(),
-                SchemaTypeId::native_word(),
+                SchemaType::native_word(),
+                SchemaType::native_word(),
             ),
         )
     }
@@ -228,8 +228,8 @@ impl AuthMultisig {
             Self::procedure_thresholds_slot().clone(),
             StorageSlotSchema::map(
                 "Procedure thresholds",
-                SchemaTypeId::native_word(),
-                SchemaTypeId::u32(),
+                SchemaType::native_word(),
+                SchemaType::u32(),
             ),
         )
     }

--- a/crates/miden-standards/src/account/auth/singlesig.rs
+++ b/crates/miden-standards/src/account/auth/singlesig.rs
@@ -2,7 +2,7 @@ use miden_protocol::Word;
 use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
 use miden_protocol::account::component::{
     AccountComponentMetadata,
-    SchemaTypeId,
+    SchemaType,
     StorageSchema,
     StorageSlotSchema,
 };
@@ -63,14 +63,14 @@ impl AuthSingleSig {
     pub fn public_key_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
         (
             Self::public_key_slot().clone(),
-            StorageSlotSchema::value("Public key commitment", SchemaTypeId::pub_key()),
+            StorageSlotSchema::value("Public key commitment", SchemaType::pub_key()),
         )
     }
     /// Returns the storage slot schema for the scheme ID slot.
     pub fn auth_scheme_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
         (
             Self::scheme_id_slot().clone(),
-            StorageSlotSchema::value("Scheme ID", SchemaTypeId::auth_scheme()),
+            StorageSlotSchema::value("Scheme ID", SchemaType::auth_scheme()),
         )
     }
 }

--- a/crates/miden-standards/src/account/auth/singlesig_acl.rs
+++ b/crates/miden-standards/src/account/auth/singlesig_acl.rs
@@ -4,7 +4,7 @@ use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
 use miden_protocol::account::component::{
     AccountComponentMetadata,
     FeltSchema,
-    SchemaTypeId,
+    SchemaType,
     StorageSchema,
     StorageSlotSchema,
 };
@@ -197,7 +197,7 @@ impl AuthSingleSigAcl {
     pub fn public_key_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
         (
             Self::public_key_slot().clone(),
-            StorageSlotSchema::value("Public key commitment", SchemaTypeId::pub_key()),
+            StorageSlotSchema::value("Public key commitment", SchemaType::pub_key()),
         )
     }
 
@@ -221,7 +221,7 @@ impl AuthSingleSigAcl {
     pub fn auth_scheme_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
         (
             Self::scheme_id_slot().clone(),
-            StorageSlotSchema::value("Scheme ID", SchemaTypeId::auth_scheme()),
+            StorageSlotSchema::value("Scheme ID", SchemaType::auth_scheme()),
         )
     }
 
@@ -231,8 +231,8 @@ impl AuthSingleSigAcl {
             Self::trigger_procedure_roots_slot().clone(),
             StorageSlotSchema::map(
                 "Trigger procedure roots",
-                SchemaTypeId::u32(),
-                SchemaTypeId::native_word(),
+                SchemaType::u32(),
+                SchemaType::native_word(),
             ),
         )
     }

--- a/crates/miden-standards/src/account/faucets/basic_fungible.rs
+++ b/crates/miden-standards/src/account/faucets/basic_fungible.rs
@@ -1,7 +1,7 @@
 use miden_protocol::account::component::{
     AccountComponentMetadata,
     FeltSchema,
-    SchemaTypeId,
+    SchemaType,
     StorageSchema,
     StorageSlotSchema,
 };
@@ -22,8 +22,8 @@ use crate::account::AuthMethod;
 use crate::account::auth::{AuthSingleSigAcl, AuthSingleSigAclConfig};
 use crate::account::components::basic_fungible_faucet_library;
 
-/// The schema type ID for token symbols.
-const TOKEN_SYMBOL_TYPE_ID: &str = "miden::standards::fungible_faucets::metadata::token_symbol";
+/// The schema type for token symbols.
+const TOKEN_SYMBOL_TYPE: &str = "miden::standards::fungible_faucets::metadata::token_symbol";
 use crate::account::interface::{AccountComponentInterface, AccountInterface, AccountInterfaceExt};
 use crate::procedure_digest;
 
@@ -148,7 +148,7 @@ impl BasicFungibleFaucet {
 
     /// Returns the storage slot schema for the metadata slot.
     pub fn metadata_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
-        let token_symbol_type = SchemaTypeId::new(TOKEN_SYMBOL_TYPE_ID).expect("valid type id");
+        let token_symbol_type = SchemaType::new(TOKEN_SYMBOL_TYPE).expect("valid type");
         (
             Self::metadata_slot().clone(),
             StorageSlotSchema::value(

--- a/crates/miden-standards/src/account/faucets/network_fungible.rs
+++ b/crates/miden-standards/src/account/faucets/network_fungible.rs
@@ -1,7 +1,7 @@
 use miden_protocol::account::component::{
     AccountComponentMetadata,
     FeltSchema,
-    SchemaTypeId,
+    SchemaType,
     StorageSchema,
     StorageSlotSchema,
 };
@@ -24,8 +24,8 @@ use super::{FungibleFaucetError, TokenMetadata};
 use crate::account::auth::NoAuth;
 use crate::account::components::network_fungible_faucet_library;
 
-/// The schema type ID for token symbols.
-const TOKEN_SYMBOL_TYPE_ID: &str = "miden::standards::fungible_faucets::metadata::token_symbol";
+/// The schema type for token symbols.
+const TOKEN_SYMBOL_TYPE: &str = "miden::standards::fungible_faucets::metadata::token_symbol";
 use crate::account::interface::{AccountComponentInterface, AccountInterface, AccountInterfaceExt};
 use crate::procedure_digest;
 
@@ -177,7 +177,7 @@ impl NetworkFungibleFaucet {
 
     /// Returns the storage slot schema for the metadata slot.
     pub fn metadata_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
-        let token_symbol_type = SchemaTypeId::new(TOKEN_SYMBOL_TYPE_ID).expect("valid type id");
+        let token_symbol_type = SchemaType::new(TOKEN_SYMBOL_TYPE).expect("valid type");
         (
             Self::metadata_slot().clone(),
             StorageSlotSchema::value(

--- a/docs/src/account/components.md
+++ b/docs/src/account/components.md
@@ -98,7 +98,7 @@ In TOML, these are declared using dotted array keys:
 
 **Value-slot** entries describe their schema via `WordSchema`. A value type can be either:
 
-- **Simple**: defined through the `type = "<identifier>"` field, indicating the expected `SchemaTypeId` for the entire word. The value is supplied at instantiation time via `InitStorageData`. Felt types are stored as full words in the following layout: `[0, 0, 0, <felt>]`.
+- **Simple**: defined through the `type = "<identifier>"` field, indicating the expected `SchemaType` for the entire word. The value is supplied at instantiation time via `InitStorageData`. Felt types are stored as full words in the following layout: `[0, 0, 0, <felt>]`.
 - **Composite**: provided through `type = [ ... ]`, which contains exactly four `FeltSchema` descriptors. Each element is either a named typed field (optionally with `default-value`) or a `void` element for reserved/padding zeros.
 
 Composite schema entries reuse the existing TOML structure for four-element words, while simple schemas rely on `type`. In our example, the `token_metadata` slot uses a composite schema (`type = [...]`) mixing typed fields (`max_supply`, `decimals`) with defaults (`symbol`) and a reserved/padding `void` element.


### PR DESCRIPTION
@PhilippGackstatter brought up the good point that the `Id` part of `SchemaTypeId` is a bit redundant. 
I know https://github.com/0xMiden/miden-base/pull/2390 adds some code related to this so maybe we can wait until that's merged to revisit this. I tried pushing a branch to the fork on top of @onurinanc 's branch but I do not have permissions, so I can't properly base this branch off of that one.