### PR TITLE
perf(protocol): optimize AccountCode equality comparison

### DIFF
--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -231,8 +231,7 @@ impl AccountCode {
 
 impl PartialEq for AccountCode {
     fn eq(&self, other: &Self) -> bool {
-        // TODO: consider checking equality based only on the set of procedures
-        self.mast == other.mast && self.procedures == other.procedures
+        self.commitment == other.commitment && self.procedures == other.procedures
     }
 }
 


### PR DESCRIPTION
## Summary

Optimize the `PartialEq` implementation for `AccountCode` by comparing `commitment` and `procedures` instead of the full `MastForest`.

## Rationale

The existing implementation compares the entire `MastForest` (which can be large and expensive to compare) alongside the procedures list. Since the `commitment` is a sequential hash of all procedure MAST roots, two `AccountCode` instances with identical commitments and procedures are guaranteed to represent the same account interface. Comparing the `MastForest` is therefore redundant.

This resolves the TODO comment that was already in the code suggesting this change.

## Changes

**`crates/miden-protocol/src/account/code/mod.rs`:**
- Changed `PartialEq` to compare `self.commitment` and `self.procedures` instead of `self.mast` and `self.procedures`

## Test plan

- `cargo check -p miden-protocol` passes
- `cargo clippy -p miden-protocol -- -D warnings` passes
- The `Eq` impl is unchanged and still derived from the updated `PartialEq`
- The `Ord` impl already compares by `commitment` only, so ordering and equality are now aligned

Closes #2429