### PR TITLE
feat: add typed constructors for AuthSingleSig

### DIFF
--- a/crates/miden-protocol/src/account/auth.rs
+++ b/crates/miden-protocol/src/account/auth.rs
@@ -240,6 +240,12 @@ impl From<falcon512_poseidon2::PublicKey> for PublicKeyCommitment {
     }
 }
 
+impl From<ecdsa_k256_keccak::PublicKey> for PublicKeyCommitment {
+    fn from(value: ecdsa_k256_keccak::PublicKey) -> Self {
+        Self(value.to_commitment())
+    }
+}
+
 impl From<PublicKeyCommitment> for Word {
     fn from(value: PublicKeyCommitment) -> Self {
         value.0

--- a/crates/miden-standards/src/account/auth/singlesig.rs
+++ b/crates/miden-standards/src/account/auth/singlesig.rs
@@ -1,5 +1,5 @@
 use miden_protocol::Word;
-use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
+use miden_protocol::account::auth::{AuthScheme, PublicKey, PublicKeyCommitment};
 use miden_protocol::account::component::{
     AccountComponentMetadata,
     SchemaType,
@@ -7,6 +7,7 @@ use miden_protocol::account::component::{
     StorageSlotSchema,
 };
 use miden_protocol::account::{AccountComponent, AccountType, StorageSlot, StorageSlotName};
+use miden_protocol::crypto::dsa::{ecdsa_k256_keccak, falcon512_poseidon2};
 use miden_protocol::utils::sync::LazyLock;
 
 use crate::account::components::singlesig_library;
@@ -50,6 +51,36 @@ impl AuthSingleSig {
     /// Creates a new [`AuthSingleSig`] component with the given `public_key`.
     pub fn new(pub_key: PublicKeyCommitment, auth_scheme: AuthScheme) -> Self {
         Self { pub_key, auth_scheme }
+    }
+
+    /// Creates a new [`AuthSingleSig`] component using the Falcon512Poseidon2 signature scheme.
+    ///
+    /// The public key commitment is derived from the provided Falcon512 public key.
+    pub fn falcon512_poseidon2(pub_key: falcon512_poseidon2::PublicKey) -> Self {
+        Self {
+            pub_key: pub_key.into(),
+            auth_scheme: AuthScheme::Falcon512Poseidon2,
+        }
+    }
+
+    /// Creates a new [`AuthSingleSig`] component using the EcdsaK256Keccak signature scheme.
+    ///
+    /// The public key commitment is derived from the provided ECDSA K256 public key.
+    pub fn ecdsa_k256_keccak(pub_key: ecdsa_k256_keccak::PublicKey) -> Self {
+        Self {
+            pub_key: pub_key.into(),
+            auth_scheme: AuthScheme::EcdsaK256Keccak,
+        }
+    }
+
+    /// Creates a new [`AuthSingleSig`] component from a [`PublicKey`].
+    ///
+    /// The authentication scheme and public key commitment are derived from the provided key.
+    pub fn from_public_key(pub_key: PublicKey) -> Self {
+        Self {
+            auth_scheme: pub_key.auth_scheme(),
+            pub_key: pub_key.to_commitment(),
+        }
     }
 
     /// Returns the [`StorageSlotName`] where the public key is stored.


### PR DESCRIPTION
## Summary

Add scheme-specific constructors to `AuthSingleSig` that accept typed public keys directly, preventing mismatches between the key type and authentication scheme.

## Rationale

The existing `AuthSingleSig::new(pub_key_commitment, auth_scheme)` constructor takes a generic `PublicKeyCommitment` and a separate `AuthScheme`, which allows callers to accidentally pair an ECDSA key commitment with `AuthScheme::Falcon512Poseidon2` (or vice versa). Typed constructors eliminate this class of bug by deriving the scheme from the key type.

## Changes

**`crates/miden-standards/src/account/auth/singlesig.rs`:**
- `falcon512_poseidon2(pub_key)`: accepts a `falcon512_poseidon2::PublicKey` and creates the component with the correct scheme
- `ecdsa_k256_keccak(pub_key)`: accepts an `ecdsa_k256_keccak::PublicKey` and creates the component with the correct scheme
- `from_public_key(pub_key)`: accepts a `PublicKey` enum and extracts both the scheme and commitment

**`crates/miden-protocol/src/account/auth.rs`:**
- Add `From<ecdsa_k256_keccak::PublicKey> for PublicKeyCommitment` for parity with the existing Falcon512 conversion (required by the new constructors)

The existing `new()` constructor is preserved for backward compatibility.

## Test plan

- `cargo check -p miden-standards` and `cargo check -p miden-protocol` both pass
- Existing tests continue to pass since the original `new()` constructor is unchanged
- The new constructors are thin wrappers over `new()` with type-safe inputs

Closes #2537