### PR TITLE
fix: output note index out of bounds in asset and attachment API

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -1176,11 +1176,15 @@ end
 #!
 #! Panics if:
 #! - the procedure is called when the active account is not the native one.
+#! - the note index points to a non-existent output note.
 #!
 #! Invocation: dynexec
 pub proc output_note_add_asset
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
+    # => [note_idx, ASSET, pad(11)]
+
+    exec.output_note::assert_note_index_in_bounds
     # => [note_idx, ASSET, pad(11)]
 
     exec.output_note::add_asset
@@ -1208,6 +1212,9 @@ end
 pub proc output_note_set_attachment
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
+    # => [note_idx, attachment_scheme, attachment_kind, ATTACHMENT, pad(9)]
+
+    exec.output_note::assert_note_index_in_bounds
     # => [note_idx, attachment_scheme, attachment_kind, ATTACHMENT, pad(9)]
 
     exec.output_note::set_attachment

--- a/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
@@ -43,8 +43,6 @@ const ERR_OUTPUT_NOTE_ATTACHMENT_KIND_NONE_MUST_HAVE_ATTACHMENT_SCHEME_NONE="att
 
 const ERR_OUTPUT_NOTE_ATTACHMENT_KIND_NONE_MUST_BE_EMPTY_WORD="attachment kind None requires ATTACHMENT to be set to an empty word"
 
-const ERR_NOTE_INVALID_INDEX="failed to find note at the given index; index must be within [0, num_of_notes]"
-
 const ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED="adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"
 
 const ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS="non-fungible asset that already exists in the note cannot be added again"
@@ -190,16 +188,11 @@ end
 #! - ASSET can be a fungible or non-fungible asset.
 #!
 #! Panics if:
-#! - the note index points to a non-existent output note.
 #! - the ASSET is malformed (e.g., invalid faucet ID).
 #! - the max amount of fungible assets is exceeded.
 #! - the non-fungible asset already exists in the note.
 #! - the total number of ASSETs exceeds the maximum of 256.
 pub proc add_asset
-    # check if the note exists, it must be within [0, num_of_notes]
-    dup exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
-    # => [note_idx, ASSET]
-
     # get a pointer to the memory address of the note at which the asset will be stored
     dup movdn.5 exec.memory::get_output_note_ptr
     # => [note_ptr, ASSET, note_idx]
@@ -257,13 +250,9 @@ end
 #! - ATTACHMENT is the attachment to be set.
 #!
 #! Panics if:
-#! - the note index points to a non-existent output note.
 #! - the attachment kind or scheme does not fit into a u32.
 #! - the attachment kind is an unknown variant.
 pub proc set_attachment
-    dup exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
-    # => [note_idx, attachment_scheme, attachment_kind, ATTACHMENT]
-
     exec.memory::get_output_note_ptr dup
     # => [note_ptr, note_ptr, attachment_scheme, attachment_kind, ATTACHMENT]
 

--- a/crates/miden-protocol/src/errors/tx_kernel.rs
+++ b/crates/miden-protocol/src/errors/tx_kernel.rs
@@ -156,8 +156,6 @@ pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SCRIPT_ROOT_WHILE_NO_NOTE_BEING_PROCES
 pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SERIAL_NUMBER_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note serial number of active note because no note is currently being processed");
 /// Error Message: "adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"
 pub const ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED: MasmError = MasmError::from_static_str("adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807");
-/// Error Message: "failed to find note at the given index; index must be within [0, num_of_notes]"
-pub const ERR_NOTE_INVALID_INDEX: MasmError = MasmError::from_static_str("failed to find note at the given index; index must be within [0, num_of_notes]");
 /// Error Message: "invalid note type"
 pub const ERR_NOTE_INVALID_TYPE: MasmError = MasmError::from_static_str("invalid note type");
 /// Error Message: "number of assets in a note exceed 255"

--- a/crates/miden-protocol/src/transaction/kernel/procedures.rs
+++ b/crates/miden-protocol/src/transaction/kernel/procedures.rs
@@ -88,9 +88,9 @@ pub const KERNEL_PROCEDURES: [Word; 53] = [
     // output_note_get_recipient
     word!("0x1ce137f0c5be72832970e6c818968a789f65b97db34515bfebb767705f28db67"),
     // output_note_add_asset
-    word!("0xaf22383e4390f4f15a429768f79aa445f8a535bb21b0807172b9ef2de063d9d1"),
+    word!("0xfaadf08ba29f58af077b81eb7a0376b60c73650f1a7a0aa6d14684f40438f18f"),
     // output_note_set_attachment
-    word!("0x800ab6457b20be22a721d61770ab493334004d2b5d01a6bbd245e49554c31a2c"),
+    word!("0xfa92885c13374dcceff7382739b15f29de94d9b919878754b6337881d77669f5"),
     // tx_get_num_input_notes
     word!("0xfcc186d4b65c584f3126dda1460b01eef977efd76f9e36f972554af28e33c685"),
     // tx_get_input_notes_commitment

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -7,6 +7,7 @@ use miden_protocol::asset::{Asset, FungibleAsset, NonFungibleAsset};
 use miden_protocol::crypto::rand::RpoRandomCoin;
 use miden_protocol::errors::tx_kernel::{
     ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS,
+    ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS,
     ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT,
 };
 use miden_protocol::note::{
@@ -48,6 +49,7 @@ use miden_standards::code_builder::CodeBuilder;
 use miden_standards::note::{NetworkAccountTarget, create_p2id_note};
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_standards::testing::note::NoteBuilder;
+use rstest::rstest;
 
 use super::{TestSetup, setup_test};
 use crate::kernel_tests::tx::ExecutionOutputExt;
@@ -1197,6 +1199,78 @@ async fn test_set_network_target_account_attachment() -> anyhow::Result<()> {
     let actual_attachment = NetworkAccountTarget::try_from(actual_note.metadata().attachment())?;
     assert_eq!(actual_attachment, attachment);
 
+    Ok(())
+}
+
+/// Test that output_note procedures abort when given an out-of-bounds note index (equal to
+/// num_output_notes).
+///
+/// Each case creates one note via `mock::util::create_default_note` (index 0), then calls the
+/// procedure under test with index 1, which is out of bounds. The bounds assertion fires before
+/// any parameter validation, so dummy values are sufficient.
+#[rstest]
+#[case::add_asset(4, 0, "add_asset")]
+#[case::get_assets_info(0, 0, "get_assets_info")]
+#[case::get_assets(0, 1, "get_assets")]
+#[case::get_recipient(0, 0, "get_recipient")]
+#[case::get_metadata(0, 0, "get_metadata")]
+#[case::set_attachment(0, 6, "set_attachment")]
+#[case::set_word_attachment(0, 5, "set_word_attachment")]
+#[case::set_array_attachment(0, 5, "set_array_attachment")]
+#[tokio::test]
+async fn test_output_note_index_out_of_bounds(
+    #[case] params_above: usize,
+    #[case] params_below: usize,
+    #[case] procedure_name: &str,
+) -> anyhow::Result<()> {
+    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
+
+    let push_below = if params_below > 0 {
+        format!("repeat.{params_below} push.99 end")
+    } else {
+        String::new()
+    };
+    let push_above = if params_above > 0 {
+        format!("repeat.{params_above} push.99 end")
+    } else {
+        String::new()
+    };
+
+    // Create one note (index 0), then try to call the procedure with index 1.
+    let code = format!(
+        "
+        use miden::protocol::output_note
+        use mock::util
+
+        use $kernel::prologue
+
+        begin
+            exec.prologue::prepare_transaction
+
+            exec.util::create_default_note
+            # => [note_idx = 0]
+            drop
+            # => []
+
+            # push garbage parameters that should sit below note_idx
+            {push_below}
+
+            # push the out-of-bounds index (1 == num_output_notes)
+            push.1
+            # => [note_idx = 1, params_below...]
+
+            # push garbage parameters that should sit above note_idx
+            {push_above}
+
+            # call the procedure under test with the invalid index
+            exec.output_note::{procedure_name}
+        end
+        ",
+    );
+
+    let exec_output = tx_context.execute_code(&code).await;
+
+    assert_execution_error!(exec_output, ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS);
     Ok(())
 }
 


### PR DESCRIPTION
Fixes output note index out of bounds in asset and attachment API by using `output_note::assert_note_index_in_bounds` consistently for all output_note APIs in `api.masm`.

Note that there were cargo deny errors in this PR's CI and ignores were added on the base branch directly in https://github.com/0xMiden/protocol/commit/17423735869c16090d9db6653761c893f287e59e, since these issues are unimportant for the audit and have been addressed on next. That way, we can cherry-pick this PR's merge commit back into next without accidentally ignoring these advisories.

closes #2763 