### PR TITLE
protocol: VM v0.22.1 compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.3 (unreleased)
+
+### Changes
+
+- Updated for compatibility with miden-vm v0.22.1 (`Arc<Library>` return types, `MastArtifact`/`PackageKind` removal) ([#2742](https://github.com/0xMiden/protocol/pull/2742)).
+
 ## 0.14.2 (2026-03-31)
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5322d00bef8b19f4cd3415da2533a87c8860c7d9b80043d6cce0f184b40c5fff"
+checksum = "d15646ebc95906b2a7cb66711d1e184f53fd6edc2605730bbcf0c2a129f792cf"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1558,24 +1569,26 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ece22da0cbf350e4a2939a07eaa3200445e42e47ce1b1ee6538723b6b40a4d4"
+checksum = "ae6013b3a390e0dcb29242f4480a7727965887bbf0903466c88f362b4cb20c0e"
 dependencies = [
  "env_logger",
  "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-mast-package",
+ "miden-package-registry",
+ "miden-project",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84a0e14ce66e76497a6771f3e360eb85557f2417ea22db279d54c1238ffafde"
+checksum = "996156b8f7c5fe6be17dea71089c6d7985c2dec1e3a4fec068b1dfc690e25df5"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1591,6 +1604,7 @@ dependencies = [
  "regex",
  "rustc_version 0.4.1",
  "semver 1.0.27",
+ "serde",
  "smallvec",
  "thiserror",
 ]
@@ -1605,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf4f5601b0d669aa125cce3bba4b98f2c8df729e2d53e66777429ac5f53e228"
+checksum = "fdec54a321cdf3d23e9ef615e91cb858038c6b4d4202507bdec048fc6d7763e4"
 dependencies = [
  "derive_more",
  "itertools 0.14.0",
@@ -1621,20 +1635,22 @@ dependencies = [
  "num-traits",
  "proptest",
  "proptest-derive",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82595fabb062315c32f6fc11c31755d3e5c6f8bc8c67d35154a067397d65b1de"
+checksum = "621e8fa911a790bcf3cd3aedce80bc10922a19d6181f08ff3ca078f955cff70b"
 dependencies = [
  "env_logger",
  "fs-err",
  "miden-assembly",
  "miden-core",
  "miden-crypto",
+ "miden-package-registry",
  "miden-processor",
  "miden-utils-sync",
  "thiserror",
@@ -1695,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ef08bafef275f0d6a15108108b3f6df6642772e0a1c05e102cb7e96841e888"
+checksum = "d6e50274d11c80b901cf6c90362de8c98c8c8ad6030c80624d683b63d899a0fb"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1740,14 +1756,15 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b24d09fda64e0751f943ac616643342b05a47d626e2ee0040b902eff3c924e"
+checksum = "bc8b2e3447fcde1f0e6b76e5219f129517639772cb02ca543177f0584e315288"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
+ "serde",
  "thiserror",
 ]
 
@@ -1788,10 +1805,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-processor"
-version = "0.22.0"
+name = "miden-package-registry"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba53ff06ef0affa0c3fb13e7e2ef5bde99f96eebcec8c360c6658050480ef676"
+checksum = "969ba3942052e52b3968e34dbd1c52c707e75777ee42ebdae2c8f57af56cf6cf"
+dependencies = [
+ "miden-assembly-syntax",
+ "miden-core",
+ "miden-mast-package",
+ "pubgrub",
+ "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec6cecbf22bd92b73a931ee80b424e46b8b7cdf4f2f3c364c25c5c15d2840da"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -1804,6 +1836,22 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "miden-project"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3840520c01881534fbbceb6b3687ec1c407fbaf310a35ce415fd3510abc52fdb"
+dependencies = [
+ "miden-assembly-syntax",
+ "miden-core",
+ "miden-mast-package",
+ "miden-package-registry",
+ "serde",
+ "serde-untagged",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -1854,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15462425359e87540d92e277cf1174a85a174ca433bd63d27286f65ab318f2d4"
+checksum = "6bb2c94e36f57684d7fa0cd382adeedc1728d502dbbe69ad1c12f4a931f45511"
 dependencies = [
  "bincode",
  "miden-air",
@@ -1983,6 +2031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46cec00c8cf32ec46df7542fb9ea15fbe7a5149920ef97776a4f4bc3a563e8de"
 dependencies = [
  "miden-crypto",
+ "serde",
  "thiserror",
 ]
 
@@ -2000,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997c842047ffa2d011eb65bf638a3135b2d52bce5b20770fcc6040f1b48c624a"
+checksum = "c4580df640d889c9f3c349cd2268968e44a99a8cf0df6c36ae5b1fb273712b00"
 dependencies = [
  "bincode",
  "miden-air",
@@ -2703,6 +2752,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,6 +2826,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pubgrub"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
+dependencies = [
+ "indexmap",
+ "log",
+ "priority-queue",
+ "rustc-hash",
+ "thiserror",
+ "version-ranges",
 ]
 
 [[package]]
@@ -3137,6 +3211,18 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
@@ -3700,6 +3786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,6 +3882,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version_check"

--- a/crates/miden-agglayer/build.rs
+++ b/crates/miden-agglayer/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fmt::Write;
 use std::path::Path;
+use std::sync::Arc;
 
 use fs_err as fs;
 use miden_assembly::diagnostics::{IntoDiagnostic, NamedSource, Result, WrapErr};
@@ -117,7 +118,7 @@ fn compile_agglayer_lib(
     let output_file = target_dir.join("agglayer").with_extension(Library::LIBRARY_EXTENSION);
     agglayer_lib.write_to_file(output_file).into_diagnostic()?;
 
-    Ok(agglayer_lib)
+    Ok(Arc::unwrap_or_clone(agglayer_lib))
 }
 
 // COMPILE EXECUTABLE MODULES
@@ -206,7 +207,7 @@ fn compile_account_components(
             target_dir.join(&component_name).with_extension(Library::LIBRARY_EXTENSION);
         component_library.write_to_file(&component_file_path).into_diagnostic()?;
 
-        component_libraries.push((component_name, component_library));
+        component_libraries.push((component_name, Arc::unwrap_or_clone(component_library)));
     }
 
     Ok(component_libraries)

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -168,7 +168,7 @@ fn compile_tx_kernel(source_dir: &Path, target_dir: &Path, build_dir: &str) -> R
 
         let masb_file_path =
             target_dir.join("kernel_library").with_extension(Library::LIBRARY_EXTENSION);
-        test_lib.write_to_file(masb_file_path).into_diagnostic()?;
+        (*test_lib).write_to_file(masb_file_path).into_diagnostic()?;
     }
 
     Ok(assembler)
@@ -284,7 +284,7 @@ fn compile_protocol_lib(
     let output_file = target_dir.join("protocol").with_extension(Library::LIBRARY_EXTENSION);
     protocol_lib.write_to_file(output_file).into_diagnostic()?;
 
-    Ok(protocol_lib)
+    Ok(Arc::unwrap_or_clone(protocol_lib))
 }
 
 // HELPER FUNCTIONS

--- a/crates/miden-protocol/src/account/builder/mod.rs
+++ b/crates/miden-protocol/src/account/builder/mod.rs
@@ -289,7 +289,7 @@ impl AccountBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::LazyLock;
+    use std::sync::{Arc, LazyLock};
 
     use assert_matches::assert_matches;
     use miden_assembly::{Assembler, Library};
@@ -312,14 +312,18 @@ mod tests {
           ";
 
     static CUSTOM_LIBRARY1: LazyLock<Library> = LazyLock::new(|| {
-        Assembler::default()
-            .assemble_library([CUSTOM_CODE1])
-            .expect("code should be valid")
+        Arc::unwrap_or_clone(
+            Assembler::default()
+                .assemble_library([CUSTOM_CODE1])
+                .expect("code should be valid"),
+        )
     });
     static CUSTOM_LIBRARY2: LazyLock<Library> = LazyLock::new(|| {
-        Assembler::default()
-            .assemble_library([CUSTOM_CODE2])
-            .expect("code should be valid")
+        Arc::unwrap_or_clone(
+            Assembler::default()
+                .assemble_library([CUSTOM_CODE2])
+                .expect("code should be valid"),
+        )
     });
 
     static CUSTOM_COMPONENT1_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -407,6 +407,8 @@ pub(crate) fn procedures_as_elements(procedures: &[AccountProcedureRoot]) -> Vec
 #[cfg(test)]
 mod tests {
 
+    use alloc::sync::Arc;
+
     use assert_matches::assert_matches;
     use miden_assembly::Assembler;
 
@@ -446,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_account_code_no_auth_component() {
-        let library = Assembler::default().assemble_library([CODE]).unwrap();
+        let library = Arc::unwrap_or_clone(Assembler::default().assemble_library([CODE]).unwrap());
         let metadata = AccountComponentMetadata::new("test::no_auth", AccountType::all());
         let component = AccountComponent::new(library, vec![], metadata).unwrap();
 
@@ -484,7 +486,9 @@ mod tests {
             end
         ";
 
-        let library = Assembler::default().assemble_library([code_with_multiple_auth]).unwrap();
+        let library = Arc::unwrap_or_clone(
+            Assembler::default().assemble_library([code_with_multiple_auth]).unwrap(),
+        );
         let metadata = AccountComponentMetadata::new("test::multiple_auth", AccountType::all());
         let component = AccountComponent::new(library, vec![], metadata).unwrap();
 

--- a/crates/miden-protocol/src/account/component/code.rs
+++ b/crates/miden-protocol/src/account/component/code.rs
@@ -84,6 +84,8 @@ impl From<AccountComponentCode> for Library {
 
 #[cfg(test)]
 mod tests {
+    use alloc::sync::Arc;
+
     use miden_core::{Felt, Word};
 
     use super::*;
@@ -92,9 +94,11 @@ mod tests {
     #[test]
     fn test_account_component_code_with_advice_map() {
         let assembler = Assembler::default();
-        let library = assembler
-            .assemble_library(["pub proc test nop end"])
-            .expect("failed to assemble library");
+        let library = Arc::unwrap_or_clone(
+            assembler
+                .assemble_library(["pub proc test nop end"])
+                .expect("failed to assemble library"),
+        );
         let component_code = AccountComponentCode::from(library);
 
         assert!(component_code.mast_forest().advice_map().is_empty());

--- a/crates/miden-protocol/src/account/component/mod.rs
+++ b/crates/miden-protocol/src/account/component/mod.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
-use miden_mast_package::{MastArtifact, Package};
+use miden_mast_package::Package;
 use miden_processor::mast::MastNodeExt;
 
 mod metadata;
@@ -104,14 +104,7 @@ impl AccountComponent {
         init_storage_data: &InitStorageData,
     ) -> Result<Self, AccountError> {
         let metadata = AccountComponentMetadata::try_from(package)?;
-        let library = match &package.mast {
-            MastArtifact::Library(library) => library.as_ref().clone(),
-            MastArtifact::Executable(_) => {
-                return Err(AccountError::other(
-                    "expected Package to contain a library, but got an executable",
-                ));
-            },
-        };
+        let library = package.mast.as_ref().clone();
 
         let component_code = AccountComponentCode::from(library);
         Self::from_library(&component_code, &metadata, init_storage_data)
@@ -235,14 +228,7 @@ mod tests {
     use alloc::sync::Arc;
 
     use miden_assembly::Assembler;
-    use miden_mast_package::{
-        MastArtifact,
-        Package,
-        PackageKind,
-        PackageManifest,
-        Section,
-        SectionId,
-    };
+    use miden_mast_package::{Package, PackageManifest, Section, SectionId, TargetType};
     use semver::Version;
 
     use super::*;
@@ -264,15 +250,15 @@ mod tests {
 
         let metadata_bytes = metadata.to_bytes();
         let package_with_metadata = Package {
-            name: "test_package".to_string(),
-            mast: MastArtifact::Library(Arc::new(library.clone())),
-            manifest: PackageManifest::new(None),
-            kind: PackageKind::AccountComponent,
+            name: "test_package".into(),
+            mast: library.clone(),
+            manifest: PackageManifest::new(core::iter::empty()).unwrap(),
+            kind: TargetType::AccountComponent,
             sections: vec![Section::new(
                 SectionId::ACCOUNT_COMPONENT_METADATA,
                 metadata_bytes.clone(),
             )],
-            version: Default::default(),
+            version: Version::new(0, 0, 0),
             description: None,
         };
 
@@ -287,12 +273,12 @@ mod tests {
 
         // Test without metadata - should fail
         let package_without_metadata = Package {
-            name: "test_package_no_metadata".to_string(),
-            mast: MastArtifact::Library(Arc::new(library)),
-            manifest: PackageManifest::new(None),
-            kind: PackageKind::AccountComponent,
+            name: "test_package_no_metadata".into(),
+            mast: library,
+            manifest: PackageManifest::new(core::iter::empty()).unwrap(),
+            kind: TargetType::AccountComponent,
             sections: vec![], // No metadata section
-            version: Default::default(),
+            version: Version::new(0, 0, 0),
             description: None,
         };
 
@@ -306,7 +292,7 @@ mod tests {
     fn test_from_library_with_init_data() {
         // Create a simple library for testing
         let library = Assembler::default().assemble_library([CODE]).unwrap();
-        let component_code = AccountComponentCode::from(library.clone());
+        let component_code = AccountComponentCode::from(Arc::unwrap_or_clone(library.clone()));
 
         // Create metadata for the component
         let metadata = AccountComponentMetadata::new("test_component", AccountType::regular())
@@ -327,12 +313,12 @@ mod tests {
 
         // Test without metadata - should fail
         let package_without_metadata = Package {
-            name: "test_package_no_metadata".to_string(),
-            mast: MastArtifact::Library(Arc::new(library)),
-            kind: PackageKind::AccountComponent,
-            manifest: PackageManifest::new(None),
+            name: "test_package_no_metadata".into(),
+            mast: library,
+            kind: TargetType::AccountComponent,
+            manifest: PackageManifest::new(core::iter::empty()).unwrap(),
             sections: vec![], // No metadata section
-            version: Default::default(),
+            version: Version::new(0, 0, 0),
             description: None,
         };
 

--- a/crates/miden-protocol/src/account/mod.rs
+++ b/crates/miden-protocol/src/account/mod.rs
@@ -549,6 +549,7 @@ fn validate_components_support_account_type(
 
 #[cfg(test)]
 mod tests {
+    use alloc::sync::Arc;
     use alloc::vec::Vec;
 
     use assert_matches::assert_matches;
@@ -800,7 +801,8 @@ mod tests {
     #[test]
     fn test_account_unsupported_component_type() {
         let code1 = "pub proc foo add end";
-        let library1 = Assembler::default().assemble_library([code1]).unwrap();
+        let library1 =
+            Arc::unwrap_or_clone(Assembler::default().assemble_library([code1]).unwrap());
 
         // This component support all account types except the regular account with updatable code.
         let metadata = AccountComponentMetadata::new(

--- a/crates/miden-protocol/src/lib.rs
+++ b/crates/miden-protocol/src/lib.rs
@@ -84,14 +84,13 @@ pub mod vm {
     pub use miden_core::events::{EventId, EventName, SystemEvent};
     pub use miden_core::program::{Program, ProgramInfo};
     pub use miden_mast_package::{
-        MastArtifact,
         Package,
         PackageExport,
-        PackageKind,
         PackageManifest,
         ProcedureExport,
         Section,
         SectionId,
+        TargetType,
     };
     pub use miden_processor::trace::RowIndex;
     pub use miden_processor::{FutureMaybeSend, StackInputs, StackOutputs};

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -5,7 +5,7 @@ use core::fmt::Display;
 use core::num::TryFromIntError;
 
 use miden_core::mast::MastNodeExt;
-use miden_mast_package::{MastArtifact, Package};
+use miden_mast_package::Package;
 
 use super::Felt;
 use crate::assembly::mast::{ExternalNodeBuilder, MastForest, MastForestContributor, MastNodeId};
@@ -142,12 +142,6 @@ impl NoteScript {
 
     /// Creates an [`NoteScript`] from a [`Package`].
     ///
-    /// # Arguments
-    ///
-    /// * `package` - The package containing the
-    ///   [`Executable`](miden_mast_package::MastArtifact::Executable) or
-    ///   [`Library`](miden_mast_package::MastArtifact::Library).
-    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -156,17 +150,7 @@ impl NoteScript {
     /// - The package contains a library which contains multiple procedures with the `@note_script`
     ///   attribute.
     pub fn from_package(package: &Package) -> Result<Self, NoteError> {
-        match &package.mast {
-            // `NoteScript`s are compiled as executables by the miden compiler's
-            // cargo extension. Source, the "midenc_flags_from_target" function:
-            // https://github.com/0xMiden/compiler/blob/d3cd8cd4a2c1dfeae8a61643aa42734a35e3e840/tools/cargo-miden/src/commands/build.rs#L334
-            MastArtifact::Executable(executable) => {
-                let program = executable.as_ref().clone();
-
-                Ok(NoteScript::new(program))
-            },
-            MastArtifact::Library(library) => Ok(NoteScript::from_library(library))?,
-        }
+        Ok(NoteScript::from_library(&package.mast))?
     }
 
     // PUBLIC ACCESSORS

--- a/crates/miden-protocol/src/testing/account_code.rs
+++ b/crates/miden-protocol/src/testing/account_code.rs
@@ -1,6 +1,8 @@
 // ACCOUNT CODE
 // ================================================================================================
 
+use alloc::sync::Arc;
+
 use miden_assembly::Assembler;
 
 use crate::account::component::AccountComponentMetadata;
@@ -20,9 +22,11 @@ pub const CODE: &str = "
 impl AccountCode {
     /// Creates a mock [AccountCode] with default assembler and mock code
     pub fn mock() -> AccountCode {
-        let library = Assembler::default()
-            .assemble_library([CODE])
-            .expect("mock account component should assemble");
+        let library = Arc::unwrap_or_clone(
+            Assembler::default()
+                .assemble_library([CODE])
+                .expect("mock account component should assemble"),
+        );
         let metadata = AccountComponentMetadata::new("miden::testing::mock", AccountType::all());
         let component = AccountComponent::new(library, vec![], metadata).unwrap();
 

--- a/crates/miden-protocol/src/testing/add_component.rs
+++ b/crates/miden-protocol/src/testing/add_component.rs
@@ -1,3 +1,5 @@
+use alloc::sync::Arc;
+
 use crate::account::component::AccountComponentMetadata;
 use crate::account::{AccountComponent, AccountType};
 use crate::assembly::{Assembler, Library};
@@ -13,9 +15,11 @@ const ADD_CODE: &str = "
 ";
 
 static ADD_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
-    Assembler::default()
-        .assemble_library([ADD_CODE])
-        .expect("add code should be valid")
+    Arc::unwrap_or_clone(
+        Assembler::default()
+            .assemble_library([ADD_CODE])
+            .expect("add code should be valid"),
+    )
 });
 
 /// Creates a mock authentication [`AccountComponent`] for testing purposes.

--- a/crates/miden-protocol/src/testing/noop_auth_component.rs
+++ b/crates/miden-protocol/src/testing/noop_auth_component.rs
@@ -1,3 +1,5 @@
+use alloc::sync::Arc;
+
 use crate::account::component::AccountComponentMetadata;
 use crate::account::{AccountComponent, AccountType};
 use crate::assembly::{Assembler, Library};
@@ -14,9 +16,11 @@ const NOOP_AUTH_CODE: &str = "
 ";
 
 static NOOP_AUTH_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
-    Assembler::default()
-        .assemble_library([NOOP_AUTH_CODE])
-        .expect("noop auth code should be valid")
+    Arc::unwrap_or_clone(
+        Assembler::default()
+            .assemble_library([NOOP_AUTH_CODE])
+            .expect("noop auth code should be valid"),
+    )
 });
 
 /// Creates a mock authentication [`AccountComponent`] for testing purposes.

--- a/crates/miden-standards/build.rs
+++ b/crates/miden-standards/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::Path;
+use std::sync::Arc;
 
 use fs_err as fs;
 use miden_assembly::diagnostics::{IntoDiagnostic, NamedSource, Result, WrapErr};
@@ -80,7 +81,7 @@ fn compile_standards_lib(
     let output_file = target_dir.join("standards").with_extension(Library::LIBRARY_EXTENSION);
     standards_lib.write_to_file(output_file).into_diagnostic()?;
 
-    Ok(standards_lib)
+    Ok(Arc::unwrap_or_clone(standards_lib))
 }
 
 // COMPILE ACCOUNT COMPONENTS

--- a/crates/miden-standards/src/code_builder/mod.rs
+++ b/crates/miden-standards/src/code_builder/mod.rs
@@ -353,7 +353,8 @@ impl CodeBuilder {
         })?;
 
         Ok(AccountComponentCode::from(Self::apply_advice_map_to_library(
-            advice_map, library,
+            advice_map,
+            Arc::unwrap_or_clone(library),
         )))
     }
 

--- a/crates/miden-standards/src/testing/mock_util_lib.rs
+++ b/crates/miden-standards/src/testing/mock_util_lib.rs
@@ -1,3 +1,5 @@
+use alloc::sync::Arc;
+
 use miden_protocol::assembly::Library;
 use miden_protocol::assembly::diagnostics::NamedSource;
 use miden_protocol::transaction::TransactionKernel;
@@ -60,11 +62,13 @@ const MOCK_UTIL_LIBRARY_CODE: &str = "
 ";
 
 static MOCK_UTIL_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
-    TransactionKernel::assembler()
-        .with_dynamic_library(StandardsLib::default())
-        .expect("dynamically linking standards library should work")
-        .assemble_library([NamedSource::new("mock::util", MOCK_UTIL_LIBRARY_CODE)])
-        .expect("mock util library should be valid")
+    Arc::unwrap_or_clone(
+        TransactionKernel::assembler()
+            .with_dynamic_library(StandardsLib::default())
+            .expect("dynamically linking standards library should work")
+            .assemble_library([NamedSource::new("mock::util", MOCK_UTIL_LIBRARY_CODE)])
+            .expect("mock util library should be valid"),
+    )
 });
 
 /// Returns the mock test [`Library`] under the `mock::util` namespace.

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -1544,8 +1544,9 @@ async fn transaction_executor_account_code_using_custom_library() -> anyhow::Res
 
     let account_component_source =
         NamedSource::new("account_component::account_module", ACCOUNT_COMPONENT_CODE);
-    let account_component_lib =
-        assembler.clone().assemble_library([account_component_source]).unwrap();
+    let account_component_lib = Arc::unwrap_or_clone(
+        assembler.clone().assemble_library([account_component_source]).unwrap(),
+    );
 
     let tx_script_src = "\
           use account_component::account_module
@@ -1991,9 +1992,11 @@ async fn merging_components_with_same_mast_root_succeeds() -> anyhow::Result<()>
         );
 
         let source = NamedSource::new("component1::interface", code);
-        TransactionKernel::assembler()
-            .assemble_library([source])
-            .expect("mock account code should be valid")
+        Arc::unwrap_or_clone(
+            TransactionKernel::assembler()
+                .assemble_library([source])
+                .expect("mock account code should be valid"),
+        )
     });
 
     static COMPONENT_2_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
@@ -2021,9 +2024,11 @@ async fn merging_components_with_same_mast_root_succeeds() -> anyhow::Result<()>
         );
 
         let source = NamedSource::new("component2::interface", code);
-        TransactionKernel::assembler()
-            .assemble_library([source])
-            .expect("mock account code should be valid")
+        Arc::unwrap_or_clone(
+            TransactionKernel::assembler()
+                .assemble_library([source])
+                .expect("mock account code should be valid"),
+        )
     });
 
     struct CustomComponent1 {

--- a/deny.toml
+++ b/deny.toml
@@ -25,6 +25,7 @@ allow = [
   "BSD-3-Clause",
   "CC0-1.0",
   "MIT",
+  "MPL-2.0",
   "Unicode-3.0",
   "Zlib",
 ]


### PR DESCRIPTION
Update miden-protocol and miden-standards for VM v0.22.1 compatibility:

- Assembler::assemble_library() now returns Arc<Library> — unwrap with Arc::unwrap_or_clone() where owned Library is needed
- PackageManifest::new() now returns Result
- Package.version changed from Option<Version> to Version
- Replace removed MastArtifact/PackageKind re-exports with TargetType
- Access package.mast (Arc<Library>) directly instead of matching on MastArtifact
  enum
