### PR TITLE
chore: Rename `ProvenBatch::new` to `new_unchecked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.15.0 (TBD)
 
+### Changes
+
+- [BREAKING] Renamed `ProvenBatch::new` to `new_unchecked` ([#2687](https://github.com/0xMiden/miden-base/issues/2687)).
+
 ## 0.14.0 (2026-03-23)
 
 ### Features

--- a/crates/miden-protocol/src/batch/proven_batch.rs
+++ b/crates/miden-protocol/src/batch/proven_batch.rs
@@ -36,13 +36,16 @@ impl ProvenBatch {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a new [`ProvenBatch`] from the provided parts.
+    /// Creates a new [`ProvenBatch`] from the provided parts without checking any constraints
+    /// except the ones listed in the errors section below.
+    ///
+    /// This should essentially never be called by users.
     ///
     /// # Errors
     ///
     /// Returns an error if the batch expiration block number is not greater than the reference
     /// block number.
-    pub fn new(
+    pub fn new_unchecked(
         id: BatchId,
         reference_block_commitment: Word,
         reference_block_num: BlockNumber,
@@ -177,7 +180,7 @@ impl Deserializable for ProvenBatch {
         let batch_expiration_block_num = BlockNumber::read_from(source)?;
         let transactions = OrderedTransactionHeaders::read_from(source)?;
 
-        Self::new(
+        Self::new_unchecked(
             id,
             reference_block_commitment,
             reference_block_num,

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -74,7 +74,7 @@ impl LocalBatchProver {
             batch_expiration_block_num,
         ) = proposed_batch.into_parts();
 
-        ProvenBatch::new(
+        ProvenBatch::new_unchecked(
             id,
             block_header.commitment(),
             block_header.block_num(),


### PR DESCRIPTION
Renames `ProvenBatch::new` to `new_unchecked` because it does not guarantee that a valid batch is created. For example, it would happily accept duplicate output notes.