### PR TITLE
feat(agglayer): add CLAIM and B2AGG cycle count benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,10 +282,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "criterion 0.6.0",
+ "miden-agglayer",
  "miden-protocol",
  "miden-standards",
  "miden-testing",
  "miden-tx",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "tokio",

--- a/bin/bench-transaction/Cargo.toml
+++ b/bin/bench-transaction/Cargo.toml
@@ -17,6 +17,7 @@ path    = "src/time_counting_benchmarks/prove.rs"
 
 [dependencies]
 # Workspace dependencies
+miden-agglayer  = { features = ["testing"], workspace = true }
 miden-protocol  = { features = ["testing"], workspace = true }
 miden-standards = { workspace = true }
 miden-testing   = { workspace = true }
@@ -24,7 +25,8 @@ miden-tx        = { workspace = true }
 
 # External dependencies
 anyhow     = { workspace = true }
-serde      = { features = ["derive"], workspace = true }
+rand       = { workspace = true }
+serde      = { features = ["derive", "std"], workspace = true }
 serde_json = { features = ["preserve_order"], package = "serde_json", version = "1.0" }
 tokio      = { features = ["macros", "rt"], workspace = true }
 

--- a/bin/bench-transaction/README.md
+++ b/bin/bench-transaction/README.md
@@ -2,7 +2,26 @@
 
 Below we describe how to benchmark Miden transactions.
 
-Benchmarks consist of two groups:
+### Benchmarked Transactions
+
+The following transactions are benchmarked:
+
+- **P2ID notes**: Consume single/two P2ID notes, create single P2ID note
+- **CLAIM notes (agglayer bridge-in)**: Consume CLAIM note for L1-to-Miden bridging and L2-to-Miden bridging
+- **B2AGG note (agglayer bridge-out)**: Consume B2AGG note for Miden-to-AggLayer bridging
+
+The CLAIM note benchmarks measure the full bridge-in flow: the benchmark setup executes
+prerequisite transactions (CONFIG_AGG_BRIDGE and UPDATE_GER) to prepare the bridge account,
+then benchmarks the CLAIM note consumption transaction itself.
+
+The B2AGG note benchmark measures the bridge-out flow: the benchmark setup registers a faucet
+in the bridge via CONFIG_AGG_BRIDGE, then benchmarks the B2AGG note consumption which validates
+the faucet, performs FPI to get origin asset data, computes the Keccak leaf hash for the MMR,
+and creates a BURN note.
+
+### Benchmark Groups
+
+Each of the above transactions is measured in two groups:
 - Benchmarking the transaction execution.
 
   For each transaction, data is collected on the number of cycles required to complete:

--- a/bin/bench-transaction/bench-tx.json
+++ b/bin/bench-transaction/bench-tx.json
@@ -1,40 +1,79 @@
 {
   "consume single P2ID note": {
-    "prologue": 3487,
-    "notes_processing": 1831,
+    "prologue": 3501,
+    "notes_processing": 1761,
     "note_execution": {
-      "0x1421e92d0f84f11b3e6f84e4e1d193e648eb820666ffb8c50ea818c25a32990c": 1791
+      "0x62e6fe0d5f649b395b5c3f63736fd7b469fd1e0e867c441696d1a70324d3f9a2": 1721
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 71195,
-      "auth_procedure": 69694,
-      "after_tx_cycles_obtained": 608
+      "total": 72351,
+      "auth_procedure": 70846,
+      "after_tx_cycles_obtained": 612
     }
   },
   "consume two P2ID notes": {
-    "prologue": 4509,
-    "notes_processing": 3668,
+    "prologue": 4537,
+    "notes_processing": 3600,
     "note_execution": {
-      "0x702c078c74683d33b507e16d9fc67f0be0cc943cd94c1f652e3a60e0f4164d9f": 1791,
-      "0x92cc0c8c208e3b8bad970c23b2c4b4c24cc8d42626b3f56363ce1a6bbf4c7ac2": 1828
+      "0x51e09a95d1aa86daa64a59ce960c7a6baba576decf870aa4500e9847c3740bf9": 1721,
+      "0xf11434d602ac1f69b171c08d5b3352c59c57ecec02e191c61b2a6599269a12c3": 1830
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 71143,
-      "auth_procedure": 69668,
-      "after_tx_cycles_obtained": 608
+      "total": 72299,
+      "auth_procedure": 70820,
+      "after_tx_cycles_obtained": 612
     }
   },
   "create single P2ID note": {
     "prologue": 1766,
     "notes_processing": 32,
     "note_execution": {},
-    "tx_script_processing": 1682,
+    "tx_script_processing": 1667,
     "epilogue": {
-      "total": 72099,
-      "auth_procedure": 69906,
-      "after_tx_cycles_obtained": 608
+      "total": 73243,
+      "auth_procedure": 71058,
+      "after_tx_cycles_obtained": 612
+    }
+  },
+  "consume CLAIM note (L1 to Miden)": {
+    "prologue": 2897,
+    "notes_processing": 28536,
+    "note_execution": {
+      "0xdbc80122500b117ed9c951e4f1362424ef081cbda9f7d4af3a6a30d1f029d376": 28496
+    },
+    "tx_script_processing": 42,
+    "epilogue": {
+      "total": 4093,
+      "auth_procedure": 880,
+      "after_tx_cycles_obtained": 612
+    }
+  },
+  "consume CLAIM note (L2 to Miden)": {
+    "prologue": 2897,
+    "notes_processing": 40786,
+    "note_execution": {
+      "0x1f04a3e738aad3c25b4148a9a1be0c4dfe8cc9ec69171909a730630045dced97": 40746
+    },
+    "tx_script_processing": 42,
+    "epilogue": {
+      "total": 4093,
+      "auth_procedure": 880,
+      "after_tx_cycles_obtained": 612
+    }
+  },
+  "consume B2AGG note (bridge-out)": {
+    "prologue": 3718,
+    "notes_processing": 145590,
+    "note_execution": {
+      "0xa0e31e2fec803d6cb21681b36ea6312d366d9bae97eea9255e43f3fb95e46524": 145550
+    },
+    "tx_script_processing": 42,
+    "epilogue": {
+      "total": 13756,
+      "auth_procedure": 880,
+      "after_tx_cycles_obtained": 612
     }
   }
 }

--- a/bin/bench-transaction/src/context_setups.rs
+++ b/bin/bench-transaction/src/context_setups.rs
@@ -1,11 +1,30 @@
 use anyhow::Result;
+pub use miden_agglayer::testing::ClaimDataSource;
+use miden_agglayer::{
+    B2AggNote,
+    ClaimNoteStorage,
+    ConfigAggBridgeNote,
+    EthAddress,
+    MetadataHash,
+    UpdateGerNote,
+    create_claim_note,
+    create_existing_agglayer_faucet,
+    create_existing_bridge_account,
+};
+use miden_protocol::Felt;
 use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::asset::{Asset, FungibleAsset};
-use miden_protocol::note::NoteType;
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::note::{NoteAssets, NoteType};
 use miden_protocol::testing::account_id::ACCOUNT_ID_SENDER;
 use miden_protocol::transaction::RawOutputNote;
 use miden_standards::code_builder::CodeBuilder;
+use miden_standards::note::StandardNote;
 use miden_testing::{Auth, MockChain, TransactionContext};
+use rand::Rng;
+
+// P2ID NOTE SETUPS
+// ================================================================================================
 
 /// Returns the transaction context which could be used to run the transaction which creates a
 /// single P2ID note.
@@ -133,4 +152,246 @@ pub fn tx_consume_two_p2id_notes() -> Result<TransactionContext> {
         .build_tx_context(account.id(), &[note_1.id(), note_2.id()], &[])?
         .disable_debug_mode()
         .build()
+}
+
+// CLAIM NOTE SETUPS
+// ================================================================================================
+
+/// Sets up and returns the transaction context for executing a CLAIM note against the bridge
+/// account.
+///
+/// This requires executing prerequisite transactions (CONFIG_AGG_BRIDGE and UPDATE_GER) during
+/// setup to prepare the bridge account state. Only the returned CLAIM transaction context is
+/// benchmarked — the prerequisite transactions are not included in cycle/time measurements.
+///
+/// The `data_source` parameter selects between L1-to-Miden and L2-to-Miden test vectors.
+pub async fn tx_consume_claim_note(data_source: ClaimDataSource) -> Result<TransactionContext> {
+    let mut builder = MockChain::builder();
+
+    // CREATE BRIDGE ADMIN ACCOUNT (sends CONFIG_AGG_BRIDGE notes)
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // CREATE GER MANAGER ACCOUNT (sends the UPDATE_GER note)
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // CREATE BRIDGE ACCOUNT
+    let bridge_seed = builder.rng_mut().draw_word();
+    let bridge_account =
+        create_existing_bridge_account(bridge_seed, bridge_admin.id(), ger_manager.id());
+    builder.add_account(bridge_account.clone())?;
+
+    // GET CLAIM DATA FROM JSON
+    let (proof_data, leaf_data, ger, _cgi_chain_hash) = data_source.get_data();
+
+    // CREATE AGGLAYER FAUCET ACCOUNT
+    let token_symbol = "AGG";
+    let decimals = 8u8;
+    let max_supply = Felt::new(FungibleAsset::MAX_AMOUNT);
+    let agglayer_faucet_seed = builder.rng_mut().draw_word();
+
+    let origin_token_address = leaf_data.origin_token_address;
+    let origin_network = leaf_data.origin_network;
+    let scale = 10u8;
+
+    let agglayer_faucet = create_existing_agglayer_faucet(
+        agglayer_faucet_seed,
+        token_symbol,
+        decimals,
+        max_supply,
+        Felt::ZERO,
+        bridge_account.id(),
+        &origin_token_address,
+        origin_network,
+        scale,
+        leaf_data.metadata_hash,
+    );
+    builder.add_account(agglayer_faucet.clone())?;
+
+    // CREATE SENDER ACCOUNT (for creating the claim note)
+    let sender_account_builder =
+        miden_protocol::account::Account::builder(builder.rng_mut().random())
+            .with_component(miden_standards::account::wallets::BasicWallet);
+    let sender_account = builder.add_account_from_builder(
+        Auth::IncrNonce,
+        sender_account_builder,
+        miden_testing::AccountState::Exists,
+    )?;
+
+    // CREATE CLAIM NOTE
+    let miden_claim_amount = leaf_data
+        .amount
+        .scale_to_token_amount(scale as u32)
+        .expect("amount should scale successfully");
+
+    let claim_inputs = ClaimNoteStorage {
+        proof_data,
+        leaf_data,
+        miden_claim_amount,
+    };
+
+    let claim_note = create_claim_note(
+        claim_inputs,
+        bridge_account.id(),
+        sender_account.id(),
+        builder.rng_mut(),
+    )?;
+
+    builder.add_output_note(RawOutputNote::Full(claim_note.clone()));
+
+    // CREATE CONFIG_AGG_BRIDGE NOTE
+    let config_note = ConfigAggBridgeNote::create(
+        agglayer_faucet.id(),
+        &origin_token_address,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(config_note.clone()));
+
+    // CREATE UPDATE_GER NOTE
+    let update_ger_note =
+        UpdateGerNote::create(ger, ger_manager.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(update_ger_note.clone()));
+
+    // BUILD MOCK CHAIN
+    let mut mock_chain = builder.build()?;
+
+    // TX0: EXECUTE CONFIG_AGG_BRIDGE NOTE TO REGISTER FAUCET IN BRIDGE
+    let config_tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[config_note.id()], &[])?
+        .build()?;
+    let config_executed = config_tx_context.execute().await?;
+
+    mock_chain.add_pending_executed_transaction(&config_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX1: EXECUTE UPDATE_GER NOTE TO STORE GER IN BRIDGE ACCOUNT
+    let update_ger_tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[update_ger_note.id()], &[])?
+        .build()?;
+    let update_ger_executed = update_ger_tx_context.execute().await?;
+
+    mock_chain.add_pending_executed_transaction(&update_ger_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX2: BUILD CLAIM NOTE TRANSACTION CONTEXT (ready to execute)
+    let faucet_foreign_inputs = mock_chain.get_foreign_account_inputs(agglayer_faucet.id())?;
+    let claim_tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[], &[claim_note])?
+        .foreign_accounts(vec![faucet_foreign_inputs])
+        .disable_debug_mode()
+        .build()?;
+
+    Ok(claim_tx_context)
+}
+
+// B2AGG NOTE SETUPS
+// ================================================================================================
+
+/// Sets up and returns the transaction context for executing a B2AGG (bridge-out) note against
+/// the bridge account.
+///
+/// This requires executing a prerequisite CONFIG_AGG_BRIDGE transaction during setup to register
+/// the faucet in the bridge. Only the returned B2AGG transaction context is benchmarked — the
+/// prerequisite CONFIG_AGG_BRIDGE transaction is not included in cycle/time measurements.
+///
+/// The setup uses the first entry from the MTF (Merkle Tree Frontier) test vectors for destination
+/// data.
+pub async fn tx_consume_b2agg_note() -> Result<TransactionContext> {
+    let vectors = &*miden_agglayer::testing::SOLIDITY_MTF_VECTORS;
+
+    let mut builder = MockChain::builder();
+
+    // CREATE BRIDGE ADMIN ACCOUNT (sends CONFIG_AGG_BRIDGE notes)
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // CREATE GER MANAGER ACCOUNT (not used in bridge-out, but required for bridge creation)
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // CREATE BRIDGE ACCOUNT
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // CREATE AGGLAYER FAUCET ACCOUNT (with conversion metadata for FPI)
+    let origin_token_address = EthAddress::from_hex(&vectors.origin_token_address)
+        .expect("valid shared origin token address");
+    let origin_network = 64u32;
+    let scale = 0u8;
+    let bridge_amount: u64 = vectors.amounts[0].parse().expect("valid amount decimal string");
+
+    let faucet = create_existing_agglayer_faucet(
+        builder.rng_mut().draw_word(),
+        "AGG",
+        8,
+        Felt::new(FungibleAsset::MAX_AMOUNT),
+        Felt::new(bridge_amount),
+        bridge_account.id(),
+        &origin_token_address,
+        origin_network,
+        scale,
+        MetadataHash::from_token_info("AGG", "AGG", 8),
+    );
+    builder.add_account(faucet.clone())?;
+
+    // CREATE CONFIG_AGG_BRIDGE NOTE (registers faucet + token address in bridge)
+    let config_note = ConfigAggBridgeNote::create(
+        faucet.id(),
+        &origin_token_address,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(config_note.clone()));
+
+    // CREATE B2AGG NOTE
+    let destination_network = vectors.destination_networks[0];
+    let destination_address =
+        EthAddress::from_hex(&vectors.destination_addresses[0]).expect("valid destination address");
+    let bridge_asset: Asset = FungibleAsset::new(faucet.id(), bridge_amount)?.into();
+    let b2agg_note = B2AggNote::create(
+        destination_network,
+        destination_address,
+        NoteAssets::new(vec![bridge_asset])?,
+        bridge_account.id(),
+        faucet.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(b2agg_note.clone()));
+
+    // BUILD MOCK CHAIN
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    // TX0: EXECUTE CONFIG_AGG_BRIDGE NOTE TO REGISTER FAUCET IN BRIDGE
+    let config_executed = mock_chain
+        .build_tx_context(bridge_account.id(), &[config_note.id()], &[])?
+        .build()?
+        .execute()
+        .await?;
+    mock_chain.add_pending_executed_transaction(&config_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX1: BUILD B2AGG NOTE TRANSACTION CONTEXT (ready to execute)
+    let burn_note_script = StandardNote::BURN.script();
+    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(faucet.id())?;
+    let b2agg_tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[b2agg_note.id()], &[])?
+        .add_note_script(burn_note_script)
+        .foreign_accounts(vec![foreign_account_inputs])
+        .disable_debug_mode()
+        .build()?;
+
+    Ok(b2agg_tx_context)
 }

--- a/bin/bench-transaction/src/cycle_counting_benchmarks/mod.rs
+++ b/bin/bench-transaction/src/cycle_counting_benchmarks/mod.rs
@@ -7,6 +7,9 @@ pub enum ExecutionBenchmark {
     ConsumeSingleP2ID,
     ConsumeTwoP2ID,
     CreateSingleP2ID,
+    ConsumeClaimNoteL1ToMiden,
+    ConsumeClaimNoteL2ToMiden,
+    ConsumeB2AggNote,
 }
 
 impl fmt::Display for ExecutionBenchmark {
@@ -15,6 +18,15 @@ impl fmt::Display for ExecutionBenchmark {
             ExecutionBenchmark::ConsumeSingleP2ID => write!(f, "consume single P2ID note"),
             ExecutionBenchmark::ConsumeTwoP2ID => write!(f, "consume two P2ID notes"),
             ExecutionBenchmark::CreateSingleP2ID => write!(f, "create single P2ID note"),
+            ExecutionBenchmark::ConsumeClaimNoteL1ToMiden => {
+                write!(f, "consume CLAIM note (L1 to Miden)")
+            },
+            ExecutionBenchmark::ConsumeClaimNoteL2ToMiden => {
+                write!(f, "consume CLAIM note (L2 to Miden)")
+            },
+            ExecutionBenchmark::ConsumeB2AggNote => {
+                write!(f, "consume B2AGG note (bridge-out)")
+            },
         }
     }
 }

--- a/bin/bench-transaction/src/main.rs
+++ b/bin/bench-transaction/src/main.rs
@@ -7,6 +7,9 @@ use miden_protocol::transaction::TransactionMeasurements;
 
 mod context_setups;
 use context_setups::{
+    ClaimDataSource,
+    tx_consume_b2agg_note,
+    tx_consume_claim_note,
     tx_consume_single_p2id_note,
     tx_consume_two_p2id_notes,
     tx_create_single_p2id_note,
@@ -44,6 +47,33 @@ async fn main() -> Result<()> {
         (
             ExecutionBenchmark::CreateSingleP2ID,
             tx_create_single_p2id_note()?
+                .execute()
+                .await
+                .map(TransactionMeasurements::from)?
+                .into(),
+        ),
+        (
+            ExecutionBenchmark::ConsumeClaimNoteL1ToMiden,
+            tx_consume_claim_note(ClaimDataSource::SimulatedL1ToMiden)
+                .await?
+                .execute()
+                .await
+                .map(TransactionMeasurements::from)?
+                .into(),
+        ),
+        (
+            ExecutionBenchmark::ConsumeClaimNoteL2ToMiden,
+            tx_consume_claim_note(ClaimDataSource::SimulatedL2ToMiden)
+                .await?
+                .execute()
+                .await
+                .map(TransactionMeasurements::from)?
+                .into(),
+        ),
+        (
+            ExecutionBenchmark::ConsumeB2AggNote,
+            tx_consume_b2agg_note()
+                .await?
                 .execute()
                 .await
                 .map(TransactionMeasurements::from)?

--- a/bin/bench-transaction/src/time_counting_benchmarks/prove.rs
+++ b/bin/bench-transaction/src/time_counting_benchmarks/prove.rs
@@ -2,7 +2,13 @@ use std::hint::black_box;
 use std::time::Duration;
 
 use anyhow::Result;
-use bench_transaction::context_setups::{tx_consume_single_p2id_note, tx_consume_two_p2id_notes};
+use bench_transaction::context_setups::{
+    ClaimDataSource,
+    tx_consume_b2agg_note,
+    tx_consume_claim_note,
+    tx_consume_single_p2id_note,
+    tx_consume_two_p2id_notes,
+};
 use criterion::{BatchSize, Criterion, SamplingMode, criterion_group, criterion_main};
 use miden_protocol::transaction::{ExecutedTransaction, ProvenTransaction};
 use miden_tx::LocalTransactionProver;
@@ -14,12 +20,24 @@ const BENCH_GROUP_EXECUTE: &str = "Execute transaction";
 const BENCH_EXECUTE_TX_CONSUME_SINGLE_P2ID: &str =
     "Execute transaction which consumes single P2ID note";
 const BENCH_EXECUTE_TX_CONSUME_TWO_P2ID: &str = "Execute transaction which consumes two P2ID notes";
+const BENCH_EXECUTE_TX_CONSUME_CLAIM_L1: &str =
+    "Execute transaction which consumes CLAIM note (L1 to Miden)";
+const BENCH_EXECUTE_TX_CONSUME_CLAIM_L2: &str =
+    "Execute transaction which consumes CLAIM note (L2 to Miden)";
+const BENCH_EXECUTE_TX_CONSUME_B2AGG: &str =
+    "Execute transaction which consumes B2AGG note (bridge-out)";
 
 const BENCH_GROUP_EXECUTE_AND_PROVE: &str = "Execute and prove transaction";
 const BENCH_EXECUTE_AND_PROVE_TX_CONSUME_SINGLE_P2ID: &str =
     "Execute and prove transaction which consumes single P2ID note";
 const BENCH_EXECUTE_AND_PROVE_TX_CONSUME_TWO_P2ID: &str =
     "Execute and prove transaction which consumes two P2ID notes";
+const BENCH_EXECUTE_AND_PROVE_TX_CONSUME_CLAIM_L1: &str =
+    "Execute and prove transaction which consumes CLAIM note (L1 to Miden)";
+const BENCH_EXECUTE_AND_PROVE_TX_CONSUME_CLAIM_L2: &str =
+    "Execute and prove transaction which consumes CLAIM note (L2 to Miden)";
+const BENCH_EXECUTE_AND_PROVE_TX_CONSUME_B2AGG: &str =
+    "Execute and prove transaction which consumes B2AGG note (bridge-out)";
 
 // CORE PROVING BENCHMARKS
 // ================================================================================================
@@ -58,6 +76,63 @@ fn core_benchmarks(c: &mut Criterion) {
                     // prepare the transaction context
                     tx_consume_two_p2id_notes()
                         .expect("failed to create a context which consumes two P2ID notes")
+                },
+                |tx_context| async move {
+                    // benchmark the transaction execution
+                    black_box(tx_context.execute().await)
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    execute_group.bench_function(BENCH_EXECUTE_TX_CONSUME_CLAIM_L1, |b| {
+        b.to_async(tokio::runtime::Builder::new_current_thread().build().unwrap())
+            .iter_batched(
+                || {
+                    // prepare the transaction context (async setup)
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("failed to build tokio runtime for setup");
+                    rt.block_on(tx_consume_claim_note(ClaimDataSource::SimulatedL1ToMiden))
+                        .expect("failed to create a context which consumes CLAIM note (L1)")
+                },
+                |tx_context| async move {
+                    // benchmark the transaction execution
+                    black_box(tx_context.execute().await)
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    execute_group.bench_function(BENCH_EXECUTE_TX_CONSUME_CLAIM_L2, |b| {
+        b.to_async(tokio::runtime::Builder::new_current_thread().build().unwrap())
+            .iter_batched(
+                || {
+                    // prepare the transaction context (async setup)
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("failed to build tokio runtime for setup");
+                    rt.block_on(tx_consume_claim_note(ClaimDataSource::SimulatedL2ToMiden))
+                        .expect("failed to create a context which consumes CLAIM note (L2)")
+                },
+                |tx_context| async move {
+                    // benchmark the transaction execution
+                    black_box(tx_context.execute().await)
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    execute_group.bench_function(BENCH_EXECUTE_TX_CONSUME_B2AGG, |b| {
+        b.to_async(tokio::runtime::Builder::new_current_thread().build().unwrap())
+            .iter_batched(
+                || {
+                    // prepare the transaction context (async setup)
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("failed to build tokio runtime for setup");
+                    rt.block_on(tx_consume_b2agg_note())
+                        .expect("failed to create a context which consumes B2AGG note")
                 },
                 |tx_context| async move {
                     // benchmark the transaction execution
@@ -119,6 +194,87 @@ fn core_benchmarks(c: &mut Criterion) {
                                 .execute()
                                 .await
                                 .expect("execution of the two P2ID note consumption tx failed"),
+                        )
+                        .await,
+                    )
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    execute_and_prove_group.bench_function(BENCH_EXECUTE_AND_PROVE_TX_CONSUME_CLAIM_L1, |b| {
+        b.to_async(tokio::runtime::Builder::new_current_thread().build().unwrap())
+            .iter_batched(
+                || {
+                    // prepare the transaction context (async setup)
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("failed to build tokio runtime for setup");
+                    rt.block_on(tx_consume_claim_note(ClaimDataSource::SimulatedL1ToMiden))
+                        .expect("failed to create a context which consumes CLAIM note (L1)")
+                },
+                |tx_context| async move {
+                    // benchmark the transaction execution and proving
+                    black_box(
+                        prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the CLAIM note (L1) consumption tx failed"),
+                        )
+                        .await,
+                    )
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    execute_and_prove_group.bench_function(BENCH_EXECUTE_AND_PROVE_TX_CONSUME_CLAIM_L2, |b| {
+        b.to_async(tokio::runtime::Builder::new_current_thread().build().unwrap())
+            .iter_batched(
+                || {
+                    // prepare the transaction context (async setup)
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("failed to build tokio runtime for setup");
+                    rt.block_on(tx_consume_claim_note(ClaimDataSource::SimulatedL2ToMiden))
+                        .expect("failed to create a context which consumes CLAIM note (L2)")
+                },
+                |tx_context| async move {
+                    // benchmark the transaction execution and proving
+                    black_box(
+                        prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the CLAIM note (L2) consumption tx failed"),
+                        )
+                        .await,
+                    )
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    execute_and_prove_group.bench_function(BENCH_EXECUTE_AND_PROVE_TX_CONSUME_B2AGG, |b| {
+        b.to_async(tokio::runtime::Builder::new_current_thread().build().unwrap())
+            .iter_batched(
+                || {
+                    // prepare the transaction context (async setup)
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("failed to build tokio runtime for setup");
+                    rt.block_on(tx_consume_b2agg_note())
+                        .expect("failed to create a context which consumes B2AGG note")
+                },
+                |tx_context| async move {
+                    // benchmark the transaction execution and proving
+                    black_box(
+                        prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the B2AGG note consumption tx failed"),
                         )
                         .await,
                     )

--- a/crates/miden-agglayer/Cargo.toml
+++ b/crates/miden-agglayer/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 [features]
 default = ["std"]
 std     = ["miden-assembly/std", "miden-core/std"]
-testing = ["miden-protocol/testing"]
+testing = ["dep:serde", "dep:serde_json", "miden-protocol/testing"]
 
 [dependencies]
 # Miden dependencies
@@ -35,6 +35,10 @@ thiserror       = { workspace = true }
 
 # Crypto
 miden-crypto = { workspace = true }
+
+# Optional testing dependencies
+serde      = { features = ["alloc", "derive"], optional = true, workspace = true }
+serde_json = { default-features = false, features = ["alloc"], optional = true, version = "1.0" }
 
 [dev-dependencies]
 miden-agglayer = { features = ["testing"], path = "." }

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -28,6 +28,8 @@ pub mod config_note;
 pub mod errors;
 pub mod eth_types;
 pub mod faucet;
+#[cfg(feature = "testing")]
+pub mod testing;
 pub mod update_ger_note;
 pub mod utils;
 

--- a/crates/miden-agglayer/src/testing/mod.rs
+++ b/crates/miden-agglayer/src/testing/mod.rs
@@ -1,0 +1,297 @@
+//! Shared test vector types and embedded JSON constants for agglayer testing.
+//!
+//! This module is gated behind the `testing` feature and provides:
+//! - Embedded JSON test vector files from `solidity-compat/test-vectors/`
+//! - Serde helpers for deserializing Foundry-generated JSON
+//! - Deserialized test vector structs (`LeafValueVector`, `ProofValueVector`, etc.)
+//! - Lazy-parsed static instances of the test vectors
+//! - `ClaimDataSource` enum for selecting between different claim data sources
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use miden_protocol::utils::hex_to_bytes;
+use miden_protocol::utils::sync::LazyLock;
+use serde::Deserialize;
+
+use crate::claim_note::{ProofData, SmtNode};
+use crate::{CgiChainHash, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash};
+
+// EMBEDDED TEST VECTOR JSON FILES
+// ================================================================================================
+
+/// Claim asset test vectors JSON — contains both LeafData and ProofData from a real claimAsset
+/// transaction.
+pub const CLAIM_ASSET_VECTORS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/claim_asset_vectors_real_tx.json");
+
+/// Bridge asset test vectors JSON — contains test data for an L1 bridgeAsset transaction.
+pub const BRIDGE_ASSET_VECTORS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/claim_asset_vectors_local_tx.json");
+
+/// Rollup deposit test vectors JSON — contains test data for a rollup deposit with two-level
+/// Merkle proofs.
+pub const ROLLUP_ASSET_VECTORS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/claim_asset_vectors_rollup_tx.json");
+
+/// Leaf data test vectors JSON from the Foundry-generated file.
+pub const LEAF_VALUE_VECTORS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/leaf_value_vectors.json");
+
+/// Merkle proof verification vectors JSON from the Foundry-generated file.
+pub const MERKLE_PROOF_VECTORS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/merkle_proof_vectors.json");
+
+/// Canonical zeros JSON from the Foundry-generated file.
+pub const CANONICAL_ZEROS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/canonical_zeros.json");
+
+/// Merkle Tree Frontier (MTF) vectors JSON from the Foundry-generated file.
+pub const MTF_VECTORS_JSON: &str =
+    include_str!("../../solidity-compat/test-vectors/merkle_tree_frontier_vectors.json");
+
+// SERDE HELPERS
+// ================================================================================================
+
+/// Deserializes a JSON value that may be either a number or a string into a `String`.
+///
+/// Foundry's `vm.serializeUint` outputs JSON numbers for uint256 values.
+/// This deserializer accepts both `"100"` (string) and `100` (number) forms.
+pub fn deserialize_uint_to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Number(n) => Ok(n.to_string()),
+        _ => Err(serde::de::Error::custom("expected a number or string for amount")),
+    }
+}
+
+/// Deserializes a JSON array of values that may be either numbers or strings into `Vec<String>`.
+///
+/// Array-level counterpart of [`deserialize_uint_to_string`].
+pub fn deserialize_uint_vec_to_strings<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => Ok(s),
+            serde_json::Value::Number(n) => Ok(n.to_string()),
+            _ => Err(serde::de::Error::custom("expected a number or string for amount")),
+        })
+        .collect()
+}
+
+// TEST VECTOR TYPES
+// ================================================================================================
+
+/// Deserialized leaf value test vector from Solidity-generated JSON.
+#[derive(Debug, Deserialize)]
+pub struct LeafValueVector {
+    pub origin_network: u32,
+    pub origin_token_address: String,
+    pub destination_network: u32,
+    pub destination_address: String,
+    #[serde(deserialize_with = "deserialize_uint_to_string")]
+    pub amount: String,
+    pub metadata_hash: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub leaf_value: String,
+}
+
+impl LeafValueVector {
+    /// Converts this test vector into a `LeafData` instance.
+    pub fn to_leaf_data(&self) -> LeafData {
+        LeafData {
+            origin_network: self.origin_network,
+            origin_token_address: EthAddress::from_hex(&self.origin_token_address)
+                .expect("valid origin token address hex"),
+            destination_network: self.destination_network,
+            destination_address: EthAddress::from_hex(&self.destination_address)
+                .expect("valid destination address hex"),
+            amount: EthAmount::from_uint_str(&self.amount).expect("valid amount uint string"),
+            metadata_hash: MetadataHash::new(
+                hex_to_bytes(&self.metadata_hash).expect("valid metadata hash hex"),
+            ),
+        }
+    }
+}
+
+/// Deserialized proof value test vector from Solidity-generated JSON.
+/// Contains SMT proofs, exit roots, global index, and expected global exit root.
+#[derive(Debug, Deserialize)]
+pub struct ProofValueVector {
+    pub smt_proof_local_exit_root: Vec<String>,
+    pub smt_proof_rollup_exit_root: Vec<String>,
+    pub global_index: String,
+    pub mainnet_exit_root: String,
+    pub rollup_exit_root: String,
+    /// Expected global exit root: keccak256(mainnetExitRoot || rollupExitRoot)
+    #[allow(dead_code)]
+    pub global_exit_root: String,
+    pub claimed_global_index_hash_chain: String,
+}
+
+impl ProofValueVector {
+    /// Converts this test vector into a `ProofData` instance.
+    pub fn to_proof_data(&self) -> ProofData {
+        let smt_proof_local: [SmtNode; 32] = self
+            .smt_proof_local_exit_root
+            .iter()
+            .map(|s| SmtNode::new(hex_to_bytes(s).expect("valid smt proof hex")))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("expected 32 SMT proof nodes for local exit root");
+
+        let smt_proof_rollup: [SmtNode; 32] = self
+            .smt_proof_rollup_exit_root
+            .iter()
+            .map(|s| SmtNode::new(hex_to_bytes(s).expect("valid smt proof hex")))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("expected 32 SMT proof nodes for rollup exit root");
+
+        ProofData {
+            smt_proof_local_exit_root: smt_proof_local,
+            smt_proof_rollup_exit_root: smt_proof_rollup,
+            global_index: GlobalIndex::from_hex(&self.global_index)
+                .expect("valid global index hex"),
+            mainnet_exit_root: ExitRoot::new(
+                hex_to_bytes(&self.mainnet_exit_root).expect("valid mainnet exit root hex"),
+            ),
+            rollup_exit_root: ExitRoot::new(
+                hex_to_bytes(&self.rollup_exit_root).expect("valid rollup exit root hex"),
+            ),
+        }
+    }
+}
+
+/// Deserialized claim asset test vector from Solidity-generated JSON.
+/// Contains both LeafData and ProofData from a real claimAsset transaction.
+#[derive(Debug, Deserialize)]
+pub struct ClaimAssetVector {
+    #[serde(flatten)]
+    pub proof: ProofValueVector,
+
+    #[serde(flatten)]
+    pub leaf: LeafValueVector,
+}
+
+/// Deserialized Merkle proof vectors from Solidity DepositContractBase.sol.
+/// Uses parallel arrays for leaves and roots. For each element from leaves/roots there are 32
+/// elements from merkle_paths, which represent the merkle path for that leaf + root.
+#[derive(Debug, Deserialize)]
+pub struct MerkleProofVerificationFile {
+    pub leaves: Vec<String>,
+    pub roots: Vec<String>,
+    pub merkle_paths: Vec<String>,
+}
+
+/// Deserialized canonical zeros from Solidity DepositContractBase.sol.
+#[derive(Debug, Deserialize)]
+pub struct CanonicalZerosFile {
+    pub canonical_zeros: Vec<String>,
+}
+
+/// Deserialized Merkle Tree Frontier (MTF) vectors from Solidity DepositContractV2.
+///
+/// Each leaf is produced by `getLeafValue` using the same hardcoded fields as `bridge_out.masm`
+/// (leafType=0, originNetwork=64, metadataHash=0), parametrised by
+/// a shared `origin_token_address`, `amounts[i]`, and per-index
+/// `destination_networks[i]` / `destination_addresses[i]`.
+///
+/// Amounts are serialized as uint256 values (JSON numbers).
+#[derive(Debug, Deserialize)]
+pub struct MtfVectorsFile {
+    pub leaves: Vec<String>,
+    pub roots: Vec<String>,
+    pub counts: Vec<u32>,
+    #[serde(deserialize_with = "deserialize_uint_vec_to_strings")]
+    pub amounts: Vec<String>,
+    pub origin_token_address: String,
+    pub destination_networks: Vec<u32>,
+    pub destination_addresses: Vec<String>,
+    pub token_name: String,
+    pub token_symbol: String,
+    pub token_decimals: u8,
+}
+
+// LAZY-PARSED TEST VECTORS
+// ================================================================================================
+
+/// Lazily parsed claim asset test vector from the JSON file.
+pub static CLAIM_ASSET_VECTOR: LazyLock<ClaimAssetVector> = LazyLock::new(|| {
+    serde_json::from_str(CLAIM_ASSET_VECTORS_JSON)
+        .expect("failed to parse claim asset vectors JSON")
+});
+
+/// Lazily parsed bridge asset test vector from the JSON file (locally simulated L1 transaction).
+pub static CLAIM_ASSET_VECTOR_LOCAL: LazyLock<ClaimAssetVector> = LazyLock::new(|| {
+    serde_json::from_str(BRIDGE_ASSET_VECTORS_JSON)
+        .expect("failed to parse bridge asset vectors JSON")
+});
+
+/// Lazily parsed rollup deposit test vector from the JSON file.
+pub static CLAIM_ASSET_VECTOR_ROLLUP: LazyLock<ClaimAssetVector> = LazyLock::new(|| {
+    serde_json::from_str(ROLLUP_ASSET_VECTORS_JSON)
+        .expect("failed to parse rollup asset vectors JSON")
+});
+
+/// Lazily parsed Merkle proof vectors from the JSON file.
+pub static SOLIDITY_MERKLE_PROOF_VECTORS: LazyLock<MerkleProofVerificationFile> =
+    LazyLock::new(|| {
+        serde_json::from_str(MERKLE_PROOF_VECTORS_JSON)
+            .expect("failed to parse Merkle proof vectors JSON")
+    });
+
+/// Lazily parsed canonical zeros from the JSON file.
+pub static SOLIDITY_CANONICAL_ZEROS: LazyLock<CanonicalZerosFile> = LazyLock::new(|| {
+    serde_json::from_str(CANONICAL_ZEROS_JSON).expect("failed to parse canonical zeros JSON")
+});
+
+/// Lazily parsed Merkle Tree Frontier (MTF) vectors from the JSON file.
+pub static SOLIDITY_MTF_VECTORS: LazyLock<MtfVectorsFile> = LazyLock::new(|| {
+    serde_json::from_str(MTF_VECTORS_JSON).expect("failed to parse MTF vectors JSON")
+});
+
+// CLAIM DATA SOURCE
+// ================================================================================================
+
+/// Identifies the source of claim data used in bridge-in tests and benchmarks.
+#[derive(Debug, Clone, Copy)]
+pub enum ClaimDataSource {
+    /// Real on-chain claimAsset data from claim_asset_vectors_real_tx.json (L1 to Miden).
+    RealL1ToMiden,
+    /// Locally simulated bridgeAsset data from claim_asset_vectors_local_tx.json (L1 to Miden).
+    SimulatedL1ToMiden,
+    /// Rollup deposit data from claim_asset_vectors_rollup_tx.json (L2 to Miden).
+    SimulatedL2ToMiden,
+}
+
+impl ClaimDataSource {
+    /// Returns the `(ProofData, LeafData, ExitRoot, CgiChainHash)` tuple for this data source.
+    pub fn get_data(self) -> (ProofData, LeafData, ExitRoot, CgiChainHash) {
+        let vector = match self {
+            ClaimDataSource::RealL1ToMiden => &*CLAIM_ASSET_VECTOR,
+            ClaimDataSource::SimulatedL1ToMiden => &*CLAIM_ASSET_VECTOR_LOCAL,
+            ClaimDataSource::SimulatedL2ToMiden => &*CLAIM_ASSET_VECTOR_ROLLUP,
+        };
+        let ger = ExitRoot::new(
+            hex_to_bytes(&vector.proof.global_exit_root).expect("valid global exit root hex"),
+        );
+        let cgi_chain_hash = CgiChainHash::new(
+            hex_to_bytes(&vector.proof.claimed_global_index_hash_chain)
+                .expect("invalid CGI chain hash"),
+        );
+
+        (vector.proof.to_proof_data(), vector.leaf.to_leaf_data(), ger, cgi_chain_hash)
+    }
+}

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -515,11 +515,10 @@ fn generate_event_file_content(
     for (event_path, event_name) in events {
         let value = EventId::from_name(event_path).as_felt().as_canonical_u64();
         debug_assert!(!event_name.is_empty());
-        writeln!(&mut output, "const {}_ID: u64 = {};", event_name, value)?;
+        writeln!(&mut output, "const {event_name}_ID: u64 = {value};")?;
         writeln!(
             &mut output,
-            "static {}_NAME: ::miden_core::events::EventName = ::miden_core::events::EventName::new(\"{}\");",
-            event_name, event_path
+            "static {event_name}_NAME: ::miden_core::events::EventName = ::miden_core::events::EventName::new(\"{event_path}\");"
         )?;
         writeln!(&mut output)?;
     }

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -43,6 +43,13 @@ use super::test_utils::{
     SOLIDITY_MERKLE_PROOF_VECTORS,
 };
 
+// CONSTANTS
+// ================================================================================================
+
+/// Maximum allowed cycle count for CLAIM note processing.
+/// Current observed values: ~25,662 (real/simulated), ~40,485 (rollup).
+const MAX_CLAIM_NOTE_PROCESSING_CYCLES: usize = 64_000;
+
 // HELPER FUNCTIONS
 // ================================================================================================
 
@@ -102,18 +109,20 @@ fn merkle_proof_verification_code(
 /// TX3: MINT → aggfaucet (mints asset, creates P2ID note)
 /// TX4: P2ID → destination (simulated case only)
 ///
-/// Parameterized over two claim data sources:
-/// - [`ClaimDataSource::Real`]: uses real [`ProofData`] and [`LeafData`] from
+/// Parameterized over three claim data sources:
+/// - [`ClaimDataSource::RealL1ToMiden`]: uses real [`ProofData`] and [`LeafData`] from
 ///   `claim_asset_vectors_real_tx.json`, captured from an actual on-chain `claimAsset` transaction.
-/// - [`ClaimDataSource::Simulated`]: uses locally generated [`ProofData`] and [`LeafData`] from
-///   `claim_asset_vectors_local_tx.json`, produced by simulating a `bridgeAsset()` call.
+/// - [`ClaimDataSource::SimulatedL1ToMiden`]: uses locally generated [`ProofData`] and [`LeafData`]
+///   from `claim_asset_vectors_local_tx.json`, produced by simulating a `bridgeAsset()` call.
+/// - [`ClaimDataSource::SimulatedL2ToMiden`]: uses rollup deposit data from
+///   `claim_asset_vectors_rollup_tx.json`, produced by simulating a rollup deposit.
 ///
 /// Note: Modifying anything in the real test vectors would invalidate the Merkle proof,
 /// as the proof was computed for the original leaf data including the original destination.
 #[rstest::rstest]
-#[case::real(ClaimDataSource::Real)]
-#[case::simulated(ClaimDataSource::Simulated)]
-#[case::rollup(ClaimDataSource::Rollup)]
+#[case::real_l1_to_miden(ClaimDataSource::RealL1ToMiden)]
+#[case::simulated_l1_to_miden(ClaimDataSource::SimulatedL1ToMiden)]
+#[case::simulated_l2_to_miden(ClaimDataSource::SimulatedL2ToMiden)]
 #[tokio::test]
 async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> anyhow::Result<()> {
     use miden_agglayer::AggLayerBridge;
@@ -179,7 +188,7 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
     // For the simulated/rollup case, create the destination account so we can consume the P2ID note
     let destination_account = if matches!(
         data_source,
-        ClaimDataSource::Simulated | ClaimDataSource::Rollup
+        ClaimDataSource::SimulatedL1ToMiden | ClaimDataSource::SimulatedL2ToMiden
     ) {
         let dest =
             Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE, IncrNonceAuthComponent);
@@ -298,6 +307,12 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
 
     assert_eq!(cgi_chain_hash, actual_cgi_chain_hash);
 
+    let claim_cycles = claim_executed.measurements().notes_processing;
+    assert!(
+        claim_cycles <= MAX_CLAIM_NOTE_PROCESSING_CYCLES,
+        "CLAIM note processing exceeded cycle budget: {claim_cycles} > {MAX_CLAIM_NOTE_PROCESSING_CYCLES}"
+    );
+
     // VERIFY MINT NOTE WAS CREATED BY THE BRIDGE
     // --------------------------------------------------------------------------------------------
     assert_eq!(claim_executed.output_notes().num_notes(), 1);
@@ -414,7 +429,7 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
 ///    been spent"
 #[tokio::test]
 async fn test_duplicate_claim_note_rejected() -> anyhow::Result<()> {
-    let data_source = ClaimDataSource::Simulated;
+    let data_source = ClaimDataSource::SimulatedL1ToMiden;
     let mut builder = MockChain::builder();
 
     // CREATE BRIDGE ADMIN ACCOUNT

--- a/crates/miden-testing/tests/agglayer/test_utils.rs
+++ b/crates/miden-testing/tests/agglayer/test_utils.rs
@@ -1,19 +1,16 @@
 extern crate alloc;
 
-use alloc::string::String;
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 
-use miden_agglayer::claim_note::{ProofData, SmtNode};
-use miden_agglayer::{
-    CgiChainHash,
-    EthAddress,
-    EthAmount,
-    ExitRoot,
-    GlobalIndex,
-    LeafData,
-    MetadataHash,
-    agglayer_library,
+use miden_agglayer::agglayer_library;
+pub use miden_agglayer::testing::{
+    ClaimDataSource,
+    LEAF_VALUE_VECTORS_JSON,
+    LeafValueVector,
+    MerkleProofVerificationFile,
+    MtfVectorsFile,
+    SOLIDITY_CANONICAL_ZEROS,
+    SOLIDITY_MERKLE_PROOF_VECTORS,
 };
 use miden_assembly::{Assembler, DefaultSourceManager};
 use miden_core_lib::CoreLibrary;
@@ -28,290 +25,25 @@ use miden_processor::{
 };
 use miden_protocol::transaction::TransactionKernel;
 use miden_protocol::utils::sync::LazyLock;
-use miden_tx::utils::hex_to_bytes;
-use serde::Deserialize;
 
 // EMBEDDED TEST VECTOR JSON FILES
 // ================================================================================================
-
-/// Claim asset test vectors JSON — contains both LeafData and ProofData from a real claimAsset
-/// transaction.
-const CLAIM_ASSET_VECTORS_JSON: &str = include_str!(
-    "../../../miden-agglayer/solidity-compat/test-vectors/claim_asset_vectors_real_tx.json"
-);
-
-/// Bridge asset test vectors JSON — contains test data for an L1 bridgeAsset transaction.
-const BRIDGE_ASSET_VECTORS_JSON: &str = include_str!(
-    "../../../miden-agglayer/solidity-compat/test-vectors/claim_asset_vectors_local_tx.json"
-);
-
-/// Rollup deposit test vectors JSON — contains test data for a rollup deposit with two-level
-/// Merkle proofs.
-const ROLLUP_ASSET_VECTORS_JSON: &str = include_str!(
-    "../../../miden-agglayer/solidity-compat/test-vectors/claim_asset_vectors_rollup_tx.json"
-);
-
-/// Leaf data test vectors JSON from the Foundry-generated file.
-pub const LEAF_VALUE_VECTORS_JSON: &str =
-    include_str!("../../../miden-agglayer/solidity-compat/test-vectors/leaf_value_vectors.json");
-
-/// Merkle proof verification vectors JSON from the Foundry-generated file.
-pub const MERKLE_PROOF_VECTORS_JSON: &str =
-    include_str!("../../../miden-agglayer/solidity-compat/test-vectors/merkle_proof_vectors.json");
-
-/// Canonical zeros JSON from the Foundry-generated file.
-pub const CANONICAL_ZEROS_JSON: &str =
-    include_str!("../../../miden-agglayer/solidity-compat/test-vectors/canonical_zeros.json");
 
 /// Merkle Tree Frontier (MTF) vectors JSON from the Foundry-generated file.
 pub const MTF_VECTORS_JSON: &str = include_str!(
     "../../../miden-agglayer/solidity-compat/test-vectors/merkle_tree_frontier_vectors.json"
 );
 
-// SERDE HELPERS
-// ================================================================================================
-
-/// Deserializes a JSON value that may be either a number or a string into a `String`.
-///
-/// Foundry's `vm.serializeUint` outputs JSON numbers for uint256 values.
-/// This deserializer accepts both `"100"` (string) and `100` (number) forms.
-fn deserialize_uint_to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = serde_json::Value::deserialize(deserializer)?;
-    match value {
-        serde_json::Value::String(s) => Ok(s),
-        serde_json::Value::Number(n) => Ok(n.to_string()),
-        _ => Err(serde::de::Error::custom("expected a number or string for amount")),
-    }
-}
-
-/// Deserializes a JSON array of values that may be either numbers or strings into `Vec<String>`.
-///
-/// Array-level counterpart of [`deserialize_uint_to_string`].
-fn deserialize_uint_vec_to_strings<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
-    values
-        .into_iter()
-        .map(|v| match v {
-            serde_json::Value::String(s) => Ok(s),
-            serde_json::Value::Number(n) => Ok(n.to_string()),
-            _ => Err(serde::de::Error::custom("expected a number or string for amount")),
-        })
-        .collect()
-}
-
-// TEST VECTOR TYPES
-// ================================================================================================
-
-/// Deserialized leaf value test vector from Solidity-generated JSON.
-#[derive(Debug, Deserialize)]
-pub struct LeafValueVector {
-    pub origin_network: u32,
-    pub origin_token_address: String,
-    pub destination_network: u32,
-    pub destination_address: String,
-    #[serde(deserialize_with = "deserialize_uint_to_string")]
-    pub amount: String,
-    pub metadata_hash: String,
-    #[allow(dead_code)]
-    pub leaf_value: String,
-}
-
-impl LeafValueVector {
-    /// Converts this test vector into a `LeafData` instance.
-    pub fn to_leaf_data(&self) -> LeafData {
-        LeafData {
-            origin_network: self.origin_network,
-            origin_token_address: EthAddress::from_hex(&self.origin_token_address)
-                .expect("valid origin token address hex"),
-            destination_network: self.destination_network,
-            destination_address: EthAddress::from_hex(&self.destination_address)
-                .expect("valid destination address hex"),
-            amount: EthAmount::from_uint_str(&self.amount).expect("valid amount uint string"),
-            metadata_hash: MetadataHash::new(
-                hex_to_bytes(&self.metadata_hash).expect("valid metadata hash hex"),
-            ),
-        }
-    }
-}
-
-/// Deserialized proof value test vector from Solidity-generated JSON.
-/// Contains SMT proofs, exit roots, global index, and expected global exit root.
-#[derive(Debug, Deserialize)]
-pub struct ProofValueVector {
-    pub smt_proof_local_exit_root: Vec<String>,
-    pub smt_proof_rollup_exit_root: Vec<String>,
-    pub global_index: String,
-    pub mainnet_exit_root: String,
-    pub rollup_exit_root: String,
-    /// Expected global exit root: keccak256(mainnetExitRoot || rollupExitRoot)
-    #[allow(dead_code)]
-    pub global_exit_root: String,
-    pub claimed_global_index_hash_chain: String,
-}
-
-impl ProofValueVector {
-    /// Converts this test vector into a `ProofData` instance.
-    pub fn to_proof_data(&self) -> ProofData {
-        let smt_proof_local: [SmtNode; 32] = self
-            .smt_proof_local_exit_root
-            .iter()
-            .map(|s| SmtNode::new(hex_to_bytes(s).expect("valid smt proof hex")))
-            .collect::<Vec<_>>()
-            .try_into()
-            .expect("expected 32 SMT proof nodes for local exit root");
-
-        let smt_proof_rollup: [SmtNode; 32] = self
-            .smt_proof_rollup_exit_root
-            .iter()
-            .map(|s| SmtNode::new(hex_to_bytes(s).expect("valid smt proof hex")))
-            .collect::<Vec<_>>()
-            .try_into()
-            .expect("expected 32 SMT proof nodes for rollup exit root");
-
-        ProofData {
-            smt_proof_local_exit_root: smt_proof_local,
-            smt_proof_rollup_exit_root: smt_proof_rollup,
-            global_index: GlobalIndex::from_hex(&self.global_index)
-                .expect("valid global index hex"),
-            mainnet_exit_root: ExitRoot::new(
-                hex_to_bytes(&self.mainnet_exit_root).expect("valid mainnet exit root hex"),
-            ),
-            rollup_exit_root: ExitRoot::new(
-                hex_to_bytes(&self.rollup_exit_root).expect("valid rollup exit root hex"),
-            ),
-        }
-    }
-}
-
-/// Deserialized claim asset test vector from Solidity-generated JSON.
-/// Contains both LeafData and ProofData from a real claimAsset transaction.
-#[derive(Debug, Deserialize)]
-pub struct ClaimAssetVector {
-    #[serde(flatten)]
-    pub proof: ProofValueVector,
-
-    #[serde(flatten)]
-    pub leaf: LeafValueVector,
-}
-
-/// Deserialized Merkle proof vectors from Solidity DepositContractBase.sol.
-/// Uses parallel arrays for leaves and roots. For each element from leaves/roots there are 32
-/// elements from merkle_paths, which represent the merkle path for that leaf + root.
-#[derive(Debug, Deserialize)]
-pub struct MerkleProofVerificationFile {
-    pub leaves: Vec<String>,
-    pub roots: Vec<String>,
-    pub merkle_paths: Vec<String>,
-}
-
-/// Deserialized canonical zeros from Solidity DepositContractBase.sol.
-#[derive(Debug, Deserialize)]
-pub struct CanonicalZerosFile {
-    pub canonical_zeros: Vec<String>,
-}
-
-/// Deserialized Merkle Tree Frontier vectors from Solidity DepositContractV2.
-///
-/// Each leaf is produced by `getLeafValue` using the same hardcoded fields as `bridge_out.masm`
-/// (leafType=0, originNetwork=64), parametrised by
-/// a shared `origin_token_address`, `amounts[i]`, per-index
-/// `destination_networks[i]` / `destination_addresses[i]`, and
-/// `metadataHash = keccak256(abi.encode(token_name, token_symbol, token_decimals))`.
-///
-/// Amounts are serialized as uint256 values (JSON numbers).
-#[derive(Debug, Deserialize)]
-pub struct MTFVectorsFile {
-    pub leaves: Vec<String>,
-    pub roots: Vec<String>,
-    pub counts: Vec<u32>,
-    #[serde(deserialize_with = "deserialize_uint_vec_to_strings")]
-    pub amounts: Vec<String>,
-    pub origin_token_address: String,
-    pub destination_networks: Vec<u32>,
-    pub destination_addresses: Vec<String>,
-    #[allow(dead_code)]
-    pub token_name: String,
-    pub token_symbol: String,
-    pub token_decimals: u8,
-}
-
 // LAZY-PARSED TEST VECTORS
 // ================================================================================================
 
-/// Lazily parsed claim asset test vector from the JSON file.
-pub static CLAIM_ASSET_VECTOR: LazyLock<ClaimAssetVector> = LazyLock::new(|| {
-    serde_json::from_str(CLAIM_ASSET_VECTORS_JSON)
-        .expect("failed to parse claim asset vectors JSON")
-});
-
-/// Lazily parsed bridge asset test vector from the JSON file (locally simulated L1 transaction).
-pub static CLAIM_ASSET_VECTOR_LOCAL: LazyLock<ClaimAssetVector> = LazyLock::new(|| {
-    serde_json::from_str(BRIDGE_ASSET_VECTORS_JSON)
-        .expect("failed to parse bridge asset vectors JSON")
-});
-
-/// Lazily parsed rollup deposit test vector from the JSON file.
-pub static CLAIM_ASSET_VECTOR_ROLLUP: LazyLock<ClaimAssetVector> = LazyLock::new(|| {
-    serde_json::from_str(ROLLUP_ASSET_VECTORS_JSON)
-        .expect("failed to parse rollup asset vectors JSON")
-});
-
-/// Lazily parsed Merkle proof vectors from the JSON file.
-pub static SOLIDITY_MERKLE_PROOF_VECTORS: LazyLock<MerkleProofVerificationFile> =
-    LazyLock::new(|| {
-        serde_json::from_str(MERKLE_PROOF_VECTORS_JSON)
-            .expect("failed to parse Merkle proof vectors JSON")
-    });
-
-/// Lazily parsed canonical zeros from the JSON file.
-pub static SOLIDITY_CANONICAL_ZEROS: LazyLock<CanonicalZerosFile> = LazyLock::new(|| {
-    serde_json::from_str(CANONICAL_ZEROS_JSON).expect("failed to parse canonical zeros JSON")
-});
-
 /// Lazily parsed Merkle Tree frontier (MTF) vectors from the JSON file.
-pub static SOLIDITY_MTF_VECTORS: LazyLock<MTFVectorsFile> = LazyLock::new(|| {
+pub static SOLIDITY_MTF_VECTORS: LazyLock<MtfVectorsFile> = LazyLock::new(|| {
     serde_json::from_str(MTF_VECTORS_JSON).expect("failed to parse MTF vectors JSON")
 });
 
 // HELPER FUNCTIONS
 // ================================================================================================
-
-/// Identifies the source of claim data used in bridge-in tests.
-#[derive(Debug, Clone, Copy)]
-pub enum ClaimDataSource {
-    /// Real on-chain claimAsset data from claim_asset_vectors_real_tx.json.
-    Real,
-    /// Locally simulated bridgeAsset data from claim_asset_vectors_local_tx.json.
-    Simulated,
-    /// Rollup deposit data from claim_asset_vectors_rollup_tx.json.
-    Rollup,
-}
-
-impl ClaimDataSource {
-    /// Returns the `(ProofData, LeafData, ExitRoot, CgiChainHash)` tuple for this data source.
-    pub fn get_data(self) -> (ProofData, LeafData, ExitRoot, CgiChainHash) {
-        let vector = match self {
-            ClaimDataSource::Real => &*CLAIM_ASSET_VECTOR,
-            ClaimDataSource::Simulated => &*CLAIM_ASSET_VECTOR_LOCAL,
-            ClaimDataSource::Rollup => &*CLAIM_ASSET_VECTOR_ROLLUP,
-        };
-        let ger = ExitRoot::new(
-            hex_to_bytes(&vector.proof.global_exit_root).expect("valid global exit root hex"),
-        );
-        let cgi_chain_hash = CgiChainHash::new(
-            hex_to_bytes(&vector.proof.claimed_global_index_hash_chain)
-                .expect("invalid CGI chain hash"),
-        );
-
-        (vector.proof.to_proof_data(), vector.leaf.to_leaf_data(), ger, cgi_chain_hash)
-    }
-}
 
 /// Execute a program with a default host and optional advice inputs.
 pub async fn execute_program_with_default_host(


### PR DESCRIPTION
Turns out that https://github.com/0xMiden/protocol/pull/2618 was never merged into `main` nor `next` (looking at the commit history, it seems that #2618 was merged into `agglayer` branch short after `agglayer` got merged into `next`).

This is targeting `main` because then we can also merge in https://github.com/0xMiden/protocol/pull/2752 cleanly, patch release (it's purely an internal perf change) and have max cycle count lowered back to 128k :)