### PR TITLE
docs(agglayer): add Faucet Registry section to the spec

### DIFF
--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -715,7 +715,7 @@ bridge maintains two registry maps:
   to a registration flag. Used during bridge-out to verify an asset's faucet is authorized
   (see `bridge_config::assert_faucet_registered`).
 - **Token registry** (`agglayer::bridge::token_registry_map`): maps Poseidon2 hashes of
-  origin token addresses to faucet account IDs. Used during bridge-in to look up the
+  native token addresses to faucet account IDs. Used during bridge-in to look up the
   correct faucet for a given origin token (see
   `bridge_config::lookup_faucet_by_token_address`).
 


### PR DESCRIPTION
Adds a new section to the AggLayer bridging spec covering faucet registration for both bridge-in (non-native ERC20 tokens) and bridge-out (Miden-native tokens) flows

## Summary

- Section 6.1: How non-native ERC20 faucets are created and registered on Miden via `CONFIG_AGG_BRIDGE` notes for bridging in.
- Section 6.2: How Miden-native tokens would be registered on EVM chains (bridge-out path).