### PR TITLE
feat(protocol): implement proper Display for fungible and non-fungible assets

### DIFF
--- a/crates/miden-protocol/src/asset/fungible.rs
+++ b/crates/miden-protocol/src/asset/fungible.rs
@@ -233,8 +233,7 @@ impl From<FungibleAsset> for Asset {
 
 impl fmt::Display for FungibleAsset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Replace with hex representation?
-        write!(f, "{self:?}")
+        write!(f, "FungibleAsset {{ issuer: {}, amount: {} }}", self.faucet_id, self.amount)
     }
 }
 

--- a/crates/miden-protocol/src/asset/mod.rs
+++ b/crates/miden-protocol/src/asset/mod.rs
@@ -214,6 +214,15 @@ impl Asset {
     }
 }
 
+impl core::fmt::Display for Asset {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Asset::Fungible(asset) => asset.fmt(f),
+            Asset::NonFungible(asset) => asset.fmt(f),
+        }
+    }
+}
+
 // SERIALIZATION
 // ================================================================================================
 

--- a/crates/miden-protocol/src/asset/nonfungible.rs
+++ b/crates/miden-protocol/src/asset/nonfungible.rs
@@ -157,8 +157,7 @@ impl NonFungibleAsset {
 
 impl fmt::Display for NonFungibleAsset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Replace with hex representation?
-        write!(f, "{self:?}")
+        write!(f, "NonFungibleAsset {{ issuer: {}, value: {} }}", self.faucet_id, self.value)
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the `Display` implementations for `FungibleAsset`, `NonFungibleAsset`, and `Asset` that previously delegated to `Debug` with stable, user-readable representations.

## Rationale

The `Debug` representation is not stable across versions and should not be used for user-facing output (error messages, logs, etc.). The TODO comments in both files noted this needed fixing.

As suggested by @bobbinth in the original discussion, the Display output now shows the issuer (faucet ID) and amount/value in a readable format:

- `FungibleAsset`: `FungibleAsset { issuer: 0x..., amount: 1000 }`
- `NonFungibleAsset`: `NonFungibleAsset { issuer: 0x..., value: [f0, f1, f2, f3] }`
- `Asset` enum: delegates to the inner type

## Changes

**`crates/miden-protocol/src/asset/fungible.rs`:**
- Display shows `issuer` (faucet ID in hex) and `amount`

**`crates/miden-protocol/src/asset/nonfungible.rs`:**
- Display shows `issuer` (faucet ID in hex) and `value` (word representation)

**`crates/miden-protocol/src/asset/mod.rs`:**
- Added `Display` impl for the `Asset` enum, delegating to inner type

## Test plan

- `cargo check -p miden-protocol` passes
- `cargo clippy -p miden-protocol -- -D warnings` passes
- The output format uses the existing `Display` impls of `AccountId` (hex) and `Word`

Closes #2526