### PR TITLE
fix(agglayer): fix incorrect stack comments

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -789,11 +789,11 @@ end
 proc build_mint_output_note
     # Step 1: Write all 18 MINT note storage items to global memory
     exec.write_mint_note_storage
-    # => [faucet_id_prefix, faucet_id_suffix]
+    # => [faucet_id_suffix, faucet_id_prefix]
 
     # Step 2: Build the MINT note recipient digest
     exec.build_mint_recipient
-    # => [MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
+    # => [MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]
 
     # Step 3: Create the output note and set the faucet attachment
     exec.create_mint_note_with_attachment
@@ -913,33 +913,33 @@ end
 #! Creates a public output note with no assets, and sets the attachment so only the
 #! target faucet can consume the note.
 #!
-#! Inputs:  [MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
+#! Inputs:  [MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]
 #! Outputs: []
 #!
 #! Invocation: exec
 proc create_mint_note_with_attachment
     # Create the MINT output note targeting the faucet
     push.OUTPUT_NOTE_TYPE_PUBLIC
-    # => [note_type, MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
+    # => [note_type, MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]
 
     # Set tag to DEFAULT
     push.DEFAULT_TAG
-    # => [note_type, MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
+    # => [tag, note_type, MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]
 
     # Create the output note (no assets - MINT notes carry no assets)
     exec.output_note::create
-    # => [note_idx, faucet_id_prefix, faucet_id_suffix]
+    # => [note_idx, faucet_id_suffix, faucet_id_prefix]
     
     movdn.2
-    # => [faucet_id_prefix, faucet_id_suffix, note_idx]
+    # => [faucet_id_suffix, faucet_id_prefix, note_idx]
 
     # Set the attachment on the MINT note to target the faucet account
     # NetworkAccountTarget attachment: targets the faucet so only it can consume the note
-    # network_account_target::new expects [prefix, suffix, exec_hint]
+    # network_account_target::new expects [suffix, prefix, exec_hint]
     # and returns [attachment_scheme, attachment_kind, ATTACHMENT]
     push.ALWAYS # exec_hint = ALWAYS
     movdn.2
-    # => [faucet_id_prefix, faucet_id_suffix, exec_hint, note_idx]
+    # => [faucet_id_suffix, faucet_id_prefix, exec_hint, note_idx]
 
     exec.network_account_target::new
     # => [attachment_scheme, attachment_kind, ATTACHMENT, note_idx]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -275,7 +275,7 @@ proc convert_asset
     # => [AMOUNT_U256_LO, AMOUNT_U256_HI, origin_addr(5), origin_network, pad(2), pad(1)]
 
     # drop the 2 trailing padding elements
-    repeat.2
+    repeat.3
         movup.14 drop
     end
     # => [AMOUNT_U256_LO, AMOUNT_U256_HI, origin_addr(5), origin_network]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -271,7 +271,7 @@ proc convert_asset
     exec.tx::execute_foreign_procedure
     # => [AMOUNT_U256_LO, AMOUNT_U256_HI, origin_addr(5), origin_network, pad(2), pad(1)]
 
-    # drop the 2 trailing padding elements
+    # drop the 3 trailing padding elements
     repeat.3
         movup.14 drop
     end

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -272,10 +272,10 @@ proc convert_asset
     # => [faucet_id_suffix, faucet_id_prefix, PROC_MAST_ROOT, amount, pad(15), pad(1)]
 
     exec.tx::execute_foreign_procedure
-    # => [AMOUNT_U256[0](4), AMOUNT_U256[1](4), origin_addr(5), origin_network, pad(2), pad(1)]
+    # => [AMOUNT_U256[0](4), AMOUNT_U256[1](4), origin_addr(5), origin_network, pad(2)]
 
-    # drop the 3 trailing padding elements
-    repeat.3
+    # drop the 2 trailing padding elements
+    repeat.2
         movup.14 drop
     end
     # => [AMOUNT_U256[0](4), AMOUNT_U256[1](4), origin_addr(5), origin_network]

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -100,11 +100,11 @@ pub proc pack_leaf_data(leaf_data_start_ptr: MemoryAddress)
 
         # compute source address for next element (counter + 1)
         dup.2 loc_load.PACKING_START_PTR_LOCAL add add.1
-        # => [next_src_addr, curr_lsb, curr_elem, counter]
+        # => [next_src_addr, curr_msb, curr_elem, counter]
 
         # load next element
         mem_load
-        # => [next_elem, curr_lsb, curr_elem, counter]
+        # => [next_elem, curr_msb, curr_elem, counter]
 
         # keep curr_msb on top for combination
         swap


### PR DESCRIPTION
This PR fixes incorrect stack comments found in `crates/miden-agglayer/asm/`.

## Summary:

## 1. `bridge_in.masm` — Missing `DEFAULT_TAG` after push

**Location:** [`create_mint_note_with_attachment`](crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm:925)

After `push.DEFAULT_TAG`, the comment omitted the newly pushed value:

```diff
  push.DEFAULT_TAG
- # => [note_type, MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]
+ # => [tag, note_type, MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]
```

---

## 2. `bridge_in.masm` — prefix/suffix order swapped in three procedures

**Location:** [`build_mint_output_note`](crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm:792), [`create_mint_note_with_attachment`](crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm:916)

Comments throughout the MINT note creation flow had `faucet_id_prefix` and `faucet_id_suffix` in the wrong order. The actual stack has `suffix` on top (matching `key_to_faucet_id`'s output), but comments said `prefix` was on top. This was as a result of the VM stack ordering update, these were just comments that didn't get updated.

```diff
  exec.write_mint_note_storage
- # => [faucet_id_prefix, faucet_id_suffix]
+ # => [faucet_id_suffix, faucet_id_prefix]

  exec.build_mint_recipient
- # => [MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
+ # => [MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]

- #! Inputs:  [MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
+ #! Inputs:  [MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]

- # network_account_target::new expects [prefix, suffix, exec_hint]
+ # network_account_target::new expects [suffix, prefix, exec_hint]
```

All downstream comments within `create_mint_note_with_attachment` were updated to match.

---

## 3. `leaf_utils.masm` — Variable name typo (`curr_lsb` → `curr_msb`)

**Location:** [`pack_leaf_data`](crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm:103)

The value at that stack position is the result of `u32shr.24`, which extracts the upper 8 bits (MSB) of the current u32 element. The existing comment on line 97 already describes this as "extract MSB (upper 8 bits)", and line 109 references it as `curr_msb`. The intermediate comments on lines 103 and 107 were inconsistent, using `curr_lsb` instead:

```diff
- # => [next_src_addr, curr_lsb, curr_elem, counter]
+ # => [next_src_addr, curr_msb, curr_elem, counter]

- # => [next_elem, curr_lsb, curr_elem, counter]
+ # => [next_elem, curr_msb, curr_elem, counter]
```

---

## 4. `bridge_out.masm` — Padding cleanup count

**Location:** [`convert_asset`](crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm:277)

The FPI call to `asset_to_origin_asset` returns `[U256(8), addr(5), origin_network, pad(2)]` — exactly 2 padding elements. The cleanup was corrected from `repeat.3` to `repeat.2` and the comment updated accordingly.
