### PR TITLE
chore: Record `next` merge into `agglayer` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Added `component_metadata()` to all account components to expose their metadata ([#2596](https://github.com/0xMiden/protocol/pull/2596)).
 - Added `Package` support in `MockChainBuilder` & `NoteScript` ([#2502](https://github.com/0xMiden/protocol/pull/2502)).
 - Added `ProgramExecutor` hooks to support DAP and other custom transaction program executors ([#2574](https://github.com/0xMiden/protocol/pull/2574)).
+- [BREAKING] Changed `native_account::remove_asset` to return the asset value remaining in the vault instead of the removed value ([#2626](https://github.com/0xMiden/protocol/pull/2626)).
+- Implement `TransactionEventId::event_name` and `Host::resolve_event` for better VM diagnostics during even handler failures ([#2628](https://github.com/0xMiden/protocol/pull/2628)).
 - Added `FixedWidthString` for fixed-width UTF-8 string storage in `miden-standards` (`miden::standards::utils::string`). ([#2633](https://github.com/0xMiden/protocol/pull/2633))
 - Added metadata hash storage to AggLayer faucet and FPI retrieval during bridge-out leaf construction ([#2583](https://github.com/0xMiden/protocol/pull/2583)).
 
@@ -99,9 +101,13 @@
 - Added Ownable2Step as an Account Component ([#2572](https://github.com/0xMiden/protocol/pull/2572))
 - [BREAKING] Introduced `PrivateNoteHeader` for output notes and removed `RawOutputNote::Header` variant ([#2569](https://github.com/0xMiden/protocol/pull/2569)).
 - [BREAKING] Changed `asset::create_fungible_asset` and `faucet::create_fungible_asset` signature to take `enable_callbacks` flag ([#2571](https://github.com/0xMiden/protocol/pull/2571)).
-
 - [BREAKING] Fixed `TokenSymbol::try_from(Felt)` to reject values below `MIN_ENCODED_VALUE`; implemented `Display` for `TokenSymbol` replacing the fallible `to_string()` method; removed `Default` derive ([#2464](https://github.com/0xMiden/protocol/issues/2464)).
 - Moved `AccountSchemaCommitment` component into a sub-module ([#2603](https://github.com/0xMiden/protocol/pull/2603)).
+- [BREAKING] `AssetVault::remove_asset` returns the asset value remaining in the vault `Option<Asset>` rather than the removed value `Asset` ([#2626](https://github.com/0xMiden/protocol/pull/2626)).
+- [BREAKING] `miden::protocol::faucet::burn` no longer returns the burnt asset value ([#2626](https://github.com/0xMiden/protocol/pull/2626)).
+- Fixed overlap in initial and active account storage slot memory region ([#2557](https://github.com/0xMiden/protocol/pull/2557)).
+- Fixed link map entry pointer validation bypass ([#2556](https://github.com/0xMiden/protocol/pull/2556)).
+- Added foreign account ID assertion in `account::load_foreign_account` ([#2560](https://github.com/0xMiden/protocol/pull/2560)).
 
 ## 0.13.3 (2026-01-27)
 

--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -583,14 +583,15 @@ pub proc account_add_asset
     # => [ASSET_VALUE', pad(12)]
 end
 
-#! Removes the specified asset from the vault.
+#! Removes the specified asset from the vault and returns the remaining asset value.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE, pad(8)]
-#! Outputs: [ASSET_VALUE, pad(12)]
+#! Outputs: [REMAINING_ASSET_VALUE, pad(12)]
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to remove from the vault.
 #! - ASSET_VALUE is the value of the asset to remove from the vault.
+#! - REMAINING_ASSET_VALUE is the value of the asset remaining in the vault after removal.
 #!
 #! Panics if:
 #! - the fungible asset is not found in the vault.
@@ -610,7 +611,7 @@ pub proc account_remove_asset
 
     # remove the specified asset from the account vault, emitting the corresponding events
     exec.account::remove_asset_from_vault
-    # => [ASSET_VALUE, pad(12)]
+    # => [REMAINING_ASSET_VALUE, pad(12)]
 end
 
 #! Returns the asset associated with the provided asset vault key in the active account's vault.
@@ -780,11 +781,11 @@ end
 #! Burn an asset from the faucet the transaction is being executed against.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE, pad(8)]
-#! Outputs: [ASSET_VALUE, pad(12)]
+#! Outputs: [pad(16)]
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to burn.
-#! - ASSET_VALUE is the value of the asset that was burned.
+#! - ASSET_VALUE is the value of the asset to burn.
 #!
 #! Panics if:
 #! - the transaction is not being executed against a faucet.
@@ -810,7 +811,7 @@ pub proc faucet_burn_asset
 
     # burn the asset
     exec.faucet::burn
-    # => [ASSET_VALUE, pad(12)]
+    # => [pad(16)]
 end
 
 #! Returns whether the active account defines callbacks.

--- a/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
@@ -64,6 +64,8 @@ const ERR_ACCOUNT_ID_UNKNOWN_STORAGE_MODE="unknown account storage mode in accou
 
 const ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT="failed to read an account map item from a non-map storage slot"
 
+const ERR_FOREIGN_ACCOUNT_ID_MISMATCH="foreign account ID provided with advice map doesn't match the ID provided by the operand stack"
+
 # CONSTANTS
 # =================================================================================================
 
@@ -740,14 +742,15 @@ pub proc add_asset_to_vault
     # => [PROCESSED_ASSET_VALUE']
 end
 
-#! Removes the specified asset from the account vault.
+#! Removes the specified asset from the account vault and returns the remaining asset value.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: [REMAINING_ASSET_VALUE]
 #!
 #! Where:
 #! - ASSET_KEY is the asset vault key of the asset to remove from the vault.
 #! - ASSET_VALUE is the value of the asset to remove from the vault.
+#! - REMAINING_ASSET_VALUE is the value of the asset remaining in the vault after removal.
 #!
 #! Panics if:
 #! - the fungible asset is not found in the vault.
@@ -768,17 +771,17 @@ pub proc remove_asset_from_vault
 
     # remove the asset from the account vault
     exec.asset_vault::remove_asset
-    # => [ASSET_VALUE, ASSET_KEY, ASSET_VALUE]
+    # => [REMAINING_ASSET_VALUE, ASSET_KEY, ASSET_VALUE]
 
-    swapw
-    # => [ASSET_KEY, ASSET_VALUE, ASSET_VALUE]
+    movdnw.2
+    # => [ASSET_KEY, ASSET_VALUE, REMAINING_ASSET_VALUE]
 
     # emit event to signal that an asset is being removed from the account vault
     emit.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT
-    # => [ASSET_KEY, ASSET_VALUE, ASSET_VALUE]
+    # => [ASSET_KEY, ASSET_VALUE, REMAINING_ASSET_VALUE]
 
     exec.account_delta::remove_asset
-    # => [ASSET_VALUE]
+    # => [REMAINING_ASSET_VALUE]
 end
 
 #! Returns the ASSET_VALUE associated with the provided asset vault key in the active account's vault.
@@ -1080,24 +1083,38 @@ end
 #! - the computed account code commitment does not match the provided account code commitment.
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
+#! - the foreign account ID obtained from the advice map doesn't match the ID provided to the
+#!   procedure.
 pub proc load_foreign_account
     emit.ACCOUNT_BEFORE_FOREIGN_LOAD_EVENT
     # => [account_id_suffix, account_id_prefix]
 
     # construct the advice map key from the account ID to load the core account data
-    exec.create_id_key
-    # OS => [ACCOUNT_ID_KEY]
+    dup.1 dup.1 exec.create_id_key
+    # OS => [ACCOUNT_ID_KEY, account_id_suffix, account_id_prefix]
 
     # move the core account data to the advice stack
     adv.push_mapval
-    # OS => [ACCOUNT_ID_KEY]
+    # OS => [ACCOUNT_ID_KEY, account_id_suffix, account_id_prefix]
     # AS => [ACCOUNT_ID_AND_NONCE, VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
 
-    # store the id and nonce of the foreign account to memory
+    # load the id and nonce of the foreign account from the advice stack overwriting the ID key
     adv_loadw
+    # OS => [account_nonce, 0, adv_account_id_suffix, adv_account_id_prefix, account_id_suffix, account_id_prefix]
+    # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
+
+    movup.5 movup.5
+    # OS => [account_id_suffix, account_id_prefix, account_nonce, 0, adv_account_id_suffix, adv_account_id_prefix]
+    # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
+
+    # check that the account ID provided by the advice map matches the one provided by the operand
+    # stack
+    dup.5 dup.5
+    exec.account_id::is_equal assert.err=ERR_FOREIGN_ACCOUNT_ID_MISMATCH
     # OS => [account_nonce, 0, account_id_suffix, account_id_prefix]
     # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
 
+    # store the id and nonce of the foreign account to memory
     exec.memory::set_account_id_and_nonce
     # OS => [account_nonce, 0, account_id_suffix, account_id_prefix]
     # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]

--- a/crates/miden-protocol/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/asset_vault.masm
@@ -150,20 +150,8 @@ pub proc add_fungible_asset
     padw loc_load.0 mem_loadw_le
     # => [VAULT_ROOT, MERGED_ASSET_VALUE, ASSET_KEY, CUR_VAULT_VALUE, MERGED_ASSET_VALUE]
 
-    movdnw.2 padw
-    # => [EMPTY_WORD, MERGED_ASSET_VALUE, ASSET_KEY, VAULT_ROOT, CUR_VAULT_VALUE, MERGED_ASSET_VALUE]
-
-    # check if amount of new asset is zero
-    # if it is zero, insert EMPTY_WORD to keep the merkle tree sparse
-    dupw.1
-    exec.fungible_asset::value_into_amount
-    eq.0
-    # => [is_amount_zero, EMPTY_WORD, MERGED_ASSET_VALUE, ASSET_KEY, VAULT_ROOT, CUR_VAULT_VALUE, MERGED_ASSET_VALUE]
-
-    # If is_amount_zero EMPTY_WORD remains.
-    # If !is_amount_zero MERGED_ASSET_VALUE remains.
-    cdropw
-    # => [EMPTY_WORD_OR_MERGED_ASSET_VALUE, ASSET_KEY, VAULT_ROOT, CUR_VAULT_VALUE, MERGED_ASSET_VALUE]
+    movdnw.2
+    # => [MERGED_ASSET_VALUE, ASSET_KEY, VAULT_ROOT, CUR_VAULT_VALUE, MERGED_ASSET_VALUE]
 
     # update asset in vault
     exec.smt::set
@@ -261,21 +249,22 @@ end
 # REMOVE ASSET
 # =================================================================================================
 
-#! Splits ASSET_VALUE off the existing asset in the vault associated with the ASSET_KEY.
+#! Splits ASSET_VALUE off the existing asset in the vault associated with the ASSET_KEY
+#! and returns the remaining asset value.
 #!
 #! For instance, if ASSET_KEY points to a fungible asset with amount 100, and ASSET_VALUE has
-#! amount 30, then a fungible asset with amount 70 remains in the vault.
+#! amount 30, then a fungible asset with amount 70 remains in the vault and is returned.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE, vault_root_ptr]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: [REMAINING_ASSET_VALUE]
 #!
 #! Where:
 #! - ASSET_KEY is the asset vault key of the fungible asset to remove from the vault.
-#! - ASSET_VALUE is the fungible asset that was removed from the vault.
+#! - REMAINING_ASSET_VALUE is the value of the fungible asset remaining in the vault after removal.
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #!
 #! Locals:
-#! - 0..4: ASSET_VALUE
+#! - 0..4: REMAINING_ASSET_VALUE
 #!
 #! Panics if:
 #! - the amount of the asset in the vault is less than the amount to be removed.
@@ -293,33 +282,22 @@ pub proc remove_fungible_asset
     movdnw.2
     # => [ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
 
-    # store ASSET_VALUE so we can return it later
-    loc_storew_le.0
-    # => [ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
-
     dupw.2 swapw
     # => [ASSET_VALUE, PEEKED_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
 
-    # compute PEEKED_ASSET_VALUE - ASSET_VALUE
+    # compute REMAINING_ASSET_VALUE = PEEKED_ASSET_VALUE - ASSET_VALUE
     exec.fungible_asset::split
-    # => [NEW_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
+    # => [REMAINING_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
 
-    padw dupw.1 exec.fungible_asset::value_into_amount
-    # => [new_amount, EMPTY_WORD, NEW_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
-
-    eq.0
-    # => [is_new_amount_zero, EMPTY_WORD, NEW_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
-
-    # If is_new_amount_zero EMPTY_WORD remains.
-    # If !is_new_amount_zero NEW_ASSET_VALUE remains.
-    cdropw
-    # => [EMPTY_WORD_OR_NEW_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
+    # store remaining asset value so we can return it later
+    loc_storew_le.0
+    # => [REMAINING_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
 
     dup.12 padw movup.4 mem_loadw_le
-    # => [VAULT_ROOT, EMPTY_WORD_OR_NEW_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
+    # => [VAULT_ROOT, REMAINING_ASSET_VALUE, ASSET_KEY, PEEKED_ASSET_VALUE, vault_root_ptr]
 
     movdnw.2
-    # => [EMPTY_WORD_OR_NEW_ASSET_VALUE, ASSET_KEY, VAULT_ROOT, PEEKED_ASSET_VALUE, vault_root_ptr]
+    # => [REMAINING_ASSET_VALUE, ASSET_KEY, VAULT_ROOT, PEEKED_ASSET_VALUE, vault_root_ptr]
 
     # update asset in vault and assert the old value is equivalent to the peeked value provided
     # via peek_asset
@@ -335,20 +313,23 @@ pub proc remove_fungible_asset
     # => [NEW_VAULT_ROOT]
 
     loc_loadw_le.0
-    # => [ASSET_VALUE]
+    # => [REMAINING_ASSET_VALUE]
 end
 
-#! Remove the specified non-fungible asset from the vault.
+#! Remove the specified non-fungible asset from the vault and return the remaining asset value.
+#!
+#! Since non-fungible assets are either fully present or absent, the remaining value after
+#! removal is always EMPTY_WORD.
 #!
 #! Note that the ASSET_VALUE is only needed to check against the asset that was removed from the
 #! vault.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE, vault_root_ptr]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: [REMAINING_ASSET_VALUE]
 #!
 #! Where:
 #! - ASSET_KEY is the asset vault key of the non-fungible asset to remove from the vault.
-#! - ASSET_VALUE is the non-fungible asset that was removed from the vault.
+#! - REMAINING_ASSET_VALUE is always EMPTY_WORD (nothing remains after removing a non-fungible asset).
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #!
 #! Panics if:
@@ -366,22 +347,27 @@ pub proc remove_non_fungible_asset
     exec.smt::set
     # => [REMOVED_ASSET_VALUE, NEW_VAULT_ROOT, ASSET_VALUE, vault_root_ptr]
 
-    dupw.2 assert_eqw.err=ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND
-    # => [NEW_VAULT_ROOT, ASSET_VALUE, vault_root_ptr]
+    movupw.2 assert_eqw.err=ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND
+    # => [NEW_VAULT_ROOT, vault_root_ptr]
 
     # update the vault root
-    movup.8 mem_storew_le dropw
-    # => [ASSET_VALUE]
+    movup.4 mem_storew_le dropw
+    # => []
+
+    # push EMPTY_WORD to represent that nothing remains after non-fungible removal
+    padw
+    # => [REMAINING_ASSET_VALUE]
 end
 
-#! Remove the specified asset from the vault.
+#! Remove the specified asset from the vault and return the remaining asset value.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE, vault_root_ptr]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: [REMAINING_ASSET_VALUE]
 #!
 #! Where:
 #! - ASSET_KEY is the asset vault key of the asset to remove from the vault.
 #! - ASSET_VALUE is the value of the asset to remove from the vault.
+#! - REMAINING_ASSET_VALUE is the value of the asset remaining in the vault after removal.
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #!
 #! Panics if:
@@ -396,9 +382,9 @@ pub proc remove_asset
     # remove the asset from the asset vault
     if.true
         exec.remove_fungible_asset
-        # => [ASSET_VALUE]
+        # => [REMAINING_ASSET_VALUE]
     else
         exec.remove_non_fungible_asset
-        # => [ASSET_VALUE]
+        # => [REMAINING_ASSET_VALUE]
     end
 end

--- a/crates/miden-protocol/asm/kernels/transaction/lib/faucet.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/faucet.masm
@@ -43,11 +43,11 @@ end
 #! against.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: []
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to burn.
-#! - ASSET_VALUE is the value of the asset value to burn.
+#! - ASSET_VALUE is the value of the asset to burn.
 #!
 #! Panics if:
 #! - the transaction is not being executed against a fungible faucet.
@@ -67,7 +67,11 @@ proc burn_fungible_asset
 
     # remove the asset from the input vault for asset preservation
     exec.asset_vault::remove_fungible_asset
-    # => [ASSET_VALUE]
+    # => [REMAINING_ASSET_VALUE]
+
+    # drop the remaining value (not meaningful to the caller)
+    dropw
+    # => []
 end
 
 # NON-FUNGIBLE ASSETS
@@ -109,11 +113,11 @@ end
 #! executed against.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: []
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to burn.
-#! - ASSET_VALUE is the value of the asset value to burn.
+#! - ASSET_VALUE is the value of the asset to burn.
 #!
 #! Panics if:
 #! - the transaction is not being executed against a non-fungible faucet.
@@ -132,7 +136,11 @@ proc burn_non_fungible_asset
     # => [ASSET_KEY, ASSET_VALUE, input_vault_root_ptr]
 
     exec.asset_vault::remove_non_fungible_asset
-    # => [ASSET_VALUE]
+    # => [REMAINING_ASSET_VALUE]
+
+    # drop the remaining value (not meaningful to the caller)
+    dropw
+    # => []
 end
 
 # PUBLIC INTERFACE
@@ -177,11 +185,11 @@ end
 #! Burn an asset from the faucet the transaction is being executed against.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: []
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to burn.
-#! - ASSET_VALUE is the value of the asset value to burn.
+#! - ASSET_VALUE is the value of the asset to burn.
 #!
 #! Panics if:
 #! - the transaction is not being executed against a faucet.
@@ -200,10 +208,10 @@ pub proc burn
     if.true
         # burn the fungible asset
         exec.burn_fungible_asset
-        # => [ASSET_VALUE]
+        # => []
     else
         # burn the non-fungible asset
         exec.burn_non_fungible_asset
-        # => [ASSET_VALUE]
+        # => []
     end
 end

--- a/crates/miden-protocol/asm/kernels/transaction/lib/link_map.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/link_map.masm
@@ -118,7 +118,7 @@ use $kernel::memory
 # ERRORS
 # =================================================================================================
 
-const ERR_LINK_MAP_CANNOT_BE_EMPTY_ON_ABSENCE_AFTER_ENTRY="map cannot be empty when proving absence after an entry"
+const ERR_LINK_MAP_EMPTY_MAP_REQUIRES_AT_HEAD_OPERATION="empty map requires operation InsertAtHead for set or AbsentAtHead for get"
 
 const ERR_LINK_MAP_PROVIDED_KEY_NOT_EQUAL_TO_ENTRY_KEY="provided key does not match key in map entry"
 
@@ -196,47 +196,55 @@ const LINK_MAP_GET_EVENT=event("miden::protocol::link_map::get")
 #!
 #! Panics if:
 #! - the host provides faulty advice. See panic sections of assert_entry_ptr_is_valid,
-#!   update_entry, insert_at_head, insert_after_entry.
+#!   update_entry, insert_at_head, insert_after_entry and assert_empty_map_op_is_at_head.
 pub proc set
     emit.LINK_MAP_SET_EVENT
     adv_push.2
     # => [operation, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 
-    dup.2 dup.2
-    # => [entry_ptr, map_ptr, operation, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
+    dup eq.INSERT_OPERATION_UPDATE swap eq.INSERT_OPERATION_AT_HEAD
+    # => [is_insert_at_head_op, is_insert_update_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 
-    exec.assert_entry_ptr_is_valid
-    # => [operation, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
+    dup dup.4
+    # => [map_ptr, is_insert_at_head_op, is_insert_at_head_op, is_insert_update_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 
-    dup eq.INSERT_OPERATION_AT_HEAD swap eq.INSERT_OPERATION_UPDATE
-    # => [is_insert_update_op, is_insert_at_head_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
+    exec.assert_empty_map_op_is_at_head
+    # => [is_insert_at_head_op, is_insert_update_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 
     if.true
-        # update existing entry
-        # drop is_insert_at_head_op and map_ptr from stack
-        drop swap drop
-        # => [entry_ptr, KEY, VALUE0, VALUE1]
+        # drop is_insert_update_op and the unvalidated entry ptr since we can load the entry ptr
+        # at the head of the map securely from map_ptr
+        drop drop
+        # => [map_ptr, KEY, VALUE0, VALUE1]
 
-        exec.update_entry
+        exec.insert_at_head
         # => []
 
-        push.0
+        push.1
         # => [is_new_key]
     else
-        # insert new entry
-        # => [is_insert_at_head_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
+        # => [is_insert_update_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
+
+        dup.2 dup.2
+        # => [entry_ptr, map_ptr, is_insert_update_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
+
+        # validate the entry pointer
+        # this can be skipped for insert_at_head because the entry_ptr is not used in that branch
+        exec.assert_entry_ptr_is_valid
+        # => [is_insert_update_op, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 
         # note: the is_new_key flag logic is duplicated rather than appended after the if-else branch
         # to avoid introducing an extra MAST node
         if.true
-            # drop the entry ptr since we can load the head from map_ptr
-            drop
-            # => [map_ptr, KEY, VALUE0, VALUE1]
+            # update existing entry
+            # drop unused map_ptr
+            swap drop
+            # => [entry_ptr, KEY, VALUE0, VALUE1]
 
-            exec.insert_at_head
+            exec.update_entry
             # => []
 
-            push.1
+            push.0
             # => [is_new_key]
         else
             # insert after existing entry
@@ -263,47 +271,62 @@ end
 #!
 #! Panics if:
 #! - the host provides faulty advice. See panic sections of assert_entry_ptr_is_valid,
-#!   get_existing_value, assert_absent_at_head, assert_absent_after_entry.
+#!   get_existing_value, assert_absent_at_head, assert_absent_after_entry and
+#!   assert_empty_map_op_is_at_head.
 pub proc get
     emit.LINK_MAP_GET_EVENT
     adv_push.2
     # => [get_operation, entry_ptr, map_ptr, KEY]
 
-    dup.2 dup.2
-    # => [entry_ptr, map_ptr, get_operation, entry_ptr, map_ptr, KEY]
+    dup eq.GET_OPERATION_FOUND swap eq.GET_OPERATION_ABSENT_AT_HEAD
+    # => [is_absent_at_head, is_found, entry_ptr, map_ptr, KEY]
 
-    exec.assert_entry_ptr_is_valid
-    # => [get_operation, entry_ptr, map_ptr, KEY]
+    dup dup.4
+    # => [map_ptr, is_absent_at_head, is_absent_at_head, is_found, entry_ptr, map_ptr, KEY]
 
-    dup eq.GET_OPERATION_ABSENT_AT_HEAD swap eq.GET_OPERATION_FOUND
-    # => [is_found, is_absent_at_head, entry_ptr, map_ptr, KEY]
+    exec.assert_empty_map_op_is_at_head
+    # => [is_absent_at_head, is_found, entry_ptr, map_ptr, KEY]
 
     if.true
-        # drop is_absent_at_head and map_ptr from stack
-        drop swap drop
-        # => [entry_ptr, KEY]
+        # drop is_found and the unvalidated entry ptr since we can load the entry ptr
+        # at the head of the map securely from map_ptr
+        drop drop
+        # => [map_ptr, KEY]
 
-        exec.get_existing_value
-        # => [VALUE0, VALUE1]
+        exec.assert_absent_at_head
+        # => []
 
-        push.1
-        # => [contains_key, VALUE0, VALUE1]
+        padw padw push.0
+        # => [contains_key, EMPTY_WORD, EMPTY_WORD]
     else
-        # assert absence of the entry
-        # => [is_absent_at_head, entry_ptr, map_ptr, KEY]
+        # => [is_found, entry_ptr, map_ptr, KEY]
+
+        dup.2 dup.2
+        # => [entry_ptr, map_ptr, is_found, entry_ptr, map_ptr, KEY]
+
+        # validate the entry pointer
+        # this can be skipped for assert_absent_at_head because the entry_ptr is not used in that
+        # branch
+        exec.assert_entry_ptr_is_valid
+        # => [is_found, entry_ptr, map_ptr, KEY]
+
+        # drop unused map_ptr
+        movup.2 drop
+        # => [is_found, entry_ptr, KEY]
 
         # note: the flag and empty word logic is duplicated rather than appended after the if-else
         # branch to avoid introducing an extra MAST node
         if.true
-            drop
-            # => [map_ptr, KEY]
+            # => [entry_ptr, KEY]
 
-            exec.assert_absent_at_head
-            # => []
+            exec.get_existing_value
+            # => [VALUE0, VALUE1]
 
-            padw padw push.0
-            # => [contains_key, EMPTY_WORD, EMPTY_WORD]
+            push.1
+            # => [contains_key, VALUE0, VALUE1]
         else
+            # => [entry_ptr, KEY]
+
             exec.assert_absent_after_entry
             # => []
 
@@ -619,17 +642,13 @@ end
 #! If KEY is greater than the key in the entry and less than the key in entry's next entry, then
 #! that proves the absence of the key.
 #!
-#! Inputs:  [entry_ptr, map_ptr, KEY]
+#! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
 #!
 #! Panics if:
-#! - the map is empty.
 #! - the KEY is not greater than the key in the entry.
 #! - the KEY is not less than the key in entry.next_entry, unless the entry is the last one in the map.
 proc assert_absent_after_entry
-    swap exec.is_empty assertz.err=ERR_LINK_MAP_CANNOT_BE_EMPTY_ON_ABSENCE_AFTER_ENTRY
-    # => [entry_ptr, KEY]
-
     movdn.4 dupw
     # => [KEY, KEY, entry_ptr]
 
@@ -855,18 +874,48 @@ proc assert_key_is_less
     # => []
 end
 
+#! Asserts that if the map is empty, the host-provided operation is the `*AT_HEAD` variant:
+#! - INSERT_OPERATION_AT_HEAD for link_map::set
+#! - GET_OPERATION_ABSENT_AT_HEAD for link_map::get
+#!
+#! This ensures the other operations never have to consider the empty map case to reduce
+#! complexity.
+#!
+#! What we want is:
+#! is_empty_map | !is_at_head_op | outcome
+#! true         | true           | panic
+#! true         | false          | ok
+#! false        | true           | ok
+#! false        | false          | ok
+#!
+#! Inputs:  [map_ptr, is_at_head_op]
+#! Outputs: []
+#!
+#! Panics if:
+#! - the map is empty and the provided operation is not the *AT_HEAD variant.
+proc assert_empty_map_op_is_at_head
+    exec.is_empty
+    # => [is_empty_map, is_at_head_op]
+
+    swap not
+    # => [!is_at_head_op, is_empty_map]
+
+    and assertz.err=ERR_LINK_MAP_EMPTY_MAP_REQUIRES_AT_HEAD_OPERATION
+    # => []
+end
+
 #! Asserts that the given entry ptr is a valid entry in the map identified by map_ptr.
 #!
 #! Inputs:  [entry_ptr, map_ptr]
 #! Outputs: []
 #!
 #! Panics if:
-#! - any of the following conditions is false, except if the map is empty:
+#! - any of the following conditions is false:
 #!   - LINK_MAP_MEMORY_START_PTR <= entry_ptr < LINK_MAP_MEMORY_END_PTR.
 #!   - entry ptr is "link map entry"-aligned, i.e. entry_ptr % LINK_MAP_ENTRY_SIZE == 0. This
 #!     works because every entry ptr is a multiple of LINK_MAP_ENTRY_SIZE.
 #!   - entry's map ptr is equal to the given map_ptr.
-pub proc assert_entry_ptr_is_valid
+proc assert_entry_ptr_is_valid
     # Check entry pointer is in valid memory range.
     # -------------------------------------------------------------------------------------------------
 
@@ -891,16 +940,8 @@ pub proc assert_entry_ptr_is_valid
     u32lt and
     # => [is_entry_ptr_in_valid_range, entry_ptr, map_ptr]
 
-    # we have to skip the assertion if the map is empty
-    dup.2 exec.is_empty
-    # => [is_empty_map, is_entry_ptr_in_valid_range, entry_ptr, map_ptr]
-
-    dup movdn.4
-    # => [is_empty_map, is_entry_ptr_in_valid_range, entry_ptr, map_ptr, is_empty_map]
-
-    # this assertion is always true if is_empty_map is true
-    or assert.err=ERR_LINK_MAP_ENTRY_PTR_IS_OUTSIDE_VALID_MEMORY_REGION
-    # => [entry_ptr, map_ptr, is_empty_map]
+    assert.err=ERR_LINK_MAP_ENTRY_PTR_IS_OUTSIDE_VALID_MEMORY_REGION
+    # => [entry_ptr, map_ptr]
 
     # Check that the entry pointer is aligned to link map entries.
     # -------------------------------------------------------------------------------------------------
@@ -910,19 +951,18 @@ pub proc assert_entry_ptr_is_valid
     # we assert that entry_ptr % LINK_MAP_ENTRY_SIZE == 0.
     # note: we previously asserted that entry_ptr fits in a u32
     dup exec.memory::get_link_map_entry_size u32mod eq.0
-    # => [is_entry_ptr_aligned, entry_ptr, map_ptr, is_empty_map]
+    # => [is_entry_ptr_aligned, entry_ptr, map_ptr]
 
-    # this assertion is always true if is_empty_map is true
-    dup.3 or assert.err=ERR_LINK_MAP_ENTRY_PTR_IS_NOT_ENTRY_ALIGNED
-    # => [entry_ptr, map_ptr, is_empty_map]
+    assert.err=ERR_LINK_MAP_ENTRY_PTR_IS_NOT_ENTRY_ALIGNED
+    # => [entry_ptr, map_ptr]
 
     # Check entry pointer's map ptr is equal to map_ptr.
     # -------------------------------------------------------------------------------------------------
 
     # check if entry_ptr.map_ptr == map_ptr
     exec.get_map_ptr eq
-    # => [entry_contains_map_ptr, is_empty_map]
+    # => [entry_contains_map_ptr]
 
-    # this assertion is always true if is_empty_map is true
-    or assert.err=ERR_LINK_MAP_MAP_PTR_IN_ENTRY_DOES_NOT_MATCH_EXPECTED_MAP_PTR
+    assert.err=ERR_LINK_MAP_MAP_PTR_IN_ENTRY_DOES_NOT_MATCH_EXPECTED_MAP_PTR
+    # => []
 end

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -216,7 +216,7 @@ const ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET=1320
 
 # Offset at which the account's active storage slot section is kept. This section contains the
 # current values of the account storage slots.
-const ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET=2340
+const ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET=3360
 
 # NATIVE ACCOUNT DELTA
 # -------------------------------------------------------------------------------------------------

--- a/crates/miden-protocol/asm/protocol/faucet.masm
+++ b/crates/miden-protocol/asm/protocol/faucet.masm
@@ -101,11 +101,11 @@ end
 #! Burn an asset from the faucet the transaction is being executed against.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: []
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to burn.
-#! - ASSET_VALUE is the value of the asset that was burned.
+#! - ASSET_VALUE is the value of the asset to burn.
 #!
 #! Panics if:
 #! - the transaction is not being executed against a faucet.
@@ -127,11 +127,11 @@ pub proc burn
     # => [offset, ASSET_KEY, ASSET_VALUE, pad(7)]
 
     syscall.exec_kernel_proc
-    # => [ASSET_VALUE, pad(12)]
+    # => [pad(16)]
 
     # clean the stack
-    swapdw dropw dropw swapw dropw
-    # => [ASSET_VALUE]
+    dropw dropw dropw dropw
+    # => []
 end
 
 #! Returns whether the active account defines callbacks.

--- a/crates/miden-protocol/asm/protocol/native_account.masm
+++ b/crates/miden-protocol/asm/protocol/native_account.masm
@@ -231,14 +231,16 @@ pub proc add_asset
     # => [ASSET_VALUE']
 end
 
-#! Remove the specified asset from the vault.
+#! Remove the specified asset from the vault and return the remaining asset value.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Outputs: [REMAINING_ASSET_VALUE]
 #!
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to remove from the vault.
 #! - ASSET_VALUE is the value of the asset to remove from the vault.
+#! - REMAINING_ASSET_VALUE is the value of the asset remaining in the vault after removal which may
+#!   be the empty word if nothing remains (e.g. if a non-fungible asset is removed).
 #!
 #! Panics if:
 #! - the fungible asset is not found in the vault.
@@ -255,11 +257,11 @@ pub proc remove_asset
     # => [offset, ASSET_KEY, ASSET_VALUE, pad(7)]
 
     syscall.exec_kernel_proc
-    # => [ASSET_VALUE, pad(12)]
+    # => [REMAINING_ASSET_VALUE, pad(12)]
 
     # clean the stack
     swapdw dropw dropw swapw dropw
-    # => [ASSET_VALUE]
+    # => [REMAINING_ASSET_VALUE]
 end
 
 # CODE

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -515,34 +515,13 @@ fn generate_event_file_content(
     for (event_path, event_name) in events {
         let value = EventId::from_name(event_path).as_felt().as_canonical_u64();
         debug_assert!(!event_name.is_empty());
-        writeln!(&mut output, "const {}: u64 = {};", event_name, value)?;
-    }
-
-    {
-        writeln!(&mut output)?;
-
-        writeln!(&mut output)?;
-
+        writeln!(&mut output, "const {}_ID: u64 = {};", event_name, value)?;
         writeln!(
             &mut output,
-            r###"
-use alloc::collections::BTreeMap;
-
-pub(crate) static EVENT_NAME_LUT: ::miden_utils_sync::LazyLock<BTreeMap<u64, &'static str>> =
-    ::miden_utils_sync::LazyLock::new(|| {{
-    BTreeMap::from_iter([
-"###
+            "static {}_NAME: ::miden_core::events::EventName = ::miden_core::events::EventName::new(\"{}\");",
+            event_name, event_path
         )?;
-
-        for (event_path, const_name) in events {
-            writeln!(&mut output, "        ({}, \"{}\"),", const_name, event_path)?;
-        }
-
-        writeln!(
-            &mut output,
-            r###"    ])
-}});"###
-        )?;
+        writeln!(&mut output)?;
     }
 
     Ok(output)

--- a/crates/miden-protocol/src/asset/vault/mod.rs
+++ b/crates/miden-protocol/src/asset/vault/mod.rs
@@ -193,9 +193,13 @@ impl AssetVault {
 
         for (&asset, &action) in delta.non_fungible().iter() {
             match action {
-                NonFungibleDeltaAction::Add => self.add_non_fungible_asset(asset),
-                NonFungibleDeltaAction::Remove => self.remove_non_fungible_asset(asset),
-            }?;
+                NonFungibleDeltaAction::Add => {
+                    self.add_non_fungible_asset(asset)?;
+                },
+                NonFungibleDeltaAction::Remove => {
+                    self.remove_non_fungible_asset(asset)?;
+                },
+            }
         }
 
         Ok(())
@@ -267,27 +271,32 @@ impl AssetVault {
 
     // REMOVE ASSET
     // --------------------------------------------------------------------------------------------
-    /// Remove the specified asset from the vault and returns the asset that was just removed.
+    /// Remove the specified asset from the vault and returns the remaining asset, if any.
+    ///
+    /// - For fungible assets, returns `Some(Asset::Fungible(remaining))` with the remaining balance
+    ///   (which may have amount 0).
+    /// - For non-fungible assets, returns `None` since non-fungible assets are either fully present
+    ///   or absent.
     ///
     /// # Errors
     /// - The fungible asset is not found in the vault.
     /// - The amount of the fungible asset in the vault is less than the amount to be removed.
     /// - The non-fungible asset is not found in the vault.
-    pub fn remove_asset(&mut self, asset: Asset) -> Result<Asset, AssetVaultError> {
+    pub fn remove_asset(&mut self, asset: Asset) -> Result<Option<Asset>, AssetVaultError> {
         match asset {
             Asset::Fungible(asset) => {
-                let asset = self.remove_fungible_asset(asset)?;
-                Ok(Asset::Fungible(asset))
+                let remaining = self.remove_fungible_asset(asset)?;
+                Ok(Some(Asset::Fungible(remaining)))
             },
             Asset::NonFungible(asset) => {
-                let asset = self.remove_non_fungible_asset(asset)?;
-                Ok(Asset::NonFungible(asset))
+                self.remove_non_fungible_asset(asset)?;
+                Ok(None)
             },
         }
     }
 
-    /// Remove the specified fungible asset from the vault and returns the asset that was just
-    /// removed. If the final amount of the asset is zero, the asset is removed from the vault.
+    /// Remove the specified fungible asset from the vault and returns the remaining fungible
+    /// asset. If the final amount of the asset is zero, the asset is removed from the vault.
     ///
     /// # Errors
     /// - The asset is not found in the vault.
@@ -325,11 +334,10 @@ impl AssetVault {
             .insert(new_asset.vault_key().to_word(), new_asset.to_value_word())
             .map_err(AssetVaultError::MaxLeafEntriesExceeded)?;
 
-        Ok(other_asset)
+        Ok(new_asset)
     }
 
-    /// Remove the specified non-fungible asset from the vault and returns the asset that was just
-    /// removed.
+    /// Remove the specified non-fungible asset from the vault.
     ///
     /// # Errors
     /// - The non-fungible asset is not found in the vault.
@@ -337,7 +345,7 @@ impl AssetVault {
     fn remove_non_fungible_asset(
         &mut self,
         asset: NonFungibleAsset,
-    ) -> Result<NonFungibleAsset, AssetVaultError> {
+    ) -> Result<(), AssetVaultError> {
         // remove the asset from the vault.
         let old = self
             .asset_tree
@@ -349,8 +357,7 @@ impl AssetVault {
             return Err(AssetVaultError::NonFungibleAssetNotFound(asset));
         }
 
-        // return the asset that was removed.
-        Ok(asset)
+        Ok(())
     }
 }
 

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -40,7 +40,7 @@ use crate::note::{
     NoteType,
     Nullifier,
 };
-use crate::transaction::{TransactionEventId, TransactionId};
+use crate::transaction::TransactionId;
 use crate::utils::serde::DeserializationError;
 use crate::vm::EventId;
 use crate::{
@@ -818,11 +818,7 @@ pub enum OutputNoteError {
 #[derive(Debug, Error)]
 pub enum TransactionEventError {
     #[error("event id {0} is not a valid transaction event")]
-    InvalidTransactionEvent(EventId, Option<&'static str>),
-    #[error("event id {0} is not a transaction kernel event")]
-    NotTransactionEvent(EventId, Option<&'static str>),
-    #[error("event id {0} can only be emitted from the root context")]
-    NotRootContext(TransactionEventId),
+    InvalidTransactionEvent(EventId),
 }
 
 // TRANSACTION TRACE PARSING ERROR

--- a/crates/miden-protocol/src/lib.rs
+++ b/crates/miden-protocol/src/lib.rs
@@ -81,7 +81,7 @@ pub mod utils {
 pub mod vm {
     pub use miden_assembly_syntax::ast::{AttributeSet, QualifiedProcedureName};
     pub use miden_core::advice::{AdviceInputs, AdviceMap};
-    pub use miden_core::events::{EventId, SystemEvent};
+    pub use miden_core::events::{EventId, EventName, SystemEvent};
     pub use miden_core::program::{Program, ProgramInfo};
     pub use miden_mast_package::{
         MastArtifact,

--- a/crates/miden-protocol/src/transaction/kernel/memory.rs
+++ b/crates/miden-protocol/src/transaction/kernel/memory.rs
@@ -40,9 +40,9 @@ pub type StorageSlot = u8;
 // | Padding            | 1_056         | 4                |                                        |
 // | Proc tracking      | 1_060         | 256              | 256 procedures max, 1 element each     |
 // | Num storage slots  | 1_316         | 4                |                                        |
-// | Initial slot info  | 1_320         | 1_020            | Only initialized on the native account |
-// | Active slot info   | 2_340         | 1_020            | 255 slots max, 8 elements each         |
-// | Padding            | 3_360         | 4_832            |                                        |
+// | Initial slot info  | 1_320         | 2_040            | Only initialized on the native account |
+// | Active slot info   | 3_360         | 2_040            | 255 slots max, 8 elements each         |
+// | Padding            | 5_400         | 2_792            |                                        |
 //
 // Storage slots are laid out as [[0, slot_type, slot_id_suffix, slot_id_prefix], SLOT_VALUE].
 
@@ -333,7 +333,7 @@ pub const ACCT_STORAGE_SLOT_VALUE_OFFSET: u8 = 4;
 /// the account data segment.
 ///
 /// This section contains the current values of the account storage slots.
-pub const ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET: MemoryAddress = 2340;
+pub const ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET: MemoryAddress = 3360;
 
 /// The memory address at which the account's active storage slots section begins in the native
 /// account.

--- a/crates/miden-protocol/src/transaction/kernel/tx_event_id.rs
+++ b/crates/miden-protocol/src/transaction/kernel/tx_event_id.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use crate::errors::TransactionEventError;
-use crate::vm::EventId;
+use crate::vm::{EventId, EventName};
 
 // CONSTANTS
 // ================================================================================================
@@ -19,64 +19,64 @@ include!(concat!(env!("OUT_DIR"), "/assets/transaction_events.rs"));
 #[repr(u64)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionEventId {
-    AccountBeforeForeignLoad = ACCOUNT_BEFORE_FOREIGN_LOAD,
+    AccountBeforeForeignLoad = ACCOUNT_BEFORE_FOREIGN_LOAD_ID,
 
-    AccountVaultBeforeAddAsset = ACCOUNT_VAULT_BEFORE_ADD_ASSET,
-    AccountVaultAfterAddAsset = ACCOUNT_VAULT_AFTER_ADD_ASSET,
+    AccountVaultBeforeAddAsset = ACCOUNT_VAULT_BEFORE_ADD_ASSET_ID,
+    AccountVaultAfterAddAsset = ACCOUNT_VAULT_AFTER_ADD_ASSET_ID,
 
-    AccountVaultBeforeRemoveAsset = ACCOUNT_VAULT_BEFORE_REMOVE_ASSET,
-    AccountVaultAfterRemoveAsset = ACCOUNT_VAULT_AFTER_REMOVE_ASSET,
+    AccountVaultBeforeRemoveAsset = ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_ID,
+    AccountVaultAfterRemoveAsset = ACCOUNT_VAULT_AFTER_REMOVE_ASSET_ID,
 
-    AccountVaultBeforeGetAsset = ACCOUNT_VAULT_BEFORE_GET_ASSET,
+    AccountVaultBeforeGetAsset = ACCOUNT_VAULT_BEFORE_GET_ASSET_ID,
 
-    AccountStorageBeforeSetItem = ACCOUNT_STORAGE_BEFORE_SET_ITEM,
-    AccountStorageAfterSetItem = ACCOUNT_STORAGE_AFTER_SET_ITEM,
+    AccountStorageBeforeSetItem = ACCOUNT_STORAGE_BEFORE_SET_ITEM_ID,
+    AccountStorageAfterSetItem = ACCOUNT_STORAGE_AFTER_SET_ITEM_ID,
 
-    AccountStorageBeforeGetMapItem = ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM,
+    AccountStorageBeforeGetMapItem = ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_ID,
 
-    AccountStorageBeforeSetMapItem = ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM,
-    AccountStorageAfterSetMapItem = ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM,
+    AccountStorageBeforeSetMapItem = ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_ID,
+    AccountStorageAfterSetMapItem = ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_ID,
 
-    AccountBeforeIncrementNonce = ACCOUNT_BEFORE_INCREMENT_NONCE,
-    AccountAfterIncrementNonce = ACCOUNT_AFTER_INCREMENT_NONCE,
+    AccountBeforeIncrementNonce = ACCOUNT_BEFORE_INCREMENT_NONCE_ID,
+    AccountAfterIncrementNonce = ACCOUNT_AFTER_INCREMENT_NONCE_ID,
 
-    AccountPushProcedureIndex = ACCOUNT_PUSH_PROCEDURE_INDEX,
+    AccountPushProcedureIndex = ACCOUNT_PUSH_PROCEDURE_INDEX_ID,
 
-    NoteBeforeCreated = NOTE_BEFORE_CREATED,
-    NoteAfterCreated = NOTE_AFTER_CREATED,
+    NoteBeforeCreated = NOTE_BEFORE_CREATED_ID,
+    NoteAfterCreated = NOTE_AFTER_CREATED_ID,
 
-    NoteBeforeAddAsset = NOTE_BEFORE_ADD_ASSET,
-    NoteAfterAddAsset = NOTE_AFTER_ADD_ASSET,
+    NoteBeforeAddAsset = NOTE_BEFORE_ADD_ASSET_ID,
+    NoteAfterAddAsset = NOTE_AFTER_ADD_ASSET_ID,
 
-    NoteBeforeSetAttachment = NOTE_BEFORE_SET_ATTACHMENT,
+    NoteBeforeSetAttachment = NOTE_BEFORE_SET_ATTACHMENT_ID,
 
-    AuthRequest = AUTH_REQUEST,
+    AuthRequest = AUTH_REQUEST_ID,
 
-    PrologueStart = PROLOGUE_START,
-    PrologueEnd = PROLOGUE_END,
+    PrologueStart = PROLOGUE_START_ID,
+    PrologueEnd = PROLOGUE_END_ID,
 
-    NotesProcessingStart = NOTES_PROCESSING_START,
-    NotesProcessingEnd = NOTES_PROCESSING_END,
+    NotesProcessingStart = NOTES_PROCESSING_START_ID,
+    NotesProcessingEnd = NOTES_PROCESSING_END_ID,
 
-    NoteExecutionStart = NOTE_EXECUTION_START,
-    NoteExecutionEnd = NOTE_EXECUTION_END,
+    NoteExecutionStart = NOTE_EXECUTION_START_ID,
+    NoteExecutionEnd = NOTE_EXECUTION_END_ID,
 
-    TxScriptProcessingStart = TX_SCRIPT_PROCESSING_START,
-    TxScriptProcessingEnd = TX_SCRIPT_PROCESSING_END,
+    TxScriptProcessingStart = TX_SCRIPT_PROCESSING_START_ID,
+    TxScriptProcessingEnd = TX_SCRIPT_PROCESSING_END_ID,
 
-    EpilogueStart = EPILOGUE_START,
-    EpilogueEnd = EPILOGUE_END,
+    EpilogueStart = EPILOGUE_START_ID,
+    EpilogueEnd = EPILOGUE_END_ID,
 
-    EpilogueAuthProcStart = EPILOGUE_AUTH_PROC_START,
-    EpilogueAuthProcEnd = EPILOGUE_AUTH_PROC_END,
+    EpilogueAuthProcStart = EPILOGUE_AUTH_PROC_START_ID,
+    EpilogueAuthProcEnd = EPILOGUE_AUTH_PROC_END_ID,
 
-    EpilogueAfterTxCyclesObtained = EPILOGUE_AFTER_TX_CYCLES_OBTAINED,
-    EpilogueBeforeTxFeeRemovedFromAccount = EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT,
+    EpilogueAfterTxCyclesObtained = EPILOGUE_AFTER_TX_CYCLES_OBTAINED_ID,
+    EpilogueBeforeTxFeeRemovedFromAccount = EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_ID,
 
-    LinkMapSet = LINK_MAP_SET,
-    LinkMapGet = LINK_MAP_GET,
+    LinkMapSet = LINK_MAP_SET_ID,
+    LinkMapGet = LINK_MAP_GET_ID,
 
-    Unauthorized = AUTH_UNAUTHORIZED,
+    Unauthorized = AUTH_UNAUTHORIZED_ID,
 }
 
 impl TransactionEventId {
@@ -91,11 +91,56 @@ impl TransactionEventId {
     pub fn event_id(&self) -> EventId {
         EventId::from_u64(self.clone() as u64)
     }
+
+    /// Returns the [`EventName`] of the transaction event.
+    pub fn event_name(&self) -> &'static EventName {
+        match self {
+            Self::AccountBeforeForeignLoad => &ACCOUNT_BEFORE_FOREIGN_LOAD_NAME,
+            Self::AccountVaultBeforeAddAsset => &ACCOUNT_VAULT_BEFORE_ADD_ASSET_NAME,
+            Self::AccountVaultAfterAddAsset => &ACCOUNT_VAULT_AFTER_ADD_ASSET_NAME,
+            Self::AccountVaultBeforeRemoveAsset => &ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_NAME,
+            Self::AccountVaultAfterRemoveAsset => &ACCOUNT_VAULT_AFTER_REMOVE_ASSET_NAME,
+            Self::AccountVaultBeforeGetAsset => &ACCOUNT_VAULT_BEFORE_GET_ASSET_NAME,
+            Self::AccountStorageBeforeSetItem => &ACCOUNT_STORAGE_BEFORE_SET_ITEM_NAME,
+            Self::AccountStorageAfterSetItem => &ACCOUNT_STORAGE_AFTER_SET_ITEM_NAME,
+            Self::AccountStorageBeforeGetMapItem => &ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_NAME,
+            Self::AccountStorageBeforeSetMapItem => &ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_NAME,
+            Self::AccountStorageAfterSetMapItem => &ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_NAME,
+            Self::AccountBeforeIncrementNonce => &ACCOUNT_BEFORE_INCREMENT_NONCE_NAME,
+            Self::AccountAfterIncrementNonce => &ACCOUNT_AFTER_INCREMENT_NONCE_NAME,
+            Self::AccountPushProcedureIndex => &ACCOUNT_PUSH_PROCEDURE_INDEX_NAME,
+            Self::NoteBeforeCreated => &NOTE_BEFORE_CREATED_NAME,
+            Self::NoteAfterCreated => &NOTE_AFTER_CREATED_NAME,
+            Self::NoteBeforeAddAsset => &NOTE_BEFORE_ADD_ASSET_NAME,
+            Self::NoteAfterAddAsset => &NOTE_AFTER_ADD_ASSET_NAME,
+            Self::NoteBeforeSetAttachment => &NOTE_BEFORE_SET_ATTACHMENT_NAME,
+            Self::AuthRequest => &AUTH_REQUEST_NAME,
+            Self::PrologueStart => &PROLOGUE_START_NAME,
+            Self::PrologueEnd => &PROLOGUE_END_NAME,
+            Self::NotesProcessingStart => &NOTES_PROCESSING_START_NAME,
+            Self::NotesProcessingEnd => &NOTES_PROCESSING_END_NAME,
+            Self::NoteExecutionStart => &NOTE_EXECUTION_START_NAME,
+            Self::NoteExecutionEnd => &NOTE_EXECUTION_END_NAME,
+            Self::TxScriptProcessingStart => &TX_SCRIPT_PROCESSING_START_NAME,
+            Self::TxScriptProcessingEnd => &TX_SCRIPT_PROCESSING_END_NAME,
+            Self::EpilogueStart => &EPILOGUE_START_NAME,
+            Self::EpilogueEnd => &EPILOGUE_END_NAME,
+            Self::EpilogueAuthProcStart => &EPILOGUE_AUTH_PROC_START_NAME,
+            Self::EpilogueAuthProcEnd => &EPILOGUE_AUTH_PROC_END_NAME,
+            Self::EpilogueAfterTxCyclesObtained => &EPILOGUE_AFTER_TX_CYCLES_OBTAINED_NAME,
+            Self::EpilogueBeforeTxFeeRemovedFromAccount => {
+                &EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_NAME
+            },
+            Self::LinkMapSet => &LINK_MAP_SET_NAME,
+            Self::LinkMapGet => &LINK_MAP_GET_NAME,
+            Self::Unauthorized => &AUTH_UNAUTHORIZED_NAME,
+        }
+    }
 }
 
 impl fmt::Display for TransactionEventId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "{}", self.event_name())
     }
 }
 
@@ -105,81 +150,83 @@ impl TryFrom<EventId> for TransactionEventId {
     fn try_from(event_id: EventId) -> Result<Self, Self::Error> {
         let raw = event_id.as_felt().as_canonical_u64();
 
-        let name = EVENT_NAME_LUT.get(&raw).copied();
-
         match raw {
-            ACCOUNT_BEFORE_FOREIGN_LOAD => Ok(TransactionEventId::AccountBeforeForeignLoad),
+            ACCOUNT_BEFORE_FOREIGN_LOAD_ID => Ok(TransactionEventId::AccountBeforeForeignLoad),
 
-            ACCOUNT_VAULT_BEFORE_ADD_ASSET => Ok(TransactionEventId::AccountVaultBeforeAddAsset),
-            ACCOUNT_VAULT_AFTER_ADD_ASSET => Ok(TransactionEventId::AccountVaultAfterAddAsset),
+            ACCOUNT_VAULT_BEFORE_ADD_ASSET_ID => Ok(TransactionEventId::AccountVaultBeforeAddAsset),
+            ACCOUNT_VAULT_AFTER_ADD_ASSET_ID => Ok(TransactionEventId::AccountVaultAfterAddAsset),
 
-            ACCOUNT_VAULT_BEFORE_REMOVE_ASSET => {
+            ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_ID => {
                 Ok(TransactionEventId::AccountVaultBeforeRemoveAsset)
             },
-            ACCOUNT_VAULT_AFTER_REMOVE_ASSET => {
+            ACCOUNT_VAULT_AFTER_REMOVE_ASSET_ID => {
                 Ok(TransactionEventId::AccountVaultAfterRemoveAsset)
             },
 
-            ACCOUNT_VAULT_BEFORE_GET_ASSET => Ok(TransactionEventId::AccountVaultBeforeGetAsset),
+            ACCOUNT_VAULT_BEFORE_GET_ASSET_ID => Ok(TransactionEventId::AccountVaultBeforeGetAsset),
 
-            ACCOUNT_STORAGE_BEFORE_SET_ITEM => Ok(TransactionEventId::AccountStorageBeforeSetItem),
-            ACCOUNT_STORAGE_AFTER_SET_ITEM => Ok(TransactionEventId::AccountStorageAfterSetItem),
+            ACCOUNT_STORAGE_BEFORE_SET_ITEM_ID => {
+                Ok(TransactionEventId::AccountStorageBeforeSetItem)
+            },
+            ACCOUNT_STORAGE_AFTER_SET_ITEM_ID => Ok(TransactionEventId::AccountStorageAfterSetItem),
 
-            ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM => {
+            ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_ID => {
                 Ok(TransactionEventId::AccountStorageBeforeGetMapItem)
             },
 
-            ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM => {
+            ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_ID => {
                 Ok(TransactionEventId::AccountStorageBeforeSetMapItem)
             },
-            ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM => {
+            ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_ID => {
                 Ok(TransactionEventId::AccountStorageAfterSetMapItem)
             },
 
-            ACCOUNT_BEFORE_INCREMENT_NONCE => Ok(TransactionEventId::AccountBeforeIncrementNonce),
-            ACCOUNT_AFTER_INCREMENT_NONCE => Ok(TransactionEventId::AccountAfterIncrementNonce),
+            ACCOUNT_BEFORE_INCREMENT_NONCE_ID => {
+                Ok(TransactionEventId::AccountBeforeIncrementNonce)
+            },
+            ACCOUNT_AFTER_INCREMENT_NONCE_ID => Ok(TransactionEventId::AccountAfterIncrementNonce),
 
-            ACCOUNT_PUSH_PROCEDURE_INDEX => Ok(TransactionEventId::AccountPushProcedureIndex),
+            ACCOUNT_PUSH_PROCEDURE_INDEX_ID => Ok(TransactionEventId::AccountPushProcedureIndex),
 
-            NOTE_BEFORE_CREATED => Ok(TransactionEventId::NoteBeforeCreated),
-            NOTE_AFTER_CREATED => Ok(TransactionEventId::NoteAfterCreated),
+            NOTE_BEFORE_CREATED_ID => Ok(TransactionEventId::NoteBeforeCreated),
+            NOTE_AFTER_CREATED_ID => Ok(TransactionEventId::NoteAfterCreated),
 
-            NOTE_BEFORE_ADD_ASSET => Ok(TransactionEventId::NoteBeforeAddAsset),
-            NOTE_AFTER_ADD_ASSET => Ok(TransactionEventId::NoteAfterAddAsset),
+            NOTE_BEFORE_ADD_ASSET_ID => Ok(TransactionEventId::NoteBeforeAddAsset),
+            NOTE_AFTER_ADD_ASSET_ID => Ok(TransactionEventId::NoteAfterAddAsset),
 
-            NOTE_BEFORE_SET_ATTACHMENT => Ok(TransactionEventId::NoteBeforeSetAttachment),
+            NOTE_BEFORE_SET_ATTACHMENT_ID => Ok(TransactionEventId::NoteBeforeSetAttachment),
 
-            AUTH_REQUEST => Ok(TransactionEventId::AuthRequest),
+            AUTH_REQUEST_ID => Ok(TransactionEventId::AuthRequest),
 
-            PROLOGUE_START => Ok(TransactionEventId::PrologueStart),
-            PROLOGUE_END => Ok(TransactionEventId::PrologueEnd),
+            PROLOGUE_START_ID => Ok(TransactionEventId::PrologueStart),
+            PROLOGUE_END_ID => Ok(TransactionEventId::PrologueEnd),
 
-            NOTES_PROCESSING_START => Ok(TransactionEventId::NotesProcessingStart),
-            NOTES_PROCESSING_END => Ok(TransactionEventId::NotesProcessingEnd),
+            NOTES_PROCESSING_START_ID => Ok(TransactionEventId::NotesProcessingStart),
+            NOTES_PROCESSING_END_ID => Ok(TransactionEventId::NotesProcessingEnd),
 
-            NOTE_EXECUTION_START => Ok(TransactionEventId::NoteExecutionStart),
-            NOTE_EXECUTION_END => Ok(TransactionEventId::NoteExecutionEnd),
+            NOTE_EXECUTION_START_ID => Ok(TransactionEventId::NoteExecutionStart),
+            NOTE_EXECUTION_END_ID => Ok(TransactionEventId::NoteExecutionEnd),
 
-            TX_SCRIPT_PROCESSING_START => Ok(TransactionEventId::TxScriptProcessingStart),
-            TX_SCRIPT_PROCESSING_END => Ok(TransactionEventId::TxScriptProcessingEnd),
+            TX_SCRIPT_PROCESSING_START_ID => Ok(TransactionEventId::TxScriptProcessingStart),
+            TX_SCRIPT_PROCESSING_END_ID => Ok(TransactionEventId::TxScriptProcessingEnd),
 
-            EPILOGUE_START => Ok(TransactionEventId::EpilogueStart),
-            EPILOGUE_AUTH_PROC_START => Ok(TransactionEventId::EpilogueAuthProcStart),
-            EPILOGUE_AUTH_PROC_END => Ok(TransactionEventId::EpilogueAuthProcEnd),
-            EPILOGUE_AFTER_TX_CYCLES_OBTAINED => {
+            EPILOGUE_START_ID => Ok(TransactionEventId::EpilogueStart),
+            EPILOGUE_AUTH_PROC_START_ID => Ok(TransactionEventId::EpilogueAuthProcStart),
+            EPILOGUE_AUTH_PROC_END_ID => Ok(TransactionEventId::EpilogueAuthProcEnd),
+            EPILOGUE_AFTER_TX_CYCLES_OBTAINED_ID => {
                 Ok(TransactionEventId::EpilogueAfterTxCyclesObtained)
             },
-            EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT => {
+            EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_ID => {
                 Ok(TransactionEventId::EpilogueBeforeTxFeeRemovedFromAccount)
             },
-            EPILOGUE_END => Ok(TransactionEventId::EpilogueEnd),
+            EPILOGUE_END_ID => Ok(TransactionEventId::EpilogueEnd),
 
-            LINK_MAP_SET => Ok(TransactionEventId::LinkMapSet),
-            LINK_MAP_GET => Ok(TransactionEventId::LinkMapGet),
+            LINK_MAP_SET_ID => Ok(TransactionEventId::LinkMapSet),
+            LINK_MAP_GET_ID => Ok(TransactionEventId::LinkMapGet),
 
-            AUTH_UNAUTHORIZED => Ok(TransactionEventId::Unauthorized),
+            AUTH_UNAUTHORIZED_ID => Ok(TransactionEventId::Unauthorized),
 
-            _ => Err(TransactionEventError::InvalidTransactionEvent(event_id, name)),
+            _ => Err(TransactionEventError::InvalidTransactionEvent(event_id)),
         }
     }
 }

--- a/crates/miden-standards/asm/standards/faucets/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/mod.masm
@@ -198,7 +198,7 @@ pub proc burn
     # burn the asset
     # this ensures we only burn assets that were issued by this faucet (which implies they are
     # fungible)
-    exec.faucet::burn dropw
+    exec.faucet::burn
     # => [amount, pad(16)]
 
     # Subtract burnt amount from current token_supply in storage.

--- a/crates/miden-standards/src/testing/mock_account_code.rs
+++ b/crates/miden-standards/src/testing/mock_account_code.rs
@@ -15,10 +15,10 @@ const MOCK_FAUCET_CODE: &str = "
     end
 
     #! Inputs:  [ASSET_KEY, ASSET_VALUE, pad(8)]
-    #! Outputs: [ASSET_VALUE, pad(12)]
+    #! Outputs: [pad(16)]
     pub proc burn
         exec.faucet::burn
-        # => [ASSET_VALUE, pad(12)]
+        # => [pad(16)]
     end
 ";
 
@@ -113,10 +113,10 @@ const MOCK_ACCOUNT_CODE: &str = "
     end
 
     #! Inputs:  [ASSET_KEY, ASSET_VALUE, pad(8)]
-    #! Outputs: [ASSET_VALUE, pad(12)]
+    #! Outputs: [REMAINING_ASSET_VALUE, pad(12)]
     pub proc remove_asset
         exec.native_account::remove_asset
-        # => [ASSET_VALUE, pad(12)]
+        # => [REMAINING_ASSET_VALUE, pad(12)]
     end
 
     #! Inputs:  [pad(16)]

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use std::collections::BTreeMap;
@@ -1865,6 +1866,86 @@ async fn test_get_initial_map_item() -> anyhow::Result<()> {
     );
 
     tx_context.execute_code(&code).await.unwrap();
+
+    Ok(())
+}
+
+/// Tests that `get_initial_item` returns the original slot values and `get_item` returns updated
+/// values after modification, for all possible storage slot indices.
+#[tokio::test]
+async fn test_get_item_and_get_initial_item_for_all_slots() -> anyhow::Result<()> {
+    // Build storage slots for all valid indices.
+    let slots: Vec<StorageSlot> = (0..AccountStorage::MAX_NUM_STORAGE_SLOTS as u32)
+        .map(|index| {
+            StorageSlot::with_value(
+                StorageSlotName::mock(index as usize),
+                Word::from([0, 0, 0, index]),
+            )
+        })
+        .collect();
+
+    let account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(MockAccountComponent::with_slots(slots.clone()))
+        .build_existing()
+        .unwrap();
+
+    let tx_context = TransactionContextBuilder::new(account).build().unwrap();
+
+    // Build MASM code that, for each slot:
+    // 1. Sets a new value [index, 0, 0, 0]
+    // 2. Asserts get_initial_item returns the original value [0, 0, 0, index]
+    // 3. Asserts get_item returns the new value [index, 0, 0, 0]
+    let mut slot_constants = String::new();
+    let mut slot_operations = String::new();
+
+    for (index, slot) in slots.iter().enumerate() {
+        let slot_name = slot.name();
+        let initial_value = slot.value();
+        // Use a different format than the initial value (index at word position 0).
+        let new_value = Word::from([index as u32, 0, 0, 0]);
+        let const_name = format!("SLOT_{index}");
+
+        slot_constants.push_str(&format!("const {const_name} = word(\"{slot_name}\")\n"));
+
+        slot_operations.push_str(&format!(
+            r#"
+                # slot {index}: set new value
+                push.{new_value}
+                push.{const_name}[0..2]
+                call.mock_account::set_item dropw drop drop
+
+                # slot {index}: assert get_initial_item returns original value
+                push.{const_name}[0..2]
+                exec.account::get_initial_item
+                push.{initial_value}
+                assert_eqw.err="slot {index}: initial value mismatch"
+
+                # slot {index}: assert get_item returns the new value
+                push.{const_name}[0..2]
+                exec.account::get_item
+                push.{new_value}
+                assert_eqw.err="slot {index}: current value mismatch"
+            "#,
+        ));
+    }
+
+    let code = format!(
+        r#"
+        use $kernel::account
+        use $kernel::prologue
+        use mock::account->mock_account
+
+        {slot_constants}
+
+        begin
+            exec.prologue::prepare_transaction
+            {slot_operations}
+        end
+        "#,
+    );
+
+    tx_context.execute_code(&code).await?;
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -556,12 +556,15 @@ async fn non_fungible_asset_delta() -> anyhow::Result<()> {
         exec.util::create_default_note_with_moved_asset
         # => []
 
-        # remove and re-add asset 3
+        # remove asset 3
         push.{ASSET3_VALUE}
         push.{ASSET3_KEY}
         exec.remove_asset
-        # => [ASSET_VALUE]
+        # => [REMAINING_ASSET_VALUE]
+        dropw
 
+        # re-add asset 3
+        push.{ASSET3_VALUE}
         push.{ASSET3_KEY}
         # => [ASSET_KEY, ASSET_VALUE]
         exec.add_asset dropw

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -1,5 +1,4 @@
 use assert_matches::assert_matches;
-use miden_protocol::ONE;
 use miden_protocol::account::AccountId;
 use miden_protocol::asset::{
     Asset,
@@ -24,6 +23,7 @@ use miden_protocol::testing::account_id::{
 };
 use miden_protocol::testing::constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA};
 use miden_protocol::transaction::memory;
+use miden_protocol::{ONE, Word};
 
 use crate::executor::CodeExecutor;
 use crate::kernel_tests::tx::ExecutionOutputExt;
@@ -362,13 +362,10 @@ async fn test_remove_fungible_asset_success_no_balance_remaining() -> anyhow::Re
 
     let exec_output = &tx_context.execute_code(&code).await?;
 
-    assert_eq!(
-        exec_output.get_stack_word(0),
-        account_vault
-            .remove_asset(Asset::Fungible(remove_fungible_asset))
-            .unwrap()
-            .to_value_word()
-    );
+    let remaining = account_vault
+        .remove_asset(Asset::Fungible(remove_fungible_asset))?
+        .expect("fungible removal should return remaining asset");
+    assert_eq!(exec_output.get_stack_word(0), remaining.to_value_word());
 
     assert_eq!(
         exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
@@ -441,13 +438,10 @@ async fn test_remove_fungible_asset_success_balance_remaining() -> anyhow::Resul
 
     let exec_output = &tx_context.execute_code(&code).await?;
 
-    assert_eq!(
-        exec_output.get_stack_word(0),
-        account_vault
-            .remove_asset(Asset::Fungible(remove_fungible_asset))
-            .unwrap()
-            .to_value_word()
-    );
+    let remaining = account_vault
+        .remove_asset(Asset::Fungible(remove_fungible_asset))?
+        .expect("fungible removal should return remaining asset");
+    assert_eq!(exec_output.get_stack_word(0), remaining.to_value_word());
 
     assert_eq!(
         exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
@@ -533,10 +527,11 @@ async fn test_remove_non_fungible_asset_success() -> anyhow::Result<()> {
 
     let exec_output = &tx_context.execute_code(&code).await?;
 
-    assert_eq!(
-        exec_output.get_stack_word(0),
-        account_vault.remove_asset(non_fungible_asset).unwrap().to_value_word()
+    assert!(
+        account_vault.remove_asset(non_fungible_asset)?.is_none(),
+        "non-fungible removal should return None"
     );
+    assert_eq!(exec_output.get_stack_word(0), Word::default());
 
     assert_eq!(
         exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -400,10 +400,6 @@ async fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
             push.{FUNGIBLE_ASSET_KEY}
             call.mock_faucet::burn
 
-            # assert the correct asset is returned
-            push.{FUNGIBLE_ASSET_VALUE}
-            assert_eqw.err="burnt asset does not match expected asset"
-
             # assert the input vault has been updated
             exec.memory::get_input_vault_root_ptr
 
@@ -565,10 +561,7 @@ async fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
             push.{NON_FUNGIBLE_ASSET_VALUE}
             push.{NON_FUNGIBLE_ASSET_KEY}
             call.mock_faucet::burn
-
-            # assert the correct asset is returned
-            push.{NON_FUNGIBLE_ASSET_VALUE}
-            assert_eqw.err="burnt asset does not match expected asset"
+            dropw
 
             # assert the input vault has been updated and does not have the burnt asset
             exec.memory::get_input_vault_root_ptr

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -7,7 +7,7 @@ use miden_processor::event::EventError;
 use miden_processor::mast::MastForest;
 use miden_processor::{FutureMaybeSend, Host, ProcessorState};
 use miden_protocol::transaction::TransactionEventId;
-use miden_protocol::vm::EventId;
+use miden_protocol::vm::{EventId, EventName};
 use miden_protocol::{CoreLibrary, Word};
 use miden_tx::TransactionExecutorHost;
 use miden_tx::auth::UnreachableAuth;
@@ -113,5 +113,9 @@ impl<'store> Host for MockHost<'store> {
                 Ok(Vec::new())
             }
         }
+    }
+
+    fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
+        self.exec_host.resolve_event(event_id)
     }
 }

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -298,10 +298,7 @@ async fn prove_burning_fungible_asset_on_existing_faucet_succeeds() -> anyhow::R
             # => []
 
             call.::miden::standards::faucets::basic_fungible::burn
-            # => [ASSET_VALUE]
-
-            # truncate the stack
-            dropw
+            # => [pad(16)]
         end
         ";
 
@@ -364,10 +361,7 @@ async fn faucet_burn_fungible_asset_fails_amount_exceeds_token_supply() -> anyho
             # => []
 
             call.::miden::standards::faucets::basic_fungible::burn
-            # => [ASSET_VALUE]
-
-            # truncate the stack
-            dropw
+            # => [pad(16)]
         end
         ";
 

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -30,7 +30,7 @@ use miden_protocol::transaction::{
     TransactionAdviceInputs,
     TransactionSummary,
 };
-use miden_protocol::vm::AdviceMap;
+use miden_protocol::vm::{AdviceMap, EventId, EventName};
 use miden_protocol::{Felt, Hasher, Word};
 use miden_standards::note::StandardNote;
 
@@ -691,6 +691,10 @@ where
 
             result.map_err(EventError::from)
         }
+    }
+
+    fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
+        self.base_host.resolve_event(event_id)
     }
 }
 

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -11,7 +11,8 @@ pub use account_procedures::AccountProcedureIndexMap;
 
 pub(crate) mod note_builder;
 use miden_protocol::CoreLibrary;
-use miden_protocol::vm::EventId;
+use miden_protocol::transaction::TransactionEventId;
+use miden_protocol::vm::{EventId, EventName};
 use note_builder::OutputNoteBuilder;
 
 mod kernel_process;
@@ -273,6 +274,20 @@ impl<'store, STORE> TransactionBaseHost<'store, STORE> {
         } else {
             Ok(None)
         }
+    }
+
+    /// Resolves an [`EventId`] to its corresponding [`EventName`], if known.
+    ///
+    /// First checks if the event is a core library event, then checks if it is a transaction
+    /// kernel event.
+    pub fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
+        if let Some(name) = self.core_lib_handlers.resolve_event(event_id) {
+            return Some(name);
+        }
+
+        TransactionEventId::try_from(event_id)
+            .ok()
+            .map(|event_id| event_id.event_name())
     }
 
     /// Converts the provided signature into an advice mutation that pushes it onto the advice stack

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -10,6 +10,7 @@ use miden_protocol::account::{AccountDelta, PartialAccount};
 use miden_protocol::assembly::debuginfo::Location;
 use miden_protocol::assembly::{SourceFile, SourceSpan};
 use miden_protocol::transaction::{InputNote, InputNotes, RawOutputNote};
+use miden_protocol::vm::{EventId, EventName};
 
 use crate::host::{RecipientData, ScriptMastForestStore, TransactionBaseHost, TransactionEvent};
 use crate::{AccountProcedureIndexMap, TransactionKernelError};
@@ -87,6 +88,10 @@ where
     ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
         let result = self.on_event_sync(process);
         async move { result }
+    }
+
+    fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
+        self.base_host.resolve_event(event_id)
     }
 }
 

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -67,7 +67,7 @@ Native account procedures can be used to write to storage, add or remove assets 
 | `set_item`                     | Sets an item in the native account storage.<br/><br/>**Inputs:** `[slot_id_suffix, slot_id_prefix, VALUE]`<br/>**Outputs:** `[OLD_VALUE]`                                                                                                 | Native & Account |
 | `set_map_item`                 | Sets VALUE under the specified KEY within the map contained in the given native account storage slot.<br/><br/>**Inputs:** `[slot_id_suffix, slot_id_prefix, KEY, VALUE]`<br/>**Outputs:** `[OLD_VALUE]`                | Native & Account |
 | `add_asset`                    | Adds the specified asset to the vault. For fungible assets, returns the total after addition.<br/><br/>**Inputs:** `[ASSET_KEY, ASSET_VALUE]`<br/>**Outputs:** `[ASSET_VALUE']`                                                  | Native & Account |
-| `remove_asset`                 | Removes the specified asset from the vault.<br/><br/>**Inputs:** `[ASSET_KEY, ASSET_VALUE]`<br/>**Outputs:** `[ASSET_VALUE]`                                                                                                     | Native & Account |
+| `remove_asset`                 | Removes the specified asset from the vault and returns the remaining asset value.<br/><br/>**Inputs:** `[ASSET_KEY, ASSET_VALUE]`<br/>**Outputs:** `[REMAINING_ASSET_VALUE]`                                                                                                     | Native & Account |
 | `was_procedure_called`         | Returns 1 if a native account procedure was called during transaction execution, and 0 otherwise.<br/><br/>**Inputs:** `[PROC_ROOT]`<br/>**Outputs:** `[was_called]`                                                     | Any              |
 
 ## Active Note Procedures (`miden::protocol::active_note`)
@@ -153,7 +153,7 @@ Faucet procedures allow reading and writing to faucet accounts to mint and burn 
 | `create_fungible_asset`        | Creates a fungible asset for the faucet the transaction is being executed against.<br/><br/>**Inputs:** `[amount]`<br/>**Outputs:** `[ASSET_KEY, ASSET_VALUE]`                              | Faucet                    |
 | `create_non_fungible_asset`    | Creates a non-fungible asset for the faucet the transaction is being executed against.<br/><br/>**Inputs:** `[DATA_HASH]`<br/>**Outputs:** `[ASSET_KEY, ASSET_VALUE]`                       | Faucet                    |
 | `mint`                         | Mint an asset from the faucet the transaction is being executed against.<br/><br/>**Inputs:** `[ASSET_KEY, ASSET_VALUE]`<br/>**Outputs:** `[NEW_ASSET_VALUE]`                                         | Native & Account & Faucet |
-| `burn`                         | Burn an asset from the faucet the transaction is being executed against.<br/><br/>**Inputs:** `[ASSET_KEY, ASSET_VALUE]`<br/>**Outputs:** `[ASSET_VALUE]`                                         | Native & Account & Faucet |
+| `burn`                         | Burn an asset from the faucet the transaction is being executed against.<br/><br/>**Inputs:** `[ASSET_KEY, ASSET_VALUE]`<br/>**Outputs:** `[]`                                         | Native & Account & Faucet |
 | `has_callbacks`                | Returns whether the active account defines callbacks.<br/><br/>**Inputs:** `[]`<br/>**Outputs:** `[has_callbacks]`                                                                                | Any                       |
 
 ## Asset Procedures (`miden::protocol::asset`)


### PR DESCRIPTION
Needed because of the branch protection rules, can't push directly to `agglayer`.
As per https://github.com/0xMiden/protocol/pull/2645, the diff from the resulting branch against `next` cleanly shows only the agglayer-specific commits
