### PR TITLE
chore: make metadata procedure names consistent and update swap tag construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [BREAKING] Reduced `MAX_ASSETS_PER_NOTE` from 255 to 64 and `NOTE_MEM_SIZE` from 3072 to 1024 ([#2741](https://github.com/0xMiden/protocol/issues/2741)).
 - Added `metadata_into_note_type` procedure to `note.masm` for extracting note type from metadata header ([#2738](https://github.com/0xMiden/protocol/pull/2738)).
 - [BREAKING] Renamed `extract_sender_from_metadata` to `metadata_into_sender` and `extract_attachment_info_from_metadata` to `metadata_into_attachment_info` in `note.masm` ([#2758](https://github.com/0xMiden/protocol/pull/2758)).
+- Updated `SwapNote::build_tag` to use 1-bit `NoteType` encoding, increasing script root bits from 14 to 15 ([#2758](https://github.com/0xMiden/protocol/pull/2758)).
 - Added `AssetAmount` wrapper type for validated fungible asset amounts ([#2721](https://github.com/0xMiden/protocol/pull/2721)).
 - [BREAKING] Renamed `ProvenBatch::new` to `new_unchecked` ([#2687](https://github.com/0xMiden/miden-base/issues/2687)).
 - Added `ShortCapitalString` type and related `TokenSymbol` and `RoleSymbol` types ([#2690](https://github.com/0xMiden/protocol/pull/2690)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - [BREAKING] Reduced `MAX_ASSETS_PER_NOTE` from 255 to 64 and `NOTE_MEM_SIZE` from 3072 to 1024 ([#2741](https://github.com/0xMiden/protocol/issues/2741)).
 - Added `metadata_into_note_type` procedure to `note.masm` for extracting note type from metadata header ([#2738](https://github.com/0xMiden/protocol/pull/2738)).
+- [BREAKING] Renamed `extract_sender_from_metadata` to `metadata_into_sender` and `extract_attachment_info_from_metadata` to `metadata_into_attachment_info` in `note.masm` ([#2758](https://github.com/0xMiden/protocol/pull/2758)).
 - Added `AssetAmount` wrapper type for validated fungible asset amounts ([#2721](https://github.com/0xMiden/protocol/pull/2721)).
 - [BREAKING] Renamed `ProvenBatch::new` to `new_unchecked` ([#2687](https://github.com/0xMiden/miden-base/issues/2687)).
 - Added `ShortCapitalString` type and related `TokenSymbol` and `RoleSymbol` types ([#2690](https://github.com/0xMiden/protocol/pull/2690)).

--- a/crates/miden-protocol/asm/protocol/active_note.masm
+++ b/crates/miden-protocol/asm/protocol/active_note.masm
@@ -184,7 +184,7 @@ pub proc get_sender
     # => [METADATA_HEADER]
 
     # extract the sender ID from the metadata header
-    exec.note::extract_sender_from_metadata
+    exec.note::metadata_into_sender
     # => [sender_id_suffix, sender_id_prefix]
 end
 

--- a/crates/miden-protocol/asm/protocol/input_note.masm
+++ b/crates/miden-protocol/asm/protocol/input_note.masm
@@ -182,7 +182,7 @@ pub proc get_sender
     # => [METADATA_HEADER]
 
     # extract the sender ID from the metadata header
-    exec.note::extract_sender_from_metadata
+    exec.note::metadata_into_sender
     # => [sender_id_suffix, sender_id_prefix]
 end
 

--- a/crates/miden-protocol/asm/protocol/note.masm
+++ b/crates/miden-protocol/asm/protocol/note.masm
@@ -182,7 +182,7 @@ end
 #! - METADATA_HEADER is the metadata of a note.
 #! - sender_{suffix,prefix} are the suffix and prefix felts of the sender ID of the note which
 #!   metadata was provided.
-pub proc extract_sender_from_metadata
+pub proc metadata_into_sender
     # => [sender_id_suffix_type_version, sender_id_prefix, tag, attachment_kind_scheme]
 
     # drop tag and attachment_kind_scheme
@@ -205,7 +205,7 @@ end
 #! - attachment_scheme is the attachment scheme of the note.
 #!
 #! Invocation: exec
-pub proc extract_attachment_info_from_metadata
+pub proc metadata_into_attachment_info
     # => [sender_id_suffix_type_version, sender_id_prefix, tag, attachment_kind_scheme]
     drop drop drop
     # => [attachment_kind_scheme]
@@ -234,7 +234,6 @@ end
 #!
 #! Invocation: exec
 pub proc metadata_into_note_type
-
     movdn.3 drop drop drop
     # => [sender_id_suffix_type_version]
 

--- a/crates/miden-standards/asm/standards/attachments/network_account_target.masm
+++ b/crates/miden-standards/asm/standards/attachments/network_account_target.masm
@@ -108,7 +108,7 @@ pub proc active_account_matches_target_account
     swapw
     # => [METADATA_HEADER, NOTE_ATTACHMENT]
 
-    exec.note::extract_attachment_info_from_metadata
+    exec.note::metadata_into_attachment_info
     # => [attachment_kind, attachment_scheme, NOTE_ATTACHMENT]
 
     swap

--- a/crates/miden-standards/src/note/swap.rs
+++ b/crates/miden-standards/src/note/swap.rs
@@ -126,7 +126,7 @@ impl SwapNote {
     ///
     /// ```text
     /// [
-    ///   note_type (2 bits) | script_root (14 bits)
+    ///   note_type (1 bit) | script_root (15 bits)
     ///   | offered_asset_faucet_id (8 bits) | requested_asset_faucet_id (8 bits)
     /// ]
     /// ```
@@ -138,10 +138,10 @@ impl SwapNote {
         requested_asset: &Asset,
     ) -> NoteTag {
         let swap_root_bytes = Self::script().root().as_bytes();
-        // Construct the swap use case ID from the 14 most significant bits of the script root. This
-        // leaves the two most significant bits zero.
-        let mut swap_use_case_id = (swap_root_bytes[0] as u16) << 6;
-        swap_use_case_id |= (swap_root_bytes[1] >> 2) as u16;
+        // Construct the swap use case ID from the 15 most significant bits of the script root. This
+        // leaves the most significant bit zero.
+        let mut swap_use_case_id = (swap_root_bytes[0] as u16) << 7;
+        swap_use_case_id |= (swap_root_bytes[1] >> 1) as u16;
 
         // Get bits 0..8 from the faucet IDs of both assets which will form the tag payload.
         let offered_asset_id: u64 = offered_asset.faucet_id().prefix().into();
@@ -152,7 +152,7 @@ impl SwapNote {
 
         let asset_pair = ((offered_asset_tag as u16) << 8) | (requested_asset_tag as u16);
 
-        let tag = ((note_type as u8 as u32) << 30)
+        let tag = ((note_type as u8 as u32) << 31)
             | ((swap_use_case_id as u32) << 16)
             | asset_pair as u32;
 
@@ -419,18 +419,18 @@ mod tests {
         let actual_tag = SwapNote::build_tag(note_type, &offered_asset, &requested_asset);
 
         assert_eq!(actual_tag.as_u32() as u16, expected_asset_pair, "asset pair should match");
-        assert_eq!((actual_tag.as_u32() >> 30) as u8, note_type as u8, "note type should match");
+        assert_eq!((actual_tag.as_u32() >> 31) as u8, note_type as u8, "note type should match");
         // Check the 8 bits of the first script root byte.
         assert_eq!(
-            (actual_tag.as_u32() >> 22) as u8,
+            (actual_tag.as_u32() >> 23) as u8,
             SwapNote::script_root().as_bytes()[0],
             "swap script root byte 0 should match"
         );
-        // Extract the 6 bits of the second script root byte and shift for comparison.
+        // Extract the 7 bits of the second script root byte and shift for comparison.
         assert_eq!(
-            ((actual_tag.as_u32() & 0b00000000_00111111_00000000_00000000) >> 16) as u8,
-            SwapNote::script_root().as_bytes()[1] >> 2,
-            "swap script root byte 1 should match with the lower two bits set to zero"
+            ((actual_tag.as_u32() & 0b00000000_01111111_00000000_00000000) >> 16) as u8,
+            SwapNote::script_root().as_bytes()[1] >> 1,
+            "swap script root byte 1 should match with the highest bit set to zero"
         );
     }
 }

--- a/crates/miden-testing/src/standards/network_account_target.rs
+++ b/crates/miden-testing/src/standards/network_account_target.rs
@@ -31,7 +31,7 @@ async fn network_account_target_get_id() -> anyhow::Result<()> {
         begin
             push.{attachment_word}
             push.{metadata_header}
-            exec.note::extract_attachment_info_from_metadata
+            exec.note::metadata_into_attachment_info
             # => [attachment_kind, attachment_scheme, NOTE_ATTACHMENT]
             swap
             # => [attachment_scheme, attachment_kind, NOTE_ATTACHMENT]

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -125,7 +125,9 @@ Note utility procedures can be used to compute the required utility data or writ
 | `write_assets_to_memory`    | Writes the assets data stored in the advice map to the memory specified by the provided destination pointer.<br/><br/>**Inputs:** `[ASSETS_COMMITMENT, num_assets, dest_ptr]`<br/>**Outputs:** `[num_assets, dest_ptr]` | Any     |
 | `build_recipient_hash`      | Returns the `RECIPIENT` for a specified `SERIAL_NUM`, `SCRIPT_ROOT`, and storage commitment.<br/><br/>**Inputs:** `[SERIAL_NUM, SCRIPT_ROOT, STORAGE_COMMITMENT]`<br/>**Outputs:** `[RECIPIENT]`                           | Any     |
 | `build_recipient`           | Builds the recipient hash from note storage, script root, and serial number.<br/><br/>**Inputs:** `[storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT]`<br/>**Outputs:** `[RECIPIENT]`                                     | Any     |
-| `extract_sender_from_metadata` | Extracts the sender ID from the provided metadata word.<br/><br/>**Inputs:** `[METADATA]`<br/>**Outputs:** `[sender_id_suffix, sender_id_prefix]` | Any     |
+| `metadata_into_sender` | Extracts the sender ID from the provided metadata word.<br/><br/>**Inputs:** `[METADATA]`<br/>**Outputs:** `[sender_id_suffix, sender_id_prefix]` | Any     |
+| `metadata_into_attachment_info` | Extracts the attachment kind and scheme from the provided metadata header.<br/><br/>**Inputs:** `[METADATA_HEADER]`<br/>**Outputs:** `[attachment_kind, attachment_scheme]` | Any     |
+| `metadata_into_note_type` | Extracts the note type from the provided metadata header. The note type is encoded as a single bit (0 = Private, 1 = Public).<br/><br/>**Inputs:** `[METADATA_HEADER]`<br/>**Outputs:** `[note_type]` | Any     |
 
 ## Transaction Procedures (`miden::protocol::tx`)
 


### PR DESCRIPTION
Small housekeeping changes:
- Make names of `miden::protocol::note` procedures consistent with the recently added `metadata_into_note_type`.
- Follow-up on note type reduction from 2 bits to 1 bit by updating the swap tag construction which wasn't updated in #2691.
