### PR TITLE
fix(docs): correct build_recipient advice map signature

### DIFF
--- a/crates/miden-protocol/asm/protocol/note.masm
+++ b/crates/miden-protocol/asm/protocol/note.masm
@@ -84,9 +84,6 @@ end
 #!
 #! Inputs:
 #!   Operand stack: [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT]
-#!   Advice map: {
-#!      STORAGE_COMMITMENT: [INPUTS],
-#!   }
 #! Outputs:
 #!   Operand stack: [RECIPIENT]
 #!   Advice map: {


### PR DESCRIPTION
The doc comment for \uild_recipient\ in \
ote.masm\ incorrectly listed \STORAGE_COMMITMENT: [INPUTS]\ as a required advice map input. However, the procedure computes the storage commitment itself via \compute_storage_commitment\ and inserts it into the advice map via \dv.insert_mem\, so callers do not need to supply it.

This removes the incorrect advice map input from the declared signature, matching the corrected signature confirmed by @PhilippGackstatter in the issue discussion.

Closes #2693