### PR TITLE
feat: implement saturating_sub for BlockNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [BREAKING] Renamed `ProvenBatch::new` to `new_unchecked` ([#2687](https://github.com/0xMiden/miden-base/issues/2687)).
 - Added shared `ProcedurePolicy` for AuthMultisig ([#2670](https://github.com/0xMiden/protocol/pull/2670)).
 - [BREAKING] Changed `NoteType` encoding from 2 bits to 1 and makes `NoteType::Private` the default ([#2691](https://github.com/0xMiden/miden-base/issues/2691)).
+- Added `BlockNumber::saturating_sub()` ([#2660](https://github.com/0xMiden/protocol/issues/2660)).
 ## 0.14.2 (2026-03-31)
 
 ### Changes

--- a/crates/miden-protocol/src/block/block_number.rs
+++ b/crates/miden-protocol/src/block/block_number.rs
@@ -72,6 +72,12 @@ impl BlockNumber {
     pub fn checked_sub(&self, rhs: u32) -> Option<Self> {
         self.0.checked_sub(rhs).map(Self)
     }
+
+    /// Saturating integer subtraction. Computes `self - rhs`, saturating at
+    /// [`BlockNumber::GENESIS`] instead of underflowing.
+    pub fn saturating_sub(&self, rhs: u32) -> Self {
+        Self(self.0.saturating_sub(rhs))
+    }
 }
 
 impl Add<u32> for BlockNumber {


### PR DESCRIPTION
Implements \saturating_sub\ for \BlockNumber\, complementing the existing \checked_sub\. Delegates to \u32::saturating_sub\, saturating at \BlockNumber::GENESIS\ on underflow.

Closes #2660