### PR TITLE
fix(protocol): correct build_recipient doc comment advice map signature

### DIFF
--- a/crates/miden-protocol/asm/protocol/note.masm
+++ b/crates/miden-protocol/asm/protocol/note.masm
@@ -84,9 +84,6 @@ end
 #!
 #! Inputs:
 #!   Operand stack: [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT]
-#!   Advice map: {
-#!      STORAGE_COMMITMENT: [INPUTS],
-#!   }
 #! Outputs:
 #!   Operand stack: [RECIPIENT]
 #!   Advice map: {


### PR DESCRIPTION
## Summary

Remove the incorrect advice map input declaration from the `build_recipient` procedure's doc comment.

## Problem

The doc comment for `build_recipient` in `note.masm` declared `STORAGE_COMMITMENT: [INPUTS]` as a required advice map input. However, the procedure computes the storage commitment internally via `compute_storage_commitment` and inserts it into the advice map itself using `adv.insert_mem`. The storage commitment does not need to be present in the advice map before calling this procedure.

## Fix

Removed the `Advice map` section from the inputs, keeping it only in the outputs where it correctly documents what the procedure produces:

\\\
Inputs:
  Operand stack: [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT]
Outputs:
  Operand stack: [RECIPIENT]
  Advice map: {
     STORAGE_COMMITMENT: [INPUTS],
     RECIPIENT: [SERIAL_SCRIPT_HASH, STORAGE_COMMITMENT],
     SERIAL_SCRIPT_HASH: [SERIAL_HASH, SCRIPT_ROOT],
     SERIAL_HASH: [SERIAL_NUM, EMPTY_WORD],
  }
\\\

This matches the corrected signature from the issue discussion.

Closes #2693