### PR TITLE
Assert foreign account ID

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
@@ -61,6 +61,8 @@ const ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE="unknown account storage mode in accou
 
 const ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT="failed to read an account map item from a non-map storage slot"
 
+const ERR_FOREIGN_ACCOUNT_ID_MISMATCH="foreign account ID provided with advice map doesn't match the ID provided by the operand stack"
+
 # CONSTANTS
 # =================================================================================================
 
@@ -1094,6 +1096,8 @@ end
 #! - the computed account code commitment does not match the provided account code commitment.
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
+#! - the foreign account ID obtained from the advice map doesn't match the ID provided to the
+#!   procedure.
 pub proc load_foreign_account
     emit.ACCOUNT_BEFORE_FOREIGN_LOAD_EVENT
     # => [account_id_prefix, account_id_suffix]
@@ -1107,8 +1111,18 @@ pub proc load_foreign_account
     # OS => [0, 0, account_id_prefix, account_id_suffix]
     # AS => [[account_id_prefix, account_id_suffix, 0, account_nonce], VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
 
+    # check that the account ID provided by the advice map matches the one provided by the operand
+    # stack
+    drop drop dup.1 dup.1
+    # OS => [account_id_prefix, account_id_suffix, account_id_prefix, account_id_suffix]
+    # AS => [[account_id_prefix, account_id_suffix, 0, account_nonce], VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
+
+    adv_push.2 exec.account_id::is_equal assert.err=ERR_FOREIGN_ACCOUNT_ID_MISMATCH
+    # OS => [account_id_prefix, account_id_suffix]
+    # AS => [0, account_nonce, VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
+
     # store the id and nonce of the foreign account to the memory
-    adv_loadw
+    adv_push.2
     exec.memory::set_account_id_and_nonce
     # OS => []
     # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]

--- a/crates/miden-protocol/src/errors/tx_kernel.rs
+++ b/crates/miden-protocol/src/errors/tx_kernel.rs
@@ -94,6 +94,8 @@ pub const ERR_FAUCET_TOTAL_ISSUANCE_PROC_CAN_ONLY_BE_CALLED_ON_FUNGIBLE_FAUCET: 
 pub const ERR_FOREIGN_ACCOUNT_CONTEXT_AGAINST_NATIVE_ACCOUNT: MasmError = MasmError::from_static_str("creation of a foreign context against the native account is forbidden");
 /// Error Message: "ID of the provided foreign account equals zero"
 pub const ERR_FOREIGN_ACCOUNT_ID_IS_ZERO: MasmError = MasmError::from_static_str("ID of the provided foreign account equals zero");
+/// Error Message: "foreign account ID provided with advice map doesn't match the ID provided by the operand stack"
+pub const ERR_FOREIGN_ACCOUNT_ID_MISMATCH: MasmError = MasmError::from_static_str("foreign account ID provided with advice map doesn't match the ID provided by the operand stack");
 /// Error Message: "commitment of the foreign account in the advice provider does not match the commitment in the account tree"
 pub const ERR_FOREIGN_ACCOUNT_INVALID_COMMITMENT: MasmError = MasmError::from_static_str("commitment of the foreign account in the advice provider does not match the commitment in the account tree");
 /// Error Message: "maximum allowed number of foreign account to be loaded (64) was exceeded"

--- a/crates/miden-protocol/src/transaction/kernel/procedures.rs
+++ b/crates/miden-protocol/src/transaction/kernel/procedures.rs
@@ -106,7 +106,7 @@ pub const KERNEL_PROCEDURES: [Word; 53] = [
     // tx_get_block_timestamp
     word!("0x7903185b847517debb6c2072364e3e757b99ee623e97c2bd0a4661316c5c5418"),
     // tx_start_foreign_context
-    word!("0x753c9c0afcbd36fc7b7ba1e8dc7b668c8aa6036ae8cf5c891587f10117669d76"),
+    word!("0x4f375affa53b2124fe69a9b7763673c41bb2336cd061589222b9472c88267fea"),
     // tx_end_foreign_context
     word!("0xaa0018aa8da890b73511879487f65553753fb7df22de380dd84c11e6f77eec6f"),
     // tx_get_expiration_delta


### PR DESCRIPTION
This small PR fixes the vulnerability during the FPI call.

It adds an assert in the `$kernel::account::load_foreign_account` procedure to check that the foreign account ID provided by the operand stack matches the account ID obtained from the advice map.

This prevents a malicious prover from providing data for a different account.