### PR TITLE
feat(asset): implement proper Display for FungibleAsset and NonFungibleAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added shared `ProcedurePolicy` for AuthMultisig ([#2670](https://github.com/0xMiden/protocol/pull/2670)).
 - [BREAKING] Changed `NoteType` encoding from 2 bits to 1 and makes `NoteType::Private` the default ([#2691](https://github.com/0xMiden/miden-base/issues/2691)).
 - Added `BlockNumber::saturating_sub()` ([#2660](https://github.com/0xMiden/protocol/issues/2660)).
+- Implemented proper `Display` for `FungibleAsset` and `NonFungibleAsset` ([#2526](https://github.com/0xMiden/protocol/issues/2526)).
 ## 0.14.2 (2026-03-31)
 
 ### Changes

--- a/crates/miden-protocol/src/asset/fungible.rs
+++ b/crates/miden-protocol/src/asset/fungible.rs
@@ -233,8 +233,7 @@ impl From<FungibleAsset> for Asset {
 
 impl fmt::Display for FungibleAsset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Replace with hex representation?
-        write!(f, "{self:?}")
+        write!(f, "FungibleAsset {{ issuer: {}, amount: {} }}", self.faucet_id, self.amount)
     }
 }
 

--- a/crates/miden-protocol/src/asset/nonfungible.rs
+++ b/crates/miden-protocol/src/asset/nonfungible.rs
@@ -157,8 +157,15 @@ impl NonFungibleAsset {
 
 impl fmt::Display for NonFungibleAsset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Replace with hex representation?
-        write!(f, "{self:?}")
+        write!(
+            f,
+            "NonFungibleAsset {{ issuer: {}, value: [{:#x}, {:#x}, {:#x}, {:#x}] }}",
+            self.faucet_id,
+            self.value[0].as_canonical_u64(),
+            self.value[1].as_canonical_u64(),
+            self.value[2].as_canonical_u64(),
+            self.value[3].as_canonical_u64(),
+        )
     }
 }
 


### PR DESCRIPTION
## Description

Replaces the Debug-delegating \Display\ implementations on \FungibleAsset\ and \NonFungibleAsset\ with stable, user-readable formats.

### FungibleAsset
\\\
FungibleAsset { issuer: 0x6d449e4034fadca075d1976fef7e38, amount: 100 }
\\\

### NonFungibleAsset
\\\
NonFungibleAsset { issuer: 0x6d449e4034fadca075d1976fef7e38, value: [0xabc, 0xdef, 0x123, 0x456] }
\\\

The previous implementation delegated to \Debug\ which is not a stable representation and should not be used for user-facing output.

Closes #2526