### PR TITLE
fix(agglayer): remove pub proc definition from internal procs

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -82,7 +82,7 @@ end
 #! - the GER is not found in storage.
 #!
 #! Invocation: exec
-pub proc assert_valid_ger
+proc assert_valid_ger
     # compute hash(GER)
     exec.poseidon2::merge
     # => [GER_HASH]
@@ -178,7 +178,7 @@ end
 #! - the faucet is not registered in the faucet registry.
 #!
 #! Invocation: exec
-pub proc assert_faucet_registered
+proc assert_faucet_registered
     # Build KEY = [0, 0, faucet_id_suffix, faucet_id_prefix]
     push.0.0
     # => [0, 0, faucet_id_suffix, faucet_id_prefix]
@@ -203,7 +203,7 @@ end
 #! - the token address is not registered in the token registry.
 #!
 #! Invocation: exec
-pub proc lookup_faucet_by_token_address
+proc lookup_faucet_by_token_address
     # Hash the token address
     exec.hash_token_address
     # => [TOKEN_ADDR_HASH]
@@ -261,7 +261,7 @@ end
 #! - the note sender does not match the bridge admin account ID.
 #!
 #! Invocation: exec
-pub proc assert_sender_is_bridge_admin
+proc assert_sender_is_bridge_admin
     push.BRIDGE_ADMIN_SLOT[0..2]
     exec.active_account::get_item
     # => [0, 0, admin_suffix, admin_prefix, pad(16)]
@@ -289,7 +289,7 @@ end
 #! - the note sender does not match the GER manager account ID.
 #!
 #! Invocation: exec
-pub proc assert_sender_is_ger_manager
+proc assert_sender_is_ger_manager
     push.GER_MANAGER_SLOT[0..2]
     exec.active_account::get_item
     # => [0, 0, mgr_suffix, mgr_prefix, pad(16)]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -457,6 +457,7 @@ proc write_address_to_memory(mem_ptr: MemoryAddress, address: EthereumAddressFor
     # => [mem_ptr+4, address(1)]
 
     mem_store
+    # => []
 end
 
 #! Computes the SERIAL_NUM of the outputted BURN note.

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -27,6 +27,7 @@ const PACKED_DATA_NUM_ELEMENTS = 29
 pub proc compute_leaf_value(leaf_data_start_ptr: MemoryAddress) -> DoubleWord
     dup
     # => [leaf_data_start_ptr, leaf_data_start_ptr]
+    
     exec.pack_leaf_data
     # => [leaf_data_start_ptr]
 

--- a/crates/miden-agglayer/asm/agglayer/common/utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/common/utils.masm
@@ -15,7 +15,7 @@ pub type EthereumAddressFormat = struct { a: felt, b: felt, c: felt, d: felt, e:
 #!
 #! Inputs:  [value]
 #! Outputs: [swapped]
-pub proc swap_u32_bytes
+proc swap_u32_bytes
     # part0 = (value & 0xFF) << 24
     dup u32and.0xFF u32shl.24
     # => [part0, value]
@@ -43,7 +43,7 @@ end
 #!
 #! Inputs:  [WORD_1, WORD_2, ptr]
 #! Outputs: [WORD_1, WORD_2, ptr]
-pub proc mem_store_double_word(
+proc mem_store_double_word(
     double_word_to_store: DoubleWord,
     mem_ptr: MemoryAddress
 ) -> (DoubleWord, MemoryAddress)
@@ -58,7 +58,7 @@ end
 #!
 #! Inputs:  [WORD_1, WORD_2, ptr]
 #! Outputs: []
-pub proc mem_store_double_word_unaligned(
+proc mem_store_double_word_unaligned(
     double_word_to_store: DoubleWord,
     mem_ptr: MemoryAddress
 )
@@ -86,7 +86,7 @@ end
 #!
 #! Inputs:  [ptr]
 #! Outputs: [WORD_1, WORD_2]
-pub proc mem_load_double_word(mem_ptr: MemoryAddress) -> DoubleWord
+proc mem_load_double_word(mem_ptr: MemoryAddress) -> DoubleWord
     padw dup.4 add.4 mem_loadw_le
     # => [WORD_2, ptr]
 


### PR DESCRIPTION
This PR removes `pub` definition from certain internal agglayer procedures. Removing `pub` definition from certain procedure definitions still results in all tests passing. 