### PR TITLE
docs(AggLayer): update with the latest changes in `agglayer` branch

### DIFF
--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -325,7 +325,7 @@ The storage is divided into three logical regions: proof data (felts 0-535), lea
 
 | Field | Value |
 |-------|-------|
-| `sender` | Any account (sender authorization enforced by the bridge's `register_faucet` procedure) |
+| `sender` | Bridge admin (sender authorization enforced by the bridge's `register_faucet` procedure) |
 | `note_type` | `NoteType::Public` |
 | `tag` | `NoteTag::default()` |
 | `attachment` | `NetworkAccountTarget` -- target is the bridge account; execution hint: Always |
@@ -363,7 +363,7 @@ CLAIM notes can be verified against it.
 
 | Field | Value |
 |-------|-------|
-| `sender` | Any account (sender authorization enforced by the bridge's `update_ger` procedure) |
+| `sender` | GER manager (sender authorization enforced by the bridge's `update_ger` procedure) |
 | `note_type` | `NoteType::Public` |
 | `tag` | `NoteTag::default()` |
 | `attachment` | `NetworkAccountTarget` -- target is the bridge account; execution hint: Always |


### PR DESCRIPTION
Reflect changes since the last agglayer merge:
- `CLAIM` consumer enforcement unified to `NetworkAccountTarget` attachment,
  removing `target_faucet_account_id` from storage and TODO https://github.com/0xMiden/protocol/issues/2468 (https://github.com/0xMiden/protocol/pull/2480)
- Sender validation moved from note scripts into bridge procedures;
  `assert_sender_is_*` are now internal, not part of public interface (https://github.com/0xMiden/protocol/pull/2511)
- `OutputNoteData` removed from `CLAIM` AdviceMap; storage shrinks 576→569
  felts; P2ID serial num and tag now derived at runtime (https://github.com/0xMiden/protocol/pull/2509)

https://claude.ai/code/session_01AKvg8rguWHdffgHpxkVYSr