### PR TITLE
Agglayer modules format unification 

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -106,7 +106,7 @@ end
 #!
 #! 1. Writes `KEY -> [1, 0, 0, 0]` into the `faucet_registry` map, where
 #!    `KEY = [0, 0, faucet_id_suffix, faucet_id_prefix]`.
-#! 2. Writes `hash(tokenAddress[5]) -> [faucet_id_suffix, faucet_id_prefix, 0, 0]` into the 
+#! 2. Writes `hash(tokenAddress[5]) -> [faucet_id_suffix, faucet_id_prefix, 0, 0]` into the
 #!    `token_registry` map.
 #!
 #! Inputs:  [origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
@@ -131,14 +131,14 @@ pub proc register_faucet
     # set_map_item expects [slot_id(2), KEY, VALUE] and returns [OLD_VALUE].
     # Build KEY = [0, 0, suffix, prefix] and VALUE = [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0]
     push.0.0.0.IS_FAUCET_REGISTERED_FLAG
-    # => [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0, 
+    # => [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0,
     #     faucet_id_suffix, faucet_id_prefix, origin_token_addr(5),
     #     faucet_id_suffix, faucet_id_prefix, pad(9)]
 
     movup.5 movup.5 push.0.0
     # => [
-    #     [0, 0, faucet_id_suffix, faucet_id_prefix], 
-    #     [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0], 
+    #     [0, 0, faucet_id_suffix, faucet_id_prefix],
+    #     [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0],
     #      origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)
     #    ]
 
@@ -217,7 +217,7 @@ proc lookup_faucet_by_token_address
 
     # Assert the token is registered: faucet_id_prefix is always non-zero for valid account IDs.
     dup.3 dup.3 push.0.0
-    # => [0, 0, faucet_id_suffix, faucet_id_prefix, 0, 0, faucet_id_suffix, faucet_id_prefix] 
+    # => [0, 0, faucet_id_suffix, faucet_id_prefix, 0, 0, faucet_id_suffix, faucet_id_prefix]
 
     exec.account_id::is_equal
     # => [is_id_zero, 0, 0, faucet_id_suffix, faucet_id_prefix]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -8,40 +8,41 @@ use miden::protocol::native_account
 # =================================================================================================
 
 const ERR_GER_NOT_FOUND = "GER not found in storage"
-const ERR_FAUCET_NOT_REGISTERED="faucet is not registered in the bridge's faucet registry"
-const ERR_TOKEN_NOT_REGISTERED="token address is not registered in the bridge's token registry"
-const ERR_SENDER_NOT_BRIDGE_ADMIN="note sender is not the bridge admin"
-const ERR_SENDER_NOT_GER_MANAGER="note sender is not the global exit root manager"
+const ERR_FAUCET_NOT_REGISTERED = "faucet is not registered in the bridge's faucet registry"
+const ERR_TOKEN_NOT_REGISTERED = "token address is not registered in the bridge's token registry"
+const ERR_SENDER_NOT_BRIDGE_ADMIN = "note sender is not the bridge admin"
+const ERR_SENDER_NOT_GER_MANAGER = "note sender is not the global exit root manager"
 
 # CONSTANTS
 # =================================================================================================
 
 # Storage slots
-const BRIDGE_ADMIN_SLOT=word("agglayer::bridge::admin_account_id")
-const GER_MANAGER_SLOT=word("agglayer::bridge::ger_manager_account_id")
-const GER_MAP_STORAGE_SLOT=word("agglayer::bridge::ger_map")
-const FAUCET_REGISTRY_MAP_SLOT=word("agglayer::bridge::faucet_registry_map")
-const TOKEN_REGISTRY_MAP_SLOT=word("agglayer::bridge::token_registry_map")
+const BRIDGE_ADMIN_SLOT = word("agglayer::bridge::admin_account_id")
+const GER_MANAGER_SLOT = word("agglayer::bridge::ger_manager_account_id")
+const GER_MAP_STORAGE_SLOT = word("agglayer::bridge::ger_map")
+const FAUCET_REGISTRY_MAP_SLOT = word("agglayer::bridge::faucet_registry_map")
+const TOKEN_REGISTRY_MAP_SLOT = word("agglayer::bridge::token_registry_map")
 
 # Flags
-const GER_KNOWN_FLAG=1
-const IS_FAUCET_REGISTERED_FLAG=1
+const GER_KNOWN_FLAG = 1
+const IS_FAUCET_REGISTERED_FLAG = 1
 
 # Offset in the local memory of the `hash_token_address` procedure
-const TOKEN_ADDR_HASH_PTR=0
+const TOKEN_ADDR_HASH_PTR = 0
 
 # PUBLIC INTERFACE
 # =================================================================================================
 
 #! Updates the Global Exit Root (GER) in the bridge account storage.
 #!
-#! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and stores it in a map
-#! with value [GER_KNOWN_FLAG, 0, 0, 0] to indicate the GER is known.
-#!
-#! Panics if the note sender is not the global exit root manager.
+#! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and stores it in a map with value
+#! [GER_KNOWN_FLAG, 0, 0, 0] to indicate the GER is known.
 #!
 #! Inputs: [GER_LOWER[4], GER_UPPER[4], pad(8)]
 #! Outputs: [pad(16)]
+#!
+#! Panics if:
+#! - the note sender is not the global exit root manager.
 #!
 #! Invocation: call
 pub proc update_ger
@@ -72,8 +73,8 @@ end
 
 #! Asserts that the provided GER is valid (exists in storage).
 #!
-#! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and looks up the hash in
-#! the GER storage map. Panics if the GER has never been stored.
+#! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and looks up the hash in the GER
+#! storage map. Panics if the GER has never been stored.
 #!
 #! Inputs: [GER_ROOT[8]]
 #! Outputs: []
@@ -105,13 +106,14 @@ end
 #!
 #! 1. Writes `KEY -> [1, 0, 0, 0]` into the `faucet_registry` map, where
 #!    `KEY = [0, 0, faucet_id_suffix, faucet_id_prefix]`.
-#! 2. Writes `hash(tokenAddress[5]) -> [faucet_id_suffix, faucet_id_prefix, 0, 0]`
-#!    into the `token_registry` map.
-#!
-#! Panics if the note sender is not the bridge admin.
+#! 2. Writes `hash(tokenAddress[5]) -> [faucet_id_suffix, faucet_id_prefix, 0, 0]` into the 
+#!    `token_registry` map.
 #!
 #! Inputs:  [origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
 #! Outputs: [pad(16)]
+#!
+#! Panics if:
+#! - the note sender is not the bridge admin.
 #!
 #! Invocation: call
 pub proc register_faucet
@@ -121,19 +123,24 @@ pub proc register_faucet
 
     # Save faucet ID for later use in token_registry
     dup.6 dup.6
-    # => [faucet_id_suffix, faucet_id_prefix, origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
+    # => [faucet_id_suffix, faucet_id_prefix, origin_token_addr(5),
+    #     faucet_id_suffix, faucet_id_prefix, pad(9)]
 
     # --- 1. Register faucet in faucet_registry ---
+
     # set_map_item expects [slot_id(2), KEY, VALUE] and returns [OLD_VALUE].
     # Build KEY = [0, 0, suffix, prefix] and VALUE = [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0]
     push.0.0.0.IS_FAUCET_REGISTERED_FLAG
-    # => [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0, faucet_id_suffix, faucet_id_prefix, origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
+    # => [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0, 
+    #     faucet_id_suffix, faucet_id_prefix, origin_token_addr(5),
+    #     faucet_id_suffix, faucet_id_prefix, pad(9)]
 
-    movup.5 movup.5
-    # => [faucet_id_suffix, faucet_id_prefix, IS_FAUCET_REGISTERED_FLAG, 0, 0, 0, origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
-
-    push.0.0
-    # => [[0, 0, faucet_id_suffix, faucet_id_prefix], [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0], origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
+    movup.5 movup.5 push.0.0
+    # => [
+    #     [0, 0, faucet_id_suffix, faucet_id_prefix], 
+    #     [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0], 
+    #      origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)
+    #    ]
 
     push.FAUCET_REGISTRY_MAP_SLOT[0..2]
     exec.native_account::set_map_item
@@ -149,10 +156,7 @@ pub proc register_faucet
     # => [TOKEN_ADDR_HASH, faucet_id_suffix, faucet_id_prefix, pad(10)]
 
     # Build VALUE = [0, 0, faucet_id_suffix, faucet_id_prefix]
-    movup.5 movup.5
-    # => [faucet_id_suffix, faucet_id_prefix, TOKEN_ADDR_HASH, pad(10)]
-
-    push.0.0
+    movup.5 movup.5 push.0.0
     # => [0, 0, faucet_id_suffix, faucet_id_prefix, TOKEN_ADDR_HASH, pad(10)]
 
     swapw
@@ -168,8 +172,7 @@ end
 
 #! Asserts that a faucet is registered in the bridge's faucet registry.
 #!
-#! Looks up the faucet ID in the faucet registry map and asserts the registration
-#! flag is set.
+#! Looks up the faucet ID in the faucet registry map and asserts the registration flag is set.
 #!
 #! Inputs:  [faucet_id_suffix, faucet_id_prefix]
 #! Outputs: []
@@ -251,8 +254,8 @@ end
 
 #! Asserts that the note sender matches the bridge admin stored in account storage.
 #!
-#! Reads the bridge admin account ID from BRIDGE_ADMIN_SLOT and compares it against
-#! the sender of the currently executing note. Panics if they do not match.
+#! Reads the bridge admin account ID from BRIDGE_ADMIN_SLOT and compares it against the sender of
+#! the currently executing note.
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [pad(16)]
@@ -279,8 +282,8 @@ end
 
 #! Asserts that the note sender matches the global exit root manager stored in account storage.
 #!
-#! Reads the GER manager account ID from GER_MANAGER_SLOT and compares it against
-#! the sender of the currently executing note. Panics if they do not match.
+#! Reads the GER manager account ID from GER_MANAGER_SLOT and compares it against the sender of the
+#! currently executing note.
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [pad(16)]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -58,11 +58,6 @@ const CGI_CHAIN_HASH_HI_SLOT_NAME = word("agglayer::bridge::cgi_chain_hash_hi")
 const CLAIM_PROOF_DATA_WORD_LEN = 134
 const CLAIM_LEAF_DATA_WORD_LEN = 8
 
-#! Note storage layout (6 felts total):
-#! - destination_network [0]    : 1 felt
-#! - destination_address [1..5] : 5 felts
-
-
 # MINT note storage layout (public mode, 18 felts total):
 # - tag               [0]      : 1 felt
 # - amount            [1]      : 1 felt
@@ -164,11 +159,11 @@ const CLAIM_DEST_ID_SUFFIX_LOCAL = 1
 # PUBLIC INTERFACE
 # =================================================================================================
 
-#! Validates a claim against the AggLayer bridge and creates a MINT note for the Agglayer faucet.
+#! Validates a claim against the AggLayer bridge and creates a MINT note for the AggLayer faucet.
 #!
 #! This procedure is called by the CLAIM note script. It validates the Merkle proof and then
 #! looks up the faucet account ID from the token registry using the origin token address from
-#! the leaf data, and creates a MINT note targeting the Agglayer Faucet.
+#! the leaf data, and creates a MINT note targeting the AggLayer Faucet.
 #!
 #! The MINT note uses the standard MINT note pattern (public mode) with 18 storage items.
 #! See `write_mint_note_storage` for the full storage layout.
@@ -240,7 +235,7 @@ pub proc claim
     exec.verify_claim_amount
     # => [faucet_id_suffix, faucet_id_prefix, pad(16)]
     
-    # Build MINT output note targeting the aggfaucet
+    # Build MINT output note targeting the AggLayer faucet
     loc_load.CLAIM_DEST_ID_PREFIX_LOCAL loc_load.CLAIM_DEST_ID_SUFFIX_LOCAL
     # => [destination_id_suffix, destination_id_prefix, faucet_id_suffix, faucet_id_prefix, pad(16)]
 
@@ -798,10 +793,10 @@ proc load_origin_token_address
     # => [origin_token_addr(5)]
 end
 
-#! Builds a PUBLIC MINT output note targeting the Agglayer Faucet.
+#! Builds a PUBLIC MINT output note targeting the AggLayer Faucet.
 #!
-#! The MINT note uses public mode (18 storage items) so the AggFaucet creates a PUBLIC P2ID note on
-#! consumption. This procedure orchestrates three steps:
+#! The MINT note uses public mode (18 storage items) so the AggLayer Faucet creates a PUBLIC P2ID
+#! note on consumption. This procedure orchestrates three steps:
 #! 1. Write all 18 MINT note storage items to global memory.
 #! 2. Build the MINT note recipient digest from the storage.
 #! 3. Create the output note, and set the attachment.

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -58,10 +58,21 @@ const CGI_CHAIN_HASH_HI_SLOT_NAME = word("agglayer::bridge::cgi_chain_hash_hi")
 const CLAIM_PROOF_DATA_WORD_LEN = 134
 const CLAIM_LEAF_DATA_WORD_LEN = 8
 
-# MINT note storage layout (public mode, 18 items):
-# [0]: tag, [1]: amount, [2]: attachment_kind, [3]: attachment_scheme,
-# [4-7]: ATTACHMENT, [8-11]: P2ID_SCRIPT_ROOT, [12-15]: SERIAL_NUM,
-# [16]: account_id_suffix, [17]: account_id_prefix
+#! Note storage layout (6 felts total):
+#! - destination_network [0]    : 1 felt
+#! - destination_address [1..5] : 5 felts
+
+
+# MINT note storage layout (public mode, 18 felts total):
+# - tag               [0]      : 1 felt
+# - amount            [1]      : 1 felt
+# - attachment_kind   [2]      : 1 felt
+# - attachment_scheme [3]      : 1 felt
+# - ATTACHMENT        [4..7]   : 4 felts
+# - P2ID_SCRIPT_ROOT  [8..11]  : 4 felts
+# - SERIAL_NUM        [12..15] : 4 felts
+# - account_id_suffix [16]     : 1 felt
+# - account_id_prefix [17]     : 1 felt
 const MINT_NOTE_NUM_STORAGE_ITEMS = 18
 
 # P2ID output note constants
@@ -153,11 +164,11 @@ const CLAIM_DEST_ID_SUFFIX_LOCAL = 1
 # PUBLIC INTERFACE
 # =================================================================================================
 
-#! Validates a claim against the AggLayer bridge and creates a MINT note for the aggfaucet.
+#! Validates a claim against the AggLayer bridge and creates a MINT note for the Agglayer faucet.
 #!
 #! This procedure is called by the CLAIM note script. It validates the Merkle proof and then
 #! looks up the faucet account ID from the token registry using the origin token address from
-#! the leaf data, and creates a MINT note targeting the aggfaucet.
+#! the leaf data, and creates a MINT note targeting the Agglayer Faucet.
 #!
 #! The MINT note uses the standard MINT note pattern (public mode) with 18 storage items.
 #! See `write_mint_note_storage` for the full storage layout.
@@ -350,12 +361,13 @@ pub proc process_global_index_rollup
     repeat.5 
         assertz.err=ERR_LEADING_BITS_NON_ZERO
     end
+    # => [mainnet_flag_le, rollup_index_le, leaf_index_le]
 
     # the next element is the mainnet flag (LE-packed u32)
     # for a rollup deposit it must be exactly 0; zero is byte-order-independent,
     # so no swap is needed before asserting
-    # => [mainnet_flag_le, rollup_index_le, leaf_index_le]
     assertz.err=ERR_BRIDGE_NOT_ROLLUP
+    # => [rollup_index_le, leaf_index_le]
 
     # byte-swap rollup_index from LE to BE
     exec.utils::swap_u32_bytes
@@ -368,8 +380,8 @@ end
 
 #! Computes the Global Exit Tree (GET) root from the mainnet and rollup exit roots.
 #!
-#! The mainnet exit root is expected at `exit_roots_ptr` and
-#! the rollup exit root is expected at `exit_roots_ptr + 8`.
+#! The mainnet exit root is expected at `exit_roots_ptr` and the rollup exit root is expected at 
+#! `exit_roots_ptr + 8`.
 #!
 #! Inputs: [exit_roots_ptr]
 #! Outputs: [GER_ROOT[8]]
@@ -421,14 +433,14 @@ pub proc verify_merkle_proof(
     # => [verification_flag]
 end
 
-#! Verifies that the faucet_mint_amount matches the raw U256 amount from the leaf data,
-#! scaled down by the faucet's scale factor.
+#! Verifies that the faucet_mint_amount matches the raw U256 amount from the leaf data, scaled down
+#! by the faucet's scale factor.
 #!
 #! This procedure:
 #! 1. Performs an FPI call to the faucet's `get_scale` procedure to retrieve the scale factor.
 #! 2. Loads the raw U256 amount from the leaf data in memory.
-#! 3. Calls `verify_u256_to_native_amount_conversion` to assert that:
-#!        faucet_mint_amount == floor(raw_amount / 10^scale)
+#! 3. Calls `verify_u256_to_native_amount_conversion` to assert that
+#!    `faucet_mint_amount == floor(raw_amount / 10^scale)`.
 #!
 #! Inputs:  [faucet_id_suffix, faucet_id_prefix]
 #! Outputs: []
@@ -524,12 +536,15 @@ end
 #! Invocation: exec
 proc verify_leaf
     movupw.2
+    # => [PROOF_DATA_KEY, LEAF_VALUE[8]]
+
     # load proof data from the advice map into memory
     adv.push_mapval
     # => [PROOF_DATA_KEY, LEAF_VALUE[8]]
 
     push.SMT_PROOF_LOCAL_EXIT_ROOT_PTR push.CLAIM_PROOF_DATA_WORD_LEN
     exec.mem::pipe_preimage_to_memory drop
+    # => [LEAF_VALUE[8]]
 
     # 1. compute GER from mainnet + rollup exit roots
     push.EXIT_ROOTS_PTR
@@ -551,8 +566,8 @@ proc verify_leaf
     # [gi0, gi1, gi2, gi3, gi4, mainnet_flag_le, rollup_index_le, leaf_index_le]
     # gi0 is on top (position 0). The mainnet flag is at stack position 5.
 
-    # Duplicate the mainnet flag element, byte-swap from LE to BE,
-    # assert it is a valid boolean (0 or 1), then use it to branch.
+    # Duplicate the mainnet flag element, byte-swap from LE to BE, assert it is a valid boolean 
+    # (0 or 1), then use it to branch.
     dup.5 exec.utils::swap_u32_bytes dup
     # => [mainnet_flag, mainnet_flag, GLOBAL_INDEX[8], LEAF_VALUE[8]]
 
@@ -561,6 +576,7 @@ proc verify_leaf
 
     if.true
         # ==================== MAINNET DEPOSIT ====================
+
         exec.process_global_index_mainnet
         # => [leaf_index, LEAF_VALUE[8]]
 
@@ -588,8 +604,9 @@ proc verify_leaf
         # => []
     else
         # ==================== ROLLUP DEPOSIT ====================
-        # mainnet_flag = 0; extract rollup_index and leaf_index via helper,
-        # then do two-level verification
+
+        # mainnet_flag = 0; extract rollup_index and leaf_index via helper, then do two-level
+        # verification
         exec.process_global_index_rollup
         # => [leaf_index, rollup_index, LEAF_VALUE[8]]
 
@@ -646,8 +663,8 @@ proc verify_leaf
     # => []
 end
 
-#! Computes the claim nullifier as Poseidon2(leaf_index, source_bridge_network), then checks
-#! that the claim has not been spent and marks it as spent.
+#! Computes the claim nullifier as Poseidon2(leaf_index, source_bridge_network), then checks that
+#! the claim has not been spent and marks it as spent.
 #!
 #! This mimics the Solidity `_setAndCheckClaimed(leafIndex, sourceBridgeNetwork)` function.
 #! See: https://github.com/agglayer/agglayer-contracts/blob/60d06fc3224792ce55dc2690d66b6719a73398e7/contracts/v2/PolygonZkEVMBridgeV2.sol#L987
@@ -678,8 +695,8 @@ proc set_and_check_claimed
     # => []
 end
 
-#! Checks that the CLAIM note has not already been spent, and marks it as spent
-#! by storing [1, 0, 0, 0] in the CLAIM_NULLIFIERS_SLOT map.
+#! Checks that the CLAIM note has not already been spent, and marks it as spent by storing
+#! [1, 0, 0, 0] in the CLAIM_NULLIFIERS_SLOT map.
 #!
 #! The nullifier is computed as Poseidon2(leaf_index, source_bridge_network), which uniquely
 #! identifies a claim in the Global Exit Root (GER) as per the AggLayer protocol.
@@ -748,8 +765,12 @@ proc load_destination_address
     # => [address[5]]
 end
 
-# Inputs: []
-# Outputs: [U256_LO, U256_HI]
+#! Loads the claim note asset amount onto the stack from memory.
+#!
+#! Inputs:  []
+#! Outputs: [U256_LO, U256_HI]
+#!
+#! Invocation: exec
 proc load_raw_claim_amount
     mem_load.OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_7
     mem_load.OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_6
@@ -777,10 +798,10 @@ proc load_origin_token_address
     # => [origin_token_addr(5)]
 end
 
-#! Builds a PUBLIC MINT output note targeting the aggfaucet.
+#! Builds a PUBLIC MINT output note targeting the Agglayer Faucet.
 #!
-#! The MINT note uses public mode (18 storage items) so the AggFaucet creates
-#! a PUBLIC P2ID note on consumption. This procedure orchestrates three steps:
+#! The MINT note uses public mode (18 storage items) so the AggFaucet creates a PUBLIC P2ID note on
+#! consumption. This procedure orchestrates three steps:
 #! 1. Write all 18 MINT note storage items to global memory.
 #! 2. Build the MINT note recipient digest from the storage.
 #! 3. Create the output note, and set the attachment.
@@ -911,8 +932,8 @@ end
 
 #! Creates the MINT output note and sets the NetworkAccountTarget attachment on it.
 #!
-#! Creates a public output note with no assets, and sets the attachment so only the
-#! target faucet can consume the note.
+#! Creates a public output note with no assets, and sets the attachment so only the target faucet
+#! can consume the note.
 #!
 #! Inputs:  [MINT_RECIPIENT, faucet_id_prefix, faucet_id_suffix]
 #! Outputs: []

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -16,7 +16,7 @@ use agglayer::faucet -> agglayer_faucet
 use agglayer::bridge::bridge_config
 use agglayer::bridge::leaf_utils
 use agglayer::bridge::merkle_tree_frontier
-use agglayer::common::utils::EthereumAddressFormat
+use agglayer::common::eth_address::EthereumAddressFormat
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -10,9 +10,7 @@ use miden::standards::note_tag::DEFAULT_TAG
 use miden::standards::note::execution_hint::ALWAYS
 use miden::protocol::types::MemoryAddress
 use miden::protocol::output_note
-use miden::core::crypto::hashes::keccak256
 use miden::core::crypto::hashes::poseidon2
-use miden::core::word
 use agglayer::common::utils
 use agglayer::faucet -> agglayer_faucet
 use agglayer::bridge::bridge_config
@@ -224,9 +222,9 @@ end
 # HELPER PROCEDURES
 # =================================================================================================
 
-#! Validates that a faucet is registered in the bridge's faucet registry, then performs
-#! an FPI call to the faucet's `asset_to_origin_asset` procedure to obtain the scaled
-#! amount, origin token address, and origin network.
+#! Validates that a faucet is registered in the bridge's faucet registry, then performs an FPI call
+#! to the faucet's `asset_to_origin_asset` procedure to obtain the scaled amount, origin token
+#! address, and origin network.
 #!
 #! Inputs:  [ASSET_KEY, ASSET_VALUE]
 #! Outputs: [AMOUNT_U256_LO, AMOUNT_U256_HI, origin_addr(5), origin_network]
@@ -234,9 +232,9 @@ end
 #! Where:
 #! - ASSET_KEY is the vault key of the asset to be bridged out.
 #! - ASSET_VALUE is the value of the asset to be bridged out.
-#! - AMOUNT_U256: scaled amount as 8 u32 limbs (little-endian)
-#! - origin_addr: origin token address (5 u32 felts)
-#! - origin_network: origin network identifier
+#! - AMOUNT_U256: scaled amount as 8 u32 limbs (little-endian).
+#! - origin_addr: origin token address (5 u32 felts).
+#! - origin_network: origin network identifier.
 #!
 #! Panics if:
 #! - The faucet is not registered in the faucet registry.
@@ -250,9 +248,8 @@ proc convert_asset
         padw padw swapdw
     end
     # => [ASSET_KEY, ASSET_VALUE, pad(16)]
-    swapw
-    exec.asset::fungible_value_into_amount
-    movdn.4
+
+    swapw exec.asset::fungible_value_into_amount movdn.4
     # => [ASSET_KEY, amount, pad(16)]
 
     exec.asset::key_into_faucet_id
@@ -326,8 +323,8 @@ end
 
 #! Loads the LET (Local Exit Tree) frontier from account storage into memory.
 #!
-#! The num_leaves is read from its dedicated value slot, and the 32 frontier entries are read
-#! from the LET map slot (double-word array, indices 0..31). The data is placed into memory at
+#! The num_leaves is read from its dedicated value slot, and the 32 frontier entries are read from
+#! the LET map slot (double-word array, indices 0..31). The data is placed into memory at
 #! LET_FRONTIER_MEM_PTR, matching the layout expected by append_and_update_frontier:
 #! [num_leaves, 0, 0, 0, [[FRONTIER_NODE_LO, FRONTIER_NODE_HI]; 32]]
 #!
@@ -396,6 +393,7 @@ proc save_let_root_and_num_leaves
     # 3. Save new_leaf_count to its value slot as [new_leaf_count, 0, 0, 0]
     push.0.0.0 movup.3
     # => [new_leaf_count, 0, 0, 0]
+
     push.LET_NUM_LEAVES_SLOT[0..2]
     exec.native_account::set_item
     dropw
@@ -542,8 +540,7 @@ proc create_burn_note
     # => [note_idx, pad(15)]
 
     # duplicate note_idx: one for set_attachment, one for add_asset
-    dup
-    swapw loc_loadw_le.ATTACHMENT_LOC
+    dup swapw loc_loadw_le.ATTACHMENT_LOC
     # => [NOTE_ATTACHMENT, note_idx, note_idx, pad(11)]
 
     loc_load.ATTACHMENT_KIND_LOC

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -20,7 +20,7 @@ const PACKED_DATA_NUM_ELEMENTS = 29
 #! Given a memory address where the unpacked leaf data starts, packs the leaf data in-place, and
 #! computes the leaf value by hashing the packed bytes.
 #!
-#! Inputs:  [LEAF_DATA_START_PTR]
+#! Inputs:  [leaf_data_start_ptr]
 #! Outputs: [LEAF_VALUE[8]]
 #!
 #! Invocation: exec
@@ -40,17 +40,17 @@ end
 
 #! Packs the raw leaf data by shifting left 3 bytes to match Solidity's abi.encodePacked format.
 #!
-#! The raw data has leafType occupying 4 bytes (as a u32 felt) but Solidity's abi.encodePacked
-#! only uses 1 byte for uint8 leafType. This procedure shifts all data left by 3 bytes so that:
+#! The raw data has leafType occupying 4 bytes (as a u32 felt) but Solidity's abi.encodePacked only
+#! uses 1 byte for uint8 leafType. This procedure shifts all data left by 3 bytes so that:
 #! - Byte 0: leafType (1 byte)
 #! - Bytes 1-4: originNetwork (4 bytes)
 #! - etc.
 #!
 #! The Keccak precompile expects u32 values packed in little-endian byte order.
-#! For each packed element, we drop the leading 3 bytes and rebuild the u32 so that
-#! bytes [b0, b1, b2, b3] map to u32::from_le_bytes([b0, b1, b2, b3]).
-#! With little-endian input limbs, the first byte comes from the MSB of `curr` and
-#! the next three bytes come from the LSBs of `next`:
+#! For each packed element, we drop the leading 3 bytes and rebuild the u32 so that bytes
+#! [b0, b1, b2, b3] map to u32::from_le_bytes([b0, b1, b2, b3]).
+#! With little-endian input limbs, the first byte comes from the MSB of `curr` and the next three
+#! bytes come from the LSBs of `next`:
 #!   packed = ((curr >> 24) & 0xFF)
 #!          | (next & 0xFF) << 8
 #!          | ((next >> 8) & 0xFF) << 16
@@ -58,6 +58,7 @@ end
 #!
 #! To help visualize the packing process, consider that each field element represents a 4-byte
 #! value [u8; 4] (LE).
+#!
 #! Memory before is:
 #!   ptr+0:       1 felt: [a, b, c, d]
 #!   ptr+1:       1 felt: [e, f, g, h]

--- a/crates/miden-agglayer/asm/agglayer/common/eth_address.masm
+++ b/crates/miden-agglayer/asm/agglayer/common/eth_address.masm
@@ -2,6 +2,11 @@ use agglayer::common::utils
 use miden::core::crypto::hashes::keccak256
 use miden::core::word
 
+# TYPE ALIASES
+# =================================================================================================
+
+pub type EthereumAddressFormat = struct { a: felt, b: felt, c: felt, d: felt, e: felt }
+
 # ERRORS
 # =================================================================================================
 

--- a/crates/miden-agglayer/asm/agglayer/common/utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/common/utils.masm
@@ -3,11 +3,6 @@
 use miden::protocol::types::DoubleWord
 use miden::protocol::types::MemoryAddress
 
-# TYPE ALIASES
-# =================================================================================================
-
-pub type EthereumAddressFormat = struct { a: felt, b: felt, c: felt, d: felt, e: felt }
-
 # BYTE MANIPULATION
 # =================================================================================================
 

--- a/crates/miden-agglayer/asm/agglayer/faucet/mod.masm
+++ b/crates/miden-agglayer/asm/agglayer/faucet/mod.masm
@@ -1,11 +1,7 @@
 use miden::core::sys
 use agglayer::common::utils
 use agglayer::common::asset_conversion
-use agglayer::common::eth_address
 use miden::protocol::active_account
-use miden::protocol::active_note
-use miden::standards::faucets
-use miden::standards::faucets::network_fungible
 
 # CONSTANTS
 # =================================================================================================
@@ -26,8 +22,7 @@ const METADATA_HASH_HI_SLOT = word("agglayer::faucet::metadata_hash_hi")
 
 #! Returns the origin token address (5 felts) from faucet conversion storage.
 #!
-#! Reads conversion_info_1 (first 4 felts of address) and conversion_info_2 (5th felt)
-#! from storage.
+#! Reads conversion_info_1 (first 4 felts of address) and conversion_info_2 (5th felt) from storage.
 #!
 #! Inputs:  []
 #! Outputs: [addr0, addr1, addr2, addr3, addr4]
@@ -80,8 +75,8 @@ end
 
 #! Returns the pre-computed metadata hash (8 u32 felts) from faucet storage.
 #!
-#! The metadata hash is `keccak256(abi.encode(name, symbol, decimals))` and is stored
-#! across two value slots (lo and hi, 4 felts each).
+#! The metadata hash is `keccak256(abi.encode(name, symbol, decimals))` and is stored across two 
+#! value slots (lo and hi, 4 felts each).
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [METADATA_HASH_LO(4), METADATA_HASH_HI(4), pad(8)]
@@ -121,12 +116,12 @@ pub proc get_scale
     # => [scale, pad(15)]
 end
 
-#! Converts a native Miden asset amount to origin asset data using the stored
-#! conversion metadata (origin_token_address, origin_network, and scale).
+#! Converts a native Miden asset amount to origin asset data using the stored conversion metadata 
+#! (origin_token_address, origin_network, and scale).
 #!
 #! This procedure is intended to be called via FPI from the bridge account.
-#! It reads the faucet's conversion metadata from storage, scales the native amount
-#! to U256 format, and returns the result along with origin token address and network.
+#! It reads the faucet's conversion metadata from storage, scales the native amount to U256 format,
+#! and returns the result along with origin token address and network.
 #!
 #! Inputs:  [amount, pad(15)]
 #! Outputs: [AMOUNT_U256_LO, AMOUNT_U256_HI, addr0, addr1, addr2, addr3, addr4, origin_network, pad(2)]
@@ -142,9 +137,7 @@ pub proc asset_to_origin_asset
     # => [amount, pad(15)]
 
     # Step 1: Get scale from storage
-    exec.get_scale_inner
-    # => [scale, amount, pad(15)]
-    swap
+    exec.get_scale_inner swap
     # => [amount, scale, pad(15)]
 
     # Step 2: Scale amount to U256
@@ -170,6 +163,7 @@ pub proc asset_to_origin_asset
     # => [U256_LO, U256_HI, addr0, addr1, addr2, addr3, addr4, origin_network, pad(15)]
 
     exec.sys::truncate_stack
+    # => [U256_LO, U256_HI, addr0, addr1, addr2, addr3, addr4, origin_network, pad(2)]
 end
 
 #! Burns the fungible asset from the active note.
@@ -190,7 +184,7 @@ end
 #! Invocation: call
 pub use ::miden::standards::faucets::basic_fungible::burn
 
-#! Re-export the network fungible faucet's mint_and_send procedure.
+#! Re-export the network fungible faucet's `mint_and_send` procedure.
 #!
 #! See `miden::standards::faucets::network_fungible::mint_and_send` for more details.
 #!

--- a/crates/miden-agglayer/asm/note_scripts/CLAIM.masm
+++ b/crates/miden-agglayer/asm/note_scripts/CLAIM.masm
@@ -37,20 +37,20 @@ const ERR_CLAIM_TARGET_ACCT_MISMATCH = "CLAIM note attachment target account doe
 #! Outputs: [pad(16)]
 #!
 #! NoteStorage layout (569 felts total):
-#! - smtProofLocalExitRoot      [0..255]  : 256 felts
-#! - smtProofRollupExitRoot     [256..511]: 256 felts
-#! - globalIndex                [512..519]: 8 felts
-#! - mainnetExitRoot            [520..527]: 8 felts
-#! - rollupExitRoot             [528..535]: 8 felts
-#! - leafType                   [536]     : 1 felt
-#! - originNetwork              [537]     : 1 felt
-#! - originTokenAddress         [538..542]: 5 felts
-#! - destinationNetwork         [543]     : 1 felt
-#! - destinationAddress         [544..548]: 5 felts
-#! - amount                     [549..556]: 8 felts
-#! - metadata                   [557..564]: 8 felts
-#! - padding                    [565..567]: 3 felts
-#! - miden_claim_amount         [568]     : 1 felt
+#! - smtProofLocalExitRoot  [0..255]   : 256 felts
+#! - smtProofRollupExitRoot [256..511] : 256 felts
+#! - globalIndex            [512..519] : 8 felts
+#! - mainnetExitRoot        [520..527] : 8 felts
+#! - rollupExitRoot         [528..535] : 8 felts
+#! - leafType               [536]      : 1 felt
+#! - originNetwork          [537]      : 1 felt
+#! - originTokenAddress     [538..542] : 5 felts
+#! - destinationNetwork     [543]      : 1 felt
+#! - destinationAddress     [544..548] : 5 felts
+#! - amount                 [549..556] : 8 felts
+#! - metadata               [557..564] : 8 felts
+#! - padding                [565..567] : 3 felts
+#! - miden_claim_amount     [568]      : 1 felt
 #!
 #! Where:
 #! - smtProofLocalExitRoot: SMT proof for local exit root (bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH])

--- a/crates/miden-agglayer/asm/note_scripts/CONFIG_AGG_BRIDGE.masm
+++ b/crates/miden-agglayer/asm/note_scripts/CONFIG_AGG_BRIDGE.masm
@@ -31,13 +31,13 @@ const ERR_CONFIG_AGG_BRIDGE_TARGET_ACCOUNT_MISMATCH = "CONFIG_AGG_BRIDGE note at
 #! Outputs: [pad(16)]
 #!
 #! NoteStorage layout (7 felts total):
-#! - origin_token_addr_0 [0]: 1 felt
-#! - origin_token_addr_1 [1]: 1 felt
-#! - origin_token_addr_2 [2]: 1 felt
-#! - origin_token_addr_3 [3]: 1 felt
-#! - origin_token_addr_4 [4]: 1 felt
-#! - faucet_id_suffix    [5]: 1 felt
-#! - faucet_id_prefix    [6]: 1 felt
+#! - origin_token_addr_0 [0] : 1 felt
+#! - origin_token_addr_1 [1] : 1 felt
+#! - origin_token_addr_2 [2] : 1 felt
+#! - origin_token_addr_3 [3] : 1 felt
+#! - origin_token_addr_4 [4] : 1 felt
+#! - faucet_id_suffix    [5] : 1 felt
+#! - faucet_id_prefix    [6] : 1 felt
 #!
 #! Where:
 #! - faucet_id_suffix: Suffix felt of the faucet account ID to register.

--- a/crates/miden-agglayer/asm/note_scripts/CONFIG_AGG_BRIDGE.masm
+++ b/crates/miden-agglayer/asm/note_scripts/CONFIG_AGG_BRIDGE.masm
@@ -76,10 +76,10 @@ begin
 
     # Load remaining origin_token_addr_[0..3] onto the stack
     padw mem_loadw_le.ORIGIN_TOKEN_ADDR_0
-    # => [addr4, addr3, addr2, addr1, addr0, faucet_id_suffix, faucet_id_prefix, pad(13)]
+    # => [addr0, addr1, addr2, addr3, addr4, faucet_id_suffix, faucet_id_prefix, pad(13)]
 
     # Register the faucet in the bridge
-    # => [addr4, addr3, addr2, addr1, addr0, faucet_id_suffix, faucet_id_prefix, pad(9), pad(4)]
+    # => [addr0, addr1, addr2, addr3, addr4, faucet_id_suffix, faucet_id_prefix, pad(9), pad(4)]
     
     call.bridge_config::register_faucet
     # => [pad(16), pad(4)]

--- a/crates/miden-agglayer/asm/note_scripts/UPDATE_GER.masm
+++ b/crates/miden-agglayer/asm/note_scripts/UPDATE_GER.masm
@@ -32,8 +32,8 @@ const ERR_UPDATE_GER_TARGET_ACCOUNT_MISMATCH = "UPDATE_GER note attachment targe
 #! Outputs: [pad(16)]
 #!
 #! NoteStorage layout (8 felts total):
-#! - GER_LOWER [0..3]
-#! - GER_UPPER [4..7]
+#! - GER_LOWER [0..3] : 4 felts
+#! - GER_UPPER [4..7] : 4 felts
 #!
 #! Panics if:
 #! - account does not expose update_ger procedure.

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -116,7 +116,7 @@ static LET_NUM_LEAVES_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// - `update_ger`, which injects a new GER into the storage map.
 /// - `bridge_out`, which bridges an asset out of Miden to the destination network.
 /// - `claim`, which validates a claim against the AggLayer bridge and creates a MINT note for the
-///   AggFaucet.
+///   AggLayer Faucet.
 ///
 /// ## Storage Layout
 ///

--- a/crates/miden-agglayer/src/claim_note.rs
+++ b/crates/miden-agglayer/src/claim_note.rs
@@ -162,7 +162,7 @@ impl TryFrom<ClaimNoteStorage> for NoteStorage {
 // ================================================================================================
 
 /// Generates a CLAIM note - a note that instructs the bridge to validate a claim and create
-/// a MINT note for the aggfaucet.
+/// a MINT note for the AggLayer Faucet.
 ///
 /// # Parameters
 /// - `storage`: The core storage for creating the CLAIM note


### PR DESCRIPTION
This PR updates the format of bridge and faucet Agglayer `masm` modules. It also fixes the address order inconsistency in config note inline docs. No actual `masm` code was changed.

Closes: https://github.com/0xMiden/protocol/issues/2692