### PR TITLE
chore: bump the toolchain

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -38,6 +38,10 @@ runs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Install Rust 1.91 for cargo-msrv
+      shell: bash
+      run: rustup toolchain install 1.91
+
     - name: Cache cargo registry and git index
       uses: actions/cache@v4
       with:
@@ -60,12 +64,15 @@ runs:
 
     - name: Install cargo-msrv
       shell: bash
+      env:
+        RUSTUP_TOOLCHAIN: "1.91"
       run: cargo binstall --no-confirm --force cargo-msrv
 
-    # Keep your existing MSRV check
     # PATH export required for check-msrv.sh subprocess (see PR #2234)
     - name: Check MSRV
       shell: bash
+      env:
+        RUSTUP_TOOLCHAIN: "1.91"
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"
         chmod +x scripts/check-msrv.sh

--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -38,10 +38,6 @@ runs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Install Rust 1.91 for cargo-msrv
-      shell: bash
-      run: rustup toolchain install 1.91
-
     - name: Cache cargo registry and git index
       uses: actions/cache@v4
       with:
@@ -64,15 +60,12 @@ runs:
 
     - name: Install cargo-msrv
       shell: bash
-      env:
-        RUSTUP_TOOLCHAIN: "1.91"
       run: cargo binstall --no-confirm --force cargo-msrv
 
+    # Keep your existing MSRV check
     # PATH export required for check-msrv.sh subprocess (see PR #2234)
     - name: Check MSRV
       shell: bash
-      env:
-        RUSTUP_TOOLCHAIN: "1.91"
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"
         chmod +x scripts/check-msrv.sh

--- a/bin/bench-note-checker/src/lib.rs
+++ b/bin/bench-note-checker/src/lib.rs
@@ -81,8 +81,6 @@ pub fn setup_mixed_notes_benchmark(config: MixedNotesConfig) -> anyhow::Result<M
     let mut failing_notes = Vec::with_capacity(config.failing_note_count);
 
     for i in 0..config.failing_note_count {
-        let mut seed = [0u8; 32];
-        seed[0] = i as u8;
         let mut rng = RandomCoin::new([i as u32, 0, 0, 0].into());
         let failing_note = NoteBuilder::new(sender, &mut rng)
             .code("begin push.0 div end") // Division by zero - will fail.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "1.90"
+channel    = "1.94"
 components = ["clippy", "rust-src", "rustfmt"]
 profile    = "minimal"
 targets    = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This fixes the release dry-run job. See https://github.com/0xMiden/miden-vm/pull/2763 for the VM analog of what's fixed here.

cargo-msrv 0.19.3 requires rustc 1.91.1 or newer, but the set toolchain is distinct. Install the 1.91 toolchain and set `RUSTUP_TOOLCHAIN=1.91` on the cargo-msrv install and MSRV check steps so the tool can build and run.

