### PR TITLE
fix(agglayer): must `padw` before loading `SERIAL_NUM`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.4 (2026-04-09)
+
+- Fixed AggLayer `write_mint_note_storage` stack padding before loading the mint serial number ([#2749](https://github.com/0xMiden/protocol/pull/2749)).
+
 ## 0.14.3 (2026-04-07)
 
 - [BREAKING] Updated for compatibility with miden-vm v0.22.1 (`Arc<Library>` return types, `MastArtifact`/`PackageKind` removal) ([#2742](https://github.com/0xMiden/protocol/pull/2742)).

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -889,7 +889,7 @@ proc write_mint_note_storage
     # => []
 
     # Write SERIAL_NUM (PROOF_DATA_KEY) to MINT note storage [12..15]
-    mem_loadw_be.CLAIM_PROOF_DATA_KEY_MEM_ADDR
+    padw mem_loadw_be.CLAIM_PROOF_DATA_KEY_MEM_ADDR
     # => [SERIAL_NUM]
 
     mem_storew_le.MINT_NOTE_STORAGE_OUTPUT_SERIAL_NUM dropw


### PR DESCRIPTION
## Summary

- Fixes a bug where `mem_loadw_be.CLAIM_PROOF_DATA_KEY_MEM_ADDR` in `write_mint_note_storage` replaces the top 4 stack elements (which contain `faucet_id_suffix` and `faucet_id_prefix`) instead of pushing additively, causing the MINT output note to have a zeroed `NetworkAccountTarget` attachment
- Prepends `padw` to push 4 sacrificial zeros that `mem_loadw_be` replaces, preserving the caller's faucet ID on the stack

Closes #2748

## Context

After the bridge successfully consumes a CLAIM note, it produces a MINT output note. The MINT note's attachment should contain the faucet's account ID so the node store can route the note to the faucet's network-tx queue. Due to this bug, the attachment contains `[0, 0, 1, 0]` (exec_hint=1 is correct, but suffix and prefix are zero), so the ntx builder never sees the `MINT` note as directed at the faucet account, and never mints.

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)