### PR TITLE
feat: Add cycle counts to successful and failed notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Added shared `ProcedurePolicy` for AuthMultisig ([#2670](https://github.com/0xMiden/protocol/pull/2670)).
 - [BREAKING] Changed `NoteType` encoding from 2 bits to 1 and makes `NoteType::Private` the default ([#2691](https://github.com/0xMiden/miden-base/issues/2691)).
 - Added `BlockNumber::saturating_sub()` ([#2660](https://github.com/0xMiden/protocol/issues/2660)).
-- [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
+- [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` and removed public fields from related types ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
 
 ## 0.14.3 (2026-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added shared `ProcedurePolicy` for AuthMultisig ([#2670](https://github.com/0xMiden/protocol/pull/2670)).
 - [BREAKING] Changed `NoteType` encoding from 2 bits to 1 and makes `NoteType::Private` the default ([#2691](https://github.com/0xMiden/miden-base/issues/2691)).
 - Added `BlockNumber::saturating_sub()` ([#2660](https://github.com/0xMiden/protocol/issues/2660)).
+- [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
 
 ## 0.14.3 (2026-04-07)
 

--- a/bin/bench-note-checker/src/lib.rs
+++ b/bin/bench-note-checker/src/lib.rs
@@ -137,14 +137,14 @@ pub async fn run_mixed_notes_check(setup: &MixedNotesSetup) -> anyhow::Result<()
     // Validate that we got the expected number of successful notes.
     assert_eq!(
         setup.expected_successful_count,
-        result.successful.len(),
+        result.successful().len(),
         "Expected {} successful notes, got {}",
         setup.expected_successful_count,
-        result.successful.len()
+        result.successful().len()
     );
 
     // Validate that we have some failed notes (all the failing ones).
-    assert!(!result.failed.is_empty(), "Expected some failed notes");
+    assert!(!result.failed().is_empty(), "Expected some failed notes");
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -36,13 +36,7 @@ use miden_standards::note::{
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_standards::testing::note::NoteBuilder;
 use miden_tx::auth::UnreachableAuth;
-use miden_tx::{
-    FailedNote,
-    NoteConsumptionChecker,
-    NoteConsumptionInfo,
-    TransactionExecutor,
-    TransactionExecutorError,
-};
+use miden_tx::{NoteConsumptionChecker, TransactionExecutor, TransactionExecutorError};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
@@ -90,15 +84,16 @@ async fn check_note_consumability_standard_notes_success() -> anyhow::Result<()>
         .check_notes_consumability(target_account_id, block_ref, notes.clone(), tx_args)
         .await?;
 
-    assert_matches!(consumption_info, NoteConsumptionInfo { successful, failed, .. } => {
-        assert_eq!(successful.len(), notes.len());
+    let successful = consumption_info.successful();
+    let failed = consumption_info.failed();
 
-        // we asserted that `successful` and `notes` vectors have the same length, so it's safe to
-        // check their equality that way
-        successful.iter().for_each(|s| assert!(notes.contains(&s.note)));
+    assert_eq!(successful.len(), notes.len());
 
-        assert!(failed.is_empty());
-    });
+    // we asserted that `successful` and `notes` vectors have the same length, so it's safe to
+    // check their equality that way
+    successful.iter().for_each(|s| assert!(notes.contains(s.note())));
+
+    assert!(failed.is_empty());
 
     Ok(())
 }
@@ -137,14 +132,15 @@ async fn check_note_consumability_custom_notes_success(
         .check_notes_consumability(account_id, block_ref, notes.clone(), tx_args)
         .await?;
 
-    assert_matches!(consumption_info, NoteConsumptionInfo { successful, failed, .. }=> {
-        if notes.is_empty() {
-            assert!(successful.is_empty());
-            assert!(failed.is_empty());
-        } else {
-            assert_eq!(successful.len(), notes.len());
-        }
-    });
+    let successful = consumption_info.successful();
+    let failed = consumption_info.failed();
+
+    if notes.is_empty() {
+        assert!(successful.is_empty());
+        assert!(failed.is_empty());
+    } else {
+        assert_eq!(successful.len(), notes.len());
+    }
     Ok(())
 }
 
@@ -216,51 +212,41 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
         .check_notes_consumability(account_id, block_ref, notes, tx_args)
         .await?;
 
-    assert_matches!(
-        consumption_info,
-        NoteConsumptionInfo {
-            successful,
-            failed
-        } => {
-                assert_eq!(failed.len(), 2);
-                assert_eq!(successful.len(), 3);
+    let successful = consumption_info.successful();
+    let failed = consumption_info.failed();
 
-                // First failing note.
-                assert_matches!(
-                    failed.first().expect("first failed notes should exist"),
-                    FailedNote {
-                        note,
-                        error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. }),
-                        ..
-                    } => {
-                        assert_eq!(
-                            note.id(),
-                            failing_note_2.id(),
-                        );
-                    }
-                );
-                // Second failing note.
-                assert_matches!(
-                    failed.get(1).expect("second failed note should exist"),
-                    FailedNote {
-                        note,
-                        error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. }),
-                        ..
-                    } => {
-                        assert_eq!(
-                            note.id(),
-                            failing_note_1.id(),
-                        );
-                    }
-                );
-                // Successful notes.
-                assert_eq!(
-                    [successful[0].note.id(), successful[1].note.id(), successful[2].note.id()],
-                    [successful_note_2.id(), successful_note_1.id(), successful_note_3.id()],
-                );
+    assert_eq!(failed.len(), 2);
+    assert_eq!(successful.len(), 3);
+
+    // First failing note.
+    let first_failed = failed.first().expect("first failed notes should exist");
+    assert_matches!(
+        first_failed.error(),
+        TransactionExecutorError::TransactionProgramExecutionFailed(
+            ExecutionError::OperationError {
+                err: miden_processor::operation::OperationError::DivideByZero,
+                ..
             }
+        )
+    );
+    assert_eq!(first_failed.note().id(), failing_note_2.id());
+
+    // Second failing note.
+    let second_failed = failed.get(1).expect("second failed note should exist");
+    assert_matches!(
+        second_failed.error(),
+        TransactionExecutorError::TransactionProgramExecutionFailed(
+            ExecutionError::OperationError {
+                err: miden_processor::operation::OperationError::DivideByZero,
+                ..
+            }
+        )
+    );
+    assert_eq!(second_failed.note().id(), failing_note_1.id());
+    // Successful notes.
+    assert_eq!(
+        [successful[0].note().id(), successful[1].note().id(), successful[2].note().id()],
+        [successful_note_2.id(), successful_note_1.id(), successful_note_3.id()],
     );
     Ok(())
 }
@@ -300,16 +286,11 @@ async fn check_note_consumability_epilogue_failure() -> anyhow::Result<()> {
         .check_notes_consumability(account_id, block_ref, notes, tx_args)
         .await?;
 
-    assert_matches!(
-       consumption_info,
-       NoteConsumptionInfo {
-           successful,
-           failed
-       } => {
-           assert!(successful.is_empty());
-           assert_eq!(failed.len(), 1);
-       }
-    );
+    let successful = consumption_info.successful();
+    let failed = consumption_info.failed();
+
+    assert!(successful.is_empty());
+    assert_eq!(failed.len(), 1);
     Ok(())
 }
 
@@ -382,51 +363,42 @@ async fn check_note_consumability_epilogue_failure_with_new_combination() -> any
         .check_notes_consumability(account_id, block_ref, notes, tx_args)
         .await?;
 
-    assert_matches!(
-        consumption_info,
-        NoteConsumptionInfo {
-            successful,
-            failed
-        } => {
-                assert_eq!(failed.len(), 2);
-                assert_eq!(successful.len(), 3);
+    let successful = consumption_info.successful();
+    let failed = consumption_info.failed();
 
-                // First failing note should be the note that does not cause epilogue failure.
-                assert_matches!(
-                    failed.first().expect("first failed notes should exist"),
-                    FailedNote {
-                        note,
-                        error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. }),
-                        ..
-                    } => {
-                        assert_eq!(
-                            note.id(),
-                            failing_note_1.id(),
-                        );
-                    }
-                );
-                // Second failing note should be the note that causes epilogue failure.
-                assert_matches!(
-                    failed.get(1).expect("second failed note should exist"),
-                    FailedNote {
-                        note,
-                        error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::FailedAssertion { .. }, .. }),
-                        ..
-                    } => {
-                        assert_eq!(
-                            note.id(),
-                            fail_epilogue_note.id(),
-                        );
-                    }
-                );
-                // Successful notes.
-                assert_eq!(
-                    [successful[0].note.id(), successful[1].note.id(), successful[2].note.id()],
-                    [successful_note_1.id(), successful_note_2.id(), successful_note_3.id()],
-                );
+    assert_eq!(failed.len(), 2);
+    assert_eq!(successful.len(), 3);
+
+    // First failing note should be the note that does not cause epilogue failure.
+    let first_failed = failed.first().expect("first failed notes should exist");
+    assert_matches!(
+        first_failed.error(),
+        TransactionExecutorError::TransactionProgramExecutionFailed(
+            ExecutionError::OperationError {
+                err: miden_processor::operation::OperationError::DivideByZero,
+                ..
             }
+        )
+    );
+    assert_eq!(first_failed.note().id(), failing_note_1.id());
+
+    // Second failing note should be the note that causes epilogue failure.
+    let second_failed = failed.get(1).expect("second failed note should exist");
+    assert_matches!(
+        second_failed.error(),
+        TransactionExecutorError::TransactionProgramExecutionFailed(
+            ExecutionError::OperationError {
+                err: miden_processor::operation::OperationError::FailedAssertion { .. },
+                ..
+            }
+        )
+    );
+    assert_eq!(second_failed.note().id(), fail_epilogue_note.id());
+
+    // Successful notes.
+    assert_eq!(
+        [successful[0].note().id(), successful[1].note().id(), successful[2].note().id()],
+        [successful_note_1.id(), successful_note_2.id(), successful_note_3.id()],
     );
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -95,7 +95,7 @@ async fn check_note_consumability_standard_notes_success() -> anyhow::Result<()>
 
         // we asserted that `successful` and `notes` vectors have the same length, so it's safe to
         // check their equality that way
-        successful.iter().for_each(|successful_note| assert!(notes.contains(successful_note)));
+        successful.iter().for_each(|s| assert!(notes.contains(&s.note)));
 
         assert!(failed.is_empty());
     });
@@ -231,7 +231,8 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
                     FailedNote {
                         note,
                         error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. })
+                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. }),
+                        ..
                     } => {
                         assert_eq!(
                             note.id(),
@@ -245,7 +246,8 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
                     FailedNote {
                         note,
                         error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. })
+                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. }),
+                        ..
                     } => {
                         assert_eq!(
                             note.id(),
@@ -255,7 +257,7 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
                 );
                 // Successful notes.
                 assert_eq!(
-                    [successful[0].id(), successful[1].id(), successful[2].id()],
+                    [successful[0].note.id(), successful[1].note.id(), successful[2].note.id()],
                     [successful_note_2.id(), successful_note_1.id(), successful_note_3.id()],
                 );
             }
@@ -395,7 +397,8 @@ async fn check_note_consumability_epilogue_failure_with_new_combination() -> any
                     FailedNote {
                         note,
                         error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. })
+                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::DivideByZero, .. }),
+                        ..
                     } => {
                         assert_eq!(
                             note.id(),
@@ -409,7 +412,8 @@ async fn check_note_consumability_epilogue_failure_with_new_combination() -> any
                     FailedNote {
                         note,
                         error: TransactionExecutorError::TransactionProgramExecutionFailed(
-                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::FailedAssertion { .. }, .. })
+                            ExecutionError::OperationError { err: miden_processor::operation::OperationError::FailedAssertion { .. }, .. }),
+                        ..
                     } => {
                         assert_eq!(
                             note.id(),
@@ -419,7 +423,7 @@ async fn check_note_consumability_epilogue_failure_with_new_combination() -> any
                 );
                 // Successful notes.
                 assert_eq!(
-                    [successful[0].id(), successful[1].id(), successful[2].id()],
+                    [successful[0].note.id(), successful[1].note.id(), successful[2].note.id()],
                     [successful_note_1.id(), successful_note_2.id(), successful_note_3.id()],
                 );
             }

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -50,12 +50,23 @@ pub(crate) enum TransactionCheckerError {
     TransactionPreparation(#[source] TransactionExecutorError),
     #[error("transaction execution prologue failed: {0}")]
     PrologueExecution(#[source] TransactionExecutorError),
-    #[error("transaction execution epilogue failed: {0}")]
-    EpilogueExecution(#[source] TransactionExecutorError),
+    #[error("transaction execution epilogue failed: {error}")]
+    EpilogueExecution {
+        error: TransactionExecutorError,
+        /// Cycle counts for notes that executed successfully before the epilogue failed.
+        successful_notes_cycle_counts: Vec<usize>,
+    },
     #[error("transaction note execution failed on note index {failed_note_index}: {error}")]
     NoteExecution {
         failed_note_index: usize,
         error: TransactionExecutorError,
+        /// Cycle counts for notes that executed successfully before the failed note.
+        successful_notes_cycle_counts: Vec<usize>,
+        /// The number of cycles consumed by the failed note before it errored.
+        ///
+        /// This is `Some` when the failure was due to exceeding the cycle limit, and `None`
+        /// for other error types where the cycle count is not meaningful.
+        failed_note_cycle_count: Option<usize>,
     },
 }
 
@@ -64,7 +75,7 @@ impl From<TransactionCheckerError> for TransactionExecutorError {
         match error {
             TransactionCheckerError::TransactionPreparation(error) => error,
             TransactionCheckerError::PrologueExecution(error) => error,
-            TransactionCheckerError::EpilogueExecution(error) => error,
+            TransactionCheckerError::EpilogueExecution { error, .. } => error,
             TransactionCheckerError::NoteExecution { error, .. } => error,
         }
     }

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -39,6 +39,7 @@ pub use notes_checker::{
     MAX_NUM_CHECKER_NOTES,
     NoteConsumptionChecker,
     NoteConsumptionInfo,
+    SuccessfulNote,
 };
 
 mod program_executor;

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -35,8 +35,8 @@ pub const MAX_NUM_CHECKER_NOTES: usize = 20;
 /// Represents a successfully consumed note along with the number of cycles it took to execute.
 #[derive(Debug)]
 pub struct SuccessfulNote {
-    pub note: Note,
-    pub num_cycles: usize,
+    note: Note,
+    num_cycles: usize,
 }
 
 impl SuccessfulNote {
@@ -44,18 +44,28 @@ impl SuccessfulNote {
     pub fn new(note: Note, num_cycles: usize) -> Self {
         Self { note, num_cycles }
     }
+
+    /// Returns a reference to the note.
+    pub fn note(&self) -> &Note {
+        &self.note
+    }
+
+    /// Returns the number of cycles consumed during execution.
+    pub fn num_cycles(&self) -> usize {
+        self.num_cycles
+    }
 }
 
 /// Represents a failed note consumption.
 #[derive(Debug)]
 pub struct FailedNote {
-    pub note: Note,
-    pub error: TransactionExecutorError,
+    note: Note,
+    error: TransactionExecutorError,
     /// The number of cycles consumed by the note before it failed.
     ///
     /// This is `Some` when the failure was due to exceeding the cycle limit, and `None`
     /// for other error types where the cycle count is not meaningful.
-    pub num_cycles: Option<usize>,
+    num_cycles: Option<usize>,
 }
 
 impl FailedNote {
@@ -63,13 +73,31 @@ impl FailedNote {
     pub fn new(note: Note, error: TransactionExecutorError, num_cycles: Option<usize>) -> Self {
         Self { note, error, num_cycles }
     }
+
+    /// Returns a reference to the note.
+    pub fn note(&self) -> &Note {
+        &self.note
+    }
+
+    /// Returns a reference to the error.
+    pub fn error(&self) -> &TransactionExecutorError {
+        &self.error
+    }
+
+    /// Returns the number of cycles consumed before failure, if available.
+    ///
+    /// This is `Some` when the failure was due to exceeding the cycle limit, and `None`
+    /// for other error types where the cycle count is not meaningful.
+    pub fn num_cycles(&self) -> Option<usize> {
+        self.num_cycles
+    }
 }
 
 /// Contains information about the successful and failed consumption of notes.
 #[derive(Default, Debug)]
 pub struct NoteConsumptionInfo {
-    pub successful: Vec<SuccessfulNote>,
-    pub failed: Vec<FailedNote>,
+    successful: Vec<SuccessfulNote>,
+    failed: Vec<FailedNote>,
 }
 
 impl NoteConsumptionInfo {
@@ -81,6 +109,21 @@ impl NoteConsumptionInfo {
     /// Creates a new [`NoteConsumptionInfo`] instance with the given successful and failed notes.
     pub fn new(successful: Vec<SuccessfulNote>, failed: Vec<FailedNote>) -> Self {
         Self { successful, failed }
+    }
+
+    /// Returns a reference to the successfully consumed notes.
+    pub fn successful(&self) -> &[SuccessfulNote] {
+        &self.successful
+    }
+
+    /// Returns a reference to the failed notes.
+    pub fn failed(&self) -> &[FailedNote] {
+        &self.failed
+    }
+
+    /// Consumes the struct and returns the successful and failed notes.
+    pub fn into_parts(self) -> (Vec<SuccessfulNote>, Vec<FailedNote>) {
+        (self.successful, self.failed)
     }
 }
 

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -376,7 +376,8 @@ where
     /// This method executes the full transaction pipeline including prologue, note execution,
     /// and epilogue phases. It returns `Ok(cycle_counts)` if all notes are successfully consumed
     /// (where `cycle_counts` contains the number of cycles for each note), or a specific
-    /// [`TransactionCheckerError`] indicating where and why the execution failed.
+    /// [`TransactionCheckerError`] indicating where and why the execution failed. The order of the
+    /// returned `cycle_counts` is guaranteed to match the order of the input notes.
     async fn try_execute_notes(
         &self,
         tx_inputs: &mut TransactionInputs,

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -1,6 +1,7 @@
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
+use miden_processor::ExecutionError;
 use miden_processor::advice::AdviceInputs;
 use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
@@ -31,35 +32,54 @@ pub const MAX_NUM_CHECKER_NOTES: usize = 20;
 // NOTE CONSUMPTION INFO
 // ================================================================================================
 
+/// Represents a successfully consumed note along with the number of cycles it took to execute.
+#[derive(Debug)]
+pub struct SuccessfulNote {
+    pub note: Note,
+    pub num_cycles: usize,
+}
+
+impl SuccessfulNote {
+    /// Constructs a new `SuccessfulNote`.
+    pub fn new(note: Note, num_cycles: usize) -> Self {
+        Self { note, num_cycles }
+    }
+}
+
 /// Represents a failed note consumption.
 #[derive(Debug)]
 pub struct FailedNote {
     pub note: Note,
     pub error: TransactionExecutorError,
+    /// The number of cycles consumed by the note before it failed.
+    ///
+    /// This is `Some` when the failure was due to exceeding the cycle limit, and `None`
+    /// for other error types where the cycle count is not meaningful.
+    pub num_cycles: Option<usize>,
 }
 
 impl FailedNote {
     /// Constructs a new `FailedNote`.
-    pub fn new(note: Note, error: TransactionExecutorError) -> Self {
-        Self { note, error }
+    pub fn new(note: Note, error: TransactionExecutorError, num_cycles: Option<usize>) -> Self {
+        Self { note, error, num_cycles }
     }
 }
 
 /// Contains information about the successful and failed consumption of notes.
 #[derive(Default, Debug)]
 pub struct NoteConsumptionInfo {
-    pub successful: Vec<Note>,
+    pub successful: Vec<SuccessfulNote>,
     pub failed: Vec<FailedNote>,
 }
 
 impl NoteConsumptionInfo {
     /// Creates a new [`NoteConsumptionInfo`] instance with the given successful notes.
-    pub fn new_successful(successful: Vec<Note>) -> Self {
+    pub fn new_successful(successful: Vec<SuccessfulNote>) -> Self {
         Self { successful, ..Default::default() }
     }
 
     /// Creates a new [`NoteConsumptionInfo`] instance with the given successful and failed notes.
-    pub fn new(successful: Vec<Note>, failed: Vec<FailedNote>) -> Self {
+    pub fn new(successful: Vec<SuccessfulNote>, failed: Vec<FailedNote>) -> Self {
         Self { successful, failed }
     }
 }
@@ -179,7 +199,7 @@ where
         // try to consume the provided note
         match self.try_execute_notes(&mut tx_inputs).await {
             // execution succeeded
-            Ok(()) => Ok(NoteConsumptionStatus::Consumable),
+            Ok(_cycle_counts) => Ok(NoteConsumptionStatus::Consumable),
             Err(tx_checker_error) => {
                 match tx_checker_error {
                     // execution failed on the preparation stage, before we actually executed the tx
@@ -195,9 +215,9 @@ where
                         Ok(NoteConsumptionStatus::UnconsumableConditions)
                     },
                     // execution failed during the epilogue
-                    TransactionCheckerError::EpilogueExecution(epilogue_error) => {
-                        Ok(handle_epilogue_error(epilogue_error))
-                    },
+                    TransactionCheckerError::EpilogueExecution {
+                        error: epilogue_error, ..
+                    } => Ok(handle_epilogue_error(epilogue_error)),
                 }
             },
         }
@@ -228,15 +248,24 @@ where
             // Execute the candidate notes.
             tx_inputs.set_input_notes(candidate_notes.clone());
             match self.try_execute_notes(&mut tx_inputs).await {
-                Ok(()) => {
+                Ok(cycle_counts) => {
                     // A full set of successful notes has been found.
-                    let successful = candidate_notes;
+                    let successful = candidate_notes
+                        .into_iter()
+                        .zip(cycle_counts)
+                        .map(|(note, num_cycles)| SuccessfulNote::new(note, num_cycles))
+                        .collect();
                     return Ok(NoteConsumptionInfo::new(successful, failed_notes));
                 },
-                Err(TransactionCheckerError::NoteExecution { failed_note_index, error }) => {
+                Err(TransactionCheckerError::NoteExecution {
+                    failed_note_index,
+                    error,
+                    failed_note_cycle_count,
+                    ..
+                }) => {
                     // SAFETY: Failed note index is in bounds of the candidate notes.
                     let failed_note = candidate_notes.remove(failed_note_index);
-                    failed_notes.push(FailedNote::new(failed_note, error));
+                    failed_notes.push(FailedNote::new(failed_note, error, failed_note_cycle_count));
 
                     // All possible candidate combinations have been attempted.
                     if candidate_notes.is_empty() {
@@ -244,7 +273,7 @@ where
                     }
                     // Continue and process the next set of candidates.
                 },
-                Err(TransactionCheckerError::EpilogueExecution(_)) => {
+                Err(TransactionCheckerError::EpilogueExecution { .. }) => {
                     let consumption_info = self
                         .find_largest_executable_combination(
                             candidate_notes,
@@ -277,6 +306,7 @@ where
         mut tx_inputs: TransactionInputs,
     ) -> NoteConsumptionInfo {
         let mut successful_notes = Vec::new();
+        let mut successful_cycle_counts = Vec::new();
         let mut failed_note_index = BTreeMap::new();
 
         // Iterate by note count: try 1 note, then 2, then 3, etc.
@@ -292,10 +322,12 @@ where
 
                 tx_inputs.set_input_notes(successful_notes.clone());
                 match self.try_execute_notes(&mut tx_inputs).await {
-                    Ok(()) => {
+                    Ok(cycle_counts) => {
                         // The successfully added note might have failed earlier. Remove it from the
                         // failed list.
                         failed_note_index.remove(&note.id());
+                        // Store the cycle counts from the latest successful execution.
+                        successful_cycle_counts = cycle_counts;
                         // This combination succeeded; remove the most recently added note from
                         // the remaining set.
                         remaining_notes.remove(idx);
@@ -306,31 +338,51 @@ where
                         // continue to next note.
                         let failed_note =
                             successful_notes.pop().expect("successful notes should not be empty");
+
+                        // Extract the failed note's cycle count if available.
+                        let num_cycles = match &error {
+                            TransactionCheckerError::NoteExecution {
+                                failed_note_cycle_count,
+                                ..
+                            } => *failed_note_cycle_count,
+                            _ => None,
+                        };
+
                         // Record the failed note (overwrite previous failures for the relevant
                         // note).
-                        failed_note_index
-                            .insert(failed_note.id(), FailedNote::new(failed_note, error.into()));
+                        failed_note_index.insert(
+                            failed_note.id(),
+                            FailedNote::new(failed_note, error.into(), num_cycles),
+                        );
                     },
                 }
             }
         }
 
+        // Pair successful notes with their cycle counts from the last successful execution.
+        let successful = successful_notes
+            .into_iter()
+            .zip(successful_cycle_counts)
+            .map(|(note, num_cycles)| SuccessfulNote::new(note, num_cycles))
+            .collect();
+
         // Append failed notes to the list of failed notes provided as input.
         failed_notes.extend(failed_note_index.into_values());
-        NoteConsumptionInfo::new(successful_notes, failed_notes)
+        NoteConsumptionInfo::new(successful, failed_notes)
     }
 
     /// Attempts to execute a transaction with the provided input notes.
     ///
     /// This method executes the full transaction pipeline including prologue, note execution,
-    /// and epilogue phases. It returns `Ok(())` if all notes are successfully consumed,
-    /// or a specific [`NoteExecutionError`] indicating where and why the execution failed.
+    /// and epilogue phases. It returns `Ok(cycle_counts)` if all notes are successfully consumed
+    /// (where `cycle_counts` contains the number of cycles for each note), or a specific
+    /// [`TransactionCheckerError`] indicating where and why the execution failed.
     async fn try_execute_notes(
         &self,
         tx_inputs: &mut TransactionInputs,
-    ) -> Result<(), TransactionCheckerError> {
+    ) -> Result<Vec<usize>, TransactionCheckerError> {
         if tx_inputs.input_notes().is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let (mut host, stack_inputs, advice_inputs) =
@@ -347,6 +399,13 @@ where
 
         match result {
             Ok(execution_output) => {
+                let cycle_counts = host
+                    .tx_progress()
+                    .note_execution()
+                    .iter()
+                    .map(|(_, interval)| interval.len())
+                    .collect();
+
                 // Set the advice inputs from the successful execution as advice inputs for
                 // reexecution. This avoids calls to the data store (to load data lazily) that have
                 // already been done as part of this execution.
@@ -357,7 +416,7 @@ where
                     ..Default::default()
                 };
                 tx_inputs.set_advice_inputs(advice_inputs);
-                Ok(())
+                Ok(cycle_counts)
             },
             Err(error) => {
                 let notes = host.tx_progress().note_execution();
@@ -372,13 +431,38 @@ where
                     notes.split_last().expect("notes vector is not empty because of earlier check");
 
                 // If the interval end of the last note is specified, then an error occurred after
-                // notes processing.
+                // notes processing. All notes executed successfully in this case.
                 if last_note_interval.end().is_some() {
-                    Err(TransactionCheckerError::EpilogueExecution(error))
+                    let successful_notes_cycle_counts =
+                        notes.iter().map(|(_, interval)| interval.len()).collect();
+                    Err(TransactionCheckerError::EpilogueExecution {
+                        error,
+                        successful_notes_cycle_counts,
+                    })
                 } else {
                     // Return the index of the failed note.
                     let failed_note_index = success_notes.len();
-                    Err(TransactionCheckerError::NoteExecution { failed_note_index, error })
+                    let successful_notes_cycle_counts =
+                        success_notes.iter().map(|(_, interval)| interval.len()).collect();
+
+                    // Compute the failed note's cycle count when the failure was due to
+                    // exceeding the cycle limit. In this case, the note's interval has a
+                    // start but no end, and the total cycles consumed equals the max allowed.
+                    let failed_note_cycle_count = match &error {
+                        TransactionExecutorError::TransactionProgramExecutionFailed(
+                            ExecutionError::CycleLimitExceeded(max_cycles),
+                        ) => last_note_interval
+                            .start()
+                            .map(|start| *max_cycles as usize - usize::from(start)),
+                        _ => None,
+                    };
+
+                    Err(TransactionCheckerError::NoteExecution {
+                        failed_note_index,
+                        error,
+                        successful_notes_cycle_counts,
+                        failed_note_cycle_count,
+                    })
                 }
             },
         }

--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -16,6 +16,7 @@ pub use executor::{
     NoteConsumptionChecker,
     NoteConsumptionInfo,
     ProgramExecutor,
+    SuccessfulNote,
     TransactionExecutor,
     TransactionExecutorHost,
 };


### PR DESCRIPTION
## Add cycle counts to successful and failed notes

Track per-note cycle counts during note consumption checking. `SuccessfulNote` now wraps a `Note` with its cycle count, and `FailedNote` includes an optional cycle count (populated when the failure is due to exceeding the cycle limit).

Closes #2684.

### Changes

- Introduce `SuccessfulNote` struct pairing a note with its execution cycle count
- Add `num_cycles: Option<usize>` to `FailedNote` (set when `CycleLimitExceeded`)
- Propagate cycle counts from `try_execute_notes` through `TransactionCheckerError` variants
- Update tests to match new struct shapes
- Make `NoteConsumptionInfo` fields private