### PR TITLE
docs(agglayer): update the spec to latest code state

### DIFF
--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -12,12 +12,6 @@ implementation are called out inline with `TODO (Future)` markers.
 
 - *Word* = 4 field elements (felts), each < p (Goldilocks prime 2^64 - 2^32 + 1).
 - *Felt* = a single Goldilocks field element.
-- Word values in this spec use **element-index notation** matching Rust's
-  `Word::new([e0, e1, e2, e3])`. MASM stack operations preserve this order:
-  `get_item` pushes `[e0, e1, e2, e3]` onto the stack with `e0` on top.
-- Procedure input/output signatures use **stack notation** (top-first), matching the
-  MASM doc comments.
-- `TODO (Future)` marks non-implemented design points.
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates Sections 1-5 to match the current agglayer branch code after the `CLAIM` flow re-orientation and token registry migration
- `CLAIM` notes now target the bridge account (not the faucet); the bridge validates proofs, looks up faucets via token registry, and creates `MINT` notes
- Adds new `MINT` note type (Section 3.7), new bridge storage slots (`token_registry_map`, `claim_nullifiers`, `cgi_chain_hash`), and new faucet procedures (`mint_and_send`, `get_metadata_hash`, `get_scale`)
- Updates all rpo256 references to poseidon2


🤖 Generated with [Claude Code](https://claude.com/claude-code)