### PR TITLE
Improve deserialization error handling in AccountCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.15.0 (TBD)
 
 ### Changes
-- Added validation of leaf type on CLAIM note processing to prevent message leaves from being processed as asset claims ([#2730](https://github.com/0xMiden/protocol/pull/2730)).
 
+- Added validation of leaf type on CLAIM note processing to prevent message leaves from being processed as asset claims ([#2730](https://github.com/0xMiden/protocol/pull/2730)).
 - [BREAKING] Reduced `MAX_ASSETS_PER_NOTE` from 255 to 64 and `NOTE_MEM_SIZE` from 3072 to 1024 ([#2741](https://github.com/0xMiden/protocol/issues/2741)).
 - Added `metadata_into_note_type` procedure to `note.masm` for extracting note type from metadata header ([#2738](https://github.com/0xMiden/protocol/pull/2738)).
 - [BREAKING] Renamed `extract_sender_from_metadata` to `metadata_into_sender` and `extract_attachment_info_from_metadata` to `metadata_into_attachment_info` in `note.masm` ([#2758](https://github.com/0xMiden/protocol/pull/2758)).
@@ -17,6 +17,10 @@
 - [BREAKING] Changed `NoteType` encoding from 2 bits to 1 and makes `NoteType::Private` the default ([#2691](https://github.com/0xMiden/miden-base/issues/2691)).
 - Added `BlockNumber::saturating_sub()` ([#2660](https://github.com/0xMiden/protocol/issues/2660)).
 - [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` and removed public fields from related types ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
+
+### Fixes
+
+- Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
 
 ## 0.14.3 (2026-04-07)
 

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -61,6 +61,32 @@ impl AccountCode {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns a new [`AccountCode`] instantiated from the provided [`MastForest`] and a list of
+    /// [`AccountProcedureRoot`]s.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - The number of procedures is smaller than 2 or greater than 256.
+    pub fn from_parts(mast: Arc<MastForest>, procedures: Vec<AccountProcedureRoot>) -> Self {
+        assert!(procedures.len() >= Self::MIN_NUM_PROCEDURES, "not enough account procedures");
+        assert!(procedures.len() <= Self::MAX_NUM_PROCEDURES, "too many account procedures");
+
+        Self {
+            commitment: build_procedure_commitment(&procedures),
+            procedures,
+            mast,
+        }
+    }
+
+    /// Returns a new [AccountCode] deserialized from the provided bytes.
+    ///
+    /// # Errors
+    /// Returns an error if account code deserialization fails.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, AccountError> {
+        Self::read_from_bytes(bytes).map_err(AccountError::AccountCodeDeserializationError)
+    }
+
     /// Creates a new [`AccountCode`] from the provided components' libraries.
     ///
     /// For testing use only.
@@ -117,32 +143,6 @@ impl AccountCode {
         })
     }
 
-    /// Returns a new [AccountCode] deserialized from the provided bytes.
-    ///
-    /// # Errors
-    /// Returns an error if account code deserialization fails.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, AccountError> {
-        Self::read_from_bytes(bytes).map_err(AccountError::AccountCodeDeserializationError)
-    }
-
-    /// Returns a new [`AccountCode`] instantiated from the provided [`MastForest`] and a list of
-    /// [`AccountProcedureRoot`]s.
-    ///
-    /// # Panics
-    ///
-    /// Panics if:
-    /// - The number of procedures is smaller than 2 or greater than 256.
-    pub fn from_parts(mast: Arc<MastForest>, procedures: Vec<AccountProcedureRoot>) -> Self {
-        assert!(procedures.len() >= Self::MIN_NUM_PROCEDURES, "not enough account procedures");
-        assert!(procedures.len() <= Self::MAX_NUM_PROCEDURES, "too many account procedures");
-
-        Self {
-            commitment: build_procedure_commitment(&procedures),
-            procedures,
-            mast,
-        }
-    }
-
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -190,7 +190,7 @@ impl AccountCode {
     /// ```
     ///
     /// And then concatenating the resulting elements into a single vector.
-    pub fn as_elements(&self) -> Vec<Felt> {
+    pub fn to_elements(&self) -> Vec<Felt> {
         procedures_as_elements(self.procedures())
     }
 
@@ -281,13 +281,33 @@ impl Serializable for AccountCode {
 
 impl Deserializable for AccountCode {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let module = Arc::new(MastForest::read_from(source)?);
+        let mast = Arc::new(MastForest::read_from(source)?);
         let num_procedures = (source.read_u8()? as usize) + 1;
+
+        // make sure the number of procedures is valid; we only check the minimum because
+        // u8::MAX + 1 is guaranteed to be less than or equal to 256
+        if num_procedures < Self::MIN_NUM_PROCEDURES {
+            return Err(DeserializationError::InvalidValue(format!(
+                "account code must contain at least {} procedures, but has only {num_procedures} procedures",
+                Self::MIN_NUM_PROCEDURES
+            )));
+        }
+
         let procedures = source
             .read_many_iter(num_procedures)?
             .collect::<Result<Vec<AccountProcedureRoot>, _>>()?;
 
-        Ok(Self::from_parts(module, procedures))
+        // make sure that all account procedures are in the MAST forest
+        for procedure in procedures.iter() {
+            if mast.find_procedure_root(procedure.as_word()).is_none() {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "procedure with root {} is missing from account code's MAST forest",
+                    procedure.as_word()
+                )));
+            }
+        }
+
+        Ok(Self::from_parts(mast, procedures))
     }
 }
 
@@ -391,13 +411,13 @@ impl AccountProcedureBuilder {
 // ================================================================================================
 
 /// Computes the commitment to the given procedures
-pub(crate) fn build_procedure_commitment(procedures: &[AccountProcedureRoot]) -> Word {
+fn build_procedure_commitment(procedures: &[AccountProcedureRoot]) -> Word {
     let elements = procedures_as_elements(procedures);
     Hasher::hash_elements(&elements)
 }
 
 /// Converts given procedures into field elements
-pub(crate) fn procedures_as_elements(procedures: &[AccountProcedureRoot]) -> Vec<Felt> {
+fn procedures_as_elements(procedures: &[AccountProcedureRoot]) -> Vec<Felt> {
     procedures.iter().flat_map(AccountProcedureRoot::as_elements).copied().collect()
 }
 

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -79,14 +79,6 @@ impl AccountCode {
         }
     }
 
-    /// Returns a new [AccountCode] deserialized from the provided bytes.
-    ///
-    /// # Errors
-    /// Returns an error if account code deserialization fails.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, AccountError> {
-        Self::read_from_bytes(bytes).map_err(AccountError::AccountCodeDeserializationError)
-    }
-
     /// Creates a new [`AccountCode`] from the provided components' libraries.
     ///
     /// For testing use only.

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -108,8 +108,6 @@ pub enum ComponentMetadataError {
 
 #[derive(Debug, Error)]
 pub enum AccountError {
-    #[error("failed to deserialize account code")]
-    AccountCodeDeserializationError(#[source] DeserializationError),
     #[error("account code does not contain an auth component")]
     AccountCodeNoAuthComponent,
     #[error("account code contains multiple auth components")]

--- a/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
+++ b/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
@@ -264,7 +264,7 @@ impl TransactionAdviceInputs {
 
         // CODE_COMMITMENT -> [[ACCOUNT_PROCEDURE_DATA]]
         let code = account.code();
-        self.add_map_entry(code.commitment(), code.as_elements());
+        self.add_map_entry(code.commitment(), code.to_elements());
 
         // --- account storage ----------------------------------------------------
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -2038,7 +2038,7 @@ fn foreign_account_data_memory_assertions(
 
     for (i, elements) in foreign_account
         .code()
-        .as_elements()
+        .to_elements()
         .chunks(AccountProcedureRoot::NUM_ELEMENTS)
         .enumerate()
     {

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -416,7 +416,7 @@ fn account_data_memory_assertions(exec_output: &ExecutionOutput, inputs: &Transa
     for (i, elements) in inputs
         .account()
         .code()
-        .as_elements()
+        .to_elements()
         .chunks(AccountProcedureRoot::NUM_ELEMENTS)
         .enumerate()
     {


### PR DESCRIPTION
This PR addresses https://github.com/0xMiden/protocol/security/advisories/GHSA-v93p-2hf4-p9cm#event-628226 and one other issue in account code deserialization.

I also made a couple of small refactorings, the most notable of which is renaming `AccountCode::as_elements()` to `AccountCode::to_elements()` as this is more consistent with our current naming convention.